### PR TITLE
fix: callback-cursor corruption, JERR->SUCCESS, bulk-op exception handling

### DIFF
--- a/php_judy.c
+++ b/php_judy.c
@@ -595,7 +595,9 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 			J1U(Rc_int, intern->array, index);
 			if (Rc_int == 1) intern->counter--;
 		}
-		return Rc_int ? SUCCESS : FAILURE;
+		/* JERR (-1) is truthy, so `Rc_int ?` would report an allocation
+		 * failure as SUCCESS. Only a real change (1) or no-op is success. */
+		return Rc_int == JERR ? FAILURE : SUCCESS;
 	} else if (intern->type == TYPE_INT_TO_INT
 			|| intern->type == TYPE_INT_TO_MIXED
 			|| intern->type == TYPE_INT_TO_PACKED) {
@@ -1179,7 +1181,9 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 			}
 		}
 	}
-	return Rc_int ? SUCCESS : FAILURE;
+	/* Only an allocation failure (JERR) is a failure; a no-op delete of an
+	 * absent key is success. Guards against JERR (-1) reporting as SUCCESS. */
+	return Rc_int == JERR ? FAILURE : SUCCESS;
 }
 /* }}} */
 
@@ -3993,6 +3997,13 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 	zval retval;
 	int action_rc = SUCCESS;
 
+	/* Private cursor for string-keyed iteration. The user callback may
+	 * re-enter an operation that writes intern->key_scratch (first/last/
+	 * toArray/keys/a nested forEach on the same object), which would corrupt
+	 * a shared cursor mid-loop. Integer-keyed types use a local Word_t index
+	 * and need no buffer. */
+	uint8_t *cursor = intern->is_integer_keyed ? NULL : emalloc(PHP_JUDY_MAX_LENGTH);
+
 	if (intern->is_integer_keyed) {
 		Word_t index = 0;
 		if (intern->type == TYPE_BITSET) {
@@ -4043,7 +4054,7 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 			}
 		}
 	} else if (intern->is_adaptive) {
-		uint8_t *key = intern->key_scratch;
+		uint8_t *key = cursor;
 		Pvoid_t *PValue;
 		key[0] = '\0';
 		JSLF(PValue, intern->key_index, key);
@@ -4087,7 +4098,7 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 		}
 
 	} else { /* string keyed */
-		uint8_t *key = intern->key_scratch;
+		uint8_t *key = cursor;
 		Pvoid_t *PValue;
 		key[0] = '\0';
 		if (intern->is_hash_keyed) {
@@ -4132,6 +4143,10 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 				}
 			}
 		}
+	}
+
+	if (cursor) {
+		efree(cursor);
 	}
 }
 static int action_foreach(judy_object *intern, zval *key, zval *retval, void *data) {
@@ -4230,6 +4245,7 @@ static void judy_object_merge_with_helper(judy_object *intern, judy_object *othe
 					ZVAL_LONG(&zidx, (zend_long)index);
 					judy_object_write_dimension_helper_zv(intern, &zidx, &val);
 				}
+				if (UNEXPECTED(EG(exception))) break;
 				J1N(Rc_int, other->array, index);
 			}
 		} else {
@@ -4242,11 +4258,14 @@ static void judy_object_merge_with_helper(judy_object *intern, judy_object *othe
 				judy_object_read_dimension_helper_zv(other, &zidx, &zval_val);
 				judy_object_write_dimension_helper_zv(intern, &zidx, &zval_val);
 				zval_ptr_dtor(&zval_val);
+				if (UNEXPECTED(EG(exception))) break;
 				JLN(PValue, other->array, index);
 			}
 		}
 	} else { /* string keyed */
-		uint8_t *key = other->key_scratch;
+		/* Private cursor: writing into `intern` can run a MIXED value's
+		 * destructor, which could re-enter and corrupt other->key_scratch. */
+		uint8_t *key = emalloc(PHP_JUDY_MAX_LENGTH);
 		Pvoid_t *PValue;
 		key[0] = '\0';
 		if (other->is_hash_keyed) {
@@ -4263,6 +4282,7 @@ static void judy_object_merge_with_helper(judy_object *intern, judy_object *othe
 			judy_object_write_dimension_helper_zv(intern, &zkey, &zval_val);
 			zval_ptr_dtor(&zval_val);
 			zval_ptr_dtor(&zkey);
+			if (UNEXPECTED(EG(exception))) break;
 
 			if (other->is_hash_keyed) {
 				JSLN(PValue, other->key_index, key);
@@ -4270,6 +4290,7 @@ static void judy_object_merge_with_helper(judy_object *intern, judy_object *othe
 				JSLN(PValue, other->array, key);
 			}
 		}
+		efree(key);
 	}
 }
 
@@ -4509,6 +4530,12 @@ static void judy_populate_from_array(zval *judy_obj, zval *arr) {
 			}
 			judy_object_write_dimension_helper(judy_obj, &offset, entry);
 			zval_ptr_dtor(&offset);
+			/* Stop on the first thrown key (embedded NUL / oversize): keep the
+			 * partial result up to the error rather than plowing on with an
+			 * exception pending. */
+			if (UNEXPECTED(EG(exception))) {
+				break;
+			}
 		} ZEND_HASH_FOREACH_END();
 		break;
 	}

--- a/tests/regression_bulk_exception_stop_001.phpt
+++ b/tests/regression_bulk_exception_stop_001.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Regression: putAll stops on the first throwing key instead of plowing on
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// judy_populate_from_array kept writing after a key threw (embedded NUL /
+// oversize), leaving an exception pending across further inserts. It must stop
+// at the first error.
+$j = new Judy(Judy::STRING_TO_INT);
+$oversize = str_repeat('x', 70000);   // >= PHP_JUDY_MAX_LENGTH: throws
+try {
+    $j->putAll(["ok1" => 1, $oversize => 2, "ok2" => 3]);
+    echo "no exception (unexpected)\n";
+} catch (\Throwable $e) {
+    echo "caught: " . $e->getMessage() . "\n";
+}
+// "ok1" landed before the bad key; iteration stopped at the throw so "ok2"
+// (after it) did not. Exactly one clean exception, no leaked pending state.
+echo "has ok1: " . (isset($j["ok1"]) ? "yes" : "no") . "\n";
+echo "count: " . $j->count() . "\n";
+// A subsequent operation must run cleanly (no lingering exception).
+$j["after"] = 9;
+echo "after-insert ok: " . $j["after"] . "\n";
+?>
+--EXPECTF--
+caught: %s
+has ok1: yes
+count: 1
+after-insert ok: 9

--- a/tests/regression_callback_reentrancy_001.phpt
+++ b/tests/regression_callback_reentrancy_001.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Regression: forEach/filter/map callbacks may re-enter without corrupting iteration
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// The callback iterator used the shared key_scratch as its cursor; a callback
+// that re-entered an operation touching that buffer (first/last/toArray/nested
+// forEach) corrupted the outer loop. Verify every element is visited exactly
+// once even when the callback re-enters.
+$long = str_repeat('q', 40);
+foreach ([Judy::STRING_TO_INT, Judy::STRING_TO_INT_HASH, Judy::STRING_TO_INT_ADAPTIVE] as $type) {
+    $j = new Judy($type);
+    foreach (['a', 'bb', 'ccc', $long] as $i => $k) { $j[$k] = $i; }
+
+    $seen = [];
+    // forEach passes ($value, $key) to the callback.
+    $j->forEach(function ($v, $k) use ($j, &$seen) {
+        // Re-enter operations that write key_scratch mid-iteration.
+        $j->first();
+        $j->last();
+        $j->toArray();
+        $seen[$k] = $v;
+    });
+    ksort($seen);
+    echo "$type: visited " . count($seen) . " -> " . implode(',', array_keys($seen)) . "\n";
+}
+?>
+--EXPECT--
+4: visited 4 -> a,bb,ccc,qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+8: visited 4 -> a,bb,ccc,qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+10: visited 4 -> a,bb,ccc,qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq


### PR DESCRIPTION
Batch 5 of the hardening sprint (follows #70/#71/#73/#74). Three verified error-path findings; regression tests for M6 and M10 confirmed to fail pre-fix.

- **M6 — callback iterator cursor corruption.** `judy_callback_iterator` used the shared `intern->key_scratch` as its loop cursor and called the user callback between advances. A callback that re-entered `first()`/`last()`/`toArray()`/a nested `forEach` on the same object overwrote the cursor → skipped/repeated elements. Now uses a private cursor. The `mergeWith` string loop had the same aliasing (a MIXED-value destructor at the destination can re-enter) and gets the same fix.
- **M7 — JERR reported as SUCCESS.** `write_dimension` (BITSET) and `unset_dimension` returned `Rc_int ? SUCCESS : FAILURE`; libjudy's `JERR` (-1) is truthy, so an allocation failure returned SUCCESS. Now fails only on `JERR`.
- **M10 — bulk ops ignored pending exceptions.** `putAll`/`fromArray`/`__unserialize` and `mergeWith` kept iterating after a key threw (embedded NUL / oversize), stacking work behind a pending exception. Now break on `EG(exception)`, keeping the partial result up to the first error.

**187/187** tests (185 + 2 new), ASAN-clean on the callback/merge paths, warning-clean. Next: adaptive set-ops fix (README roadmap), then docs/release polish.