### PR TITLE
feat: implement JsonSerializable and __serialize/__unserialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ Please report bugs and issues on the GitHub repository:
 - [x] **Performance**: Optimize `get_iterator` to use native C iterators.
 - [x] **Core Features**: Implement `slice($start, $end)` for efficient range queries.
 - [x] **Set Operations**: Add native methods for Union, Intersection, and Difference (especially for BITSET).
-- [ ] **Serialization**: Implement `__serialize`/`__unserialize` for optimized binary persistence.
-- [ ] **Interoperability**: Implement `JsonSerializable` interface.
+- [x] **Serialization**: Implement `__serialize`/`__unserialize` for optimized binary persistence.
+- [x] **Interoperability**: Implement `JsonSerializable` interface.
 - [ ] **Testing**: More comprehensive test coverage.
 - [ ] **Documentation**: Document memory usage patterns vs standard arrays.
 

--- a/config.m4
+++ b/config.m4
@@ -60,6 +60,7 @@ if test "$PHP_JUDY" != "no"; then
   fi
   
   PHP_NEW_EXTENSION(judy, php_judy.c $judy_sources, $ext_shared)
+  PHP_ADD_EXTENSION_DEP(judy, json)
   PHP_ADD_BUILD_DIR($ext_builddir/lib, 1)
   PHP_SUBST(JUDY_SHARED_LIBADD)
 

--- a/config.w32
+++ b/config.w32
@@ -6,6 +6,7 @@ ARG_WITH("judy", "Judy support", "no");
 if (PHP_JUDY != "no") {
 	if (CHECK_LIB("libJudy_a.lib;libJudy.lib", "judy", PHP_JUDY) && CHECK_HEADER_ADD_INCLUDE("Judy.h", "CFLAGS_JUDY", PHP_JUDY + ";" + PHP_JUDY + "\\include")) {
 		EXTENSION("judy", "php_judy.c judy_arrayaccess.c judy_handlers.c judy_iterator.c");
+		ADD_EXTENSION_DEP("judy", "json");
 		AC_DEFINE('HAVE_JUDY', 1, 'Have Judy library');
 
 		ADD_FLAG("CFLAGS_JUDY", "/D JU_WIN");

--- a/package.xml
+++ b/package.xml
@@ -79,6 +79,18 @@
          <file name="tests/slice_string_to_int_001.phpt" role="test" />
          <file name="tests/slice_string_to_mixed_001.phpt" role="test" />
          <file name="tests/slice_empty_001.phpt" role="test" />
+         <file name="tests/json_serialize_bitset_001.phpt" role="test" />
+         <file name="tests/json_serialize_int_to_int_001.phpt" role="test" />
+         <file name="tests/json_serialize_int_to_mixed_001.phpt" role="test" />
+         <file name="tests/json_serialize_string_to_int_001.phpt" role="test" />
+         <file name="tests/json_serialize_string_to_mixed_001.phpt" role="test" />
+         <file name="tests/json_serialize_empty_001.phpt" role="test" />
+         <file name="tests/serialize_roundtrip_bitset_001.phpt" role="test" />
+         <file name="tests/serialize_roundtrip_int_to_int_001.phpt" role="test" />
+         <file name="tests/serialize_roundtrip_int_to_mixed_001.phpt" role="test" />
+         <file name="tests/serialize_roundtrip_string_to_int_001.phpt" role="test" />
+         <file name="tests/serialize_roundtrip_string_to_mixed_001.phpt" role="test" />
+         <file name="tests/serialize_error_001.phpt" role="test" />
          <file md5sum="3022d615e01248b9aedcc07d53f9d298" name="tests/clone_bitset_001.phpt" role="test" />
          <file md5sum="ebf5a62bedc4d0100256bc6db614cac0" name="tests/int_to_int_001.phpt" role="test" />
          <file md5sum="293c4e8f37490390abeaac289e8d4ee7" name="tests/int_to_int_002.phpt" role="test" />

--- a/tests/json_serialize_bitset_001.phpt
+++ b/tests/json_serialize_bitset_001.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Judy BITSET jsonSerialize() - returns flat array of set indices
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::BITSET);
+$j[1] = true;
+$j[5] = true;
+$j[10] = true;
+
+$json = json_encode($j);
+echo "JSON: $json\n";
+
+// Verify it's a flat array
+$decoded = json_decode($json, true);
+var_dump($decoded);
+
+// Empty BITSET
+$empty = new Judy(Judy::BITSET);
+echo "Empty: " . json_encode($empty) . "\n";
+?>
+--EXPECT--
+JSON: [1,5,10]
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(5)
+  [2]=>
+  int(10)
+}
+Empty: []

--- a/tests/json_serialize_empty_001.phpt
+++ b/tests/json_serialize_empty_001.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Judy jsonSerialize() - all empty types
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$types = [
+    'BITSET' => Judy::BITSET,
+    'INT_TO_INT' => Judy::INT_TO_INT,
+    'INT_TO_MIXED' => Judy::INT_TO_MIXED,
+    'STRING_TO_INT' => Judy::STRING_TO_INT,
+    'STRING_TO_MIXED' => Judy::STRING_TO_MIXED,
+];
+
+foreach ($types as $name => $type) {
+    $j = new Judy($type);
+    echo "$name: " . json_encode($j) . "\n";
+}
+?>
+--EXPECT--
+BITSET: []
+INT_TO_INT: []
+INT_TO_MIXED: []
+STRING_TO_INT: []
+STRING_TO_MIXED: []

--- a/tests/json_serialize_int_to_int_001.phpt
+++ b/tests/json_serialize_int_to_int_001.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Judy INT_TO_INT jsonSerialize() - returns index => value object
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::INT_TO_INT);
+$j[0] = 100;
+$j[5] = 200;
+$j[10] = 300;
+
+$json = json_encode($j);
+echo "JSON: $json\n";
+
+$decoded = json_decode($json, true);
+var_dump($decoded);
+
+// Empty
+$empty = new Judy(Judy::INT_TO_INT);
+echo "Empty: " . json_encode($empty) . "\n";
+?>
+--EXPECT--
+JSON: {"0":100,"5":200,"10":300}
+array(3) {
+  [0]=>
+  int(100)
+  [5]=>
+  int(200)
+  [10]=>
+  int(300)
+}
+Empty: []

--- a/tests/json_serialize_int_to_mixed_001.phpt
+++ b/tests/json_serialize_int_to_mixed_001.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Judy INT_TO_MIXED jsonSerialize() - returns index => mixed value object
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::INT_TO_MIXED);
+$j[0] = "hello";
+$j[5] = 42;
+$j[10] = true;
+$j[15] = null;
+
+$json = json_encode($j);
+echo "JSON: $json\n";
+
+$decoded = json_decode($json, true);
+var_dump($decoded);
+?>
+--EXPECT--
+JSON: {"0":"hello","5":42,"10":true,"15":null}
+array(4) {
+  [0]=>
+  string(5) "hello"
+  [5]=>
+  int(42)
+  [10]=>
+  bool(true)
+  [15]=>
+  NULL
+}

--- a/tests/json_serialize_string_to_int_001.phpt
+++ b/tests/json_serialize_string_to_int_001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Judy STRING_TO_INT jsonSerialize() - returns key => value object
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::STRING_TO_INT);
+$j["apple"] = 1;
+$j["banana"] = 2;
+$j["cherry"] = 3;
+
+$json = json_encode($j);
+echo "JSON: $json\n";
+
+$decoded = json_decode($json, true);
+var_dump($decoded);
+?>
+--EXPECT--
+JSON: {"apple":1,"banana":2,"cherry":3}
+array(3) {
+  ["apple"]=>
+  int(1)
+  ["banana"]=>
+  int(2)
+  ["cherry"]=>
+  int(3)
+}

--- a/tests/json_serialize_string_to_mixed_001.phpt
+++ b/tests/json_serialize_string_to_mixed_001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Judy STRING_TO_MIXED jsonSerialize() - returns key => mixed value object
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::STRING_TO_MIXED);
+$j["name"] = "John";
+$j["age"] = 30;
+$j["active"] = true;
+
+$json = json_encode($j);
+echo "JSON: $json\n";
+
+$decoded = json_decode($json, true);
+var_dump($decoded);
+?>
+--EXPECT--
+JSON: {"active":true,"age":30,"name":"John"}
+array(3) {
+  ["active"]=>
+  bool(true)
+  ["age"]=>
+  int(30)
+  ["name"]=>
+  string(4) "John"
+}

--- a/tests/serialize_error_001.phpt
+++ b/tests/serialize_error_001.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Judy __unserialize() - error handling for invalid data
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// Test 1: Missing 'type' key
+try {
+    $data = 'O:4:"Judy":1:{s:4:"data";a:0:{}}';
+    $j = unserialize($data);
+    echo "FAIL: should have thrown\n";
+} catch (\Exception $e) {
+    echo "Missing type: " . $e->getMessage() . "\n";
+}
+
+// Test 2: Missing 'data' key
+try {
+    $data = 'O:4:"Judy":1:{s:4:"type";i:1;}';
+    $j = unserialize($data);
+    echo "FAIL: should have thrown\n";
+} catch (\Exception $e) {
+    echo "Missing data: " . $e->getMessage() . "\n";
+}
+
+// Test 3: Invalid type value
+try {
+    $data = 'O:4:"Judy":2:{s:4:"type";i:99;s:4:"data";a:0:{}}';
+    $j = unserialize($data);
+    echo "FAIL: should have thrown\n";
+} catch (\Exception $e) {
+    echo "Invalid type: " . $e->getMessage() . "\n";
+}
+
+// Test 4: Valid empty roundtrip
+$j = new Judy(Judy::BITSET);
+$s = serialize($j);
+$r = unserialize($s);
+echo "Empty BITSET count: " . $r->count() . "\n";
+echo "Empty BITSET type: " . $r->getType() . "\n";
+?>
+--EXPECTF--
+Missing type: Invalid serialization data for Judy array
+Missing data: Invalid serialization data for Judy array
+%AInvalid type: Invalid Judy type in serialized data
+Empty BITSET count: 0
+Empty BITSET type: 1

--- a/tests/serialize_roundtrip_bitset_001.phpt
+++ b/tests/serialize_roundtrip_bitset_001.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Judy BITSET serialize/unserialize roundtrip
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::BITSET);
+$j[1] = true;
+$j[5] = true;
+$j[100] = true;
+$j[1000] = true;
+
+$serialized = serialize($j);
+echo "Serialized OK\n";
+
+$restored = unserialize($serialized);
+
+echo "Type: " . $restored->getType() . " (BITSET=" . Judy::BITSET . ")\n";
+echo "Count: " . $restored->count() . "\n";
+
+// Verify all indices
+echo "Has 1: " . var_export(isset($restored[1]), true) . "\n";
+echo "Has 5: " . var_export(isset($restored[5]), true) . "\n";
+echo "Has 100: " . var_export(isset($restored[100]), true) . "\n";
+echo "Has 1000: " . var_export(isset($restored[1000]), true) . "\n";
+echo "Has 50: " . var_export(isset($restored[50]), true) . "\n";
+
+// Verify iteration
+foreach ($restored as $k => $v) {
+    echo "  $k => " . var_export($v, true) . "\n";
+}
+?>
+--EXPECT--
+Serialized OK
+Type: 1 (BITSET=1)
+Count: 4
+Has 1: true
+Has 5: true
+Has 100: true
+Has 1000: true
+Has 50: false
+  1 => true
+  5 => true
+  100 => true
+  1000 => true

--- a/tests/serialize_roundtrip_int_to_int_001.phpt
+++ b/tests/serialize_roundtrip_int_to_int_001.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Judy INT_TO_INT serialize/unserialize roundtrip
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::INT_TO_INT);
+$j[0] = 100;
+$j[5] = 200;
+$j[10] = 300;
+
+$serialized = serialize($j);
+$restored = unserialize($serialized);
+
+echo "Type: " . $restored->getType() . " (INT_TO_INT=" . Judy::INT_TO_INT . ")\n";
+echo "Count: " . $restored->count() . "\n";
+
+foreach ($restored as $k => $v) {
+    echo "  $k => $v\n";
+}
+
+// Verify independence
+$restored[0] = 999;
+echo "Original [0]: " . $j[0] . "\n";
+echo "Restored [0]: " . $restored[0] . "\n";
+?>
+--EXPECT--
+Type: 2 (INT_TO_INT=2)
+Count: 3
+  0 => 100
+  5 => 200
+  10 => 300
+Original [0]: 100
+Restored [0]: 999

--- a/tests/serialize_roundtrip_int_to_mixed_001.phpt
+++ b/tests/serialize_roundtrip_int_to_mixed_001.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Judy INT_TO_MIXED serialize/unserialize roundtrip
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::INT_TO_MIXED);
+$j[0] = "hello";
+$j[5] = 42;
+$j[10] = [1, 2, 3];
+$j[15] = true;
+$j[20] = null;
+
+$serialized = serialize($j);
+$restored = unserialize($serialized);
+
+echo "Type: " . $restored->getType() . " (INT_TO_MIXED=" . Judy::INT_TO_MIXED . ")\n";
+echo "Count: " . $restored->count() . "\n";
+
+foreach ($restored as $k => $v) {
+    echo "  $k => " . var_export($v, true) . "\n";
+}
+?>
+--EXPECT--
+Type: 3 (INT_TO_MIXED=3)
+Count: 5
+  0 => 'hello'
+  5 => 42
+  10 => array (
+  0 => 1,
+  1 => 2,
+  2 => 3,
+)
+  15 => true
+  20 => NULL

--- a/tests/serialize_roundtrip_string_to_int_001.phpt
+++ b/tests/serialize_roundtrip_string_to_int_001.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Judy STRING_TO_INT serialize/unserialize roundtrip
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::STRING_TO_INT);
+$j["apple"] = 1;
+$j["banana"] = 2;
+$j["cherry"] = 3;
+
+$serialized = serialize($j);
+$restored = unserialize($serialized);
+
+echo "Type: " . $restored->getType() . " (STRING_TO_INT=" . Judy::STRING_TO_INT . ")\n";
+echo "Count: " . $restored->count() . "\n";
+
+foreach ($restored as $k => $v) {
+    echo "  $k => $v\n";
+}
+
+// Verify key lookup
+echo "banana: " . $restored["banana"] . "\n";
+?>
+--EXPECT--
+Type: 4 (STRING_TO_INT=4)
+Count: 3
+  apple => 1
+  banana => 2
+  cherry => 3
+banana: 2

--- a/tests/serialize_roundtrip_string_to_mixed_001.phpt
+++ b/tests/serialize_roundtrip_string_to_mixed_001.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Judy STRING_TO_MIXED serialize/unserialize roundtrip
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$j = new Judy(Judy::STRING_TO_MIXED);
+$j["name"] = "John";
+$j["age"] = 30;
+$j["scores"] = [85, 92, 78];
+$j["active"] = true;
+
+$serialized = serialize($j);
+$restored = unserialize($serialized);
+
+echo "Type: " . $restored->getType() . " (STRING_TO_MIXED=" . Judy::STRING_TO_MIXED . ")\n";
+echo "Count: " . $restored->count() . "\n";
+
+foreach ($restored as $k => $v) {
+    echo "  $k => " . var_export($v, true) . "\n";
+}
+?>
+--EXPECT--
+Type: 5 (STRING_TO_MIXED=5)
+Count: 4
+  active => true
+  age => 30
+  name => 'John'
+  scores => array (
+  0 => 85,
+  1 => 92,
+  2 => 78,
+)


### PR DESCRIPTION
## Summary

- Implements `JsonSerializable` interface so `json_encode($judy)` works natively, returning appropriate JSON format per type (flat array for BITSET, associative object for INT_TO_INT, INT_TO_MIXED, STRING_TO_INT, STRING_TO_MIXED)
- Implements `__serialize()` / `__unserialize()` for native PHP `serialize()` / `unserialize()` support with type-preserving roundtrip across all 5 Judy array types
- Shared `judy_build_data_array()` helper avoids code duplication between `jsonSerialize` and `__serialize`
- Adds `json` extension dependency to module deps (`judy_deps[]`), `config.m4`, and `config.w32`
- 12 new `.phpt` test files covering all types, empty arrays, roundtrip integrity, and error handling
- Checks off **Serialization** and **JsonSerializable** items in README roadmap

## Implementation details

### JsonSerializable output format
| Type | JSON output |
|------|------------|
| BITSET | `[1, 5, 10]` (flat array of set indices) |
| INT_TO_INT | `{"0": 100, "5": 200}` (index => value) |
| INT_TO_MIXED | `{"0": "hello", "5": [1,2]}` (index => mixed) |
| STRING_TO_INT | `{"foo": 100}` (key => value) |
| STRING_TO_MIXED | `{"foo": "bar"}` (key => mixed) |

### Serialization format
`__serialize()` returns `['type' => int, 'data' => array]` where `data` matches the `jsonSerialize()` format. `__unserialize()` validates type, reconstructs the Judy array via `judy_object_write_dimension_helper()`.

## Test plan
- [x] 85/85 tests pass (Docker PHP 8.3)
- [x] CI matrix (PHP 8.1-8.5, Linux + Windows)
- [x] Verify `pecl package package.xml` produces valid `.tgz`