### PR TITLE
Adoption batch 1: Packagist metadata, README refresh, governance files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Report a crash, wrong result, memory issue, or build failure
+labels: [bug]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: PHP Judy version
+      description: "`php -r 'echo judy_version();'`"
+      placeholder: "2.4.1"
+    validations:
+      required: true
+  - type: input
+    id: php
+    attributes:
+      label: PHP version
+      description: "`php -v` (include NTS/ZTS)"
+      placeholder: "8.4.1 NTS"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: Installation method
+      options:
+        - PIE
+        - PECL
+        - install-php-extensions (Docker)
+        - Manual build from source
+        - Distro package
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      placeholder: "Ubuntu 24.04 x86_64 / macOS 15 arm64 / Windows 11 x64"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction script
+      description: The smallest PHP script that shows the problem.
+      render: php
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Crash output / valgrind report (if any)
+      description: For crashes, a backtrace or `USE_ZEND_ALLOC=0 valgrind php ...` output helps a lot.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/orieg/php-judy/security/advisories/new
+    about: Please report memory-safety and security issues privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest a new capability or API improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that PHP Judy doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: API sketch, expected semantics, or prior art in other languages/libraries.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Native arrays, php-ds, workarounds you tried.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ go-pear.phar
 judy-*/
 test-package/
 temp_update/
+
+# Claude Code session files
+.claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to PHP Judy
+
+Thanks for your interest in contributing! PHP Judy is a C extension, so the
+workflow differs a bit from a pure-PHP project. This guide covers everything
+needed to build, test, and submit changes.
+
+## Prerequisites
+
+- PHP 8.1+ with development headers (`php-dev` / `php-devel`, or a source build)
+- The libJudy C library and headers:
+  - Debian/Ubuntu: `apt-get install libjudy-dev`
+  - Fedora/RHEL: `dnf install Judy-devel`
+  - macOS: `brew install judy`
+  - Windows: build libJudy from source (see the Windows section in [README.md](README.md))
+- Standard C toolchain (`gcc`/`clang`, `make`, `autoconf`)
+
+## Building from source
+
+```sh
+phpize
+./configure --with-judy=/usr
+make
+```
+
+To try the freshly-built extension without installing it:
+
+```sh
+php -d extension=modules/judy.so -r 'var_dump(judy_version());'
+```
+
+## Running the tests
+
+The test suite is a standard `.phpt` suite under `tests/`:
+
+```sh
+make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+```
+
+A failing test leaves `tests/<name>.diff` / `.out` / `.exp` files behind for
+inspection. Please add a `.phpt` test for every behavior change or bug fix —
+regression tests are what keep a C extension safe to evolve.
+
+## Code conventions
+
+- **Zero compiler warnings.** CI fails on any warning in the extension source
+  files. Build with `make` and check the output before pushing.
+- **Memory safety first.** Every error path must release what it acquired.
+  When in doubt, test with valgrind:
+  `USE_ZEND_ALLOC=0 valgrind php -d extension=modules/judy.so tests/<script>.php`
+- Match the style of the surrounding code.
+
+## API changes
+
+The public API is defined in `Judy.stub.php`. If you change it:
+
+1. Regenerate the arginfo header (see the build output / `php_judy.h` includes).
+2. Regenerate `API.md`: `php scripts/generate-api-docs.php` — CI fails if
+   `API.md` is stale relative to the stub.
+
+## Version bumps (maintainers)
+
+The version string must change in lockstep in `php_judy.h`
+(`PHP_JUDY_VERSION`) and `package.xml` (release + api version). CI validates
+they match, and the release workflow validates the git tag against both.
+See the [Releasing section in README.md](README.md#releasing) for the full
+release checklist.
+
+## Benchmarks
+
+Benchmark scripts live in `examples/`. CI compares each PR against the
+committed baseline in `baselines/latest.json`. If your change legitimately
+shifts performance, mention it in the PR description; do not update the
+baseline in a feature PR.
+
+## Submitting a pull request
+
+1. Fork and create a topic branch off `main`.
+2. Make your change with tests.
+3. Ensure `make test` passes and the build is warning-free.
+4. Open a PR with a clear description of what changed and why.
+
+For larger changes, please open an issue first to discuss the approach.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 **PHP Judy** - Extension for creating and accessing dynamic arrays
 
+[![CI](https://github.com/orieg/php-judy/actions/workflows/ci.yml/badge.svg)](https://github.com/orieg/php-judy/actions/workflows/ci.yml)
+[![Packagist Version](https://img.shields.io/packagist/v/orieg/judy)](https://packagist.org/packages/orieg/judy)
+[![Packagist Downloads](https://img.shields.io/packagist/dt/orieg/judy)](https://packagist.org/packages/orieg/judy/stats)
+[![PHP Version](https://img.shields.io/packagist/dependency-v/orieg/judy/php?label=php)](https://packagist.org/packages/orieg/judy)
+[![License](https://img.shields.io/packagist/l/orieg/judy)](LICENSE)
 [![PECL](https://img.shields.io/badge/PECL-Judy-blue.svg)](https://pecl.php.net/package/Judy)
-[![Packagist](https://img.shields.io/badge/Packagist-orieg/judy-orange.svg)](https://packagist.org/packages/orieg/judy)
-[![PHP Version](https://img.shields.io/badge/PHP-8.1+-green.svg)](https://php.net)
-[![License](https://img.shields.io/badge/License-PHP-blue.svg)](LICENSE)
 
 ## Table of Contents
 
@@ -22,7 +24,7 @@
 
 ## Introduction
 
-**php-judy** is an extension by Nicolas Brousse for the Judy C library. It is tested in CI against PHP 8.1–8.5 (and, experimentally, PHP 8.6). The package metadata still declares a minimum of PHP 8.0, but 8.0 is no longer covered by CI.
+**php-judy** is an extension by Nicolas Brousse for the Judy C library. It is compatible with PHP 8.1 and newer, tested in CI against PHP 8.1–8.5 (and, experimentally, PHP 8.6).
 
 - **PECL Package**: [http://pecl.php.net/package/Judy](http://pecl.php.net/package/Judy)
 - **Packagist Package**: [https://packagist.org/packages/orieg/judy](https://packagist.org/packages/orieg/judy)
@@ -31,6 +33,15 @@
 A Judy array is a complex but very fast associative array data structure for storing and looking up values using integer or string keys. Unlike normal arrays, Judy arrays may be sparse; that is, they may have large ranges of unassigned indices.
 
 - **Wikipedia**: [http://en.wikipedia.org/wiki/Judy_array](http://en.wikipedia.org/wiki/Judy_array)
+
+### Why PHP Judy?
+
+- **2-4x less memory** than native PHP arrays for large integer-keyed datasets, and **~10x less** for presence tracking with `BITSET` (1M elements)
+- **Faster bulk operations**: `getAll()`, `toArray()`, and `fromArray()` run in native C, 1.3-3x faster than element-by-element loops; atomic `increment()` avoids the read-modify-write round trip
+- **Ordered keys for free**: range queries, `first()`/`next()` navigation, and neighbor lookups that hash tables can't do
+- **Honest trade-off**: for random access on small dense datasets, native PHP arrays are faster. See [BENCHMARK.md](BENCHMARK.md) for full numbers and a decision guide on when (not) to use Judy.
+
+Judy shines in long-running PHP processes (CLI tools, queue workers, Swoole/RoadRunner/FrankenPHP/Octane workers) that hold large sparse keysets in memory.
 
 The PHP extension is based on the Judy C library that implements a dynamic array. A Judy array consumes memory only when populated yet can grow to take advantage of all available memory. Judy's key benefits are: scalability, performance, memory efficiency, and ease of use. Judy arrays are designed to grow without tuning into the peta-element range, scaling near O(log-base-256) -- 1 more RAM access at 256 X population.
 
@@ -66,10 +77,20 @@ PHP PIE (PHP Extension Installer) is the easiest way to install PHP Judy on supp
 curl -sSL https://pie.dev/installer | php
 
 # Install PHP Judy using PIE
-pie install judy
+pie install orieg/judy
 ```
 
-**Note**: PHP PIE automatically handles dependencies and builds the extension for your specific PHP version and platform.
+**Note**: PHP PIE automatically handles dependencies and builds the extension for your specific PHP version and platform. The package is listed on [Packagist](https://packagist.org/packages/orieg/judy) among the [PIE-installable extensions](https://packagist.org/extensions).
+
+### A2. Docker
+
+In Docker images based on the official `php` images, the simplest path is [`install-php-extensions`](https://github.com/mlocati/docker-php-extension-installer), which supports Judy on PHP 8.1+:
+
+```dockerfile
+FROM php:8.4-cli
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN install-php-extensions judy
+```
 
 ### B. Using PECL
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| 2.4.x   | ✅        |
+| < 2.4   | ❌        |
+
+## Reporting a vulnerability
+
+PHP Judy is a C extension that processes user-supplied keys and values, so
+memory-safety issues (out-of-bounds access, use-after-free, uninitialized
+reads) are treated as security bugs.
+
+**Please do not open a public issue for suspected vulnerabilities.**
+
+Instead, report privately via
+[GitHub private vulnerability reporting](https://github.com/orieg/php-judy/security/advisories/new).
+
+Please include:
+
+- The extension version (`php -r 'echo judy_version();'`) and PHP version
+- Platform and how the extension was installed (PIE, PECL, source)
+- A minimal reproduction script
+- Any crash output, valgrind report, or sanitizer trace if available
+
+You will receive an acknowledgment, and a fix or mitigation plan will be
+coordinated with you before public disclosure.

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,25 @@
     "name": "orieg/judy",
     "type": "php-ext",
     "description": "PHP Judy implements sparse dynamic arrays (aka Judy Arrays).",
+    "keywords": [
+        "judy",
+        "judy-arrays",
+        "sparse-array",
+        "data-structures",
+        "bitset",
+        "trie",
+        "memory",
+        "performance",
+        "extension",
+        "pie"
+    ],
     "license": "PHP-3.01",
     "homepage": "https://github.com/orieg/php-judy",
+    "support": {
+        "issues": "https://github.com/orieg/php-judy/issues",
+        "source": "https://github.com/orieg/php-judy",
+        "docs": "https://github.com/orieg/php-judy/blob/main/API.md"
+    },
     "authors": [
         {
             "name": "Nicolas Brousse",
@@ -13,7 +30,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0.0"
+        "php": ">=8.1.0"
     },
     "php-ext": {
         "extension-name": "judy",

--- a/package.xml
+++ b/package.xml
@@ -263,7 +263,7 @@
    <dependencies>
       <required>
          <php>
-            <min>8.0.0</min>
+            <min>8.1.0</min>
          </php>
          <pearinstaller>
             <min>1.4.8</min>


### PR DESCRIPTION
First batch of the adoption/visibility plan.

## Packaging (Packagist discoverability)
- `composer.json`: add `keywords` + `support` block (page currently has neither, hurting Packagist search)
- Raise PHP floor to **8.1** in `composer.json` + `package.xml` (8.0 is EOL and untested in CI — the README claimed 8.0 while the CI matrix starts at 8.1)

## README
- Live badges (CI status, Packagist version/downloads/PHP/license) replacing static shields
- **Why PHP Judy?** headline summary above the fold with the key BENCHMARK.md numbers (2-4x memory, ~10x for BITSET) and the honest trade-off
- Fix PIE command: `pie install orieg/judy` (the previous `pie install judy` is not a valid package name; CI uses the vendor-qualified form)
- Document the Docker path via mlocati `install-php-extensions judy` (already supported upstream, previously undocumented)
- Drift fixes: remove nonexistent `libjudy/` directory entry, de-hardcode the test count, roadmap accuracy edits (JLG+JLI scope; adaptive set-op correctness)

## Governance
- `CONTRIBUTING.md`: full C-extension build/test workflow, stub/API.md regeneration, version-lockstep rule, benchmark-baseline policy
- `SECURITY.md`: private vulnerability reporting via GitHub security advisories
- Issue templates: structured bug report + feature request forms
- `.gitignore`: ignore `.claude/` session files

No C code changes; no behavior changes.