### PR TITLE
chore: release v2.4.2

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -42,7 +42,7 @@ Modern data structures like Swiss tables (used in abseil and Folly) and Robin Ho
 
 - **Hardware**: Tests run on modern x86_64 systems with sufficient RAM to avoid memory pressure
 - **Operating System**: Linux (Docker containers for consistency)
-- **PHP Version**: 8.x with Judy extension 2.4.1
+- **PHP Version**: 8.x with Judy extension 2.4.2
 - **Test Methodology**: Multiple iterations with statistical analysis (min/max/median/percentiles)
 - **Memory Measurement**: Using `memory_get_usage(true)` and `Judy::memoryUsage()`
 
@@ -397,5 +397,5 @@ php examples/run-benchmarks-robust.php
 
 Our methodology and insights are informed by the [Rusty Russell benchmark comparison](https://rusty.ozlabs.org/2010/11/08/hashtables-vs-judy-arrays-round-1.html) between hashtables and Judy arrays, which demonstrates Judy's strengths in ordered access patterns and memory efficiency.
 
-**Judy Extension Version**: 2.4.1
+**Judy Extension Version**: 2.4.2
 **Last Updated**: August 2026

--- a/package.xml
+++ b/package.xml
@@ -16,11 +16,11 @@
       <email>nicolas@brousse.info</email>
       <active>yes</active>
    </lead>
-   <date>2026-08-13</date>
+   <date>2026-08-14</date>
    <time>00:00:00</time>
    <version>
-      <release>2.4.1</release>
-      <api>2.4.1</api>
+      <release>2.4.2</release>
+      <api>2.4.2</api>
    </version>
    <stability>
       <release>stable</release>
@@ -28,8 +28,28 @@
    </stability>
    <license uri="http://www.php.net/license">PHP</license>
    <notes>
-- FIX: PHP 8.6 build -- XtOffsetOf() alias removed in PHP 8.6.0alpha2; use
-  standard C offsetof() instead (thanks Remi Collet, PR #65)
+- SECURITY: fix use-after-free write on *_TO_MIXED overwrite/unset when a stored
+  value's destructor re-enters and mutates the same array (write-before-dtor /
+  delete-before-free)
+- SECURITY: fix type confusion (UB) in getAll()/next()/rewind() for adaptive
+  types, which queried a JudyHS operation against the JudyL (SSO) store
+- FIX: add get_gc handler so reference cycles through MIXED values are collectable
+  (previously leaked until request shutdown)
+- FIX: STRING_TO_*_ADAPTIVE counter no longer double-counts when the value 0 is
+  re-stored (size/count/equals/averageValues were affected)
+- FIX: $j[] = append after clone/fromArray/putAll no longer overwrites index 0
+- FIX: first()/last()/searchNext()/prev() now work on adaptive types
+- FIX: fromArray()/putAll() reject non-integer keys on integer-keyed types instead
+  of inserting at the string's hash
+- FIX: __unserialize() on a populated object frees prior contents (no leak)
+- FIX: forEach()/filter()/map() callbacks may re-enter without corrupting iteration
+- FIX: equals() on INT_TO_PACKED no longer risks an infinite loop
+- FIX: allocation failure (JERR) during write/unset is reported as failure, not success
+- FIX: bulk operations stop on the first thrown key instead of continuing with a
+  pending exception; clone/slice no longer leak zvals or diverge on OOM paths
+- FEATURE: set operations (intersect/diff/xor) now supported for STRING_TO_INT_ADAPTIVE
+- BUILD: extension compiles warning-free; CI now fails on any new compiler warning
+- BUILD: minimum PHP raised to 8.1 (PHP 8.0 is no longer tested in CI)
    </notes>
    <contents>
       <dir name="/">
@@ -275,6 +295,21 @@
       <configureoption default="autodetect" name="with-judy" prompt="Please provide the prefix of libJudy installation" />
    </extsrcrelease>
    <changelog>
+      <release>
+         <date>2026-08-13</date>
+         <version>
+            <release>2.4.1</release>
+            <api>2.4.1</api>
+         </version>
+         <stability>
+            <release>stable</release>
+            <api>stable</api>
+         </stability>
+         <notes>
+- FIX: PHP 8.6 build -- XtOffsetOf() alias removed in PHP 8.6.0alpha2; use
+  standard C offsetof() instead (thanks Remi Collet, PR #65)
+         </notes>
+      </release>
       <release>
          <date>2026-03-02</date>
          <version>

--- a/php_judy.h
+++ b/php_judy.h
@@ -19,7 +19,7 @@
 #ifndef PHP_JUDY_H
 #define PHP_JUDY_H
 
-#define PHP_JUDY_VERSION "2.4.1"
+#define PHP_JUDY_VERSION "2.4.2"
 #define PHP_JUDY_EXTNAME "judy"
 
 /* Windows x64 (LLP64): Force 64-bit Word_t to match libjudy ABI.


### PR DESCRIPTION
Patch release folding in the security/correctness hardening sprint (PRs #70–#77).

Version bump only — all fixes already merged to main; this bumps `php_judy.h` + `package.xml` (2.4.1 → 2.4.2), rotates the 2.4.1 notes into the `<changelog>`, and refreshes the BENCHMARK stamps. `tests/001.phpt` needed no change (now version-agnostic).

**Highlights (full list in the release notes):**
- **Security:** `*_TO_MIXED` use-after-free on destructor re-entrancy; adaptive-type confusion (UB) in `getAll()`/`next()`/`rewind()`.
- **Leaks:** `get_gc` for MIXED reference cycles; `__unserialize` reinit leak; clone/slice OOM-path leaks.
- **Silent corruption:** adaptive counter drift on value 0; append-after-clone overwriting index 0; integer-key coercion; `equals()` packed infinite loop; JERR-reported-as-success; bulk-op exception handling; callback-cursor corruption.
- **Feature:** set operations now work for `STRING_TO_INT_ADAPTIVE`.
- **Build:** warning-free + a CI gate to keep it that way.

Verified in an isolated worktree: 188/188 tests, 0 warnings, `php_judy.h` ↔ `package.xml` version match (what `validate-pecl` checks).

**After merge:** publish the GitHub release as `v2.4.2` (I can run `gh release create` on your go-ahead — it's an outward publish). The CI perf baseline stays at 2.4.1 (the correct previous-release comparison); bump it to 2.4.2 in a follow-up once 2.4.2 is on PECL.