### PR TITLE
Fix build with PHP 8.6.0alpha2

### DIFF
--- a/php_judy.c
+++ b/php_judy.c
@@ -1138,7 +1138,7 @@ PHP_MINIT_FUNCTION(judy)
 	judy_handlers.has_dimension = judy_object_has_dimension;
 	judy_handlers.dtor_obj = zend_objects_destroy_object;
 	judy_handlers.free_obj = judy_object_free_storage;
-	judy_handlers.offset = XtOffsetOf(judy_object, std);
+	judy_handlers.offset = offsetof(judy_object, std);
 
 	/* implements some interface to provide access to judy object as an array */
 	zend_class_implements(judy_ce, 4, zend_ce_arrayaccess, zend_ce_countable, zend_ce_iterator, php_json_serializable_ce);

--- a/php_judy.h
+++ b/php_judy.h
@@ -215,7 +215,7 @@ typedef struct _judy_object {
 } judy_object;
 
 static inline judy_object *php_judy_object(zend_object *obj) {
-	return (judy_object *)((char*)(obj) - XtOffsetOf(judy_object, std));
+	return (judy_object *)((char*)(obj) - offsetof(judy_object, std));
 }
 
 static inline int judy_pack_short_string_internal(const char *str, size_t len, Word_t *index)


### PR DESCRIPTION
  . The XtOffsetOf() alias of C’s offsetof() macro has been removed. Use
    offsetof() directly.