### PR TITLE
chore: bump first-party actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Judy library
         run: sudo apt-get update && sudo apt-get install -y libjudy-dev
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junit-linux-${{ matrix.php-version }}
           path: junit.xml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload baseline benchmark results
         if: always() && matrix.php-version == '8.4'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-baseline-linux-php${{ matrix.php-version }}
           path: |
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-linux-php${{ matrix.php-version }}
           path: |
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify PHP_JUDY_VERSION matches package.xml
         run: |
@@ -182,7 +182,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
@@ -365,7 +365,7 @@ jobs:
 
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junit-windows-${{ matrix.php-version }}-${{ matrix.arch }}-${{ matrix.ts }}
           path: ${{ runner.temp }}\junit.xml
@@ -424,7 +424,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-windows-php${{ matrix.php-version }}-${{ matrix.arch }}-${{ matrix.ts }}
           path: |
@@ -464,18 +464,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: baselines
 
       - name: Download all test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: junit-*
           path: artifacts
 
       - name: Download benchmark artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: benchmark-*
           path: benchmarks
@@ -1304,7 +1304,7 @@ jobs:
         # report-posting issues never fail the run after tests pass.
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate tag matches package.xml version
         run: |
@@ -38,7 +38,7 @@ jobs:
       matrix: ${{ steps.extension-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Get the extension matrix
         id: extension-matrix
         uses: php/php-windows-builder/extension-matrix@v1
@@ -51,7 +51,7 @@ jobs:
       matrix: ${{fromJson(needs.get-extension-matrix.outputs.matrix)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -179,7 +179,7 @@ jobs:
         run: pecl package package.xml
 
       - name: Upload PECL package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pecl-package
           path: "*.tgz"
@@ -197,7 +197,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download PECL package artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pecl-package
 


### PR DESCRIPTION
Every CI/release run currently logs `Node.js 20 is deprecated… forced to run on Node.js 24` for the first-party actions. Harmless today (the runner forces Node 24 and all runs are green), but the compatibility forcing will eventually be removed, so this bumps to the current majors:

- `actions/checkout` v4 → v7
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `actions/github-script` v7 → v9

Left alone deliberately: `ilammy/msvc-dev-cmd@v1` (latest major of that action; still Node 20-declared upstream), `shivammathur/setup-php@v2` and `EnricoMi/publish-unit-test-result-action@v2` (current), `php/php-windows-builder@v1` (upstream-managed).

This PR's CI run exercises the full junit/benchmark artifact upload→download→report flow, validating the artifact-action bumps end to end. The `release.yml` changes only get exercised on the next release publish.