### PR TITLE
Fix segfault described in issue #19

### DIFF
--- a/php_judy.c
+++ b/php_judy.c
@@ -214,6 +214,11 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value T
 	if (offset) {
 		CHECK_ARRAY_AND_ARG_TYPE(dummy, pstring_key, return FAILURE);
 		(void)dummy;
+	} else {
+		if (intern->type == TYPE_STRING_TO_INT || intern->type == TYPE_STRING_TO_MIXED) {
+			php_error_docref(NULL TSRMLS_CC, E_ERROR, "Judy STRING_TO_INT and STRING_TO_MIXED values cannot be set without key specifying");
+			return FAILURE;
+		}
 	}
 
 	if (intern->type == TYPE_BITSET) {

--- a/tests/string_to_int_005.phpt
+++ b/tests/string_to_int_005.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Check for Judy STRING_TO_INT works with $a[] = $b (expect fatal error)
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$judy = new Judy(Judy::STRING_TO_INT);
+$judy[] = 1;
+
+echo "Done\n";
+?>
+--EXPECTF--
+Fatal error: main(): Judy STRING_TO_INT and STRING_TO_MIXED values cannot be set without key specifying in %s

--- a/tests/string_to_mixed_005.phpt
+++ b/tests/string_to_mixed_005.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Check for Judy STRING_TO_MIXED works with $a[] = $b (expect fatal error)
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$judy = new Judy(Judy::STRING_TO_MIXED);
+$judy[] = 1;
+
+echo "Done\n";
+?>
+--EXPECTF--
+Fatal error: main(): Judy STRING_TO_INT and STRING_TO_MIXED values cannot be set without key specifying in %s


### PR DESCRIPTION
Judy STRING_TO_INT and STRING_TO_MIXED values cannot be set without key specifying.

Fixes #19.
