### PR TITLE
docs: Ecosystem section linking judy-polyfill and judy-cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ Set ops (return new Judy): `union`, `intersect`, `diff`, `xor`; in-place:
 
 Functions: `judy_version(): string`, `judy_type(mixed): int`.
 
+For code that must run where the extension may be absent, depend on
+[orieg/judy-polyfill](https://github.com/orieg/judy-polyfill) (pure-PHP,
+API-parity-tested) and suggest `ext-judy`; a PSR-16 cache built on this API
+is [orieg/judy-cache](https://github.com/orieg/judy-cache).
+
 ### Pitfalls that agents get wrong
 
 - **`next()` is the Iterator method** (returns void, advances the cursor).

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 2. [Directory Contents](#directory-contents)
 3. [Installation](#installation)
 4. [Usage Examples](#usage-examples)
-5. [Reporting Bugs](#reporting-bugs)
-6. [Roadmap](#roadmap)
-7. [Releasing](#releasing)
-8. [License](#license)
-9. [Contributing](#contributing)
-10. [Support](#support)
+5. [Ecosystem](#ecosystem)
+6. [Reporting Bugs](#reporting-bugs)
+7. [Roadmap](#roadmap)
+8. [Releasing](#releasing)
+9. [License](#license)
+10. [Contributing](#contributing)
+11. [Support](#support)
 
 ## Introduction
 
@@ -454,6 +455,19 @@ Beyond basic array access, Judy provides a rich API including:
 - **Comparison**: `equals()`
 
 For complete method signatures, parameter details, and type compatibility, see [API.md](API.md).
+
+## Ecosystem
+
+- **[orieg/judy-polyfill](https://github.com/orieg/judy-polyfill)** — pure-PHP
+  fallback providing the `Judy` class API when the extension is absent.
+  Library authors: depend on the polyfill (`composer require
+  orieg/judy-polyfill`) and suggest `ext-judy`; users who install the
+  extension get native performance transparently. Parity with the extension
+  is CI-verified on every PHP version.
+- **[orieg/judy-cache](https://github.com/orieg/judy-cache)** — PSR-16 cache
+  (plus a Symfony Cache adapter) backed by Judy's sorted trie, with O(range)
+  prefix invalidation for long-running PHP (Octane, Swoole, RoadRunner,
+  FrankenPHP workers).
 
 ## Reporting Bugs
 


### PR DESCRIPTION
Cross-links the two new companion packages from the extension's README and AGENTS.md:

- [orieg/judy-polyfill](https://packagist.org/packages/orieg/judy-polyfill) — pure-PHP Judy API, parity-verified against ext-judy 2.4.2 (249 checks, CI on PHP 8.1-8.5 with/without the extension). Gives library authors a safe way to depend on the Judy API.
- [orieg/judy-cache](https://github.com/orieg/judy-cache) — PSR-16 cache + Symfony adapter on the sorted trie, with O(range) prefix invalidation.

Docs only.