### PR TITLE
feat: correct set operations for STRING_TO_INT_ADAPTIVE

### DIFF
--- a/php_judy.c
+++ b/php_judy.c
@@ -2285,8 +2285,9 @@ static void judy_create_bitset_result(zval *return_value)
 /* {{{ Helper to validate that both operands support set operations and have the same type */
 static int judy_validate_set_operands(judy_object *self, judy_object *other)
 {
-	if (self->type != TYPE_BITSET && self->type != TYPE_INT_TO_INT && 
-		self->type != TYPE_STRING_TO_INT && self->type != TYPE_STRING_TO_INT_HASH) {
+	if (self->type != TYPE_BITSET && self->type != TYPE_INT_TO_INT &&
+		self->type != TYPE_STRING_TO_INT && self->type != TYPE_STRING_TO_INT_HASH &&
+		self->type != TYPE_STRING_TO_INT_ADAPTIVE) {
 		zend_throw_exception(NULL, "Set operations are only supported on BITSET and integer-valued arrays", 0);
 		return FAILURE;
 	}
@@ -2535,13 +2536,12 @@ alloc_error_il:
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 			int exists = 0;
 			Pvoid_t *VOther = NULL;
-			if (intern->is_hash_keyed) {
-				JHSG(VOther, other->array, key, (Word_t)strlen((char *)key));
-				if (VOther != NULL) exists = 1;
-			} else {
-				JSLG(VOther, other->array, key);
-				if (VOther != NULL) exists = 1;
-			}
+			/* Dispatch across other's layout (plain JudySL, JudyHS, or
+			 * adaptive SSO/JudyHS). Previously JHSG was run on other->array
+			 * unconditionally for is_hash_keyed, which is wrong for adaptive
+			 * (its short keys live in a JudyL). */
+			VOther = judy_string_value_slot(other, key, (Word_t)strlen((char *)key));
+			if (VOther != NULL) exists = 1;
 
 			if (exists) {
 				zval zkey, zval_val;
@@ -2657,13 +2657,12 @@ alloc_error_il:
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 			int exists = 0;
 			Pvoid_t *VOther = NULL;
-			if (intern->is_hash_keyed) {
-				JHSG(VOther, other->array, key, (Word_t)strlen((char *)key));
-				if (VOther != NULL) exists = 1;
-			} else {
-				JSLG(VOther, other->array, key);
-				if (VOther != NULL) exists = 1;
-			}
+			/* Dispatch across other's layout (plain JudySL, JudyHS, or
+			 * adaptive SSO/JudyHS). Previously JHSG was run on other->array
+			 * unconditionally for is_hash_keyed, which is wrong for adaptive
+			 * (its short keys live in a JudyL). */
+			VOther = judy_string_value_slot(other, key, (Word_t)strlen((char *)key));
+			if (VOther != NULL) exists = 1;
 
 			if (!exists) {
 				zval zkey, zval_val;
@@ -2807,15 +2806,8 @@ alloc_error_il:
 
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 			int exists = 0;
-			if (intern->is_hash_keyed) {
-				Pvoid_t *HExists;
-				JHSG(HExists, other->array, key, (Word_t)strlen((char *)key));
-				if (HExists != NULL) exists = 1;
-			} else {
-				Pvoid_t *SExists;
-				JSLG(SExists, other->array, key);
-				if (SExists != NULL) exists = 1;
-			}
+			Pvoid_t *VOther = judy_string_value_slot(other, key, (Word_t)strlen((char *)key));
+			if (VOther != NULL) exists = 1;
 
 			if (!exists) {
 				zval zkey, zval_val;
@@ -2845,15 +2837,8 @@ alloc_error_il:
 
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 			int exists = 0;
-			if (intern->is_hash_keyed) {
-				Pvoid_t *HExists;
-				JHSG(HExists, intern->array, okey, (Word_t)strlen((char *)okey));
-				if (HExists != NULL) exists = 1;
-			} else {
-				Pvoid_t *SExists;
-				JSLG(SExists, intern->array, okey);
-				if (SExists != NULL) exists = 1;
-			}
+			Pvoid_t *VSelf = judy_string_value_slot(intern, okey, (Word_t)strlen((char *)okey));
+			if (VSelf != NULL) exists = 1;
 
 			if (!exists) {
 				zval zkey, zval_val;

--- a/tests/regression_adaptive_setops_001.phpt
+++ b/tests/regression_adaptive_setops_001.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Regression: set operations work correctly for STRING_TO_INT_ADAPTIVE (SSO + long keys)
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// Adaptive set operations were rejected by the validator; the underlying
+// existence checks used JHSG on the JudyL (SSO) store, which is wrong. Verify
+// intersect/diff/xor/union now give correct results across short (SSO-packed)
+// and long (JudyHS) keys.
+$long1 = str_repeat('a', 40);
+$long2 = str_repeat('b', 40);
+
+function mk(array $keys): Judy {
+    $j = new Judy(Judy::STRING_TO_INT_ADAPTIVE);
+    foreach ($keys as $k => $v) { $j[$k] = $v; }
+    return $j;
+}
+function keys_of(Judy $j): array {
+    $out = [];
+    foreach ($j as $k => $v) { $out[$k] = $v; }
+    ksort($out);
+    return $out;
+}
+
+$a = mk(['x' => 1, 'yy' => 2, $long1 => 3, $long2 => 4]);   // short x,yy + long a,b
+$b = mk(['yy' => 20, $long2 => 40, 'zzz' => 5]);            // short yy,zzz + long b
+
+echo "intersect: " . json_encode(keys_of($a->intersect($b))) . "\n"; // yy, long2
+echo "diff: " . json_encode(keys_of($a->diff($b))) . "\n";           // x, long1
+echo "xor: " . json_encode(keys_of($a->xor($b))) . "\n";             // x, long1, zzz
+echo "union: " . json_encode(keys_of($a->union($b))) . "\n";         // all (a wins)
+?>
+--EXPECT--
+intersect: {"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb":4,"yy":2}
+diff: {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":3,"x":1}
+xor: {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":3,"x":1,"zzz":5}
+union: {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":3,"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb":4,"x":1,"yy":2,"zzz":5}


### PR DESCRIPTION
Implements the **README roadmap** item: *"Fix intersect()/diff()/xor() correctness for adaptive types (SSO keys incorrectly checked via JHSG on the JudyL array); union() already works correctly."*

Set operations previously **rejected** adaptive types at the validator, and the underlying membership probes were wrong for them (they ran `JHSG` on `other->array` for any `is_hash_keyed` operand, but an adaptive array's short keys live in a JudyL and its long keys in `hs_array`). This:

- widens `judy_validate_set_operands` to accept `STRING_TO_INT_ADAPTIVE`, and
- routes every existence probe in `intersect`/`diff`/`xor` through the `judy_string_value_slot()` helper (added in #74), which dispatches correctly across plain JudySL / JudyHS / adaptive SSO+JudyHS layouts.

`union()` needed no change (it copies both operands without probing membership against the other). Result construction and value read/write already dispatch on type.

> **Note — this expands accepted input:** adaptive-typed set operations that used to throw now work. It doesn't change behavior for the already-supported types.

New regression test exercises intersect/diff/xor/union with both SSO-packed short keys and long (JudyHS) keys; verified to throw pre-fix and give correct results after. **188/188** tests, **ASAN-clean**, warning-clean. Docs (README roadmap line → done, API.md note) follow in the docs batch.