### PR TITLE
fix: adaptive navigation, integer-key coercion, unserialize leak, bulk MIXED UAF

### DIFF
--- a/php_judy.c
+++ b/php_judy.c
@@ -1499,8 +1499,9 @@ PHP_METHOD(Judy, first)
 		JSLF(PValue, intern->array, key);
 		if (JUDY_LIKELY(PValue != NULL && PValue != PJERR))
 			RETURN_STRING((char *)key);
-	} else if (intern->type == TYPE_STRING_TO_MIXED_HASH
-			|| intern->type == TYPE_STRING_TO_INT_HASH) {
+	} else if (intern->is_hash_keyed) {
+		/* HASH and ADAPTIVE types both keep every key in the JudySL
+		 * key_index, so first/searchNext/last/prev navigate it uniformly. */
 		char        *str;
 		size_t       str_length = 0;
 
@@ -1592,8 +1593,9 @@ PHP_METHOD(Judy, searchNext)
 		JSLN(PValue, intern->array, key);
 		if (JUDY_LIKELY(PValue != NULL && PValue != PJERR))
 			RETURN_STRING((char *)key);
-	} else if (intern->type == TYPE_STRING_TO_MIXED_HASH
-			|| intern->type == TYPE_STRING_TO_INT_HASH) {
+	} else if (intern->is_hash_keyed) {
+		/* HASH and ADAPTIVE types both keep every key in the JudySL
+		 * key_index, so first/searchNext/last/prev navigate it uniformly. */
 		char        *str;
 		size_t       str_length;
 
@@ -1917,8 +1919,9 @@ PHP_METHOD(Judy, last)
 		JSLL(PValue, intern->array, key);
 		if (JUDY_LIKELY(PValue != NULL && PValue != PJERR))
 			RETURN_STRING((char *)key);
-	} else if (intern->type == TYPE_STRING_TO_MIXED_HASH
-			|| intern->type == TYPE_STRING_TO_INT_HASH) {
+	} else if (intern->is_hash_keyed) {
+		/* HASH and ADAPTIVE types both keep every key in the JudySL
+		 * key_index, so first/searchNext/last/prev navigate it uniformly. */
 		char        *str;
 		size_t       str_length = 0;
 
@@ -2005,8 +2008,9 @@ PHP_METHOD(Judy, prev)
 		JSLP(PValue, intern->array, key);
 		if (JUDY_LIKELY(PValue != NULL && PValue != PJERR))
 			RETURN_STRING((char *)key);
-	} else if (intern->type == TYPE_STRING_TO_MIXED_HASH
-			|| intern->type == TYPE_STRING_TO_INT_HASH) {
+	} else if (intern->is_hash_keyed) {
+		/* HASH and ADAPTIVE types both keep every key in the JudySL
+		 * key_index, so first/searchNext/last/prev navigate it uniformly. */
 		char        *str;
 		size_t       str_length;
 
@@ -4258,10 +4262,12 @@ PHP_METHOD(Judy, __unserialize)
 		return;
 	}
 
-	intern->array = (Pvoid_t) NULL;
+	/* __unserialize is a public method and may be invoked on an already-
+	 * populated object; free any existing contents (using the current type's
+	 * layout) before re-initialising, otherwise the old tree and its zvals
+	 * leak. judy_free_array_internal() NULLs array/key_index/hs_array. */
+	judy_free_array_internal(intern);
 	intern->counter = 0;
-	intern->key_index = (Pvoid_t) NULL;
-	intern->hs_array = (Pvoid_t) NULL;
 	judy_init_type_flags(intern, jtype);
 
 	if (intern->is_string_keyed && !intern->key_scratch) {
@@ -4316,6 +4322,12 @@ static void judy_populate_from_array(zval *judy_obj, zval *arr) {
 	{
 		Pvoid_t *PValue;
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(arr), num_key, str_key, entry) {
+			if (UNEXPECTED(str_key != NULL)) {
+				php_error_docref(NULL, E_WARNING,
+					"Judy integer-keyed type ignores non-integer array key \"%s\"",
+					ZSTR_VAL(str_key));
+				continue;
+			}
 			Word_t index = (Word_t)num_key;
 			zend_long lval = zval_get_long(entry); /* evaluate before JLI to prevent UAF via callbacks */
 			Pvoid_t *PExisting;
@@ -4332,19 +4344,28 @@ static void judy_populate_from_array(zval *judy_obj, zval *arr) {
 	{
 		Pvoid_t *PValue;
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(arr), num_key, str_key, entry) {
+			if (UNEXPECTED(str_key != NULL)) {
+				php_error_docref(NULL, E_WARNING,
+					"Judy integer-keyed type ignores non-integer array key \"%s\"",
+					ZSTR_VAL(str_key));
+				continue;
+			}
 			Word_t index = (Word_t)num_key;
 			JLI(PValue, intern->array, index);
 			if (PValue != NULL && PValue != PJERR) {
-				if (*(Pvoid_t *)PValue != NULL) {
-					zval *old_value = JUDY_MVAL_READ(PValue);
+				zval *old_value = JUDY_MVAL_READ(PValue);
+				zval *new_value = emalloc(sizeof(zval));
+				ZVAL_COPY(new_value, entry);
+				/* Publish new value before destroying old: old_value's
+				 * destructor may re-enter and invalidate PValue (same UAF
+				 * guard as the write_dimension MIXED paths). */
+				JUDY_MVAL_WRITE(PValue, new_value);
+				if (old_value != NULL) {
 					zval_ptr_dtor(old_value);
 					efree(old_value);
 				} else {
 					intern->counter++;
 				}
-				zval *new_value = emalloc(sizeof(zval));
-				ZVAL_COPY(new_value, entry);
-				JUDY_MVAL_WRITE(PValue, new_value);
 			}
 		} ZEND_HASH_FOREACH_END();
 		break;
@@ -4353,6 +4374,12 @@ static void judy_populate_from_array(zval *judy_obj, zval *arr) {
 	{
 		Pvoid_t *PValue;
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(arr), num_key, str_key, entry) {
+			if (UNEXPECTED(str_key != NULL)) {
+				php_error_docref(NULL, E_WARNING,
+					"Judy integer-keyed type ignores non-integer array key \"%s\"",
+					ZSTR_VAL(str_key));
+				continue;
+			}
 			Word_t index = (Word_t)num_key;
 			judy_packed_value *packed = judy_pack_value(entry);
 			if (!packed) continue;

--- a/tests/regression_adaptive_navigation_001.phpt
+++ b/tests/regression_adaptive_navigation_001.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Regression: first/last/searchNext/prev work on adaptive types (not silent NULL)
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// Adaptive types were missing from the first/last/searchNext/prev type
+// dispatch and returned NULL on a populated array. Exercise both SSO-packed
+// short keys and long (JudyHS) keys.
+$long = str_repeat('z', 40);
+foreach ([Judy::STRING_TO_INT_ADAPTIVE, Judy::STRING_TO_MIXED_ADAPTIVE] as $type) {
+    $j = new Judy($type);
+    $j['b']   = 1;
+    $j['d']   = 2;
+    $j[$long] = 3;   // long key sorts after 'b','d'
+
+    var_dump($j->first());
+    var_dump($j->last());
+    var_dump($j->searchNext('b'));
+    var_dump($j->prev($long));
+}
+?>
+--EXPECT--
+string(1) "b"
+string(40) "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+string(1) "d"
+string(1) "d"
+string(1) "b"
+string(40) "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+string(1) "d"
+string(1) "d"

--- a/tests/regression_int_keyed_string_key_001.phpt
+++ b/tests/regression_int_keyed_string_key_001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Regression: fromArray/putAll on integer-keyed types reject non-integer keys (no hash-as-index)
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// Previously a string key on an integer-keyed type used num_key (the bucket
+// hash) as the index — silent corruption. Now such keys are skipped with a
+// warning; integer keys still insert normally.
+foreach ([Judy::INT_TO_INT, Judy::INT_TO_MIXED, Judy::INT_TO_PACKED] as $type) {
+    $j = Judy::fromArray($type, [0 => 'a', 'foo' => 'b', 5 => 'c']);
+    echo "count: " . $j->count() . "\n";
+    echo "has 0: " . (isset($j[0]) ? 'yes' : 'no') . ", has 5: " . (isset($j[5]) ? 'yes' : 'no') . "\n";
+}
+?>
+--EXPECTF--
+Warning: Judy::fromArray(): Judy integer-keyed type ignores non-integer array key "foo" in %s
+count: 2
+has 0: yes, has 5: yes
+
+Warning: Judy::fromArray(): Judy integer-keyed type ignores non-integer array key "foo" in %s
+count: 2
+has 0: yes, has 5: yes
+
+Warning: Judy::fromArray(): Judy integer-keyed type ignores non-integer array key "foo" in %s
+count: 2
+has 0: yes, has 5: yes

--- a/tests/regression_unserialize_reinit_leak_001.phpt
+++ b/tests/regression_unserialize_reinit_leak_001.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Regression: __unserialize on a populated object frees prior contents (no leak)
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// __unserialize is public and may be called on a populated object. It must
+// free the previous tree (and its zvals) before re-initialising, else the old
+// contents leak. Each re-init below installs a large tree, so a missing free
+// leaks it every iteration and memory grows without bound.
+$data = [];
+for ($i = 0; $i < 300; $i++) { $data[$i] = str_repeat('v', 64); }
+$payload = ['type' => Judy::INT_TO_MIXED, 'data' => $data];
+
+$j = new Judy(Judy::INT_TO_MIXED);
+$j->__unserialize($payload);       // first install (baseline includes one tree)
+$base = memory_get_usage();
+for ($i = 0; $i < 50; $i++) {
+    $j->__unserialize($payload);   // each must free the previous 300-entry tree
+}
+$growth = memory_get_usage() - $base;
+
+echo "count after re-init: " . $j->count() . "\n";
+echo "value: " . $j[1] . "\n";
+// A missing free leaks ~50 * 300 zvals + string refs (megabytes). Post-fix
+// growth is near zero; allow generous slack for allocator bookkeeping.
+echo "bounded growth: " . ($growth < 100000 ? "yes" : "no ($growth)") . "\n";
+?>
+--EXPECT--
+count after re-init: 300
+value: vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+bounded growth: yes


### PR DESCRIPTION
Batch 2 of the hardening sprint (follows #70). Four more verified correctness/leak fixes; each with a regression test proven to fail against the pre-fix build. No new features.

| id | sev | bug |
|----|-----|-----|
| M3 | MAJOR | `first()`/`last()`/`searchNext()`/`prev()` had no dispatch branch for the two ADAPTIVE types → returned NULL on a populated array. Routed through the `key_index` navigation the HASH types already use (via `is_hash_keyed`). |
| M4 | MAJOR | `fromArray()`/`putAll()`/`__unserialize()` on integer-keyed types used the bucket hash (`num_key`) as the index for **string** array keys — silent insertion at a garbage index. Non-integer keys are now skipped with an `E_WARNING`. |
| M8 | MAJOR (leak) | `__unserialize()` is public and can be called on a populated object; it NULLed the tree pointers without freeing, leaking the old tree + zvals (measured ~240 KB over 50 re-inits). Now frees via `judy_free_array_internal()` first. |
| C2 follow-up | CRITICAL-class | The `INT_TO_MIXED` **bulk-populate** overwrite still had the dtor-before-write ordering that the #70 sweep missed (Janca had listed this exact site). Applied the same write-before-dtor UAF guard. |

## Verification
- Full suite: **184/184** (181 + 3 new), 0 skips.
- All three new regression tests confirmed to **fail against pre-fix** and pass after (M8 leaked 240 KB pre-fix; M3/M4 gave wrong answers).

Remaining batches (robustness: get_gc / callback-cursor / JERR-handling; adaptive set-ops fix; docs/release) follow separately.