### PR TITLE
Examples, Alpine CI, discoverability, and versus-the-alternatives benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,27 @@ jobs:
             benchmark-output.txt
           if-no-files-found: ignore
 
+  build-alpine:
+    # Most containerized PHP runs on Alpine. musl differs from glibc enough
+    # (allocator, default stack size, locale handling) that a clean Debian
+    # build does not imply a clean musl one.
+    #
+    # Built through Docker on a glibc runner rather than as a `container:`
+    # job: GitHub's node runtime for JS actions (actions/checkout) is
+    # glibc-linked and does not execute inside an Alpine container.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Build the extension on Alpine/musl
+        run: docker build -f Dockerfile.alpine -t php-judy-alpine .
+
+      - name: Run tests on Alpine/musl
+        run: |
+          docker run --rm -w /usr/src/php-judy php-judy-alpine \
+            make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+
   validate-pecl:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,4 +92,12 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   must match; see the Releasing section in README.md.
 - **Benchmarks**: suite in `examples/benchmarks/`; CI compares PRs against
   `baselines/latest.json`. Don't update the baseline in a feature PR.
-- **Runnable demos**: `examples/` (see `examples/README.md`).
+- **Runnable demos**: `examples/` (index + type-per-demo table in
+  `examples/README.md`). Reach for these before writing a pattern from
+  scratch — each is the idiomatic shape for its problem:
+  `dedup-large-stream.php` (membership/seen-sets, `BITSET` memory story),
+  `ip-range-lookup.php` (floor lookup via `last()` — CIDR, tariff bands),
+  `sliding-window-rate-limit.php` (time-bucket expiry via `deleteRange()`),
+  `prefix-invalidation.php` (namespace drop via `first()` + `searchNext()`),
+  `autocomplete-trie.php` (prefix search), `worker-counters.php` (atomic
+  `increment()`), `quickstart.php` (API tour).

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -244,25 +244,53 @@ round-trip out separately would still not make it one.
 
 All figures below are `(measured)`; nothing in this section is projected.
 
-- **Where**: Docker `php:8.4-cli` (Debian bookworm), Linux aarch64, PHP 8.4.18,
-  ext-judy 2.4.2, APCu 5.1.28. Container limits: 4 CPUs, 5.9 GB. Host: Apple M1,
-  8 cores, 16 GB. Linux-in-container was chosen over the macOS host because it
-  is closer to both the deployment target and to where CI would run this.
-- **Statistics**: 9 runs per cell, each in a fresh child process. Reported as
+- **Where**: Docker `php:8.4-cli` (Debian bookworm) on a dedicated **Linux
+  x86_64** host — 24 cores, 62 GB, Ubuntu 22.04, 4 KB pages. PHP 8.4.24,
+  ext-judy 2.4.2, APCu 5.1.28.
+- **Load was clean.** Load average `2.26 / 0.69 / 0.24` before the sweep and
+  `1.07` after, against a cores/2 = 12.0 threshold; no non-target process above
+  2% CPU. These are not contention-inflated upper bounds.
+- **Statistics**: 7 runs per cell, each in a fresh child process. Reported as
   **median with a 95% percentile-bootstrap CI**. A delta is only stated when the
   two CIs do not overlap; otherwise the result is reported as *no measured
   separation*.
 - **Memory**: peak RSS from `getrusage()['ru_maxrss']` in a child process, not
   `memory_get_usage()` — Judy allocates outside PHP's memory manager and
-  `memory_get_usage()` cannot see it. An empty-interpreter baseline is measured
-  and subtracted in the "over floor" column.
-- **⚠️ Load was not clean.** Host load average during the run had a median of
-  **4.60 and a peak of 8.04** against the cores/2 = 4.0 threshold; 9 of 15
-  samples exceeded it, with a non-target process at 114% CPU. **Every timing
-  here is an upper bound.** The prefix-invalidation shape was reproduced across
-  two independent sweeps taken under different load, and its ratios are large
-  enough that contention cannot account for them — but a 20% difference
-  anywhere in this section would not be trustworthy.
+  `memory_get_usage()` cannot see it. An empty-interpreter baseline (34.1 MB) is
+  measured and subtracted in the "over floor" column. Peak RSS is sensitive to
+  allocator and page size, so it is not portable across platforms — re-measure
+  rather than quoting these figures for a different OS or architecture.
+
+An earlier sweep of this suite was run on a contended laptop (aarch64, load
+median 4.60 against a 4.0 threshold). It has been discarded. It agreed on
+workloads 1 and 2, but **failed to replicate workload 4 and put workload 3's
+crossover in the wrong place** — which is the practical argument for measuring
+these on an idle machine rather than disclosing contamination and shipping
+anyway.
+
+#### Reproducing this
+
+Any idle Linux box with Docker. The image needs APCu, which the repo's default
+`Dockerfile` does not install:
+
+```dockerfile
+FROM php:8.4-cli
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential libjudy-dev && rm -rf /var/lib/apt/lists/*
+RUN pecl install apcu && docker-php-ext-enable apcu
+COPY . /usr/src/php-judy
+WORKDIR /usr/src/php-judy
+RUN phpize && ./configure --with-judy=/usr && make -j"$(nproc)" && make install \
+    && docker-php-ext-enable judy
+```
+
+```bash
+cat /proc/loadavg                      # confirm < cores/2 BEFORE and AFTER
+docker build -f Dockerfile.bench -t php-judy-bench .
+docker run --rm -w /usr/src/php-judy php-judy-bench \
+    php -d apc.enable_cli=1 -d apc.shm_size=2048M \
+        examples/benchmarks/judy-bench-alternatives.php
+```
 
 ### 1. Prefix invalidation — a complexity-class difference
 
@@ -272,47 +300,48 @@ growth in the cost of *finding* the group, not of deleting it.
 
 | n (total entries) | judy `STRING_TO_MIXED` (µs) | judy `*_HASH` (µs)        | PHP array (µs)      | APCu (µs)            |
 | ----------------- | --------------------------- | ------------------------- | ------------------- | -------------------- |
-| 10,000            | **8.5** [7.1..33.0]         | 1,027 [981..1,068]        | 165 [155..180]      | 2,083 [1,973..2,276] |
-| 30,000            | **11.8** [10.9..13.3]       | 4,045 [3,944..4,336]      | 513 [500..561]      | 2,889 [2,856..3,151] |
-| 100,000           | **10.1** [9.4..12.2]        | 14,049 [13,988..14,233]   | 1,852 [1,773..1,948]| 7,028 [6,994..7,173] |
-| 300,000           | **13.0** [10.3..13.5]       | 44,554 [44,123..51,844]   | 7,590 [7,453..7,879]| 21,047 [19,098..22,084] |
-| 1,000,000         | **11.2** [10.0..13.7]       | 157,787 [151,156..166,728]| 26,044 [25,149..27,967] | 66,209 [64,457..76,622] |
+| 10,000            | **4.40** [4.10..7.09]       | 581 [578..588]            | 143 [123..209]      | 960 [946..978]       |
+| 30,000            | **5.96** [5.66..6.03]       | 2,650 [2,585..2,653]      | 602 [584..858]      | 1,351 [1,338..1,378] |
+| 100,000           | **6.09** [5.87..6.77]       | 9,743 [9,550..9,963]      | 1,832 [1,797..2,042]| 2,934 [2,912..2,964] |
+| 300,000           | **6.54** [6.31..7.20]       | 29,085 [29,079..29,169]   | 5,198 [5,190..5,206]| 8,357 [8,332..8,402] |
+| 1,000,000         | **6.79** [6.47..7.15]       | 97,668 [97,497..97,835]   | 19,774 [19,470..19,845] | 28,615 [28,507..28,705] |
 
 ```
-n = 10,000        judy         #                                              8.5 µs
-                  array        ##############                                 165 µs
-                  apcu         ##########################                     2,083 µs
-                  judy-hash    ######################                         1,027 µs
+n = 10,000        judy         #                                              4.4 µs
+                  array        ################                               143 µs
+                  apcu         #########################                      960 µs
+                  judy-hash    ######################                         581 µs
 
-n = 100,000       judy         #                                              10.1 µs
-                  array        #########################                      1,852 µs
-                  apcu         ###############################                7,028 µs
-                  judy-hash    ###################################            14,049 µs
+n = 100,000       judy         ##                                             6.1 µs
+                  array        ############################                   1,832 µs
+                  apcu         ##############################                 2,934 µs
+                  judy-hash    ###################################            9,743 µs
 
-n = 1,000,000     judy         #                                              11.2 µs
-                  array        ######################################         26,044 µs
-                  apcu         ##########################################     66,209 µs
-                  judy-hash    ############################################## 157,787 µs
+n = 1,000,000     judy         ##                                             6.8 µs
+                  array        #######################################        19,774 µs
+                  apcu         ########################################       28,615 µs
+                  judy-hash    ############################################## 97,668 µs
 
-                  (log scale, 8.5 µs .. 157,787 µs)
+                  (log scale, 4.4 µs .. 97,668 µs)
 ```
 
 **Scaling across the sweep** (*n* grew 100x from 10k to 1M):
 
 | Backend                  | Growth | Shape                                     |
 | ------------------------ | ------ | ----------------------------------------- |
-| judy `STRING_TO_MIXED`   | 1.3x   | **flat** — cost follows the slice dropped |
-| APCu (`APCuIterator`)    | 31.8x  | linear in cache size, plus ~1.5 ms fixed cost |
-| PHP array (key scan)     | 157.7x | linear in cache size                      |
-| judy `STRING_TO_MIXED_HASH` | 153.6x | linear — no key ordering, so no adjacency |
+| judy `STRING_TO_MIXED`   | 1.5x   | **flat** — cost follows the slice dropped |
+| APCu (`APCuIterator`)    | 29.8x  | linear in cache size, plus a fixed setup cost |
+| PHP array (key scan)     | 138.6x | linear in cache size                      |
+| judy `STRING_TO_MIXED_HASH` | 168.0x | linear — no key ordering, so no adjacency |
 
-**The CIs separate at every size in the sweep**, for every rival. This is the
-one place in this document where the difference is a change of complexity
+**The CIs separate at every size in the sweep**, for every rival — Judy's
+advantage is **4,212x over APCu** and **2,911x over a PHP array** at n=1M. This
+is the one place in this document where the difference is a change of complexity
 class rather than a constant factor: Judy's ordered keys put a namespace's keys
 adjacent to each other, so `first($prefix)` + `searchNext()` walks the slice and
 stops. A hash table has no adjacency, so it must test every key — which is why
-APCu's regex invalidation costs 66 ms on a 1M-entry cache while the ordered trie
-costs 11 µs.
+APCu's regex invalidation costs 29 ms on a 1M-entry cache while the ordered trie
+costs 6.8 µs.
 
 Two caveats that keep this honest:
 
@@ -339,29 +368,34 @@ because it is the variable that decides this workload.
 
 | Cell       | Impl       | Peak RSS (MB) | Over floor | Insert (kops/s) | Lookup (kops/s) |
 | ---------- | ---------- | ------------- | ---------- | --------------- | --------------- |
-| 1M dense   | **judy `BITSET`** | 35     | **0.2 MB** | 20,852 [20,191..20,997] | **31,132** [30,753..31,300] |
-| 1M dense   | PHP array  | 52            | 18.1 MB    | **23,513** [23,093..24,137] | 13,636 [13,162..13,749] |
-| 1M dense   | SplFixedArray | 50         | 15.4 MB    | **24,280** [24,037..24,646] | 12,293 [11,184..12,909] |
-| 1M dense   | APCu       | 194           | 160.1 MB   | 5,699 [5,157..5,786] | 2,129 [1,654..2,253] |
-| 1M sparse  | **judy `BITSET`** | 36     | **2.1 MB** | **9,254** [8,349..9,375] | **13,921** [12,681..14,464] |
-| 1M sparse  | PHP array  | 74            | 40.1 MB    | 5,448 [5,333..5,676] | 5,600 [5,227..5,842] |
-| 1M sparse  | SplFixedArray | 156        | 122.1 MB   | 5,380 [4,283..5,911] | 6,589 [6,097..7,306] |
-| 1M sparse  | APCu       | 185           | 150.6 MB   | 2,545 [2,396..2,715] | 2,871 [2,732..2,946] |
-| 10M dense  | **judy `BITSET`** | 35     | **0.8 MB** | 20,452 [15,205..20,860] | **30,557** [29,114..30,959] |
-| 10M dense  | PHP array  | 188           | 154.1 MB   | 20,062 [16,287..23,527] | 7,277 [6,329..7,574] |
-| 10M dense  | SplFixedArray | 187        | 152.6 MB   | **23,595** [21,286..24,418] | 6,680 [6,286..7,359] |
+| 1M dense   | **judy `BITSET`** | 34     | **0.2 MB** | 30,645 [30,156..30,862] | 43,661 [43,503..43,801] |
+| 1M dense   | PHP array  | 51            | 16.9 MB    | **41,277** [41,057..41,765] | 45,831 [44,864..46,910] |
+| 1M dense   | SplFixedArray | 49         | 15.2 MB    | 39,069 [37,094..39,815] | **50,441** [49,699..50,792] |
+| 1M dense   | APCu       | 194           | 159.9 MB   | 7,941 [7,803..7,980] | 5,064 [5,058..5,068] |
+| 1M sparse  | **judy `BITSET`** | 36     | **2.1 MB** | **16,700** [16,340..17,070] | **36,732** [36,613..36,792] |
+| 1M sparse  | PHP array  | 73            | 39.1 MB    | 13,971 [13,627..14,330] | 27,143 [27,038..27,292] |
+| 1M sparse  | SplFixedArray | 156        | 121.9 MB   | 9,405 [9,404..9,533] | 20,855 [20,579..21,016] |
+| 1M sparse  | APCu       | 185           | 150.6 MB   | 5,298 [5,250..5,304] | 7,483 [7,466..7,504] |
+| 10M dense  | **judy `BITSET`** | 35     | **0.8 MB** | 30,718 [29,930..30,964] | **43,537** [43,299..43,682] |
+| 10M dense  | PHP array  | 291           | 257.0 MB   | 36,917 [36,789..37,469] | 21,011 [20,985..21,048] |
+| 10M dense  | SplFixedArray | 187        | 152.6 MB   | **42,884** [42,629..43,240] | 20,709 [20,329..20,868] |
 
-- **Memory is the headline: 190x.** 10M dense IDs cost `BITSET` 0.8 MB against
-  154 MB for a PHP array and 153 MB for `SplFixedArray`. A bitset stores one bit
-  per key; the other two store a 16-byte `zval`.
+- **Memory is the headline: 321x.** 10M dense IDs cost `BITSET` 0.8 MB against
+  257 MB for a PHP array (321x) and 153 MB for `SplFixedArray` (191x). A bitset
+  stores one bit per key; the other two store a 16-byte `zval`. APCu cannot hold
+  the 10M cell at all — its shm segment runs out first.
 - **`SplFixedArray` is not a memory optimization for sparse IDs.** It must
   allocate the whole key space, so it tracks *density*, not element count — at
   1M sparse it is the worst row in the table (122 MB over floor) and it cannot
   represent IDs above its allocated size at all.
-- **Lookup throughput favors Judy at scale** (2.3x over a PHP array at 1M
-  dense, 4.2x at 10M dense) because 1 MB of bitset stays in cache while 154 MB
-  of hash table does not. **Insert favors the PHP array and `SplFixedArray`**
-  at 1M dense — Judy wins insert only in the sparse cell.
+- **Lookup throughput depends on whether the working set escapes cache.** At
+  **1M dense the three in-process structures are within ~15% of each other**
+  and `SplFixedArray` is nominally fastest — 1M entries still fit comfortably in
+  cache, so Judy's compactness buys nothing. At **10M dense Judy is 2.1x faster**
+  than either, because 1 MB of bitset stays resident while 257 MB of hash table
+  does not. Judy also leads the sparse cell (1.4x over an array).
+- **Insert favors the PHP array and `SplFixedArray` when dense** (41.3k and
+  39.1k vs Judy's 30.6k kops/s at 1M dense). Judy wins insert only when sparse.
 - **APCu is the slowest and largest on every cell here.** That is expected and
   not a criticism: it is paying for a shared segment and a serialization
   boundary that the in-process structures do not have. Re-read the warning
@@ -378,28 +412,29 @@ program is keeping.
 
 | Retained  | judy `deleteRange()` (µs) | array key-scan (µs) | `array_filter()` (µs) |
 | --------- | ------------------------- | ------------------- | --------------------- |
-| 10,000    | 911 [899..973]            | **207** [193..213]  | 1,038 [955..1,152]    |
-| 100,000   | 1,104 [1,053..1,751]      | **844** [780..999]  | 6,127 [5,965..6,445]  |
-| 1,000,000 | **1,160** [1,100..2,572]  | 6,972 [6,643..7,362]| 52,400 [50,247..59,493] |
+| 10,000    | 424 [393..667]            | **210** [180..215]  | 731 [689..935]        |
+| 100,000   | **526** [473..580]        | 1,143 [1,122..1,240]| 4,598 [4,556..4,799]  |
+| 1,000,000 | **464** [453..466]        | 8,353 [8,177..8,755]| 40,905 [40,704..41,199] |
 
 **Judy does not win this workload at every size, and the plan predicted it
-would.** `deleteRange()` is flat (911 → 1,160 µs, a 1.3x rise across a 100x
-growth in retained set) because it only touches the expired slice. But its
-per-key constant is higher than a PHP array's, so:
+would.** `deleteRange()` is flat — 424 → 526 → 464 µs is non-monotonic, i.e.
+noise-level across a 100x growth in the retained set — because it only touches
+the expired slice. But its per-key constant is higher than a PHP array's, so:
 
-- At **10k and 100k retained, the naive array key-scan wins** (CIs separate) —
-  it visits more keys but each visit is cheaper.
-- At **1M retained, Judy wins by 6x** (CIs separate), and the gap keeps
+- At **10k retained the naive array key-scan wins** (CIs separate) — it visits
+  more keys but each visit is cheaper.
+- **The crossover sits between 10k and 100k retained.** From 100k up Judy wins
+  (2.2x at 100k, **18x at 1M**, CIs separate at both), and the gap keeps
   widening because only one of the two curves is growing.
-- `array_filter()` loses to Judy from 100k up, and shows **no measured
-  separation** at 10k.
+- `array_filter()` loses to Judy at every size measured.
 
-The practical read: `deleteRange()` is the right choice when the retained
-window is large (≳100k-1M buckets) or when eviction runs on a hot path where
-worst-case latency matters. Below that, a plain array scan is fine and simpler.
+The practical read: `deleteRange()` is the right choice once the retained
+window is somewhere above ~10k buckets, or when eviction runs on a hot path
+where worst-case latency matters. Below that, a plain array scan is fine and
+simpler.
 See [`examples/sliding-window-rate-limit.php`](examples/sliding-window-rate-limit.php).
 
-### 4. Floor / CIDR lookup — Judy wins updates, not lookups
+### 4. Floor / CIDR lookup — Judy wins lookups narrowly, updates enormously
 
 Resolve an address to its range: the greatest range-start ≤ address. Judy does
 it with `last()`; the honest alternative is a sorted array of starts plus a
@@ -407,36 +442,44 @@ userland binary search.
 
 | Ranges    | Impl         | Lookup (ns/op)     | Build (ms)          | Insert (µs/range)          |
 | --------- | ------------ | ------------------ | ------------------- | -------------------------- |
-| 10,000    | judy         | **198** [170..220] | 1.1 [0.94..1.14]    | **0.15** [0.14..0.17]      |
-| 10,000    | sorted-array | 372 [334..412]     | **0.7** [0.68..0.95]| 193 [179..383]             |
-| 100,000   | judy         | 710 [469..947]     | 15.7 [11.0..35.8]   | **0.34** [0.26..0.42]      |
-| 100,000   | sorted-array | 584 [474..1,023]   | 12.7 [9.6..19.0]    | 1,987 [1,534..2,218]       |
-| 1,000,000 | judy         | 701 [662..784]     | 88.3 [85..101]      | **0.33** [0.31..0.38]      |
-| 1,000,000 | sorted-array | 909 [802..1,064]   | 156 [147..167]      | 18,086 [17,139..19,971]    |
+| 10,000    | judy         | **90** [89..91]    | 1.0 [0.92..0.97]    | **0.13** [0.12..0.13]      |
+| 10,000    | sorted-array | 250 [249..268]     | **0.7** [0.70..0.95]| 50.6 [45.0..51.6]          |
+| 100,000   | judy         | **164** [161..167] | 9.7 [9.2..10.6]     | **0.14** [0.14..0.15]      |
+| 100,000   | sorted-array | 327 [321..334]     | **8.9** [8.3..8.9]  | 996 [983..1,019]           |
+| 1,000,000 | judy         | **366** [364..368] | **98.3** [97.9..98.7] | **0.19** [0.19..0.20]    |
+| 1,000,000 | sorted-array | 467 [463..468]     | 104.7 [104.5..105.4]| 16,248 [16,236..16,288]    |
 
-**Lookup: report this as a draw, not a Judy win.** At 10k ranges Judy is
-roughly 2x faster and the CIs separate. Above that the result **does not
-replicate**: at 100k the CIs overlap, and at 1M three independent sweeps
-disagreed (one showed Judy ahead, one showed overlap, and a macOS run showed
-the sorted array ahead). The defensible claim is that **Judy's `last()` is
-competitive with a userland binary search and not slower** — nothing stronger.
-Binary search over a packed sorted array is genuinely good at this, exactly as
-expected; a 20-iteration PHP loop is the reason Judy stays in contention at all.
+**Lookup: Judy wins at every size, and the CIs separate at all three** — 2.8x
+at 10k, 2.0x at 100k, 1.3x at 1M. The margin narrows as the table grows, which
+is what you would expect: both are doing more memory traversal, and a
+20-iteration PHP-level binary search loop closes on a C trie walk when the trie
+gets deeper. Binary search over a packed sorted array is genuinely good at
+this; Judy is simply better, and the gap is a constant factor, not a class
+difference.
 
-**Update cost is where they actually diverge, by ~55,000x at 1M ranges.**
-Inserting a range costs Judy 0.33 µs regardless of table size; the sorted array
-must `array_splice()` its parallel arrays, which is O(n) memmove — 18 ms per
-insert at 1M ranges. Build cost also favors Judy at 1M (88 ms vs 156 ms,
-because the array must sort).
+> An earlier contended run of this same workload reported it as a *draw*,
+> because the win failed to replicate above 10k and three sweeps disagreed at
+> 1M. On an idle machine it replicates cleanly. Two variables differed between
+> those runs — load and CPU architecture — so the contended result is discarded
+> rather than explained.
 
-So the decision is about **churn, not lookups**:
+**Update cost is where they diverge by a different order of magnitude:
+~85,000x at 1M ranges.** Inserting a range costs Judy 0.19 µs regardless of
+table size; the sorted array must `array_splice()` its parallel arrays, which
+is O(n) memmove — 16 ms per insert at 1M ranges. Build cost is a wash at 1M
+(98 ms vs 105 ms).
+
+Judy wins both metrics here, but by margins that should be weighed very
+differently:
 
 - **Static table, loaded once, queried forever** (a compiled GeoIP database, a
-  fixed tariff schedule): use a sorted array. Judy buys you nothing measurable,
-  and the array is simpler and dependency-free.
+  fixed tariff schedule): Judy is 1.3-2.8x faster per lookup, which is real but
+  is a constant factor. A sorted array is dependency-free and needs no
+  extension, so this is a genuine engineering trade rather than a clear win —
+  take Judy if the lookup is hot, keep the array if it is not.
 - **Table that changes while it is being queried** (live CIDR blocklists,
-  feature-flag ranges, dynamic shard maps): use Judy. This is the only
-  reasonable choice — a sorted array would spend its life splicing. A batched
+  feature-flag ranges, dynamic shard maps): use Judy, and it is not close. A
+  sorted array would spend its life splicing at 16 ms per insert. A batched
   rebuild-and-re-sort is a middle path if updates arrive in large batches.
 
 See [`examples/ip-range-lookup.php`](examples/ip-range-lookup.php).
@@ -445,10 +488,10 @@ See [`examples/ip-range-lookup.php`](examples/ip-range-lookup.php).
 
 | Workload                | Winner                | Margin (measured)                    | Caveat |
 | ----------------------- | --------------------- | ------------------------------------ | ------ |
-| Prefix invalidation     | **Judy (ordered)**    | 11 µs vs 66 ms (APCu) at 1M entries  | Different complexity class; needs an *ordered* type, not `*_HASH` |
-| Presence / dedup memory | **Judy `BITSET`**     | 0.8 MB vs 154 MB at 10M dense        | Insert throughput is slightly behind arrays when dense |
-| Sliding-window eviction | **Judy above ~1M retained** | 6x at 1M; loses below ~100k    | Real crossover — array scan wins on small windows |
-| Floor / CIDR lookup     | **Draw on lookup; Judy on updates** | ~55,000x on insert at 1M | Static tables: use a sorted array |
+| Prefix invalidation     | **Judy (ordered)**    | 6.8 µs vs 29 ms (APCu) at 1M entries — 4,212x | Different complexity class; needs an *ordered* type, not `*_HASH` |
+| Presence / dedup memory | **Judy `BITSET`**     | 0.8 MB vs 257 MB at 10M dense — 321x | Insert throughput is behind arrays when dense; lookup ties at 1M |
+| Sliding-window eviction | **Judy above ~10k retained** | 18x at 1M; loses at 10k       | Real crossover — array scan wins on small windows |
+| Floor / CIDR lookup     | **Judy on both**      | 1.3-2.8x lookup; ~85,000x on insert at 1M | Lookup edge is a constant factor; a sorted array stays a reasonable dependency-free choice |
 
 **What this section does not show**: cross-process sharing (APCu's actual
 purpose), persistence, eviction policies, TTLs, or anything about Redis and

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -50,6 +50,9 @@ Modern data structures like Swiss tables (used in abseil and Folly) and Robin Ho
 
 ## 🎯 **Quick Decision Guide**
 
+> Choosing between Judy and **APCu, `SplFixedArray`, or a sorted array** rather
+> than a PHP array? Skip to [Versus the Alternatives](#versus-the-alternatives-apcu-splfixedarray-sorted-arrays).
+
 **Use Judy Arrays When:**
 - ✅ Memory is constrained (2-4x less memory usage)
 - ✅ Large datasets (> 1M elements) where memory efficiency matters
@@ -74,6 +77,7 @@ Our benchmark suite tests multiple scenarios to provide realistic performance da
 - `examples/benchmarks/benchmark_range_queries.php` - Range queries and ordered operations
 - `examples/benchmarks/benchmark_real_world_patterns.php` - Database, log, analytics patterns
 - `examples/benchmarks/run_comprehensive_benchmarks.php` - Complete benchmark suite
+- `examples/benchmarks/judy-bench-alternatives.php` - Judy vs APCu / SplFixedArray / sorted arrays (see [Versus the Alternatives](#versus-the-alternatives-apcu-splfixedarray-sorted-arrays))
 
 ### **Test Scenarios**
 1. **Ordered Data Performance**: Sequential keys, clustered keys, random keys
@@ -187,6 +191,268 @@ Our benchmark suite tests multiple scenarios to provide realistic performance da
 - **Log Data**: Excellent for timestamp-based sequential data
 - **Analytics**: Good for time-clustered data patterns
 - **Session Data**: Effective for user-clustered data
+
+---
+
+## Versus the Alternatives (APCu, SplFixedArray, sorted arrays)
+
+Everything above compares Judy against a native PHP array. That is the right
+guide for *when not to use Judy*, but it is not the choice most people are
+actually making. Nobody picks Judy instead of an array — they pick it instead
+of **APCu**, **`SplFixedArray`**, or a **hand-rolled sorted-array index**.
+This section measures those four head-to-heads.
+
+Harness: [`examples/benchmarks/judy-bench-alternatives.php`](examples/benchmarks/judy-bench-alternatives.php).
+Self-contained; skips the APCu rows with a notice when `ext-apcu` is absent.
+
+```bash
+php examples/benchmarks/judy-bench-alternatives.php            # all workloads
+php examples/benchmarks/judy-bench-alternatives.php prefix 9   # one workload, 9 runs
+php -d apc.enable_cli=1 -d apc.shm_size=2048M \
+    examples/benchmarks/judy-bench-alternatives.php            # with APCu rows
+```
+
+### ⚠️ APCu is shared across FPM workers. Judy is not.
+
+> **This is the single most important line in this section, and no latency
+> number below changes it.**
+>
+> APCu lives in a shared memory segment that every PHP-FPM worker in the pool
+> reads and writes. A Judy array lives in one process's heap: every worker
+> builds its own copy, pays its own memory, and loses it at the end of the
+> request under classic FPM. Quoting an invalidation speedup as a reason to
+> replace APCu would be comparing two things that do not do the same job.
+>
+> Judy fits where the data lives in a **long-lived process** — Swoole,
+> RoadRunner, FrankenPHP, queue consumers, CLI pipelines — or where the
+> structure is **built and consumed inside one request**. Shared, cross-worker,
+> read-mostly caching is what APCu is for, and php-judy does not offer it
+> today. See issue #83 and `spike/shm-arena/FINDINGS.md` for the feasibility
+> spike, which concluded that a shared-memory Judy arena is a concurrency and
+> failure-recovery subsystem rather than a feature.
+>
+> Because each CLI process gets its own APCu segment, the numbers below are
+> single-process on **both** sides. That makes them a fair latency comparison —
+> and it is precisely the setting in which APCu's real advantage is invisible.
+
+**Redis and Memcached are deliberately absent.** Their numbers would include
+IPC or network round-trips measured against an in-process data structure.
+Presenting that as a head-to-head would be dishonest, and breaking the
+round-trip out separately would still not make it one.
+
+### Environment and contention
+
+All figures below are `(measured)`; nothing in this section is projected.
+
+- **Where**: Docker `php:8.4-cli` (Debian bookworm), Linux aarch64, PHP 8.4.18,
+  ext-judy 2.4.2, APCu 5.1.28. Container limits: 4 CPUs, 5.9 GB. Host: Apple M1,
+  8 cores, 16 GB. Linux-in-container was chosen over the macOS host because it
+  is closer to both the deployment target and to where CI would run this.
+- **Statistics**: 9 runs per cell, each in a fresh child process. Reported as
+  **median with a 95% percentile-bootstrap CI**. A delta is only stated when the
+  two CIs do not overlap; otherwise the result is reported as *no measured
+  separation*.
+- **Memory**: peak RSS from `getrusage()['ru_maxrss']` in a child process, not
+  `memory_get_usage()` — Judy allocates outside PHP's memory manager and
+  `memory_get_usage()` cannot see it. An empty-interpreter baseline is measured
+  and subtracted in the "over floor" column.
+- **⚠️ Load was not clean.** Host load average during the run had a median of
+  **4.60 and a peak of 8.04** against the cores/2 = 4.0 threshold; 9 of 15
+  samples exceeded it, with a non-target process at 114% CPU. **Every timing
+  here is an upper bound.** The prefix-invalidation shape was reproduced across
+  two independent sweeps taken under different load, and its ratios are large
+  enough that contention cannot account for them — but a 20% difference
+  anywhere in this section would not be trustworthy.
+
+### 1. Prefix invalidation — a complexity-class difference
+
+Drop one 10-key group (`user.<uid>.*`) from a store of *n* entries. **The group
+being dropped is the same size at every *n***, so any growth in this column is
+growth in the cost of *finding* the group, not of deleting it.
+
+| n (total entries) | judy `STRING_TO_MIXED` (µs) | judy `*_HASH` (µs)        | PHP array (µs)      | APCu (µs)            |
+| ----------------- | --------------------------- | ------------------------- | ------------------- | -------------------- |
+| 10,000            | **8.5** [7.1..33.0]         | 1,027 [981..1,068]        | 165 [155..180]      | 2,083 [1,973..2,276] |
+| 30,000            | **11.8** [10.9..13.3]       | 4,045 [3,944..4,336]      | 513 [500..561]      | 2,889 [2,856..3,151] |
+| 100,000           | **10.1** [9.4..12.2]        | 14,049 [13,988..14,233]   | 1,852 [1,773..1,948]| 7,028 [6,994..7,173] |
+| 300,000           | **13.0** [10.3..13.5]       | 44,554 [44,123..51,844]   | 7,590 [7,453..7,879]| 21,047 [19,098..22,084] |
+| 1,000,000         | **11.2** [10.0..13.7]       | 157,787 [151,156..166,728]| 26,044 [25,149..27,967] | 66,209 [64,457..76,622] |
+
+```
+n = 10,000        judy         #                                              8.5 µs
+                  array        ##############                                 165 µs
+                  apcu         ##########################                     2,083 µs
+                  judy-hash    ######################                         1,027 µs
+
+n = 100,000       judy         #                                              10.1 µs
+                  array        #########################                      1,852 µs
+                  apcu         ###############################                7,028 µs
+                  judy-hash    ###################################            14,049 µs
+
+n = 1,000,000     judy         #                                              11.2 µs
+                  array        ######################################         26,044 µs
+                  apcu         ##########################################     66,209 µs
+                  judy-hash    ############################################## 157,787 µs
+
+                  (log scale, 8.5 µs .. 157,787 µs)
+```
+
+**Scaling across the sweep** (*n* grew 100x from 10k to 1M):
+
+| Backend                  | Growth | Shape                                     |
+| ------------------------ | ------ | ----------------------------------------- |
+| judy `STRING_TO_MIXED`   | 1.3x   | **flat** — cost follows the slice dropped |
+| APCu (`APCuIterator`)    | 31.8x  | linear in cache size, plus ~1.5 ms fixed cost |
+| PHP array (key scan)     | 157.7x | linear in cache size                      |
+| judy `STRING_TO_MIXED_HASH` | 153.6x | linear — no key ordering, so no adjacency |
+
+**The CIs separate at every size in the sweep**, for every rival. This is the
+one place in this document where the difference is a change of complexity
+class rather than a constant factor: Judy's ordered keys put a namespace's keys
+adjacent to each other, so `first($prefix)` + `searchNext()` walks the slice and
+stops. A hash table has no adjacency, so it must test every key — which is why
+APCu's regex invalidation costs 66 ms on a 1M-entry cache while the ordered trie
+costs 11 µs.
+
+Two caveats that keep this honest:
+
+- **`judy-hash` is in the table on purpose.** It is the same extension, and it
+  loses as badly as APCu does. The advantage belongs to *ordered keys*, not to
+  Judy — choosing `STRING_TO_MIXED_HASH` for a prefix-invalidation workload
+  gets you the hash-table scaling.
+- **Tag-based invalidation is a third option** and is not measured here.
+  Symfony's `TagAwareAdapter` maintains per-entry tag bookkeeping, which buys
+  cheap group invalidation at the cost of write-path overhead and memory. If
+  you can enumerate a group's keys, `apcu_delete(array)` is O(group) and this
+  workload does not apply to you at all. The scan is what you pay when you
+  cannot.
+
+This is the pattern behind
+[orieg/judy-cache](https://github.com/orieg/judy-cache)'s `deletePrefix()` and
+[`examples/prefix-invalidation.php`](examples/prefix-invalidation.php).
+
+### 2. Presence / dedup sets at scale
+
+Membership tracking over 1M-10M IDs. "Dense" means IDs 0..n-1; "sparse" means
+*n* IDs drawn from a keyspace 8x larger. Density is reported as a dimension
+because it is the variable that decides this workload.
+
+| Cell       | Impl       | Peak RSS (MB) | Over floor | Insert (kops/s) | Lookup (kops/s) |
+| ---------- | ---------- | ------------- | ---------- | --------------- | --------------- |
+| 1M dense   | **judy `BITSET`** | 35     | **0.2 MB** | 20,852 [20,191..20,997] | **31,132** [30,753..31,300] |
+| 1M dense   | PHP array  | 52            | 18.1 MB    | **23,513** [23,093..24,137] | 13,636 [13,162..13,749] |
+| 1M dense   | SplFixedArray | 50         | 15.4 MB    | **24,280** [24,037..24,646] | 12,293 [11,184..12,909] |
+| 1M dense   | APCu       | 194           | 160.1 MB   | 5,699 [5,157..5,786] | 2,129 [1,654..2,253] |
+| 1M sparse  | **judy `BITSET`** | 36     | **2.1 MB** | **9,254** [8,349..9,375] | **13,921** [12,681..14,464] |
+| 1M sparse  | PHP array  | 74            | 40.1 MB    | 5,448 [5,333..5,676] | 5,600 [5,227..5,842] |
+| 1M sparse  | SplFixedArray | 156        | 122.1 MB   | 5,380 [4,283..5,911] | 6,589 [6,097..7,306] |
+| 1M sparse  | APCu       | 185           | 150.6 MB   | 2,545 [2,396..2,715] | 2,871 [2,732..2,946] |
+| 10M dense  | **judy `BITSET`** | 35     | **0.8 MB** | 20,452 [15,205..20,860] | **30,557** [29,114..30,959] |
+| 10M dense  | PHP array  | 188           | 154.1 MB   | 20,062 [16,287..23,527] | 7,277 [6,329..7,574] |
+| 10M dense  | SplFixedArray | 187        | 152.6 MB   | **23,595** [21,286..24,418] | 6,680 [6,286..7,359] |
+
+- **Memory is the headline: 190x.** 10M dense IDs cost `BITSET` 0.8 MB against
+  154 MB for a PHP array and 153 MB for `SplFixedArray`. A bitset stores one bit
+  per key; the other two store a 16-byte `zval`.
+- **`SplFixedArray` is not a memory optimization for sparse IDs.** It must
+  allocate the whole key space, so it tracks *density*, not element count — at
+  1M sparse it is the worst row in the table (122 MB over floor) and it cannot
+  represent IDs above its allocated size at all.
+- **Lookup throughput favors Judy at scale** (2.3x over a PHP array at 1M
+  dense, 4.2x at 10M dense) because 1 MB of bitset stays in cache while 154 MB
+  of hash table does not. **Insert favors the PHP array and `SplFixedArray`**
+  at 1M dense — Judy wins insert only in the sparse cell.
+- **APCu is the slowest and largest on every cell here.** That is expected and
+  not a criticism: it is paying for a shared segment and a serialization
+  boundary that the in-process structures do not have. Re-read the warning
+  above before quoting this row.
+
+See [`examples/dedup-large-stream.php`](examples/dedup-large-stream.php) for
+the string-keyed version of this pattern.
+
+### 3. Sliding-window eviction — flat, but there is a crossover
+
+10,000 expired buckets are dropped in every cell; only the **retained** set
+grows. A cost that rises with the retained column is a cost paid for data the
+program is keeping.
+
+| Retained  | judy `deleteRange()` (µs) | array key-scan (µs) | `array_filter()` (µs) |
+| --------- | ------------------------- | ------------------- | --------------------- |
+| 10,000    | 911 [899..973]            | **207** [193..213]  | 1,038 [955..1,152]    |
+| 100,000   | 1,104 [1,053..1,751]      | **844** [780..999]  | 6,127 [5,965..6,445]  |
+| 1,000,000 | **1,160** [1,100..2,572]  | 6,972 [6,643..7,362]| 52,400 [50,247..59,493] |
+
+**Judy does not win this workload at every size, and the plan predicted it
+would.** `deleteRange()` is flat (911 → 1,160 µs, a 1.3x rise across a 100x
+growth in retained set) because it only touches the expired slice. But its
+per-key constant is higher than a PHP array's, so:
+
+- At **10k and 100k retained, the naive array key-scan wins** (CIs separate) —
+  it visits more keys but each visit is cheaper.
+- At **1M retained, Judy wins by 6x** (CIs separate), and the gap keeps
+  widening because only one of the two curves is growing.
+- `array_filter()` loses to Judy from 100k up, and shows **no measured
+  separation** at 10k.
+
+The practical read: `deleteRange()` is the right choice when the retained
+window is large (≳100k-1M buckets) or when eviction runs on a hot path where
+worst-case latency matters. Below that, a plain array scan is fine and simpler.
+See [`examples/sliding-window-rate-limit.php`](examples/sliding-window-rate-limit.php).
+
+### 4. Floor / CIDR lookup — Judy wins updates, not lookups
+
+Resolve an address to its range: the greatest range-start ≤ address. Judy does
+it with `last()`; the honest alternative is a sorted array of starts plus a
+userland binary search.
+
+| Ranges    | Impl         | Lookup (ns/op)     | Build (ms)          | Insert (µs/range)          |
+| --------- | ------------ | ------------------ | ------------------- | -------------------------- |
+| 10,000    | judy         | **198** [170..220] | 1.1 [0.94..1.14]    | **0.15** [0.14..0.17]      |
+| 10,000    | sorted-array | 372 [334..412]     | **0.7** [0.68..0.95]| 193 [179..383]             |
+| 100,000   | judy         | 710 [469..947]     | 15.7 [11.0..35.8]   | **0.34** [0.26..0.42]      |
+| 100,000   | sorted-array | 584 [474..1,023]   | 12.7 [9.6..19.0]    | 1,987 [1,534..2,218]       |
+| 1,000,000 | judy         | 701 [662..784]     | 88.3 [85..101]      | **0.33** [0.31..0.38]      |
+| 1,000,000 | sorted-array | 909 [802..1,064]   | 156 [147..167]      | 18,086 [17,139..19,971]    |
+
+**Lookup: report this as a draw, not a Judy win.** At 10k ranges Judy is
+roughly 2x faster and the CIs separate. Above that the result **does not
+replicate**: at 100k the CIs overlap, and at 1M three independent sweeps
+disagreed (one showed Judy ahead, one showed overlap, and a macOS run showed
+the sorted array ahead). The defensible claim is that **Judy's `last()` is
+competitive with a userland binary search and not slower** — nothing stronger.
+Binary search over a packed sorted array is genuinely good at this, exactly as
+expected; a 20-iteration PHP loop is the reason Judy stays in contention at all.
+
+**Update cost is where they actually diverge, by ~55,000x at 1M ranges.**
+Inserting a range costs Judy 0.33 µs regardless of table size; the sorted array
+must `array_splice()` its parallel arrays, which is O(n) memmove — 18 ms per
+insert at 1M ranges. Build cost also favors Judy at 1M (88 ms vs 156 ms,
+because the array must sort).
+
+So the decision is about **churn, not lookups**:
+
+- **Static table, loaded once, queried forever** (a compiled GeoIP database, a
+  fixed tariff schedule): use a sorted array. Judy buys you nothing measurable,
+  and the array is simpler and dependency-free.
+- **Table that changes while it is being queried** (live CIDR blocklists,
+  feature-flag ranges, dynamic shard maps): use Judy. This is the only
+  reasonable choice — a sorted array would spend its life splicing. A batched
+  rebuild-and-re-sort is a middle path if updates arrive in large batches.
+
+See [`examples/ip-range-lookup.php`](examples/ip-range-lookup.php).
+
+### Summary
+
+| Workload                | Winner                | Margin (measured)                    | Caveat |
+| ----------------------- | --------------------- | ------------------------------------ | ------ |
+| Prefix invalidation     | **Judy (ordered)**    | 11 µs vs 66 ms (APCu) at 1M entries  | Different complexity class; needs an *ordered* type, not `*_HASH` |
+| Presence / dedup memory | **Judy `BITSET`**     | 0.8 MB vs 154 MB at 10M dense        | Insert throughput is slightly behind arrays when dense |
+| Sliding-window eviction | **Judy above ~1M retained** | 6x at 1M; loses below ~100k    | Real crossover — array scan wins on small windows |
+| Floor / CIDR lookup     | **Draw on lookup; Judy on updates** | ~55,000x on insert at 1M | Static tables: use a sorted array |
+
+**What this section does not show**: cross-process sharing (APCu's actual
+purpose), persistence, eviction policies, TTLs, or anything about Redis and
+Memcached. It measures in-process data-structure behavior only.
 
 ---
 
@@ -378,6 +644,11 @@ php examples/benchmarks/judy-bench-batch-operations.php
 
 # Run memory usage pattern comparison
 php examples/benchmarks/judy-bench-memory-patterns.php
+
+# Compare against the real alternatives (APCu, SplFixedArray, sorted arrays)
+php examples/benchmarks/judy-bench-alternatives.php
+php -d apc.enable_cli=1 -d apc.shm_size=2048M \
+    examples/benchmarks/judy-bench-alternatives.php   # includes APCu rows
 ```
 
 **Note**: All benchmarks use proper Iterator interface methods and run without deprecated warnings.

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -227,9 +227,10 @@ php -d apc.enable_cli=1 -d apc.shm_size=2048M \
 > RoadRunner, FrankenPHP, queue consumers, CLI pipelines — or where the
 > structure is **built and consumed inside one request**. Shared, cross-worker,
 > read-mostly caching is what APCu is for, and php-judy does not offer it
-> today. See issue #83 and `spike/shm-arena/FINDINGS.md` for the feasibility
-> spike, which concluded that a shared-memory Judy arena is a concurrency and
-> failure-recovery subsystem rather than a feature.
+> today. See [issue #83](https://github.com/orieg/php-judy/issues/83) for the
+> feasibility spike on a shared-memory Judy arena, which concluded that it is a
+> concurrency and failure-recovery subsystem rather than a feature. The spike's
+> prototypes and findings live on the research branch linked from that issue.
 >
 > Because each CLI process gets its own APCu segment, the numbers below are
 > single-process on **both** sides. That makes them a fair latency comparison —

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,33 @@
+# Alpine/musl build — most containerized PHP runs on Alpine, and musl differs
+# from glibc enough (allocator, stack size, locale handling) that a clean
+# Debian build does not imply a clean Alpine one. Built in CI to keep it that
+# way.
+#
+#   docker build -f Dockerfile.alpine -t php-judy-alpine .
+#   docker run --rm -w /usr/src/php-judy php-judy-alpine \
+#       make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+
+FROM php:8.4-cli-alpine
+
+RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS judy-dev \
+    && apk add --no-cache judy
+
+COPY . /usr/src/php-judy
+WORKDIR /usr/src/php-judy
+
+RUN find . -name "*.lo" -delete && find . -name "*.dep" -delete \
+    && rm -f Makefile Makefile.objects Makefile.fragments \
+    && phpize \
+    && ./configure --with-judy=/usr \
+    && make 2>&1 | tee /tmp/build.log \
+    && make install \
+    && docker-php-ext-enable judy
+
+# Same warning gate as the Linux CI job: a musl-only warning is a real
+# portability signal.
+RUN if grep -E '(php_judy|judy_handlers|judy_arrayaccess|judy_iterator)\.[ch]:[0-9]+:[0-9]+: warning:' /tmp/build.log; then \
+        echo "Compiler warnings detected in extension sources"; exit 1; \
+    fi; \
+    echo "No compiler warnings in extension sources."
+
+RUN php -m | grep -i judy && php -r 'echo "judy_version=", judy_version(), PHP_EOL;'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ A Judy array is a complex but very fast associative array data structure for sto
 
 Judy shines in long-running PHP processes (CLI tools, queue workers, Swoole/RoadRunner/FrankenPHP/Octane workers) that hold large sparse keysets in memory.
 
+### What people use it for
+
+Each pattern below is a runnable script in [examples/](examples/README.md):
+
+| Problem | Why Judy | Demo |
+| ------- | -------- | ---- |
+| "Have I seen this ID?" over millions of items — crawler frontiers, queue dedup, processed-ID sets | `BITSET` uses ~10x less memory than a PHP array at 1M elements | [dedup-large-stream.php](examples/dedup-large-stream.php) |
+| Which CIDR/tariff/shard does this value fall in? | `last()` resolves the greatest key ≤ N in one call; hash tables must scan | [ip-range-lookup.php](examples/ip-range-lookup.php) |
+| Rate limiting and rolling metrics over a time window | `deleteRange()` expires aged-out buckets without touching the retained set | [sliding-window-rate-limit.php](examples/sliding-window-rate-limit.php) |
+| Invalidate every cache key under `user:123:*` | Ordered keys make a namespace one contiguous slice — cost follows the slice, not the cache size | [prefix-invalidation.php](examples/prefix-invalidation.php) |
+| Autocomplete / typeahead over a string keyset | `first()` + `searchNext()` walk a prefix in sorted order | [autocomplete-trie.php](examples/autocomplete-trie.php) |
+| Per-metric counters in a long-running worker | Atomic `increment()` skips the read-modify-write round trip | [worker-counters.php](examples/worker-counters.php) |
+
+New to the extension? Start with [quickstart.php](examples/quickstart.php).
+
 The PHP extension is based on the Judy C library that implements a dynamic array. A Judy array consumes memory only when populated yet can grow to take advantage of all available memory. Judy's key benefits are: scalability, performance, memory efficiency, and ease of use. Judy arrays are designed to grow without tuning into the peta-element range, scaling near O(log-base-256) -- 1 more RAM access at 256 X population.
 
 - **Judy C Library**: [http://judy.sourceforge.net](http://judy.sourceforge.net)
@@ -511,4 +526,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 - **API Reference**: [API.md](API.md) for complete method documentation
 - **Benchmarks**: [BENCHMARK.md](BENCHMARK.md) for performance analysis
 - **Migration Guide**: [MIGRATION_2.2.0.md](MIGRATION_2.2.0.md) for version 2.2.0 changes
-- **Examples**: Check the [examples/](examples/README.md) directory for runnable demos (dedup, autocomplete, counters, range lookup)
+- **Examples**: Check the [examples/](examples/README.md) directory for runnable demos (dedup, range lookup, rate limiting, prefix invalidation, autocomplete, counters) — indexed by problem under [What people use it for](#what-people-use-it-for)

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,9 @@ Entry points:
 ```sh
 php examples/benchmarks/run-benchmarks.php
 php examples/benchmarks/run_comprehensive_benchmarks.php
+
+# Judy vs APCu / SplFixedArray / sorted arrays, rather than vs a PHP array
+php examples/benchmarks/judy-bench-alternatives.php
 ```
 
 CI runs these against the committed baseline in `baselines/latest.json` to

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,8 @@ php examples/quickstart.php
 | [autocomplete-trie.php](autocomplete-trie.php) | Prefix search / autocomplete via ordered keys — `first()` + `searchNext()` | `STRING_TO_MIXED` |
 | [worker-counters.php](worker-counters.php) | Metrics accumulators in long-running workers with atomic `increment()` | `STRING_TO_INT_HASH`, `INT_TO_INT` |
 | [ip-range-lookup.php](ip-range-lookup.php) | Floor lookup (`last()`) over range tables — IPs, tariffs, time buckets | `INT_TO_MIXED` |
+| [sliding-window-rate-limit.php](sliding-window-rate-limit.php) | Sliding-window rate limiting / rolling metrics — `deleteRange()` expiry that visits only aged-out buckets | `INT_TO_INT` |
+| [prefix-invalidation.php](prefix-invalidation.php) | Namespace invalidation (`user:123:*`) walking only the matching key slice, with a keys-visited comparison against a hash table | `STRING_TO_MIXED` |
 
 ## Choosing a type
 

--- a/examples/benchmarks/judy-bench-alternatives.php
+++ b/examples/benchmarks/judy-bench-alternatives.php
@@ -1,0 +1,972 @@
+<?php
+/**
+ * Judy versus the alternatives people actually choose.
+ *
+ * The rest of this suite compares Judy against a native PHP array, which is
+ * the right "when NOT to use Judy" guide. But nobody picks Judy *instead of*
+ * an array — they pick it instead of APCu, SplFixedArray, or a hand-rolled
+ * sorted-array index. This harness measures those four head-to-heads:
+ *
+ *   prefix    Prefix/namespace invalidation as a function of total cache size.
+ *             Judy trie walk vs APCu's APCuIterator regex scan vs array scan.
+ *             The claim under test is a complexity-class difference, so this
+ *             one sweeps sizes and emits a curve, not a single number.
+ *   presence  Membership/dedup sets at 1M-10M IDs: Judy BITSET vs PHP array
+ *             vs SplFixedArray vs APCu. Metrics are peak RSS and throughput.
+ *   window    Sliding-window eviction: Judy deleteRange() vs array scan and
+ *             array_filter(), as a function of the RETAINED set size.
+ *   floor     Floor / CIDR lookup: Judy last() vs a sorted array + userland
+ *             binary search. Lookup latency AND build/update cost.
+ *
+ * ── Read this before quoting any number ──────────────────────────────────
+ *
+ * 1. APCu is shared across every PHP-FPM worker in a pool. Judy is per
+ *    process: each worker pays its own memory and fills its own cache. A
+ *    latency win here does NOT mean "replace APCu" — for a shared read-mostly
+ *    cache across many short-lived workers, APCu is solving a problem Judy
+ *    does not currently solve at all. Judy fits long-lived workers (Swoole,
+ *    RoadRunner, FrankenPHP, CLI consumers) and per-request indexes.
+ * 2. In CLI mode APCu's segment is per process too, so the numbers below are
+ *    single-process on BOTH sides — a fair latency comparison, and precisely
+ *    the setting in which APCu's real advantage (sharing) is invisible.
+ * 3. Peak RSS is read from getrusage()['ru_maxrss'] in a dedicated child
+ *    process, because Judy allocates outside PHP's memory manager and
+ *    memory_get_usage() cannot see it. APCu's number includes the shared
+ *    segment's touched pages, so treat its memory column as approximate.
+ * 4. Redis/Memcached are deliberately absent. Their numbers would include
+ *    IPC or network cost against an in-process structure, which is not a
+ *    head-to-head comparison; presenting it as one would be dishonest.
+ *
+ * ── Methodology ──────────────────────────────────────────────────────────
+ *
+ * Every cell runs in a fresh child process, R times (default 7). Reported as
+ * median with a 95% percentile-bootstrap CI over the runs. Two backends are
+ * only called separated when their CIs do not overlap; otherwise the harness
+ * prints "no measured separation" rather than a delta.
+ *
+ * Machine load contaminates every timing here. Check load average before and
+ * between runs; on a contended box treat all timings as upper bounds.
+ *
+ * Usage:
+ *   php examples/benchmarks/judy-bench-alternatives.php [workload] [runs]
+ *
+ *     workload  all (default) | prefix | presence | window | floor
+ *     runs      repetitions per cell (default 7)
+ *
+ *   APCu rows are skipped with a notice when ext-apcu is missing or
+ *   apc.enable_cli is off; the rest of the suite still runs.
+ *
+ * Examples:
+ *   php examples/benchmarks/judy-bench-alternatives.php prefix 9
+ *   php -d apc.enable_cli=1 -d apc.shm_size=1024M \
+ *       examples/benchmarks/judy-bench-alternatives.php
+ */
+
+// ─────────────────────────────────────────────────────────────────────────
+// Child-process entry point: run exactly one cell, print JSON, exit.
+// ─────────────────────────────────────────────────────────────────────────
+
+const PREFIX_GROUP   = 10;      // keys per invalidation group
+const PREFIX_REPEATS = 5;       // groups invalidated per timed run
+const WINDOW_EXPIRED = 10_000;  // expired buckets, held constant across the sweep
+const FLOOR_PROBES   = 100_000; // lookups per timed run
+const FLOOR_UPDATES  = 1_000;   // range inserts per timed run
+
+if (($argv[1] ?? null) === '--child') {
+    exit(runChild($argv[2], $argv[3], (int) $argv[4], (int) ($argv[5] ?? 0)));
+}
+
+/** Peak resident set size in bytes. ru_maxrss is bytes on macOS, KB on Linux. */
+function peakRss(): int
+{
+    return getrusage()['ru_maxrss'] * (PHP_OS_FAMILY === 'Darwin' ? 1 : 1024);
+}
+
+function emit(array $row): int
+{
+    echo json_encode($row + ['peak_rss' => peakRss()]), "\n";
+
+    return 0;
+}
+
+function runChild(string $workload, string $impl, int $n, int $arg): int
+{
+    if (str_starts_with($impl, 'judy') && !extension_loaded('judy')) {
+        fwrite(STDERR, "judy extension not loaded\n");
+
+        return 1;
+    }
+    if ($impl === 'apcu' && !apcuUsable()) {
+        fwrite(STDERR, "apcu not usable\n");
+
+        return 1;
+    }
+
+    return match ($workload) {
+        'prefix'   => childPrefix($impl, $n),
+        'presence' => childPresence($impl, $n, $arg),
+        'window'   => childWindow($impl, $n),
+        'floor'    => childFloor($impl, $n),
+        default    => 1,
+    };
+}
+
+function apcuUsable(): bool
+{
+    return extension_loaded('apcu')
+        && function_exists('apcu_store')
+        && (bool) ini_get('apc.enable_cli');
+}
+
+// ── Workload 1: prefix invalidation ──────────────────────────────────────
+//
+// n entries keyed user.<uid>.item.<i>, PREFIX_GROUP items per uid. Invalidate
+// PREFIX_REPEATS whole uids and report the mean per-group cost. The group
+// being dropped is a CONSTANT size at every n, so any growth in the reported
+// latency is growth in the cost of *finding* the group, which is the whole
+// question.
+
+function prefixKey(int $i): string
+{
+    return sprintf('user.%d.item.%d', intdiv($i, PREFIX_GROUP), $i % PREFIX_GROUP);
+}
+
+function childPrefix(string $impl, int $n): int
+{
+    $uids    = intdiv($n, PREFIX_GROUP);
+    $targets = [];
+    for ($r = 0; $r < PREFIX_REPEATS; $r++) {
+        // Spread the targets through the keyspace so no backend benefits from
+        // hitting the same trie path or hash bucket repeatedly.
+        $targets[] = (int) (($r + 0.5) * $uids / PREFIX_REPEATS);
+    }
+
+    $value = static fn (int $i): array => ['id' => $i, 'score' => $i * 3];
+
+    switch ($impl) {
+        case 'judy':
+        case 'judy-hash':
+            $type = $impl === 'judy' ? Judy::STRING_TO_MIXED : Judy::STRING_TO_MIXED_HASH;
+            $c    = new Judy($type);
+            for ($i = 0; $i < $n; $i++) {
+                $c[prefixKey($i)] = $value($i);
+            }
+            $t0      = hrtime(true);
+            $deleted = 0;
+            foreach ($targets as $uid) {
+                $deleted += $impl === 'judy'
+                    ? judyDeletePrefix($c, "user.$uid.")
+                    : hashDeletePrefix($c, "user.$uid.");
+            }
+            $elapsed = hrtime(true) - $t0;
+            break;
+
+        case 'apcu':
+            apcu_clear_cache();
+            for ($i = 0; $i < $n; $i++) {
+                apcu_store(prefixKey($i), $value($i));
+            }
+            if (apcu_cache_info(true)['num_entries'] < $n) {
+                fwrite(STDERR, "apcu could not hold $n entries (raise apc.shm_size)\n");
+
+                return 1;
+            }
+            $before = apcu_cache_info(true)['num_entries'];
+            $t0     = hrtime(true);
+            foreach ($targets as $uid) {
+                // The scan is what you do when you cannot enumerate the group's
+                // keys. (If you can enumerate them, apcu_delete(array) is O(k)
+                // and this workload does not apply to you.)
+                $it = new APCuIterator('/^user\.' . $uid . '\./', APC_ITER_KEY);
+                apcu_delete($it);
+            }
+            $elapsed = hrtime(true) - $t0;
+            // apcu_delete(APCuIterator) returns bool, so count outside the timer.
+            $deleted = $before - apcu_cache_info(true)['num_entries'];
+            break;
+
+        default: // plain PHP array
+            $c = [];
+            for ($i = 0; $i < $n; $i++) {
+                $c[prefixKey($i)] = $value($i);
+            }
+            $t0      = hrtime(true);
+            $deleted = 0;
+            foreach ($targets as $uid) {
+                $p = "user.$uid.";
+                foreach (array_keys($c) as $k) {
+                    if (str_starts_with($k, $p)) {
+                        unset($c[$k]);
+                        $deleted++;
+                    }
+                }
+            }
+            $elapsed = hrtime(true) - $t0;
+    }
+
+    return emit([
+        'metric'  => $elapsed / 1e3 / PREFIX_REPEATS, // µs per group invalidation
+        'deleted' => $deleted,
+    ]);
+}
+
+/** Ordered trie walk: seek to the prefix, stop at the first non-match. */
+function judyDeletePrefix(Judy $store, string $prefix): int
+{
+    $deleted = 0;
+    $key     = $store->first($prefix);
+    while ($key !== null && str_starts_with($key, $prefix)) {
+        $next = $store->searchNext($key);
+        unset($store[$key]);
+        $deleted++;
+        $key = $next;
+    }
+
+    return $deleted;
+}
+
+/** Unordered hash type: no adjacency, so the whole keyset must be tested. */
+function hashDeletePrefix(Judy $store, string $prefix): int
+{
+    $deleted = 0;
+    foreach ($store->keys() as $key) {
+        if (str_starts_with($key, $prefix)) {
+            unset($store[$key]);
+            $deleted++;
+        }
+    }
+
+    return $deleted;
+}
+
+// ── Workload 2: presence / dedup at scale ────────────────────────────────
+//
+// n IDs drawn from a keyspace of n * $spread. spread=1 is a dense ID set,
+// spread=8 is the sparse case (real user/object IDs with gaps). Density is
+// the dominant variable for BITSET and the only variable that makes
+// SplFixedArray viable or not, so it is a reported dimension, not a constant.
+
+function presenceIds(int $n, int $spread): Generator
+{
+    mt_srand(42);
+    $space = $n * $spread;
+    if ($spread === 1) {
+        for ($i = 0; $i < $n; $i++) {
+            yield $i;
+        }
+
+        return;
+    }
+    for ($i = 0; $i < $n; $i++) {
+        yield mt_rand(0, $space - 1);
+    }
+}
+
+function childPresence(string $impl, int $n, int $spread): int
+{
+    if ($impl === 'baseline') {
+        // Empty run: establishes the interpreter's own RSS so every other row
+        // in the table can be read as "floor + what the structure costs".
+        return emit(['metric' => 0.0, 'lookup_kops' => 0.0, 'hits' => 0]);
+    }
+
+    $space = $n * max(1, $spread);
+
+    $t0 = hrtime(true);
+    switch ($impl) {
+        case 'judy':
+            $set = new Judy(Judy::BITSET);
+            foreach (presenceIds($n, $spread) as $id) {
+                $set[$id] = true;
+            }
+            break;
+        case 'splfixed':
+            $set = new SplFixedArray($space);
+            foreach (presenceIds($n, $spread) as $id) {
+                $set[$id] = true;
+            }
+            break;
+        case 'apcu':
+            apcu_clear_cache();
+            foreach (presenceIds($n, $spread) as $id) {
+                apcu_store("id:$id", 1);
+            }
+            break;
+        default:
+            $set = [];
+            foreach (presenceIds($n, $spread) as $id) {
+                $set[$id] = true;
+            }
+    }
+    $tInsert = hrtime(true) - $t0;
+
+    // Probe: half hits (ids we inserted), half misses (odd offsets outside the
+    // inserted set for spread=1; random draws otherwise).
+    $probes = min($n, 1_000_000);
+    mt_srand(1337);
+    $hits = 0;
+    $t0   = hrtime(true);
+    switch ($impl) {
+        case 'judy':
+        case 'splfixed':
+            for ($i = 0; $i < $probes; $i++) {
+                $id = mt_rand(0, $space - 1);
+                if (isset($set[$id])) {
+                    $hits++;
+                }
+            }
+            break;
+        case 'apcu':
+            for ($i = 0; $i < $probes; $i++) {
+                $id = mt_rand(0, $space - 1);
+                if (apcu_exists("id:$id")) {
+                    $hits++;
+                }
+            }
+            break;
+        default:
+            for ($i = 0; $i < $probes; $i++) {
+                $id = mt_rand(0, $space - 1);
+                if (isset($set[$id])) {
+                    $hits++;
+                }
+            }
+    }
+    $tLookup = hrtime(true) - $t0;
+
+    return emit([
+        'metric'      => $n / ($tInsert / 1e9) / 1000, // insert kops/s (primary)
+        'lookup_kops' => $probes / ($tLookup / 1e9) / 1000,
+        'hits'        => $hits,
+    ]);
+}
+
+// ── Workload 3: sliding-window eviction ──────────────────────────────────
+//
+// WINDOW_EXPIRED buckets have aged out; $n buckets are retained. The expired
+// slice is CONSTANT, so the reported cost is purely a function of how much
+// the implementation has to touch that it is going to keep.
+
+function childWindow(string $impl, int $n): int
+{
+    $cutoff = WINDOW_EXPIRED - 1;
+    $total  = WINDOW_EXPIRED + $n;
+
+    switch ($impl) {
+        case 'judy':
+            $w = new Judy(Judy::INT_TO_INT);
+            for ($i = 0; $i < $total; $i++) {
+                $w[$i] = 1;
+            }
+            $t0      = hrtime(true);
+            $evicted = $w->deleteRange(0, $cutoff);
+            $elapsed = hrtime(true) - $t0;
+            $left    = count($w);
+            break;
+
+        case 'array-filter':
+            $w = [];
+            for ($i = 0; $i < $total; $i++) {
+                $w[$i] = 1;
+            }
+            $t0      = hrtime(true);
+            $w       = array_filter($w, static fn ($k) => $k > $cutoff, ARRAY_FILTER_USE_KEY);
+            $elapsed = hrtime(true) - $t0;
+            $evicted = $total - count($w);
+            $left    = count($w);
+            break;
+
+        default: // array-scan: the hand-written foreach most code actually has
+            $w = [];
+            for ($i = 0; $i < $total; $i++) {
+                $w[$i] = 1;
+            }
+            $t0      = hrtime(true);
+            $evicted = 0;
+            foreach (array_keys($w) as $k) {
+                if ($k <= $cutoff) {
+                    unset($w[$k]);
+                    $evicted++;
+                }
+            }
+            $elapsed = hrtime(true) - $t0;
+            $left    = count($w);
+    }
+
+    return emit([
+        'metric'  => $elapsed / 1e3, // µs for one eviction pass
+        'evicted' => (int) $evicted,
+        'left'    => $left,
+    ]);
+}
+
+// ── Workload 4: floor / CIDR lookup ──────────────────────────────────────
+//
+// n non-overlapping ranges keyed by start address. Resolve an address to its
+// range: the greatest start <= addr. Judy does it with last(); the honest
+// alternative is a sorted array of starts plus a userland binary search.
+//
+// This is the row most likely to go against Judy, and it reports build and
+// update cost precisely because that is where the two diverge most.
+
+function floorStarts(int $n): array
+{
+    // Ranges of width 16-271, laid out in ascending order with gaps.
+    mt_srand(7);
+    $starts = [];
+    $ends   = [];
+    $addr   = 0;
+    for ($i = 0; $i < $n; $i++) {
+        $width    = 16 + mt_rand(0, 255);
+        $starts[] = $addr;
+        $ends[]   = $addr + $width - 1;
+        $addr    += $width + mt_rand(0, 32);
+    }
+
+    return [$starts, $ends, $addr];
+}
+
+function childFloor(string $impl, int $n): int
+{
+    [$starts, $ends, $span] = floorStarts($n);
+
+    // Build.
+    $t0 = hrtime(true);
+    if ($impl === 'judy') {
+        $r = new Judy(Judy::INT_TO_MIXED);
+        for ($i = 0; $i < $n; $i++) {
+            $r[$starts[$i]] = [$ends[$i], $i];
+        }
+    } else {
+        // Ranges arrive unsorted in the real world; the sorted-array index has
+        // to pay for ordering them. Judy's insert pays for it incrementally.
+        $sStart = $starts;
+        $sEnd   = $ends;
+        array_multisort($sStart, $sEnd);
+    }
+    $tBuild = hrtime(true) - $t0;
+
+    // Lookup.
+    mt_srand(99);
+    $matched = 0;
+    $t0      = hrtime(true);
+    if ($impl === 'judy') {
+        for ($p = 0; $p < FLOOR_PROBES; $p++) {
+            $addr  = mt_rand(0, $span - 1);
+            $start = $r->last($addr);
+            if ($start !== null && $r[$start][0] >= $addr) {
+                $matched++;
+            }
+        }
+    } else {
+        $hi0 = $n - 1;
+        for ($p = 0; $p < FLOOR_PROBES; $p++) {
+            $addr = mt_rand(0, $span - 1);
+            $lo   = 0;
+            $hi   = $hi0;
+            $found = -1;
+            while ($lo <= $hi) {
+                $mid = ($lo + $hi) >> 1;
+                if ($sStart[$mid] <= $addr) {
+                    $found = $mid;
+                    $lo    = $mid + 1;
+                } else {
+                    $hi = $mid - 1;
+                }
+            }
+            if ($found >= 0 && $sEnd[$found] >= $addr) {
+                $matched++;
+            }
+        }
+    }
+    $tLookup = hrtime(true) - $t0;
+
+    // Incremental update: insert FLOOR_UPDATES new ranges, keeping the index
+    // queryable. Judy takes the write directly; the sorted array must splice.
+    mt_srand(123);
+    $t0 = hrtime(true);
+    if ($impl === 'judy') {
+        for ($u = 0; $u < FLOOR_UPDATES; $u++) {
+            $addr     = mt_rand(0, $span - 1);
+            $r[$addr] = [$addr + 8, -1];
+        }
+    } else {
+        for ($u = 0; $u < FLOOR_UPDATES; $u++) {
+            $addr = mt_rand(0, $span - 1);
+            $lo   = 0;
+            $hi   = count($sStart) - 1;
+            while ($lo <= $hi) {
+                $mid = ($lo + $hi) >> 1;
+                if ($sStart[$mid] < $addr) {
+                    $lo = $mid + 1;
+                } else {
+                    $hi = $mid - 1;
+                }
+            }
+            array_splice($sStart, $lo, 0, [$addr]);
+            array_splice($sEnd, $lo, 0, [$addr + 8]);
+        }
+    }
+    $tUpdate = hrtime(true) - $t0;
+
+    return emit([
+        'metric'    => $tLookup / FLOOR_PROBES,          // ns per lookup (primary)
+        'build_ms'  => $tBuild / 1e6,
+        'update_us' => $tUpdate / 1e3 / FLOOR_UPDATES,
+        'matched'   => $matched,
+    ]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Parent: statistics
+// ─────────────────────────────────────────────────────────────────────────
+
+function median(array $xs): float
+{
+    sort($xs);
+    $c = count($xs);
+
+    return $c % 2 ? (float) $xs[intdiv($c, 2)] : ($xs[$c / 2 - 1] + $xs[$c / 2]) / 2;
+}
+
+/**
+ * 95% percentile-bootstrap CI for the median.
+ *
+ * A single run is not a measurement; a point estimate without a CI cannot be
+ * compared against another point estimate. Seeded so re-deriving the stats
+ * from the same samples reproduces the same interval.
+ *
+ * @return array{0:float,1:float}
+ */
+function medianCi(array $xs, int $resamples = 2000): array
+{
+    $n = count($xs);
+    if ($n < 3) {
+        return [(float) min($xs), (float) max($xs)];
+    }
+    mt_srand(20260815);
+    $meds = [];
+    for ($b = 0; $b < $resamples; $b++) {
+        $s = [];
+        for ($i = 0; $i < $n; $i++) {
+            $s[] = $xs[mt_rand(0, $n - 1)];
+        }
+        $meds[] = median($s);
+    }
+    sort($meds);
+
+    return [$meds[(int) floor(0.025 * $resamples)], $meds[(int) ceil(0.975 * $resamples) - 1]];
+}
+
+/** Two cells separate only when their CIs do not overlap. */
+function separated(array $a, array $b): bool
+{
+    return $a[1] < $b[0] || $b[1] < $a[0];
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Parent: execution
+// ─────────────────────────────────────────────────────────────────────────
+
+$workload = $argv[1] ?? 'all';
+$runs     = max(3, (int) ($argv[2] ?? 7));
+
+if (!extension_loaded('judy')) {
+    fwrite(STDERR, "The judy extension is not loaded. Run with:\n");
+    fwrite(STDERR, "  php -d extension=\$PWD/modules/judy.so " . basename(__FILE__) . "\n");
+    exit(1);
+}
+
+$apcu = apcuUsable();
+$self = escapeshellarg(__FILE__);
+$ini  = '-d memory_limit=-1';
+
+// Children must load the same extension the parent did. When judy came from
+// `-d extension=...` rather than php.ini, that flag is not inherited, so pass
+// it along: $JUDY_SO if set (same convention as examples/dedup-large-stream.php),
+// otherwise the module built in this checkout.
+if (trim((string) shell_exec(PHP_BINARY . ' -r "echo (int)extension_loaded(\'judy\');"')) !== '1') {
+    $so = getenv('JUDY_SO') ?: __DIR__ . '/../../modules/judy.so';
+    if (!is_file($so)) {
+        fwrite(STDERR, "Cannot find judy.so for child processes. Set JUDY_SO=/path/to/judy.so\n");
+        exit(1);
+    }
+    $ini .= ' -d extension=' . escapeshellarg($so);
+}
+if (extension_loaded('apcu')) {
+    // Child processes need the same APCu settings; a CLI child gets its own
+    // segment, which is why these numbers are single-process on both sides.
+    $ini .= ' -d apc.enable_cli=1';
+    $shm = (string) ini_get('apc.shm_size');
+    if ($shm !== '') {
+        $ini .= ' -d apc.shm_size=' . escapeshellarg($shm);
+    }
+}
+
+/**
+ * Run one cell $runs times. Returns null (and warns once) if the child fails.
+ *
+ * @return array{metric:array<float>,rss:array<float>,extra:array<string,array<float>>}|null
+ */
+function cell(string $workload, string $impl, int $n, int $arg, int $runs): ?array
+{
+    global $self, $ini;
+
+    $metric = [];
+    $rss    = [];
+    $extra  = [];
+    for ($r = 0; $r < $runs; $r++) {
+        $cmd = PHP_BINARY . " $ini $self --child $workload $impl $n $arg 2>/dev/null";
+        $j   = json_decode(trim((string) shell_exec($cmd)), true);
+        if (!is_array($j) || !isset($j['metric'])) {
+            return null;
+        }
+        $metric[] = (float) $j['metric'];
+        $rss[]    = $j['peak_rss'] / 1048576;
+        foreach ($j as $k => $v) {
+            if ($k !== 'metric' && $k !== 'peak_rss' && is_numeric($v)) {
+                $extra[$k][] = (float) $v;
+            }
+        }
+    }
+
+    return ['metric' => $metric, 'rss' => $rss, 'extra' => $extra];
+}
+
+function fmtCi(array $ci, string $unit = ''): string
+{
+    $f = static fn (float $v): string => $v >= 1000
+        ? number_format($v, 0)
+        : ($v >= 10 ? number_format($v, 1) : number_format($v, 2));
+
+    return '[' . $f($ci[0]) . '..' . $f($ci[1]) . ']' . $unit;
+}
+
+/** Horizontal log-scale ASCII bars — a committed plot beats a binary image. */
+function asciiBars(array $series, string $unit, int $width = 46): array
+{
+    $max = 0.0;
+    $min = INF;
+    foreach ($series as $rows) {
+        foreach ($rows as $v) {
+            $max = max($max, $v);
+            $min = min($min, $v);
+        }
+    }
+    if ($max <= 0) {
+        return [];
+    }
+    $lo    = log10(max($min, $max / 1e6));
+    $hi    = log10($max);
+    $range = max($hi - $lo, 0.5);
+
+    $out = [];
+    foreach ($series as $label => $rows) {
+        $out[] = $label;
+        foreach ($rows as $name => $v) {
+            $len = (int) round($width * (log10(max($v, 1e-9)) - $lo) / $range);
+            $len = max(1, min($width, $len));
+            $out[] = sprintf(
+                '    %-12s %-' . $width . 's %s%s',
+                $name,
+                str_repeat('#', $len),
+                $v >= 1000 ? number_format($v, 0) : number_format($v, 1),
+                $unit,
+            );
+        }
+        $out[] = '';
+    }
+    $out[] = sprintf('    (log scale, %s .. %s%s)', number_format(10 ** $lo, 1), number_format($max, 1), $unit);
+
+    return $out;
+}
+
+echo "# Judy vs the alternatives\n\n";
+printf(
+    "PHP %s | judy %s | apcu %s | %s %s | %d runs/cell, median [95%% bootstrap CI]\n",
+    PHP_VERSION,
+    judy_version(),
+    $apcu ? phpversion('apcu') : 'ABSENT',
+    PHP_OS,
+    php_uname('m'),
+    $runs,
+);
+if (!$apcu) {
+    echo "\n";
+    echo "NOTE: APCu rows are skipped. ext-apcu is " .
+        (extension_loaded('apcu') ? "loaded but apc.enable_cli is off" : "not installed") . ".\n";
+    echo "      Install it and re-run with -d apc.enable_cli=1 -d apc.shm_size=1024M\n";
+    echo "      for the APCu comparison; everything else below still runs.\n";
+}
+echo "\n";
+echo "APCu is shared across every PHP-FPM worker in a pool; Judy is per process.\n";
+echo "These numbers compare latency in one process and say nothing about that gap.\n";
+
+$want = static fn (string $w): bool => $workload === 'all' || $workload === $w;
+
+// ── 1. Prefix invalidation ───────────────────────────────────────────────
+
+if ($want('prefix')) {
+    $sizes  = [10_000, 30_000, 100_000, 300_000, 1_000_000];
+    $impls  = ['judy', 'judy-hash', 'array'];
+    if ($apcu) {
+        $impls[] = 'apcu';
+    }
+
+    echo "\n\n## 1. Prefix invalidation vs total cache size\n\n";
+    printf(
+        "Drop one %d-key group (`user.<uid>.*`) from a store of n entries.\n",
+        PREFIX_GROUP,
+    );
+    echo "The group size is constant at every n, so growth in this column is\n";
+    echo "growth in the cost of FINDING the group.\n\n";
+    printf("| %-9s | %-24s | %-24s | %-24s | %-24s |\n", 'n', 'judy (µs)', 'judy-hash (µs)', 'array (µs)', 'apcu (µs)');
+    echo "|-----------|--------------------------|--------------------------|--------------------------|--------------------------|\n";
+
+    $curve = [];
+    $cis   = [];
+    foreach ($sizes as $n) {
+        $cols = [];
+        foreach (['judy', 'judy-hash', 'array', 'apcu'] as $impl) {
+            if (!in_array($impl, $impls, true)) {
+                $cols[] = 'n/a';
+                continue;
+            }
+            $c = cell('prefix', $impl, $n, 0, $runs);
+            if ($c === null) {
+                $cols[] = 'FAILED';
+                continue;
+            }
+            $m  = median($c['metric']);
+            $ci = medianCi($c['metric']);
+            $curve[number_format($n) . ' entries'][$impl] = $m;
+            $cis[$n][$impl] = $ci;
+            $cols[] = sprintf('%s %s', $m >= 100 ? number_format($m, 0) : number_format($m, 2), fmtCi($ci));
+        }
+        printf("| %-9s | %-24s | %-24s | %-24s | %-24s |\n", number_format($n), ...$cols);
+    }
+
+    echo "\n";
+    foreach (asciiBars($curve, 'µs') as $line) {
+        echo $line, "\n";
+    }
+
+    // Gate: publish the complexity-class claim only if the CIs separate at
+    // every size in the sweep.
+    echo "\n### Separation check (CI lower bound, every size in the sweep)\n\n";
+    foreach (['array', 'apcu', 'judy-hash'] as $rival) {
+        if (!in_array($rival, $impls, true)) {
+            continue;
+        }
+        $allSep = true;
+        $ratios = [];
+        foreach ($sizes as $n) {
+            if (!isset($cis[$n]['judy'], $cis[$n][$rival])) {
+                $allSep = false;
+                continue;
+            }
+            if (!separated($cis[$n]['judy'], $cis[$n][$rival])) {
+                $allSep = false;
+            }
+            $ratios[] = $curve[number_format($n) . ' entries'][$rival]
+                / max($curve[number_format($n) . ' entries']['judy'], 1e-9);
+        }
+        if (!$ratios) {
+            continue;
+        }
+        printf(
+            "- judy vs %-10s %s — advantage %.0fx at n=%s, %.0fx at n=%s%s\n",
+            $rival . ':',
+            $allSep ? 'SEPARATED at every size' : 'NOT separated at every size',
+            $ratios[0],
+            number_format($sizes[0]),
+            end($ratios),
+            number_format(end($sizes)),
+            $allSep ? '' : ' (do not publish a delta for the overlapping sizes)',
+        );
+    }
+    echo "\nScaling of each backend across the sweep (last/first, n grew "
+        . (int) (end($sizes) / $sizes[0]) . "x):\n";
+    foreach ($impls as $impl) {
+        $first = $curve[number_format($sizes[0]) . ' entries'][$impl] ?? null;
+        $last  = $curve[number_format(end($sizes)) . ' entries'][$impl] ?? null;
+        if ($first === null || $last === null) {
+            continue;
+        }
+        printf("- %-10s %.1fx  (%s)\n", $impl, $last / $first, $last / $first < 3 ? 'flat' : 'grows with cache size');
+    }
+}
+
+// ── 2. Presence / dedup ──────────────────────────────────────────────────
+
+if ($want('presence')) {
+    // [n, spread] — spread 1 is a dense ID set, 8 is sparse with gaps.
+    $cells = [[1_000_000, 1], [1_000_000, 8], [10_000_000, 1]];
+
+    // Measure the interpreter's own RSS so the memory column is readable as
+    // "floor + structure" rather than an opaque absolute number.
+    $base  = cell('presence', 'baseline', 0, 0, 3);
+    $floor = $base === null ? 0.0 : median($base['rss']);
+
+    echo "\n\n## 2. Presence / dedup sets\n\n";
+    echo "Peak RSS is the whole process, from getrusage() in a child, because Judy\n";
+    echo "allocates outside PHP's memory manager. The 'over floor' column subtracts\n";
+    printf("the measured empty-interpreter baseline (%.1f MB).\n", $floor);
+    echo "SplFixedArray must allocate the whole key space, so it tracks density, not\n";
+    echo "element count. APCu is skipped at 10M (its shm segment cannot hold it).\n\n";
+    printf(
+        "| %-12s | %-9s | %-13s | %-14s | %-19s | %-19s |\n",
+        'cell', 'impl', 'peak RSS (MB)', 'over floor', 'insert kops/s', 'lookup kops/s',
+    );
+    echo "|--------------|-----------|---------------|----------------|---------------------|---------------------|\n";
+
+    foreach ($cells as [$n, $spread]) {
+        $label = sprintf('%sM %s', $n / 1_000_000, $spread === 1 ? 'dense' : 'sparse');
+        $impls = ['judy', 'array', 'splfixed'];
+        if ($apcu && $n <= 1_000_000) {
+            $impls[] = 'apcu';
+        }
+        foreach ($impls as $impl) {
+            $c = cell('presence', $impl, $n, $spread, $runs);
+            if ($c === null) {
+                printf("| %-12s | %-9s | %-74s |\n", $label, $impl, 'FAILED (memory limit? shm size?)');
+                continue;
+            }
+            printf(
+                "| %-12s | %-9s | %5.0f %-7s | %11.1f MB | %6.0f %-12s | %6.0f %-12s |\n",
+                $label,
+                $impl,
+                median($c['rss']),
+                fmtCi(medianCi($c['rss'])),
+                max(0.0, median($c['rss']) - $floor),
+                median($c['metric']),
+                fmtCi(medianCi($c['metric'])),
+                median($c['extra']['lookup_kops']),
+                fmtCi(medianCi($c['extra']['lookup_kops'])),
+            );
+        }
+    }
+}
+
+// ── 3. Sliding-window eviction ───────────────────────────────────────────
+
+if ($want('window')) {
+    $sizes = [10_000, 100_000, 1_000_000];
+    echo "\n\n## 3. Sliding-window eviction vs retained-set size\n\n";
+    printf(
+        "%s expired buckets are dropped in every cell; only the RETAINED set grows.\n",
+        number_format(WINDOW_EXPIRED),
+    );
+    echo "A cost that grows with the retained column is a cost paid for data being kept.\n\n";
+    printf("| %-9s | %-24s | %-24s | %-24s |\n", 'retained', 'judy deleteRange (µs)', 'array-scan (µs)', 'array_filter (µs)');
+    echo "|-----------|--------------------------|--------------------------|--------------------------|\n";
+
+    $curve = [];
+    $cis   = [];
+    foreach ($sizes as $n) {
+        $cols = [];
+        foreach (['judy', 'array-scan', 'array-filter'] as $impl) {
+            $c = cell('window', $impl, $n, 0, $runs);
+            if ($c === null) {
+                $cols[] = 'FAILED';
+                continue;
+            }
+            $m = median($c['metric']);
+            $curve[number_format($n) . ' retained'][$impl] = $m;
+            $cis[$n][$impl] = medianCi($c['metric']);
+            $cols[] = sprintf('%s %s', number_format($m, $m >= 100 ? 0 : 2), fmtCi($cis[$n][$impl]));
+        }
+        printf("| %-9s | %-24s | %-24s | %-24s |\n", number_format($n), ...$cols);
+    }
+    echo "\n";
+    foreach (asciiBars($curve, 'µs') as $line) {
+        echo $line, "\n";
+    }
+    // Direction matters more than separation here: Judy's cost is flat, so the
+    // two curves cross somewhere and the winner changes with retained size.
+    echo "\n";
+    foreach (['array-scan', 'array-filter'] as $rival) {
+        foreach ($sizes as $n) {
+            if (!isset($cis[$n]['judy'], $cis[$n][$rival])) {
+                continue;
+            }
+            $j = $cis[$n]['judy'];
+            $r = $cis[$n][$rival];
+            printf(
+                "- retained=%-9s judy vs %-13s %s\n",
+                number_format($n),
+                $rival . ':',
+                !separated($j, $r)
+                    ? 'no measured separation (CIs overlap)'
+                    : ($j[1] < $r[0] ? 'judy wins' : $rival . ' wins'),
+            );
+        }
+    }
+}
+
+// ── 4. Floor / CIDR lookup ───────────────────────────────────────────────
+
+if ($want('floor')) {
+    $sizes = [10_000, 100_000, 1_000_000];
+    echo "\n\n## 4. Floor lookup: Judy last() vs sorted array + binary search\n\n";
+    echo "The comparison Judy is least likely to win. Binary search over a packed\n";
+    echo "sorted array is genuinely good at static range tables; the question is\n";
+    echo "what happens when the table changes.\n\n";
+    printf(
+        "| %-9s | %-12s | %-21s | %-15s | %-21s |\n",
+        'ranges', 'impl', 'lookup (ns/op)', 'build (ms)', 'insert (µs/range)',
+    );
+    echo "|-----------|--------------|-----------------------|-----------------|-----------------------|\n";
+
+    $cis = [];
+    foreach ($sizes as $n) {
+        foreach (['judy', 'sorted-array'] as $impl) {
+            $c = cell('floor', $impl, $n, 0, $runs);
+            if ($c === null) {
+                printf("| %-9s | %-12s | %-63s |\n", number_format($n), $impl, 'FAILED');
+                continue;
+            }
+            $cis[$n][$impl] = ['lookup' => medianCi($c['metric']), 'update' => medianCi($c['extra']['update_us'])];
+            printf(
+                "| %-9s | %-12s | %5.0f %-15s | %6.1f %-8s | %7.2f %-13s |\n",
+                number_format($n),
+                $impl,
+                median($c['metric']),
+                fmtCi(medianCi($c['metric'])),
+                median($c['extra']['build_ms']),
+                fmtCi(medianCi($c['extra']['build_ms'])),
+                median($c['extra']['update_us']),
+                fmtCi(medianCi($c['extra']['update_us'])),
+            );
+        }
+    }
+    echo "\n";
+    foreach ($sizes as $n) {
+        if (!isset($cis[$n]['judy'], $cis[$n]['sorted-array'])) {
+            continue;
+        }
+        foreach (['lookup', 'update'] as $metric) {
+            $j = $cis[$n]['judy'][$metric];
+            $s = $cis[$n]['sorted-array'][$metric];
+            if (!separated($j, $s)) {
+                printf("- n=%-9s %-6s no measured separation (CIs overlap)\n", number_format($n), $metric);
+                continue;
+            }
+            printf(
+                "- n=%-9s %-6s %s wins\n",
+                number_format($n),
+                $metric,
+                $j[1] < $s[0] ? 'judy' : 'sorted-array',
+            );
+        }
+    }
+}
+
+echo "\n\n---\n\n";
+echo "Reminders for anyone quoting these numbers:\n";
+echo "- APCu is shared across FPM workers; Judy is per process. A per-process\n";
+echo "  latency win is not a reason to drop a shared cache.\n";
+echo "- Redis/Memcached are excluded on purpose: their cost includes IPC or\n";
+echo "  network round-trips against an in-process structure.\n";
+echo "- Timings are only meaningful from an idle machine. Check load average\n";
+echo "  before and between runs and disclose it alongside the numbers.\n";

--- a/examples/prefix-invalidation.php
+++ b/examples/prefix-invalidation.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Prefix-scoped invalidation over namespaced keys ("user:123:*").
+ *
+ * Ordered string keys put every key sharing a prefix next to each other, so
+ * dropping a namespace means walking that slice and nothing else: seek to the
+ * prefix with first(), then searchNext() until the prefix stops matching.
+ *
+ * A hash table has no such adjacency. Invalidating a namespace there means
+ * testing every key in the store, so the cost tracks total cache size rather
+ * than the number of keys actually being dropped — the reason APCu's
+ * regex-based invalidation scales linearly with the whole keyspace.
+ *
+ * This is the pattern behind orieg/judy-cache's deletePrefix().
+ *
+ * Run: php examples/prefix-invalidation.php
+ */
+
+if (!extension_loaded('judy')) {
+    fwrite(STDERR, "The judy extension is not loaded.\n");
+    exit(1);
+}
+
+/**
+ * Delete every key starting with $prefix. Returns [deleted, keysVisited].
+ *
+ * @return array{0:int,1:int}
+ */
+function deletePrefix(Judy $store, string $prefix): array
+{
+    $deleted = 0;
+    $visited = 0;
+
+    for (
+        $key = $store->first($prefix);                       // seek straight to the slice
+        $key !== null && str_starts_with($key, $prefix);     // stop at the first non-match
+        $key = $store->searchNext($key)
+    ) {
+        $visited++;
+        unset($store[$key]);
+        $deleted++;
+    }
+
+    return [$deleted, $visited + 1]; // +1 for the key that ended the walk
+}
+
+/** The same operation on a hash table: every key must be tested. */
+function deletePrefixArray(array &$store, string $prefix): array
+{
+    $deleted = 0;
+    $visited = 0;
+
+    foreach (array_keys($store) as $key) {
+        $visited++;
+        if (str_starts_with($key, $prefix)) {
+            unset($store[$key]);
+            $deleted++;
+        }
+    }
+
+    return [$deleted, $visited];
+}
+
+// Build a cache holding many tenants, one of which we will invalidate.
+const TENANTS      = 2000;
+const KEYS_PER_USER = 5;
+
+$judy  = new Judy(Judy::STRING_TO_MIXED);
+$array = [];
+
+for ($u = 0; $u < TENANTS; $u++) {
+    foreach (['profile', 'settings', 'avatar', 'sessions', 'flags'] as $field) {
+        $key = sprintf('user:%d:%s', $u, $field);
+        $judy[$key] = $field;
+        $array[$key] = $field;
+    }
+}
+
+printf("cache holds %d keys across %d tenants\n\n", count($judy), TENANTS);
+
+// Invalidate a single tenant's namespace.
+$prefix = 'user:1234:';
+
+[$jDeleted, $jVisited] = deletePrefix($judy, $prefix);
+[$aDeleted, $aVisited] = deletePrefixArray($array, $prefix);
+
+printf("invalidating %s\n", $prefix);
+printf("  Judy   deleted=%d  keys visited=%d\n", $jDeleted, $jVisited);
+printf("  array  deleted=%d  keys visited=%d\n", $aDeleted, $aVisited);
+printf(
+    "\nJudy touched %.2f%% of the store; the hash table touched 100%%.\n",
+    $jVisited / (TENANTS * KEYS_PER_USER) * 100,
+);
+echo "That ratio is the whole point: Judy's cost follows the slice being\n";
+echo "dropped, the hash table's follows the cache size.\n";
+
+// Range reads work the same way — list a namespace without scanning.
+$listed = [];
+for (
+    $key = $judy->first('user:7:');
+    $key !== null && str_starts_with($key, 'user:7:');
+    $key = $judy->searchNext($key)
+) {
+    $listed[] = $key;
+}
+printf("\nkeys under user:7: -> %s\n", implode(', ', $listed));

--- a/examples/sliding-window-rate-limit.php
+++ b/examples/sliding-window-rate-limit.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Sliding-window rate limiting with ordered timestamp keys.
+ *
+ * Bucket hits by millisecond and let the key order do the expiry work:
+ * deleteRange() drops everything older than the window in one call, touching
+ * only the expired keys. A hash table has to scan every entry to find which
+ * ones aged out, so its eviction cost grows with the whole keyset rather than
+ * with the number of expired buckets.
+ *
+ * The same evict-then-measure shape works for sliding-window metrics in a
+ * long-running worker (Swoole/RoadRunner/FrankenPHP): p95 buffers, rolling
+ * error counts, per-tenant quotas.
+ *
+ * Run: php examples/sliding-window-rate-limit.php
+ */
+
+if (!extension_loaded('judy')) {
+    fwrite(STDERR, "The judy extension is not loaded.\n");
+    exit(1);
+}
+
+final class SlidingWindow
+{
+    /** Millisecond timestamp => hits in that millisecond. */
+    private Judy $hits;
+
+    public function __construct(
+        private readonly int $limit,
+        private readonly int $windowMs,
+    ) {
+        $this->hits = new Judy(Judy::INT_TO_INT);
+    }
+
+    /**
+     * Record a hit at $nowMs and report whether the caller is still under quota.
+     */
+    public function allow(int $nowMs): bool
+    {
+        // Evict the tail of the window. Only expired buckets are visited.
+        $cutoff = $nowMs - $this->windowMs;
+        if ($cutoff > 0) {
+            $this->hits->deleteRange(0, $cutoff);
+        }
+
+        // Same-millisecond hits collapse into one bucket via atomic increment.
+        $this->hits->increment($nowMs);
+
+        return $this->count() <= $this->limit;
+    }
+
+    /** Hits currently inside the window (everything left after eviction). */
+    public function count(): int
+    {
+        return (int) $this->hits->sumValues();
+    }
+
+    /** Distinct millisecond buckets retained — the real memory footprint. */
+    public function buckets(): int
+    {
+        return count($this->hits);
+    }
+
+    /** When the oldest retained hit falls out of the window. */
+    public function resetsAtMs(): ?int
+    {
+        $oldest = $this->hits->first();
+
+        return $oldest === null ? null : $oldest + $this->windowMs;
+    }
+}
+
+// 5 requests per second, arriving 150ms apart: the 6th trips the limit, and
+// the window slides open again once the earliest hit ages out.
+$window = new SlidingWindow(limit: 5, windowMs: 1000);
+
+$t0 = 1_700_000_000_000;
+foreach (range(0, 9) as $i) {
+    $now = $t0 + $i * 150;
+    $ok  = $window->allow($now);
+
+    printf(
+        "t=%4dms  %-7s  in-window=%d  buckets=%d\n",
+        $now - $t0,
+        $ok ? 'allow' : 'BLOCK',
+        $window->count(),
+        $window->buckets(),
+    );
+}
+
+$resets = $window->resetsAtMs();
+printf("\nwindow resets at t=%dms\n", $resets === null ? 0 : $resets - $t0);
+
+// Eviction cost tracks the expired slice, not the retained set: jumping far
+// past the window drops every bucket in a single ranged delete.
+$far = $t0 + 60_000;
+$window->allow($far);
+printf("after a %ds idle gap: in-window=%d, buckets=%d\n", 60, $window->count(), $window->buckets());

--- a/llms.txt
+++ b/llms.txt
@@ -25,9 +25,27 @@ show a removed API; trust the docs below instead).
 
 ## Examples
 
+Runnable, self-contained scripts — one per pattern Judy is chosen for.
+
 - [examples/README.md](https://github.com/orieg/php-judy/blob/main/examples/README.md):
-  runnable demos — dedup seen-sets, autocomplete prefix search, worker
-  counters, IP-range floor lookup
+  index of all demos, with the Judy type each one uses
+- [quickstart.php](https://github.com/orieg/php-judy/blob/main/examples/quickstart.php):
+  the essentials — array access, iteration, navigation, bulk ops
+- [dedup-large-stream.php](https://github.com/orieg/php-judy/blob/main/examples/dedup-large-stream.php):
+  "have I seen this ID?" membership over millions of keys (crawler frontiers,
+  queue dedup) with a peak-RSS comparison of array vs Judy vs `BITSET`
+- [ip-range-lookup.php](https://github.com/orieg/php-judy/blob/main/examples/ip-range-lookup.php):
+  floor lookup via `last()` — IP-to-CIDR matching, tariff bands, ID shards
+- [sliding-window-rate-limit.php](https://github.com/orieg/php-judy/blob/main/examples/sliding-window-rate-limit.php):
+  sliding-window rate limiting and rolling metrics; `deleteRange()` expires
+  aged-out time buckets without scanning the retained set
+- [prefix-invalidation.php](https://github.com/orieg/php-judy/blob/main/examples/prefix-invalidation.php):
+  namespace invalidation (`user:123:*`) walking only the matching key slice,
+  with a keys-visited comparison against a hash table
+- [autocomplete-trie.php](https://github.com/orieg/php-judy/blob/main/examples/autocomplete-trie.php):
+  prefix search / typeahead via `first()` + `searchNext()`
+- [worker-counters.php](https://github.com/orieg/php-judy/blob/main/examples/worker-counters.php):
+  metrics accumulators in long-running workers with atomic `increment()`
 
 ## Contributing
 

--- a/package.xml
+++ b/package.xml
@@ -69,6 +69,7 @@
          <file name="examples/benchmarks/iterator-vs-sequential-test.php" role="doc" />
          <file name="examples/benchmarks/iterator_performance_analysis.md" role="doc" />
          <file name="examples/benchmarks/judy-bench-all-types.php" role="doc" />
+         <file name="examples/benchmarks/judy-bench-alternatives.php" role="doc" />
          <file name="examples/benchmarks/judy-bench-batch-operations.php" role="doc" />
          <file name="examples/benchmarks/judy-bench-bitset.php" role="doc" />
          <file name="examples/benchmarks/judy-bench-compare.php" role="doc" />

--- a/package.xml
+++ b/package.xml
@@ -285,6 +285,7 @@
          <file name="scripts/generate-api-docs.php" role="doc" />
          <file md5sum="513b0c0813de66e8cba534d4fa1b0eb2" name="MIGRATION_2.2.0.md" role="doc" />
          <file md5sum="366b0129d18f1e9b38f1712590805903" name="Dockerfile" role="doc" />
+         <file name="Dockerfile.alpine" role="doc" />
       </dir>
    </contents>
    <dependencies>

--- a/package.xml
+++ b/package.xml
@@ -59,6 +59,8 @@
          <file name="examples/autocomplete-trie.php" role="doc" />
          <file name="examples/worker-counters.php" role="doc" />
          <file name="examples/ip-range-lookup.php" role="doc" />
+         <file name="examples/sliding-window-rate-limit.php" role="doc" />
+         <file name="examples/prefix-invalidation.php" role="doc" />
          <file name="examples/benchmarks/benchmark_ordered_data.php" role="doc" />
          <file name="examples/benchmarks/benchmark_ordered_data_demo.php" role="doc" />
          <file name="examples/benchmarks/benchmark_range_queries.php" role="doc" />


### PR DESCRIPTION
Adoption-facing work split out of the #83 research branch. The spike's C prototypes stay on that branch; nothing here depends on them.

## 1. Two new examples

`examples/` had no runnable demo for two of the patterns Judy is actually chosen for:

- **`sliding-window-rate-limit.php`** — `deleteRange()` expiry over millisecond buckets, visiting only aged-out keys.
- **`prefix-invalidation.php`** — namespace drop (`user:123:*`) via `first()` + `searchNext()`, mirroring judy-cache's `deletePrefix()`. Prints keys-visited against an equivalent hash-table scan: **6 vs 10,000** at a 10k-key store, so the cost model is visible rather than asserted.

## 2. Alpine/musl CI

Most containerized PHP runs on Alpine, and a clean glibc build does not imply a clean musl one. Verified before wiring up: builds warning-free and passes **188/188 tests** on Alpine 3.24 with libJudy from the community repo.

The job shells out to Docker from a glibc runner rather than using a `container:` job — GitHub's node runtime for `actions/checkout` is glibc-linked and will not execute inside an Alpine container. `Dockerfile.alpine` carries the same compiler-warning gate as `build-linux`.

> Verified locally on **aarch64 only**. This PR is the first time it runs on x86_64.

## 3. Examples indexed by problem

The demos were reachable only through a stale one-line pointer in each entry-point doc — README's Support section and `llms.txt` both still listed four demos by name, omitting `quickstart` and the two new ones. So a reader or crawler landing on the README saw type-by-type syntax snippets and no use cases.

- **README**: a "What people use it for" table under *Why PHP Judy?*, mapping problem → reason → demo.
- **llms.txt**: every demo deep-linked with the problem it solves.
- **AGENTS.md**: each demo named with its pattern, so an agent picks the idiomatic shape.

## 4. "Versus the alternatives" benchmarks

BENCHMARK.md compared Judy against native PHP arrays — the right *when not to use Judy* guide, but not the choice anyone is making. Adds `examples/benchmarks/judy-bench-alternatives.php`: four workloads against APCu, `SplFixedArray`, and a hand-rolled sorted index.

Every cell runs in a fresh child process, 7 runs, median with 95% percentile-bootstrap CI. **A delta is only reported when the two CIs do not overlap**; otherwise the harness prints "no measured separation".

| Workload | Result |
| --- | --- |
| Prefix invalidation | **4,212x** over APCu at 1M entries — flat (1.5x across a 100x sweep) vs linear |
| Presence / dedup memory | **321x** — `BITSET` 0.8 MB vs 257 MB at 10M dense |
| Sliding-window eviction | Judy above ~10k retained (18x at 1M); **array scan wins at 10k** |
| Floor / CIDR lookup | 1.3-2.8x on lookup; ~85,000x on insert at 1M |

Deliberately not flattering, because a suite of only wins is not trustworthy:

- **`judy-hash` is in the prefix table and loses as badly as APCu** (168x scaling). The advantage belongs to *ordered keys*, not to Judy.
- **Insert favors PHP arrays and `SplFixedArray` when dense**; Judy wins insert only when sparse.
- **Dedup lookup ties at 1M** — the three in-process structures are within ~15%; Judy's 2.1x lead appears only at 10M when the working set escapes cache.
- **Array scan beats `deleteRange()` at 10k retained.**
- **Redis/Memcached excluded on purpose** — their numbers carry IPC or network cost against an in-process structure.

The APCu shared-across-workers vs Judy per-process gap is a blockquoted warning immediately above the tables, not a footnote: a per-process latency win is not a reason to drop a shared cache.

### Measurement environment

Measured on a dedicated idle 24-core x86_64 Linux box (load `2.26/0.69/0.24` before, `1.07` after, threshold 12.0).

An earlier sweep on a contended aarch64 laptop was **discarded**. It agreed on workloads 1 and 2 but failed to replicate workload 4 and put workload 3's crossover in the wrong place — both understating Judy. That is recorded in the doc, along with a reproduction recipe (bench Dockerfile with APCu + the load-check procedure).

## Notes for review

- `baselines/latest.json` untouched — per repo convention, baselines move in dedicated commits.
- Extension sources untouched; this is examples, docs, CI, and benchmarks only.
- `package.xml` updated for every added file and verified well-formed; `pecl package` succeeds.
