### PR TITLE
perf(filter): reuse the iterator's value instead of a second lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,9 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   separate process for honest comparisons.
 - **`*_HASH` types do not iterate in key order.** If you need ordered/prefix
   walks over string keys, use `STRING_TO_INT`/`STRING_TO_MIXED` (trie).
+- **`filter()` copies a snapshot.** The value written to the result is the one
+  the predicate received; a predicate that writes or unsets `$this[$key]` does
+  not change what that element contributes to the result.
 - **`count()` takes no arguments** (Countable); ranged counting is
   `size($start, $end)` or `populationCount($start, $end)`.
 - **Random access on small dense datasets is faster with native arrays.**

--- a/API.md
+++ b/API.md
@@ -450,6 +450,8 @@ public function filter(callable $predicate): Judy
 
 Returns a new Judy array containing only elements for which `$predicate($key, $value)` returns `true`.
 
+The value copied into the result is the one the predicate was handed. A predicate that writes or unsets `$this[$key]` does not change what is copied for that element.
+
 **Supported types**: All types.
 
 ### map()

--- a/Judy.stub.php
+++ b/Judy.stub.php
@@ -249,7 +249,13 @@ class Judy implements ArrayAccess, Countable, Iterator, JsonSerializable
      */
     public function forEach(callable $callback): void {}
 
-    /** Return a new Judy array containing only elements matching the predicate. */
+    /**
+     * Return a new Judy array containing only elements matching the predicate.
+     *
+     * The value copied into the result is the one the predicate was handed. A
+     * predicate that writes or unsets `$this[$key]` does not change what is
+     * copied for that element.
+     */
     public function filter(callable $predicate): Judy {}
 
     /** Return a new Judy array with values transformed by the callback. */

--- a/package.xml
+++ b/package.xml
@@ -255,6 +255,7 @@
          <file name="tests/delete_range_001.phpt" role="test" />
          <file name="tests/equals_001.phpt" role="test" />
          <file name="tests/foreach_string_key_stress_001.phpt" role="test" />
+         <file name="tests/filter_snapshot_semantics_001.phpt" role="test" />
          <file name="tests/adaptive_clone_isset_unset_empty_slice.phpt" role="test" />
          <file name="tests/keys_values_001.phpt" role="test" />
          <file name="tests/merge_with.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -3967,7 +3967,16 @@ PHP_METHOD(Judy, equals)
 }
 /* }}} */
 
-typedef int (*judy_callback_action)(judy_object *intern, zval *key, zval *value, void *data);
+/* Callback action hook.
+ *
+ * `value` is the element's value as the iterator already materialised it in
+ * args[0] — an owned zval (ZVAL_COPY for MIXED types, a scalar otherwise) that
+ * stays valid for the whole action call even if the user callback mutated or
+ * deleted the underlying entry. Actions that need the value must use it rather
+ * than reading the store again: a second lookup costs a full descend per
+ * element and would observe post-callback state (see issue #85). `retval` is
+ * what the user callback returned. */
+typedef int (*judy_callback_action)(judy_object *intern, zval *key, zval *value, zval *retval, void *data);
 
 static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, zend_fcall_info_cache *fci_cache, judy_callback_action action, void *data)
 {
@@ -3996,7 +4005,7 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 				fci->retval = &retval;
 
 				if (zend_call_function(fci, fci_cache) == SUCCESS && !Z_ISUNDEF(retval)) {
-					action_rc = action(intern, &args[1], &retval, data);
+					action_rc = action(intern, &args[1], &args[0], &retval, data);
 					zval_ptr_dtor(&retval);
 				} else {
 					action_rc = FAILURE;
@@ -4022,7 +4031,7 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 				fci->retval = &retval;
 
 				if (zend_call_function(fci, fci_cache) == SUCCESS && !Z_ISUNDEF(retval)) {
-					action_rc = action(intern, &args[1], &retval, data);
+					action_rc = action(intern, &args[1], &args[0], &retval, data);
 					zval_ptr_dtor(&retval);
 				} else {
 					action_rc = FAILURE;
@@ -4061,7 +4070,7 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 				fci->retval = &retval;
 
 				if (zend_call_function(fci, fci_cache) == SUCCESS && !Z_ISUNDEF(retval)) {
-					action_rc = action(intern, &args[1], &retval, data);
+					action_rc = action(intern, &args[1], &args[0], &retval, data);
 					zval_ptr_dtor(&retval);
 				} else {
 					action_rc = FAILURE;
@@ -4104,7 +4113,7 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 				fci->retval = &retval;
 
 				if (zend_call_function(fci, fci_cache) == SUCCESS && !Z_ISUNDEF(retval)) {
-					action_rc = action(intern, &args[1], &retval, data);
+					action_rc = action(intern, &args[1], &args[0], &retval, data);
 					zval_ptr_dtor(&retval);
 				} else {
 					action_rc = FAILURE;
@@ -4127,7 +4136,7 @@ static void judy_callback_iterator(judy_object *intern, zend_fcall_info *fci, ze
 		efree(cursor);
 	}
 }
-static int action_foreach(judy_object *intern, zval *key, zval *retval, void *data) {
+static int action_foreach(judy_object *intern, zval *key, zval *value, zval *retval, void *data) {
 	return SUCCESS; /* forEach just calls the callback, iterator handles it */
 }
 
@@ -4146,17 +4155,16 @@ PHP_METHOD(Judy, forEach)
 }
 /* }}} */
 
-static int action_filter(judy_object *intern, zval *key, zval *retval, void *data) {
+static int action_filter(judy_object *intern, zval *key, zval *value, zval *retval, void *data) {
 	judy_object *result = (judy_object *)data;
 	if (zend_is_true(retval)) {
-		/* We need to re-fetch the value from 'intern' to put it into 'result'
-		   because 'retval' is the callback result (bool), not the original value. */
-		zval value;
-		ZVAL_UNDEF(&value);
-		judy_object_read_dimension_helper_zv(intern, key, &value);
-		if (!Z_ISUNDEF(value)) {
-			judy_object_write_dimension_helper_zv(result, key, &value);
-			zval_ptr_dtor(&value);
+		/* Copy the value the iterator handed the predicate, not a fresh read of
+		 * the store: the re-read cost a second full descend per surviving
+		 * element (issue #85) and made the copied value depend on whatever the
+		 * predicate did to $this. filter() takes a snapshot — the element as it
+		 * was when the predicate saw it. */
+		if (JUDY_LIKELY(!Z_ISUNDEF_P(value))) {
+			judy_object_write_dimension_helper_zv(result, key, value);
 		}
 	}
 	return SUCCESS;
@@ -4178,7 +4186,7 @@ PHP_METHOD(Judy, filter)
 }
 /* }}} */
 
-static int action_map(judy_object *intern, zval *key, zval *retval, void *data) {
+static int action_map(judy_object *intern, zval *key, zval *value, zval *retval, void *data) {
 	judy_object *result = (judy_object *)data;
 	/* retval is the mapped value. We put it into the result at the same key. */
 	judy_object_write_dimension_helper_zv(result, key, retval);

--- a/scripts/api-metadata.php
+++ b/scripts/api-metadata.php
@@ -283,7 +283,7 @@ $judy->forEach(function ($key, $value) {
 PHP,
         ],
         'filter' => [
-            'description' => 'Returns a new Judy array containing only elements for which `$predicate($key, $value)` returns `true`.',
+            'description' => "Returns a new Judy array containing only elements for which `\$predicate(\$key, \$value)` returns `true`.\n\nThe value copied into the result is the one the predicate was handed. A predicate that writes or unsets `\$this[\$key]` does not change what is copied for that element.",
             'supported_types' => 'All types.',
         ],
         'map' => [

--- a/tests/filter_snapshot_semantics_001.phpt
+++ b/tests/filter_snapshot_semantics_001.phpt
@@ -1,0 +1,138 @@
+--TEST--
+Judy::filter() copies the value the predicate saw (snapshot), not a re-read
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// filter() used to re-read $this[$key] after the predicate returned, which was
+// a second full lookup per surviving element and made the copied value depend
+// on whatever the predicate did to $this. It now copies the value the iterator
+// already handed the predicate. This test pins that contract.
+
+$types = [
+    'INT_TO_INT'                => Judy::INT_TO_INT,
+    'INT_TO_MIXED'              => Judy::INT_TO_MIXED,
+    'INT_TO_PACKED'             => Judy::INT_TO_PACKED,
+    'STRING_TO_INT'             => Judy::STRING_TO_INT,
+    'STRING_TO_MIXED'           => Judy::STRING_TO_MIXED,
+    'STRING_TO_INT_HASH'        => Judy::STRING_TO_INT_HASH,
+    'STRING_TO_MIXED_HASH'      => Judy::STRING_TO_MIXED_HASH,
+    'STRING_TO_INT_ADAPTIVE'    => Judy::STRING_TO_INT_ADAPTIVE,
+    'STRING_TO_MIXED_ADAPTIVE'  => Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+function fill(Judy $j, bool $stringKeyed): array
+{
+    $keys = $stringKeyed
+        ? ['a', 'bb', 'ccc', str_repeat('z', 40)]
+        : [0, 1, 2, 3];
+    foreach ($keys as $i => $k) {
+        $j[$k] = ($i + 1) * 10;
+    }
+    return $keys;
+}
+
+echo "== plain predicate ==\n";
+foreach ($types as $name => $t) {
+    $j = new Judy($t);
+    $stringKeyed = str_starts_with($name, 'STRING_');
+    fill($j, $stringKeyed);
+    $out = $j->filter(fn($v, $k) => $v >= 20);
+    echo "$name: " . json_encode($out->toArray()) . "\n";
+}
+
+echo "\n== predicate mutates \$this[\$k] in place ==\n";
+foreach ($types as $name => $t) {
+    $j = new Judy($t);
+    $stringKeyed = str_starts_with($name, 'STRING_');
+    fill($j, $stringKeyed);
+    // Snapshot semantics: filter copies 10/20/30/40, not the 999 written back.
+    $out = $j->filter(function ($v, $k) use ($j) { $j[$k] = 999; return true; });
+    echo "$name: filtered=" . json_encode(array_values($out->toArray()))
+        . " source=" . json_encode(array_values($j->toArray())) . "\n";
+}
+
+echo "\n== predicate deletes \$this[\$k] ==\n";
+foreach ($types as $name => $t) {
+    $j = new Judy($t);
+    $stringKeyed = str_starts_with($name, 'STRING_');
+    fill($j, $stringKeyed);
+    // The element the predicate accepted is still copied: it existed when the
+    // predicate ran. The source ends up empty.
+    $out = $j->filter(function ($v, $k) use ($j) { unset($j[$k]); return true; });
+    echo "$name: filtered=" . count($out) . " source=" . count($j) . "\n";
+}
+
+echo "\n== mixed payloads survive the copy ==\n";
+foreach (['INT_TO_MIXED' => Judy::INT_TO_MIXED,
+          'STRING_TO_MIXED' => Judy::STRING_TO_MIXED,
+          'STRING_TO_MIXED_HASH' => Judy::STRING_TO_MIXED_HASH,
+          'STRING_TO_MIXED_ADAPTIVE' => Judy::STRING_TO_MIXED_ADAPTIVE] as $name => $t) {
+    $j = new Judy($t);
+    $stringKeyed = str_starts_with($name, 'STRING_');
+    $keys = $stringKeyed ? ['k1', 'k2', 'k3'] : [0, 1, 2];
+    $j[$keys[0]] = ['nested' => [1, 2, 3]];
+    $j[$keys[1]] = 'a string value';
+    $j[$keys[2]] = 3.5;
+    // Delete every entry from inside the predicate: the copies must not be
+    // affected by the source's zvals being destroyed.
+    $out = $j->filter(function ($v, $k) use ($j) { unset($j[$k]); return true; });
+    echo "$name: " . json_encode($out->toArray()) . "\n";
+}
+
+echo "\n== BITSET ==\n";
+$b = new Judy(Judy::BITSET);
+foreach ([2, 4, 7, 11] as $i) { $b[$i] = true; }
+$out = $b->filter(fn($v, $k) => $k % 2 === 0);
+echo "BITSET: " . json_encode($out->toArray()) . "\n";
+
+echo "\n== predicate returning false keeps result empty ==\n";
+$j = new Judy(Judy::STRING_TO_INT_HASH);
+fill($j, true);
+echo "count=" . count($j->filter(fn($v, $k) => false)) . "\n";
+?>
+--EXPECT--
+== plain predicate ==
+INT_TO_INT: {"1":20,"2":30,"3":40}
+INT_TO_MIXED: {"1":20,"2":30,"3":40}
+INT_TO_PACKED: {"1":20,"2":30,"3":40}
+STRING_TO_INT: {"bb":20,"ccc":30,"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz":40}
+STRING_TO_MIXED: {"bb":20,"ccc":30,"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz":40}
+STRING_TO_INT_HASH: {"bb":20,"ccc":30,"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz":40}
+STRING_TO_MIXED_HASH: {"bb":20,"ccc":30,"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz":40}
+STRING_TO_INT_ADAPTIVE: {"bb":20,"ccc":30,"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz":40}
+STRING_TO_MIXED_ADAPTIVE: {"bb":20,"ccc":30,"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz":40}
+
+== predicate mutates $this[$k] in place ==
+INT_TO_INT: filtered=[10,20,30,40] source=[999,999,999,999]
+INT_TO_MIXED: filtered=[10,20,30,40] source=[999,999,999,999]
+INT_TO_PACKED: filtered=[10,20,30,40] source=[999,999,999,999]
+STRING_TO_INT: filtered=[10,20,30,40] source=[999,999,999,999]
+STRING_TO_MIXED: filtered=[10,20,30,40] source=[999,999,999,999]
+STRING_TO_INT_HASH: filtered=[10,20,30,40] source=[999,999,999,999]
+STRING_TO_MIXED_HASH: filtered=[10,20,30,40] source=[999,999,999,999]
+STRING_TO_INT_ADAPTIVE: filtered=[10,20,30,40] source=[999,999,999,999]
+STRING_TO_MIXED_ADAPTIVE: filtered=[10,20,30,40] source=[999,999,999,999]
+
+== predicate deletes $this[$k] ==
+INT_TO_INT: filtered=4 source=0
+INT_TO_MIXED: filtered=4 source=0
+INT_TO_PACKED: filtered=4 source=0
+STRING_TO_INT: filtered=4 source=0
+STRING_TO_MIXED: filtered=4 source=0
+STRING_TO_INT_HASH: filtered=4 source=0
+STRING_TO_MIXED_HASH: filtered=4 source=0
+STRING_TO_INT_ADAPTIVE: filtered=4 source=0
+STRING_TO_MIXED_ADAPTIVE: filtered=4 source=0
+
+== mixed payloads survive the copy ==
+INT_TO_MIXED: [{"nested":[1,2,3]},"a string value",3.5]
+STRING_TO_MIXED: {"k1":{"nested":[1,2,3]},"k2":"a string value","k3":3.5}
+STRING_TO_MIXED_HASH: {"k1":{"nested":[1,2,3]},"k2":"a string value","k3":3.5}
+STRING_TO_MIXED_ADAPTIVE: {"k1":{"nested":[1,2,3]},"k2":"a string value","k3":3.5}
+
+== BITSET ==
+BITSET: [2,4]
+
+== predicate returning false keeps result empty ==
+count=0


### PR DESCRIPTION
Implements the `filter()` half of #85. The larger `*_HASH`/`*_ADAPTIVE` mirroring work from that issue is **not** here — see [Deliberately out of scope](#deliberately-out-of-scope).

## What changed

`action_filter` re-read `$this[$key]` through `judy_object_read_dimension_helper_zv()` *after* the predicate returned, even though `judy_callback_iterator` already held the value in `args[0]`. On string-keyed types that re-read is a full JudySL descend per surviving element.

`judy_callback_action` now takes the value alongside the callback's return value, and `action_filter` copies `args[0]` directly. `args[0]` is an owned zval (`ZVAL_COPY` for MIXED types, scalar otherwise), so it stays valid for the whole action call regardless of what the predicate did to the store.

## Behavior change — please read, this is the reviewable part

**`filter()` now takes a snapshot.** The element is copied as the predicate saw it.

This is a fix, not a regression, and the case that shows why is a predicate that mutates the value it just approved:

```php
$j = new Judy(Judy::STRING_TO_MIXED);
$j['x'] = 5;
$r = $j->filter(function ($v, $k) use ($j) { $ok = ($v === 5); $j[$k] = 999; return $ok; });
```

| | result |
| --- | --- |
| main today | `{"x": 999}` |
| this PR | `{"x": 5}` |
| native `array_filter` | `{"x": 5}` |

On `main`, `filter(fn($v) => $v === 5)` returns an element whose value is `999`: the value the predicate tested is not the value returned. That breaks filter's basic contract, and it diverges from `array_filter`, which already evaluates against a snapshot. This PR makes php-judy match native PHP.

The realistic filter-and-delete idiom is **unaffected** — a predicate that returns `false` when it unsets behaves identically before and after:

```php
$r = $j->filter(function ($v, $k) use ($j) {
    if (bad($v)) { unset($j[$k]); return false; }   // same result on both
    return true;
});
```

The only case that changes is a predicate returning `true` while unsetting the key it just approved (previously dropped from the result, now kept) — contradictory intent with no coherent reason to depend on it.

### Release requirement

Version files are not touched here, since a release is its own step in this repo. **The next release must be a minor bump, not a patch**, and its `package.xml` `<notes>` needs an explicit BC line, e.g.:

> BC: `filter()` now evaluates against a snapshot of each value; a predicate that mutates or unsets `$this[$k]` no longer changes what is copied. Matches `array_filter`.

## Measured

honeycomb, dedicated idle 24-core x86_64, PHP 8.4.24, n=500K, median of 5, base/opt interleaved. `/proc/loadavg` 0.08 → 0.92 against a cores/2 = 12.0 threshold.

`filter(true)`, ns/element, base → opt:

| type | keylen 16 | keylen 40 |
| --- | --- | --- |
| `STRING_TO_INT` | 271.3 → 237.5 (**−12.5%**) | 277.9 → 244.5 (−12.0%) |
| `STRING_TO_INT_HASH` | 396.8 → 367.6 (−7.3%) | 633.6 → 595.6 (−6.0%) |
| `STRING_TO_MIXED_HASH` | 488.3 → 462.0 (−5.4%) | 853.2 → 815.9 (−4.4%) |
| `STRING_TO_INT_ADAPTIVE` | 401.7 → 372.9 (−7.2%) | 706.0 → 667.4 (−5.5%) |
| `STRING_TO_MIXED_ADAPTIVE` | 483.4 → 462.1 (−4.4%) | 855.7 → 816.9 (−4.5%) |
| `INT_TO_INT` | 78.2 → 67.1 (**−14.2%**) | 151.9 → 141.1 (−7.1%) |
| `INT_TO_MIXED` | 71.3 → 60.0 (−15.8%) | 71.4 → 60.4 (−15.4%) |

−33.8 ns on `STRING_TO_INT` and −11.1 ns on `INT_TO_INT` reproduce #85's projected 36.5 / 12.2 ns.

**Controls behaved.** Every non-`filter` op on every type moved within ±1.3% — `keys`/`values`/`toArray`/`foreach`/`forEach_noop`/`map_id`/`filter_false` are flat. The two >3% excursions are small-absolute ops (`INT_TO_INT foreach` −3.7%; `INT_TO_MIXED filter_false` +5.5% = +1.4 ns) and are noise.

## Verification

- **189/189 tests pass** on macOS/PHP 8.5 and Linux/PHP 8.4.
- New `tests/filter_snapshot_semantics_001.phpt`: all 10 types × {plain predicate, predicate mutates `$this[$k]`, predicate unsets `$this[$k]`, mixed payloads (array/string/double) deleted from under the copy, BITSET, all-false}. Listed in `package.xml`; XML re-validated.
- `USE_ZEND_ALLOC=0 valgrind` memcheck over the new test plus all 7 existing callback/foreach tests: **8/8 pass, 0 leaked, no memcheck reports.**
- Zero compiler warnings in extension sources.
- `Judy.stub.php` + `scripts/api-metadata.php` document the snapshot semantics; `API.md` regenerated (`--check` clean). AGENTS.md gains the pitfall.
- `baselines/latest.json` untouched.

## Deliberately out of scope

- **The `*_HASH`/`*_ADAPTIVE` second-lookup mirroring** (the larger win in #85, 22–98 ns/element). The audit found the mutation surface is wider than #85 estimated — 24 sites, not 6 — and it needs `deleteRange` fixed first plus a debug-assertion harness, because a divergence between the two stores is invisible to valgrind. Tracked in #85.
- **A separate memory-safety bug**: `deleteRange()` destroys values before removing tree entries, which is a userland-reachable use-after-free and double free on `main` today (valgrind-confirmed at `php_judy.c:3667/3668`). Same class as the 2.4.2 `write-before-dtor` fixes, missed in this method. Being fixed separately — it touches the same file, so expect a small conflict depending on merge order.
