### PR TITLE
fix: memory-safety & correctness bugs in MIXED/adaptive/packed paths

### DIFF
--- a/judy_handlers.c
+++ b/judy_handlers.c
@@ -234,6 +234,10 @@ zend_object *judy_object_clone(zend_object *this_ptr)
 
 	new_obj->array = newJArray;
 	new_obj->counter = old_obj->counter;
+	/* Do not trust a copied append watermark: force the next `$j[] =` to
+	 * recompute the empty slot, otherwise a cloned array would append at
+	 * index 0 and overwrite an existing element. */
+	new_obj->next_empty_is_valid = 0;
 	judy_init_type_flags(new_obj, old_obj->type);
 
 	if (new_obj->is_string_keyed && !new_obj->key_scratch) {

--- a/php_judy.c
+++ b/php_judy.c
@@ -572,17 +572,21 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 		} else if (intern->type == TYPE_INT_TO_MIXED) {
 			JLI(PValue, intern->array, index);
 			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				zval *old_value, *new_value;
-				if (JUDY_MVAL_READ(PValue) != NULL) {
-					old_value = JUDY_MVAL_READ(PValue);
+				zval *old_value = JUDY_MVAL_READ(PValue);
+				zval *new_value = emalloc(sizeof(zval));
+				ZVAL_COPY(new_value, value);
+				/* Publish the new value into the slot BEFORE destroying the
+				 * old one: old_value's destructor can run arbitrary PHP that
+				 * re-enters and restructures this array, invalidating PValue.
+				 * Writing first keeps the slot consistent no matter what the
+				 * destructor does. */
+				JUDY_MVAL_WRITE(PValue, new_value);
+				if (old_value != NULL) {
 					zval_ptr_dtor(old_value);
 					efree(old_value);
 				} else {
 					intern->counter++;
 				}
-				new_value = emalloc(sizeof(zval));
-				ZVAL_COPY(new_value, value);
-				JUDY_MVAL_WRITE(PValue, new_value);
 				return SUCCESS;
 			}
 			return FAILURE;
@@ -631,17 +635,18 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 
 		JSLI(PValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key));
 		if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-			zval *old_value, *new_value;
-			if (JUDY_MVAL_READ(PValue) != NULL) {
-				old_value = JUDY_MVAL_READ(PValue);
+			zval *old_value = JUDY_MVAL_READ(PValue);
+			zval *new_value = emalloc(sizeof(zval));
+			ZVAL_COPY(new_value, value);
+			/* Write new value before destroying old (see INT_TO_MIXED note):
+			 * old_value's destructor may re-enter and invalidate PValue. */
+			JUDY_MVAL_WRITE(PValue, new_value);
+			if (old_value != NULL) {
 				zval_ptr_dtor(old_value);
 				efree(old_value);
 			} else {
 				intern->counter++;
 			}
-			new_value = emalloc(sizeof(zval));
-			ZVAL_COPY(new_value, value);
-			JUDY_MVAL_WRITE(PValue, new_value);
 			res = SUCCESS;
 		} else {
 			res = FAILURE;
@@ -662,12 +667,8 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 
 		JHSI(HValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
 		if (JUDY_LIKELY(HValue != NULL && HValue != PJERR)) {
-			zval *old_value, *new_value;
-			if (JUDY_MVAL_READ(HValue) != NULL) {
-				old_value = JUDY_MVAL_READ(HValue);
-				zval_ptr_dtor(old_value);
-				efree(old_value);
-			} else {
+			zval *old_value = JUDY_MVAL_READ(HValue);
+			if (old_value == NULL) {
 				/* Register key in JudySL key_index for iteration support */
 				JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
 				if (JUDY_UNLIKELY(KValue == PJERR)) {
@@ -678,9 +679,14 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 				}
 				intern->counter++;
 			}
-			new_value = ecalloc(1, sizeof(zval));
+			zval *new_value = ecalloc(1, sizeof(zval));
 			ZVAL_COPY(new_value, value);
+			/* Write new value before destroying old (see INT_TO_MIXED note). */
 			JUDY_MVAL_WRITE(HValue, new_value);
+			if (old_value != NULL) {
+				zval_ptr_dtor(old_value);
+				efree(old_value);
+			}
 			res = SUCCESS;
 		} else {
 			res = FAILURE;
@@ -727,6 +733,7 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 			return FAILURE;
 		}
 		Pvoid_t *PValue;
+		Pvoid_t *PExisting;
 		Pvoid_t *KValue;
 		int res;
 		Word_t key_len = (Word_t)Z_STRLEN_P(pstring_key);
@@ -735,9 +742,12 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 		zend_long lval = zval_get_long(value);
 
 		if (judy_pack_short_string_internal(Z_STRVAL_P(pstring_key), key_len, &sso_idx)) {
+			/* Probe existence before insert: value 0 is a legal stored value,
+			 * so a zero slot must not be mistaken for a brand-new key. */
+			JLG(PExisting, intern->array, sso_idx);
 			JLI(PValue, intern->array, sso_idx);
 			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				if (*(Word_t *)PValue == 0) {
+				if (PExisting == NULL) {
 					/* New key — register in key_index for iteration */
 					JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
 					if (JUDY_UNLIKELY(KValue == PJERR)) {
@@ -752,9 +762,10 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 				res = FAILURE;
 			}
 		} else {
+			JHSG(PExisting, intern->hs_array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
 			JHSI(PValue, intern->hs_array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
 			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				if (*(Word_t *)PValue == 0) {
+				if (PExisting == NULL) {
 					JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
 					if (JUDY_UNLIKELY(KValue == PJERR)) {
 						int Rc_tmp;
@@ -784,11 +795,8 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 		if (judy_pack_short_string_internal(Z_STRVAL_P(pstring_key), key_len, &sso_idx)) {
 			JLI(PValue, intern->array, sso_idx);
 			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				if (*(Pvoid_t *)PValue != NULL) {
-					zval *old_value = JUDY_MVAL_READ(PValue);
-					zval_ptr_dtor(old_value);
-					efree(old_value);
-				} else {
+				zval *old_value = JUDY_MVAL_READ(PValue);
+				if (old_value == NULL) {
 					JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
 					if (JUDY_UNLIKELY(KValue == PJERR)) {
 						JLD(res, intern->array, sso_idx);
@@ -798,7 +806,12 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 				}
 				zval *new_value = emalloc(sizeof(zval));
 				ZVAL_COPY(new_value, value);
+				/* Write new value before destroying old (see INT_TO_MIXED note). */
 				JUDY_MVAL_WRITE(PValue, new_value);
+				if (old_value != NULL) {
+					zval_ptr_dtor(old_value);
+					efree(old_value);
+				}
 				res = SUCCESS;
 			} else {
 				res = FAILURE;
@@ -806,11 +819,8 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 		} else {
 			JHSI(PValue, intern->hs_array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
 			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				if (*(Pvoid_t *)PValue != NULL) {
-					zval *old_value = JUDY_MVAL_READ(PValue);
-					zval_ptr_dtor(old_value);
-					efree(old_value);
-				} else {
+				zval *old_value = JUDY_MVAL_READ(PValue);
+				if (old_value == NULL) {
 					JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
 					if (JUDY_UNLIKELY(KValue == PJERR)) {
 						int Rc_tmp;
@@ -821,7 +831,12 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 				}
 				zval *new_value = emalloc(sizeof(zval));
 				ZVAL_COPY(new_value, value);
+				/* Write new value before destroying old (see INT_TO_MIXED note). */
 				JUDY_MVAL_WRITE(PValue, new_value);
+				if (old_value != NULL) {
+					zval_ptr_dtor(old_value);
+					efree(old_value);
+				}
 				res = SUCCESS;
 			} else {
 				res = FAILURE;
@@ -977,9 +992,12 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 			JLG(PValue, intern->array, j_index);
 			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 				zval *value = JUDY_MVAL_READ(PValue);
+				/* Remove the slot before running the value's destructor:
+				 * the destructor can re-enter and unset the same key, which
+				 * would otherwise re-read this slot and double-free `value`. */
+				JLD(Rc_int, intern->array, j_index);
 				zval_ptr_dtor(value);
 				efree(value);
-				JLD(Rc_int, intern->array, j_index);
 			}
 		}
 		if (Rc_int == 1) {
@@ -994,12 +1012,15 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 			Pvoid_t *PValue;
 			JLG(PValue, intern->array, sso_idx);
 			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				if (intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE) {
-					zval *value = JUDY_MVAL_READ(PValue);
+				/* Capture the value, remove the slot, then destroy the value
+				 * (delete-before-free guards against destructor re-entrancy). */
+				zval *value = (intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE)
+					? JUDY_MVAL_READ(PValue) : NULL;
+				JLD(Rc_int, intern->array, sso_idx);
+				if (value != NULL) {
 					zval_ptr_dtor(value);
 					efree(value);
 				}
-				JLD(Rc_int, intern->array, sso_idx);
 				if (Rc_int == 1) {
 					int Rc_idx_del;
 					JSLD(Rc_idx_del, intern->key_index, key);
@@ -1012,12 +1033,13 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 			Pvoid_t *HValue;
 			JHSG(HValue, intern->hs_array, key, key_len);
 			if (JUDY_LIKELY(HValue != NULL && HValue != PJERR)) {
-				if (intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE) {
-					zval *value = JUDY_MVAL_READ(HValue);
+				zval *value = (intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE)
+					? JUDY_MVAL_READ(HValue) : NULL;
+				JHSD(Rc_int, intern->hs_array, key, key_len);
+				if (value != NULL) {
 					zval_ptr_dtor(value);
 					efree(value);
 				}
-				JHSD(Rc_int, intern->hs_array, key, key_len);
 				if (Rc_int == 1) {
 					int Rc_idx_del;
 					JSLD(Rc_idx_del, intern->key_index, key);
@@ -1035,9 +1057,10 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 			JSLG(PValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key));
 			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 				zval *value = JUDY_MVAL_READ(PValue);
+				/* Delete before free (destructor re-entrancy guard). */
+				JSLD(Rc_int, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key));
 				zval_ptr_dtor(value);
 				efree(value);
-				JSLD(Rc_int, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key));
 			}
 		}
 		if (Rc_int == 1) {
@@ -1050,9 +1073,10 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 		JHSG(HValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
 		if (JUDY_LIKELY(HValue != NULL && HValue != PJERR)) {
 			zval *value = JUDY_MVAL_READ(HValue);
+			/* Delete before free (destructor re-entrancy guard). */
+			JHSD(Rc_int, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
 			zval_ptr_dtor(value);
 			efree(value);
-			JHSD(Rc_int, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
 			if (Rc_int == 1) {
 				int Rc_del = 0;
 				JSLD(Rc_del, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
@@ -1384,6 +1408,37 @@ PHP_METHOD(Judy, byCount)
 }
 /* }}} */
 
+/* {{{ judy_string_value_slot — fetch the value slot for a string key.
+   Dispatches across the storage layouts so callers never query the wrong
+   structure: plain JudySL (value lives in `array`), JudyHS-backed *_HASH
+   (value in `array`), and adaptive types (SSO short keys live in the JudyL
+   `array`, long keys in the JudyHS `hs_array`). Returns NULL when the key is
+   absent (including the PJERR sentinel). This is the one correct place for
+   the dispatch — several iteration paths previously called JHSG on the JudyL
+   `array` for adaptive types, which is a type confusion (see issue: adaptive
+   getAll/next/rewind). */
+static inline Pvoid_t *judy_string_value_slot(judy_object *intern, const uint8_t *key, Word_t klen)
+{
+	Pvoid_t *slot = NULL;
+	if (intern->is_adaptive) {
+		Word_t sso_idx;
+		if (judy_pack_short_string_internal((const char *)key, (size_t)klen, &sso_idx)) {
+			JLG(slot, intern->array, sso_idx);
+		} else {
+			JHSG(slot, intern->hs_array, (uint8_t *)key, klen);
+		}
+	} else if (intern->is_hash_keyed) {
+		JHSG(slot, intern->array, (uint8_t *)key, klen);
+	} else {
+		JSLG(slot, intern->array, (uint8_t *)key);
+	}
+	if (slot == PJERR) {
+		return NULL;
+	}
+	return slot;
+}
+/* }}} */
+
 /* {{{ proto mixed Judy::first([mixed index])
    Search (inclusive) for the first index present that is equal to or greater than the passed Index */
 PHP_METHOD(Judy, first)
@@ -1658,22 +1713,13 @@ PHP_METHOD(Judy, next)
 			zval_ptr_dtor(&intern->iterator_key);
 			ZVAL_STRING(&intern->iterator_key, (char *)key);
 
-			if (intern->is_hash_keyed) {
-				Pvoid_t *HValue;
-				JHSG(HValue, intern->array, key, (Word_t)strlen((char *)key));
-				if (HValue != NULL && HValue != PJERR) {
-					if (intern->type == TYPE_STRING_TO_INT_HASH) {
-						ZVAL_LONG(&intern->iterator_data, JUDY_LVAL_READ(HValue));
-					} else {
-						zval *value = JUDY_MVAL_READ(HValue);
-						ZVAL_COPY(&intern->iterator_data, value);
-					}
+			Pvoid_t *VValue = judy_string_value_slot(intern, key, (Word_t)strlen((char *)key));
+			if (VValue != NULL) {
+				if (JUDY_IS_MIXED_VALUE(intern)) {
+					ZVAL_COPY(&intern->iterator_data, JUDY_MVAL_READ(VValue));
+				} else {
+					ZVAL_LONG(&intern->iterator_data, JUDY_LVAL_READ(VValue));
 				}
-			} else if (JUDY_IS_MIXED_VALUE(intern)) {
-				zval *value = JUDY_MVAL_READ(PValue);
-				ZVAL_COPY(&intern->iterator_data, value);
-			} else {
-				ZVAL_LONG(&intern->iterator_data, JUDY_LVAL_READ(PValue));
 			}
 			intern->iterator_initialized = 1;
 		} else {
@@ -1751,22 +1797,13 @@ PHP_METHOD(Judy, rewind)
 		if (PValue != NULL && PValue != PJERR) {
 			zval_ptr_dtor(&intern->iterator_key);
 			ZVAL_STRING(&intern->iterator_key, (const char *) key);
-			if (intern->is_hash_keyed) {
-				Pvoid_t *HValue;
-				JHSG(HValue, intern->array, key, (Word_t)strlen((char *)key));
-				if (HValue != NULL && HValue != PJERR) {
-					if (intern->type == TYPE_STRING_TO_INT_HASH) {
-						ZVAL_LONG(&intern->iterator_data, JUDY_LVAL_READ(HValue));
-					} else {
-						zval *value = JUDY_MVAL_READ(HValue);
-						ZVAL_COPY(&intern->iterator_data, value);
-					}
+			Pvoid_t *VValue = judy_string_value_slot(intern, key, (Word_t)strlen((char *)key));
+			if (VValue != NULL) {
+				if (JUDY_IS_MIXED_VALUE(intern)) {
+					ZVAL_COPY(&intern->iterator_data, JUDY_MVAL_READ(VValue));
+				} else {
+					ZVAL_LONG(&intern->iterator_data, JUDY_LVAL_READ(VValue));
 				}
-			} else if (JUDY_IS_MIXED_VALUE(intern)) {
-				zval *value = JUDY_MVAL_READ(PValue);
-				ZVAL_COPY(&intern->iterator_data, value);
-			} else {
-				ZVAL_LONG(&intern->iterator_data, JUDY_LVAL_READ(PValue));
 			}
 			intern->iterator_initialized = 1;
 		} else {
@@ -3742,17 +3779,22 @@ PHP_METHOD(Judy, equals)
 				} else if (intern->type == TYPE_INT_TO_PACKED) {
 					judy_packed_value *p1 = JUDY_PVAL_READ(PVal1);
 					judy_packed_value *p2 = JUDY_PVAL_READ(PVal2);
-					if (p1 == p2) continue;
-					if (!p1 || !p2) RETURN_FALSE;
-					if (p1->tag != p2->tag) RETURN_FALSE;
-					/* Simplified comparison for packed values */
-					zval v1, v2;
-					judy_unpack_value(p1, &v1);
-					judy_unpack_value(p2, &v2);
-					int same = zend_is_identical(&v1, &v2);
-					zval_ptr_dtor(&v1);
-					zval_ptr_dtor(&v2);
-					if (!same) RETURN_FALSE;
+					/* Only compare when the slots differ; when identical
+					 * (including both NULL) they are equal. Must not `continue`
+					 * here — that would skip the JLN advance below and loop
+					 * forever on equal NULL-packed slots. */
+					if (p1 != p2) {
+						if (!p1 || !p2) RETURN_FALSE;
+						if (p1->tag != p2->tag) RETURN_FALSE;
+						/* Simplified comparison for packed values */
+						zval v1, v2;
+						judy_unpack_value(p1, &v1);
+						judy_unpack_value(p2, &v2);
+						int same = zend_is_identical(&v1, &v2);
+						zval_ptr_dtor(&v1);
+						zval_ptr_dtor(&v2);
+						if (!same) RETURN_FALSE;
+					}
 				}
 				JLN(PVal1, intern->array, index);
 			}
@@ -4253,6 +4295,11 @@ static void judy_populate_from_array(zval *judy_obj, zval *arr) {
 	zend_string *str_key;
 	zend_ulong num_key;
 
+	/* Bulk-insert paths write via raw JLI/J1S and never advance the append
+	 * watermark. Invalidate it so a later `$j[] =` recomputes the true empty
+	 * slot instead of appending at the stale index 0. */
+	intern->next_empty_is_valid = 0;
+
 	switch (intern->type) {
 	case TYPE_BITSET:
 	{
@@ -4433,36 +4480,18 @@ PHP_METHOD(Judy, getAll)
 			}
 		} else { /* is_string_keyed */
 			zend_string *skey = zval_get_string(key_entry);
-			if (intern->is_hash_keyed) {
-				Pvoid_t *HValue;
-				JHSG(HValue, intern->array, (uint8_t *)ZSTR_VAL(skey), (Word_t)ZSTR_LEN(skey));
-				if (JUDY_UNLIKELY(HValue == NULL || HValue == PJERR)) {
-					add_assoc_null(return_value, ZSTR_VAL(skey));
-				} else if (intern->type == TYPE_STRING_TO_INT_HASH) {
-					add_assoc_long(return_value, ZSTR_VAL(skey), JUDY_LVAL_READ(HValue));
-				} else if (JUDY_LIKELY(JUDY_MVAL_READ(HValue) != NULL)) {
-					zval *value = JUDY_MVAL_READ(HValue);
-					Z_TRY_ADDREF_P(value);
-					add_assoc_zval(return_value, ZSTR_VAL(skey), value);
-				} else {
-					add_assoc_null(return_value, ZSTR_VAL(skey));
-				}
+			Pvoid_t *VValue = judy_string_value_slot(intern,
+				(uint8_t *)ZSTR_VAL(skey), (Word_t)ZSTR_LEN(skey));
+			if (VValue == NULL) {
+				add_assoc_null(return_value, ZSTR_VAL(skey));
+			} else if (!JUDY_IS_MIXED_VALUE(intern)) {
+				add_assoc_long(return_value, ZSTR_VAL(skey), JUDY_LVAL_READ(VValue));
+			} else if (JUDY_LIKELY(JUDY_MVAL_READ(VValue) != NULL)) {
+				zval *value = JUDY_MVAL_READ(VValue);
+				Z_TRY_ADDREF_P(value);
+				add_assoc_zval(return_value, ZSTR_VAL(skey), value);
 			} else {
-				Pvoid_t *PValue;
-				JSLG(PValue, intern->array, (uint8_t *)ZSTR_VAL(skey));
-				if (JUDY_UNLIKELY(PValue == NULL || PValue == PJERR)) {
-					add_assoc_null(return_value, ZSTR_VAL(skey));
-				} else if (intern->type == TYPE_STRING_TO_INT) {
-					add_assoc_long(return_value, ZSTR_VAL(skey), JUDY_LVAL_READ(PValue));
-				} else { /* TYPE_STRING_TO_MIXED */
-					if (JUDY_LIKELY(JUDY_MVAL_READ(PValue) != NULL)) {
-						zval *value = JUDY_MVAL_READ(PValue);
-						Z_TRY_ADDREF_P(value);
-						add_assoc_zval(return_value, ZSTR_VAL(skey), value);
-					} else {
-						add_assoc_null(return_value, ZSTR_VAL(skey));
-					}
-				}
+				add_assoc_null(return_value, ZSTR_VAL(skey));
 			}
 			zend_string_release(skey);
 		}

--- a/tests/regression_adaptive_counter_zero_value_001.phpt
+++ b/tests/regression_adaptive_counter_zero_value_001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Regression: adaptive INT counter must not drift when value 0 is re-stored
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// Value 0 is a legal stored value and must not be mistaken for "empty slot".
+// Re-storing a key whose current value is 0 previously double-counted.
+foreach (['short', 'a_much_longer_key_that_exceeds_sso_packing_threshold'] as $k) {
+    $j = new Judy(Judy::STRING_TO_INT_ADAPTIVE);
+    $j[$k] = 0;
+    $j[$k] = 5;   // overwrite: must NOT increment count again
+    echo "count after overwrite of 0: " . $j->count() . "\n";
+    echo "value: " . $j[$k] . "\n";
+
+    $j[$k] = 0;   // overwrite back to 0
+    $j[$k] = 0;   // and again
+    echo "count after more overwrites: " . $j->count() . "\n";
+}
+?>
+--EXPECT--
+count after overwrite of 0: 1
+value: 5
+count after more overwrites: 1
+count after overwrite of 0: 1
+value: 5
+count after more overwrites: 1

--- a/tests/regression_adaptive_iteration_001.phpt
+++ b/tests/regression_adaptive_iteration_001.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Regression: adaptive types iterate/getAll correctly (no JHSG-on-JudyL type confusion)
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// getAll(), foreach (get_iterator), and manual rewind()/next() previously
+// called JHSG on the JudyL `array` for adaptive types (type confusion / UB).
+// Mix short (SSO-packed) and long (JudyHS) keys to exercise both stores.
+$long = str_repeat('x', 40);
+foreach ([Judy::STRING_TO_INT_ADAPTIVE, Judy::STRING_TO_MIXED_ADAPTIVE] as $type) {
+    $j = new Judy($type);
+    $j['a'] = ($type === Judy::STRING_TO_INT_ADAPTIVE) ? 1 : 'one';
+    $j[$long] = ($type === Judy::STRING_TO_INT_ADAPTIVE) ? 2 : 'two';
+
+    // getAll with an explicit key list
+    $all = $j->getAll(['a', $long]);
+    ksort($all);
+    echo "getAll: " . json_encode($all) . "\n";
+
+    // foreach (get_iterator path)
+    $seen = [];
+    foreach ($j as $k => $v) { $seen[$k] = $v; }
+    ksort($seen);
+    echo "foreach: " . json_encode($seen) . "\n";
+
+    // manual Iterator rewind()/current()/next()
+    $manual = [];
+    for ($j->rewind(); $j->valid(); $j->next()) {
+        $manual[$j->key()] = $j->current();
+    }
+    ksort($manual);
+    echo "manual: " . json_encode($manual) . "\n";
+}
+?>
+--EXPECT--
+getAll: {"a":1,"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx":2}
+foreach: {"a":1,"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx":2}
+manual: {"a":1,"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx":2}
+getAll: {"a":"one","xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx":"two"}
+foreach: {"a":"one","xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx":"two"}
+manual: {"a":"one","xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx":"two"}

--- a/tests/regression_append_after_bulk_clone_001.phpt
+++ b/tests/regression_append_after_bulk_clone_001.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Regression: append ($j[] =) after fromArray/putAll/clone must not overwrite index 0
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// The append watermark (next_empty) must be invalidated by bulk populate and
+// clone, otherwise the first $j[] = lands at index 0 and clobbers an element.
+
+// fromArray
+$a = Judy::fromArray(Judy::INT_TO_INT, [0 => 100, 1 => 200, 2 => 300]);
+$a[] = 999;
+echo "fromArray: index 0 = {$a[0]}, appended = {$a[3]}, count = " . $a->count() . "\n";
+
+// putAll
+$b = new Judy(Judy::INT_TO_INT);
+$b->putAll([0 => 10, 1 => 20]);
+$b[] = 30;
+echo "putAll: index 0 = {$b[0]}, appended = {$b[2]}, count = " . $b->count() . "\n";
+
+// clone
+$c = new Judy(Judy::INT_TO_INT);
+$c[0] = 1; $c[1] = 2;
+$d = clone $c;
+$d[] = 3;
+echo "clone: index 0 = {$d[0]}, appended = {$d[2]}, count = " . $d->count() . "\n";
+?>
+--EXPECT--
+fromArray: index 0 = 100, appended = 999, count = 4
+putAll: index 0 = 10, appended = 30, count = 3
+clone: index 0 = 1, appended = 3, count = 3

--- a/tests/regression_mixed_destructor_reentrancy_001.phpt
+++ b/tests/regression_mixed_destructor_reentrancy_001.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Regression: *_TO_MIXED overwrite/unset survive a destructor that mutates the same array
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// The overwrite and unset paths held a raw Judy slot pointer across
+// zval_ptr_dtor(old), which runs a user __destruct that can re-enter and
+// restructure the tree — a use-after-free write/double-free. These exercises
+// must complete with correct state and no crash.
+
+function run($type, $mk) {
+    $j = new Judy($type);
+    // A value whose destructor mutates the SAME Judy array.
+    $evil = new class($j) {
+        public $j;
+        function __construct($j) { $this->j = $j; }
+        function __destruct() {
+            // Re-enter and mutate the same array to force tree restructuring
+            // while the C code may still hold a slot pointer.
+            $k = $GLOBALS['neighbor'];
+            $this->j[$k] = 1;
+            unset($this->j[$k]);
+        }
+    };
+    $ka = $mk(1); $kb = $mk(2);
+    $GLOBALS['neighbor'] = $kb;
+    $j[$ka] = $evil;
+    unset($evil);            // drop our local ref; slot holds the only ref now
+    $j[$kb] = 7;             // populate neighbor
+    $j[$ka] = "overwrite";   // <-- dtor of evil fires mid-overwrite
+    echo "overwrite ok: " . ($j[$ka] === "overwrite" ? "yes" : "no") . "\n";
+
+    // Now the unset path
+    $evil2 = new class($j) {
+        public $j;
+        function __construct($j) { $this->j = $j; }
+        function __destruct() {
+            $k = $GLOBALS['neighbor2'];
+            $this->j[$k] = 2;
+            unset($this->j[$k]);
+        }
+    };
+    $kc = $mk(3); $kd = $mk(4);
+    $GLOBALS['neighbor2'] = $kd;
+    $j[$kc] = $evil2;
+    unset($evil2);
+    $j[$kd] = 8;
+    unset($j[$kc]);          // <-- dtor of evil2 fires mid-unset
+    echo "unset ok: " . (isset($j[$kc]) ? "no" : "yes") . "\n";
+}
+
+run(Judy::INT_TO_MIXED,               fn($n) => $n);
+run(Judy::STRING_TO_MIXED,            fn($n) => "k$n");
+run(Judy::STRING_TO_MIXED_HASH,       fn($n) => "k$n");
+run(Judy::STRING_TO_MIXED_ADAPTIVE,   fn($n) => "k$n");
+run(Judy::STRING_TO_MIXED_ADAPTIVE,   fn($n) => str_repeat("k$n", 20));
+echo "done\n";
+?>
+--EXPECT--
+overwrite ok: yes
+unset ok: yes
+overwrite ok: yes
+unset ok: yes
+overwrite ok: yes
+unset ok: yes
+overwrite ok: yes
+unset ok: yes
+overwrite ok: yes
+unset ok: yes
+done

--- a/tests/regression_packed_equals_001.phpt
+++ b/tests/regression_packed_equals_001.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Regression: INT_TO_PACKED equals() terminates and compares correctly
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// equals() for INT_TO_PACKED previously used `continue` on an equal-slot
+// shortcut, which skipped the loop advance and could loop forever. Verify it
+// terminates and gives correct equality across scalar/string/complex packed
+// values.
+function mk(array $pairs) {
+    $j = new Judy(Judy::INT_TO_PACKED);
+    foreach ($pairs as $k => $v) { $j[$k] = $v; }
+    return $j;
+}
+$a = mk([1 => 10, 2 => "str", 3 => [1, 2, 3], 4 => 3.5]);
+$b = mk([1 => 10, 2 => "str", 3 => [1, 2, 3], 4 => 3.5]);
+$c = mk([1 => 10, 2 => "str", 3 => [1, 2, 9], 4 => 3.5]);
+
+echo "a equals b: " . ($a->equals($b) ? "yes" : "no") . "\n";
+echo "a equals c: " . ($a->equals($c) ? "yes" : "no") . "\n";
+echo "empty equals empty: " . ((new Judy(Judy::INT_TO_PACKED))->equals(new Judy(Judy::INT_TO_PACKED)) ? "yes" : "no") . "\n";
+echo "done\n";
+?>
+--EXPECT--
+a equals b: yes
+a equals c: no
+empty equals empty: yes
+done


### PR DESCRIPTION
First batch of a hardening sprint. A 3-lens expert review (C-safety / security / robustness) of the extension surfaced correctness and memory-safety bugs beyond routine polish; this PR fixes the five that were **verified against source**, each with a regression test. No new features; no API changes.

## Fixes

| id | sev | bug |
|----|-----|-----|
| C1 | CRITICAL | Adaptive types set `is_hash_keyed`, so `getAll()`/`next()`/`rewind()` ran `JHSG` on the JudyL `array` (adaptive short keys live in a JudyL; the JudyHS is in `hs_array`) — type confusion / UB on any populated adaptive array. |
| C2 | CRITICAL (hardening) | Every `*_TO_MIXED` overwrite held a raw Judy slot pointer across `zval_ptr_dtor(old)`, which runs a user `__destruct` that can re-enter and restructure the tree, then wrote through that pointer — a use-after-free write pattern. Unset paths had the sibling free-before-delete. |
| C3 | correctness | `equals()` `INT_TO_PACKED` used `continue` on an equal-slot shortcut, skipping the `JLN` advance — an infinite loop if a NULL-packed slot exists. |
| M1 | MAJOR | `STRING_TO_*_ADAPTIVE` used `value == 0` as a "new key" sentinel, double-counting when `0` is re-stored — corrupts `size()`/`count()`/`equals()`/`averageValues()`. |
| M2 | MAJOR | `clone` and bulk populate (`fromArray`/`putAll`/`__unserialize`) never invalidated the append watermark, so `$j[] =` after them overwrote index 0. |

## Approach

- **C1** is fixed once via a new `judy_string_value_slot()` helper that does the correct storage-layout dispatch; all three sites route through it. (Root cause of this bug class is hand-copied dispatch — a broader dedup is queued for a later batch.)
- **C2** applies write-before-dtor on overwrite and delete-before-free on unset across all five MIXED variants (INT, STRING, HASH, both ADAPTIVE).
- **M1** mirrors the existence pre-check the `*_HASH` types already use.

## Verification

- Full suite green: **181/181** (176 existing + 5 new), 0 skips, PHP 8.5 / macOS ARM.
- The three deterministic regression tests (C1, M1, M2) were confirmed to **fail against the pre-fix build** and pass after.
- **Honest scope note:** the C2 use-after-free is verified by code review (the exact held-pointer-across-destructor pattern) and the fix is the textbook remedy; a deterministic userland crash PoC was **not** achieved (small-array JudyL leaf layout kept the slot alive in the attempt), so its regression test guards state-correctness under destructor re-entrancy rather than proving exploitation. Post-fix runs are AddressSanitizer-clean.
- C3's infinite loop needs a NULL-packed slot not reachable from userland today; the fix is defensive and its test guards general packed-`equals()` correctness.

Further hardening batches (unserialize validation, remaining silent-corruption MAJORs, `get_gc`, docs/release) follow in separate PRs.