### PR TITLE
docs: backend evaluation (Judy vs ART) and research/ harnesses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,16 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   `API.md` is stale.
 - **Version lockstep**: `php_judy.h` (`PHP_JUDY_VERSION`) and `package.xml`
   must match; see the Releasing section in README.md.
+- **Measured claims have re-runnable harnesses**: `research/` (see
+  `research/README.md`) holds standalone C benches backing doc and issue
+  claims — `shm-arena/` for #83, `iteration-cost/` for #85. Nothing there
+  ships or builds with the extension. Re-run rather than trusting a number,
+  and only on an idle machine.
+- **Backend choice is settled, don't relitigate it**: `BACKEND_EVALUATION.md`
+  measures libJudy against ART (tie on lookup, 27% worse memory for ART) and
+  explains why Masstree/HOT/Wormhole don't apply to a single-threaded,
+  short-key, per-process extension. Verdict: keep Judy. Read it before
+  proposing a backend swap.
 - **Benchmarks**: suite in `examples/benchmarks/`; CI compares PRs against
   `baselines/latest.json`. Don't update the baseline in a feature PR.
 - **Runnable demos**: `examples/` (index + type-per-demo table in

--- a/BACKEND_EVALUATION.md
+++ b/BACKEND_EVALUATION.md
@@ -1,0 +1,282 @@
+# Backend Evaluation: should php-judy still be built on Judy?
+
+**Scope**: whether the C data structure underneath this extension should be
+replaced by a more modern ordered index (ART, Masstree, HOT, Wormhole).
+
+**Audience**: maintainers. This is not a user-facing "should I use Judy"
+guide — that is [BENCHMARK.md](BENCHMARK.md), which compares php-judy against
+the alternatives a *PHP application* would choose (APCu, `SplFixedArray`,
+sorted arrays). This document asks the different question of what the
+*extension itself* should be built on.
+
+**Superseded when**: a backend swap is actually undertaken, or when these
+measurements are redone against a different ART implementation, a different
+key distribution, or integer-keyed workloads (see
+[What would change the verdict](#what-would-change-the-verdict)).
+
+**Verdict as measured: keep Judy.** ART ties on point lookup, costs 27% more
+memory, and wins only a constant factor on prefix operations. The evaluation
+did surface one actionable finding that needs no backend change — see
+[The useful finding](#the-useful-finding-iteration-cost-is-an-api-shape-problem).
+
+---
+
+## Why this question comes up
+
+Judy is a ~2002 HP design. The ordered in-memory index literature has moved on:
+ART (Leis et al., ICDE 2013), Masstree (Mao et al., EuroSys 2012), HOT (Binna
+et al., SIGMOD 2018), Wormhole (Wu et al., EuroSys 2019). If one of those is
+materially better on the axes php-judy sells — memory efficiency and ordered
+operations — the extension is carrying a legacy dependency for no reason.
+
+## Method
+
+Two steps, cheapest first, because step 1 can make step 2 unnecessary.
+
+### Step 1: bound the achievable win before measuring any replacement
+
+If the PHP extension boundary dominates the cost of an operation, then no
+backend can help and the question is closed without implementing anything.
+This is an Amdahl bound and it costs almost nothing to derive.
+
+Measured at n=1,000,000, `INT_TO_INT`, random point lookups, 5M reps:
+
+| Layer | ns/op |
+| ----- | ----- |
+| Raw C `JudyLGet` (including loop + key generation) | 17.39 |
+| PHP interpreter floor (same loop, no Judy access) | 15.97 |
+| PHP loop + `$j[$k]` | 39.30 |
+| **Marginal cost of the Judy access through PHP** | **23.33** |
+
+The extension boundary — `offsetGet` dispatch plus zval marshalling — is
+therefore roughly **6-8 ns**, and the C structure is **~65-75% of the marginal
+cost** of an operation.
+
+**This result permits the investigation to continue.** Had the boundary
+dominated, a faster structure would have been invisible from PHP. It does not,
+so a materially faster backend would show up end to end.
+
+It also sets the ceiling. Judy work is ~40% of the total 39.30 ns operation, so
+in this synthetic tight loop an *infinitely fast* replacement caps out at ~39%
+improvement, and a realistic 2x structure yields ~19%. In application code —
+where surrounding PHP work dwarfs both terms — the visible gain is smaller
+again.
+
+### Step 2: head-to-head in pure C
+
+No PHP extension was written. Comparing the libraries directly answers the
+performance question at a fraction of the cost, and if the candidate does not
+win in C it cannot win through a binding.
+
+ART implementation: [armon/libart](https://github.com/armon/libart), the
+reference C99 implementation. Compared against JudySL, since the workload of
+interest is ordered string keys with prefix operations.
+
+## Results
+
+Environment: dedicated idle x86_64 Linux host, 24 cores, 62 GB, Ubuntu 22.04,
+4 KB pages, load average 0.00-0.04 throughout (threshold cores/2 = 12.0).
+`gcc -O2 -Wall -Wextra`, zero warnings. 1,000,000 keys of the form
+`user:%08lu:f%lu` — 10 keys per user, so a prefix names a real 10-key group.
+3 runs per structure; the spread across runs was within a few percent on every
+metric.
+
+All figures `(measured)`.
+
+| Metric | JudySL | ART | Winner |
+| ------ | ------ | --- | ------ |
+| Insert | ~124 ns/op | ~110 ns/op | ART 1.13x |
+| **Point lookup** | ~179 ns/op | ~174 ns/op | **tie (3%)** |
+| Prefix scan (10-key group) | ~1.34 µs | ~0.54 µs | ART 2.5x |
+| Ordered iteration | ~67 ns/key | ~2.7 ns/key | ART 25x — *see caveat* |
+| **Peak RSS** | **51.8 MB** | 65.8 MB | **Judy 1.27x** |
+
+Reading these:
+
+- **Point lookup is a tie.** This is the metric ART is best known for, and on
+  this key shape it does not separate from Judy. The primary motivation for a
+  swap is absent.
+- **Memory moves the wrong way.** ART costs 27% more. Memory efficiency is
+  php-judy's headline claim, so a swap would regress the thing the project
+  sells hardest.
+- **Prefix is a constant factor, not a class change.** Both structures walk
+  only the matching slice; BENCHMARK.md already measures php-judy at 4,212x
+  over APCu on this workload, so 2.5x on top does not change any strategic
+  conclusion.
+
+### The iteration number: first explanation was wrong
+
+The initial reading of the 25x gap was that it is an artifact of API shape —
+`JSLN` materializes the next key into a caller-supplied buffer on every step,
+while `art_iter` performs a DFS and hands a callback a pointer. On that
+reading the cost would be per-key key reconstruction, and therefore fixable
+inside php-judy with no backend change.
+
+**That hypothesis was measured and refuted** (see
+[issue #85](https://github.com/orieg/php-judy/issues/85)). Three
+discriminators, all against it:
+
+| Test | Expectation if key materialization dominates | Measured |
+| ---- | -------------------------------------------- | -------- |
+| Key length 16 → 64 bytes (4x the bytes to write) | ~proportional rise | 70.5 → 77.8 ns, **+10%** |
+| n 100K → 1M (10x working set) | cache effects | 66.4 → 70.2 ns, **+6%** |
+| `JSLN − JSLG` replayed in iteration order — same descend and locality, no key written back | falls with shorter keys | 33.1 / 30.7 / 31.1 / 32.9 ns at keylen 16/24/40/64 — **flat** |
+
+The actual decomposition of that ~70 ns is roughly **37 ns stateless root
+descend + 32 ns successor search + ~1 ns of key bytes.** The cost is JudySL's
+structure and libJudy's *stateless* API — every `JSLN` re-descends from the
+root — not the caller-supplied buffer.
+
+This makes the gap **more** significant, not less. `Judy.h` exposes no cursor
+or iterator primitive, so there is no cheaper call for php-judy to switch to:
+this is a genuine backend property that the extension cannot optimize away.
+ART's callback iteration is structurally preferable here, not incidentally
+faster.
+
+It does not change the verdict — memory still favours Judy by 27% and point
+lookup is still a tie — but it is the one axis on which a backend swap would
+buy something real, and it should be weighed by anyone revisiting this.
+
+## What the investigation found instead
+
+Decomposing `forEach()` at the PHP level did surface a large addressable cost,
+in a different place than predicted: the four `*_HASH` / `*_ADAPTIVE` types
+perform a **second full lookup per element** during ordered traversal — 22
+ns/element at 16-byte keys, 98 ns/element (46% of `forEach()`) at 40-byte keys.
+That is an extension-level fix requiring no backend change, tracked in
+[#85](https://github.com/orieg/php-judy/issues/85).
+
+The same measurement retired the roadmap item's original framing: "vtable
+dispatch" targets a few nanoseconds inside a 6-15 ns glue bucket, and userland
+callback dispatch is only ~10 ns. `Judy::forEach()` on `INT_TO_INT` (26.4
+ns/element) already beats `array_map()` over a native PHP array (29.0).
+
+## Why Masstree, HOT, and Wormhole do not apply
+
+These were considered and rejected on design-intent grounds rather than
+measured, because their contributions target axes this extension does not
+have. Each is a real advance; none of them advances anything php-judy is
+constrained by.
+
+**Masstree — optimized for concurrent multicore throughput.** It is a
+B+tree-of-tries built around fine-grained optimistic concurrency so that many
+cores can read and write one shared structure without serializing. That is its
+reason to exist. PHP's execution model gives each worker process its own
+structure: there is exactly one thread touching a given Judy array, and no
+cross-process sharing. Adopting Masstree would mean paying for concurrency
+control machinery — extra indirection, version validation on read paths — to
+protect against contention that cannot occur. The one scenario where its design
+would pay off is a structure shared across FPM workers, and that path was
+evaluated and closed in
+[issue #83](https://github.com/orieg/php-judy/issues/83): a shared-memory Judy
+arena turned out to require a concurrency and failure-recovery subsystem larger
+than the feature.
+
+**HOT — optimized for long keys with poor prefix structure.** A plain radix
+trie's height grows with key length, so long keys mean many pointer hops. HOT's
+contribution is to bound height by letting each node discriminate on a variable
+number of bits rather than a fixed byte, keeping fanout high regardless of how
+the key bytes are distributed. That is a large win when keys are long and do
+not share prefixes usefully. php-judy's keys are the opposite: integers, or
+short application strings — cache keys, IDs, namespaced identifiers of a few
+tens of bytes, typically with heavy shared prefixes, which is the case ordinary
+radix compression already handles well. The height problem HOT solves is not
+one this extension has.
+
+**Wormhole — optimized for asymptotics on very long keys at large N.** It is a
+hash table / trie / B+tree hybrid whose headline property is lookup cost
+scaling with key *length* rather than with the number of keys, and it is
+likewise built with concurrent access in mind. That trade pays off when N is
+very large and keys are long. In php-judy, N is bounded by what a single worker
+can hold in memory, and keys are short — so the asymptotic improvement applies
+to a regime the extension does not operate in, while the structural complexity
+applies always.
+
+The common thread: all three spend complexity on **concurrency** and **long-key
+asymptotics**. php-judy is single-threaded per process with short keys, and its
+competitive axis is **memory footprint**, where Judy already measures well —
+ART, the one candidate actually benchmarked here, lost that axis by 27%.
+
+There is also a maintenance dimension. libJudy is a stable, packaged system
+dependency available from apt, apk, and Homebrew. These are research
+prototypes; adopting one means vendoring and maintaining it, in-tree, for the
+lifetime of the extension.
+
+## Verdict
+
+**Keep Judy. Do not build a php-ART extension.** On the measured evidence it
+ties on lookup, regresses memory 27%, and wins a constant factor on prefix
+operations. The Amdahl bound says a backend swap *could* be visible from PHP,
+but only for a meaningfully faster structure, and ART is not one here.
+
+## Caveats
+
+Stated plainly, because they bound how far this verdict generalizes:
+
+- **One ART implementation.** armon/libart is the reference C99 implementation,
+  not necessarily the fastest. This is not a verdict on ART as an algorithm.
+- **One key shape.** Fixed-length, highly structured, heavy shared prefixes —
+  a shape both structures handle well. A different key distribution could move
+  these numbers.
+- **String keys only.** Integer-keyed workloads were not tested. Judy's
+  `BITSET`/`INT_TO_INT` memory advantage is strongest there, so the gap would
+  most likely widen in Judy's favour — but that is an expectation, not a
+  measurement.
+- **No deletion or churn workload.** Both structures were measured
+  insert-then-read.
+- **Values are `void *` on both sides.** A real extension adds zval handling,
+  which taxes both equally and shrinks any relative difference.
+- **Masstree, HOT, and Wormhole were not benchmarked** — they were excluded on
+  design-intent grounds, argued above. That is a reasoned exclusion, not a
+  measured one.
+
+## Reproduction
+
+Requires libJudy, gcc, and an **idle** machine — check `cat /proc/loadavg`
+before and between runs and treat anything above cores/2 as contaminated.
+
+Both harnesses are committed under
+[`research/backend-comparison/`](research/backend-comparison/). libart is not
+vendored — clone it alongside:
+
+```sh
+cd research/backend-comparison
+git clone --depth 1 https://github.com/armon/libart.git
+
+# Step 2 — ART vs JudySL. One structure per process so peak RSS is attributable.
+gcc -O2 -Wall -Wextra -I libart/src -o cmp cmp.c libart/src/art.c -lJudy
+./cmp judy 1000000
+./cmp art  1000000
+
+# Step 1 — the Amdahl bound. Run the PHP arm with the built extension.
+gcc -O2 -Wall -Wextra -o amdahl amdahl.c -lJudy
+./amdahl 1000000 5000000
+php -d extension=../../modules/judy.so amdahl.php 1000000 5000000
+```
+
+What each one does:
+
+- **`amdahl.c` / `amdahl.php`** — the same random point-lookup loop in C
+  (`JLG`) and in PHP (`$j[$k]`), each with a matching no-access "floor" loop so
+  the difference isolates the extension boundary. Keys via xorshift so
+  generation cost is identical in both arms and inside both loops.
+- **`cmp.c`** — inserts n keys `user:%08lu:f%lu` (10 per user, so a prefix
+  names a real group) into either JudySL or an `art_tree`, then times insert,
+  random point lookup, full ordered iteration, and a single-group prefix scan,
+  reporting peak RSS from `getrusage(RUSAGE_SELF)`.
+
+## What would change the verdict
+
+Any of these would justify redoing this evaluation:
+
+- A measured integer-keyed comparison showing ART competitive on memory.
+- A different ART implementation, or a different key distribution, showing a
+  real point-lookup separation rather than a 3% tie.
+- php-judy acquiring a shared-memory backend, which would make Masstree's
+  concurrency design relevant for the first time — currently closed via
+  [#83](https://github.com/orieg/php-judy/issues/83).
+- **Partially met already**: ordered string iteration is ~25x cheaper in ART,
+  and #85 established the cause is JudySL's stateless per-call root descend
+  with no cursor primitive available — so php-judy cannot close it. If a
+  workload emerges where ordered traversal dominates and memory does not, that
+  is the case for revisiting this, and it is the strongest one available.

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -227,10 +227,10 @@ php -d apc.enable_cli=1 -d apc.shm_size=2048M \
 > RoadRunner, FrankenPHP, queue consumers, CLI pipelines — or where the
 > structure is **built and consumed inside one request**. Shared, cross-worker,
 > read-mostly caching is what APCu is for, and php-judy does not offer it
-> today. See [issue #83](https://github.com/orieg/php-judy/issues/83) for the
+> today. See [issue #83](https://github.com/orieg/php-judy/issues/83) and
+> [`research/shm-arena/FINDINGS.md`](research/shm-arena/FINDINGS.md) for the
 > feasibility spike on a shared-memory Judy arena, which concluded that it is a
-> concurrency and failure-recovery subsystem rather than a feature. The spike's
-> prototypes and findings live on the research branch linked from that issue.
+> concurrency and failure-recovery subsystem rather than a feature.
 >
 > Because each CLI process gets its own APCu segment, the numbers below are
 > single-process on **both** sides. That makes them a fair latency comparison —

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ For a detailed performance comparison with native PHP arrays, please see the [BE
 README.md            This file
 API.md               Complete API reference
 BENCHMARK.md         Performance benchmarks and analysis
+BACKEND_EVALUATION.md  Judy vs ART/Masstree/HOT/Wormhole as the C backend
 MIGRATION_2.2.0.md   Migration guide for version 2.2.0
 LICENSE              The PHP License used by this project
 
 tests/               Unit and regression tests (.phpt)
 examples/            Runnable demos (see examples/README.md) + benchmark suite
+research/            Standalone C harnesses backing measured claims (not shipped)
 scripts/             API-doc generation helpers
 *.c, *.h             C source and header files
 Judy.stub.php        PHP stub for IDE autocompletion
@@ -493,9 +495,25 @@ Please report bugs and issues on the GitHub repository:
 ## Roadmap
 
 - Eliminate redundant JLG+JLI double traversal in write hot paths for `INT_TO_INT`, `STRING_TO_INT`, and `STRING_TO_INT_HASH` types
-- C-level `forEach()`/`filter()`/`map()` performance tuning (vtable dispatch)
+- Remove the per-element second lookup during ordered traversal of the
+  `*_HASH`/`*_ADAPTIVE` types — worth 22 ns/element at 16-byte keys and 98
+  ns/element (46% of `forEach()`) at 40-byte keys ([#85](https://github.com/orieg/php-judy/issues/85))
 - Binary serialization format for faster `__serialize`/`__unserialize`
 - Extend `increment()` to adaptive types
+
+Retired: *"C-level `forEach()`/`filter()`/`map()` performance tuning (vtable
+dispatch)"*. Measurement in [#85](https://github.com/orieg/php-judy/issues/85)
+found userland callback dispatch is only ~10 ns/element inside a 6-15 ns glue
+bucket, and `Judy::forEach()` on `INT_TO_INT` (26.4 ns/element) already beats
+`array_map()` over a native PHP array (29.0). The addressable cost was
+elsewhere: the `filter()` half shipped in
+[#86](https://github.com/orieg/php-judy/pull/86), and the larger second-lookup
+item is listed above.
+
+Whether the extension should keep libJudy as its backend at all — measured
+against the Adaptive Radix Tree, with Masstree/HOT/Wormhole considered — is
+evaluated in [BACKEND_EVALUATION.md](BACKEND_EVALUATION.md). Current verdict:
+keep Judy.
 
 ## Releasing
 

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,13 @@ show a removed API; trust the docs below instead).
 - [API.md](https://github.com/orieg/php-judy/blob/main/API.md): complete API
   reference, generated from the canonical stub
 - [BENCHMARK.md](https://github.com/orieg/php-judy/blob/main/BENCHMARK.md):
-  measured performance, memory numbers, when (not) to use Judy
+  measured performance, memory numbers, when (not) to use Judy, and php-judy
+  versus APCu / SplFixedArray / sorted arrays
+- [BACKEND_EVALUATION.md](https://github.com/orieg/php-judy/blob/main/BACKEND_EVALUATION.md):
+  maintainer-facing — whether the extension should keep libJudy as its C
+  backend, measured against the Adaptive Radix Tree (ART) with Masstree, HOT
+  and Wormhole considered. Verdict: keep Judy (ART ties on lookup and costs
+  27% more memory)
 - [README.md](https://github.com/orieg/php-judy/blob/main/README.md):
   install paths for Linux/macOS/Windows/Docker, usage examples per type
 

--- a/package.xml
+++ b/package.xml
@@ -282,6 +282,7 @@
          <file md5sum="302250a837e8e489f3e465bdfd488f32" name="README.md" role="doc" />
          <file md5sum="730470b2aca686ddbea82a2b2af03a1a" name="CREDITS" role="doc" />
          <file md5sum="af4d88a4da7b16aaf4f92d7fe619e6be" name="BENCHMARK.md" role="doc" />
+         <file name="BACKEND_EVALUATION.md" role="doc" />
          <file name="API.md" role="doc" />
          <file name="scripts/api-metadata.php" role="doc" />
          <file name="scripts/generate-api-docs.php" role="doc" />

--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,31 @@
+# research/
+
+Standalone C harnesses backing claims made elsewhere in the repo. **Nothing
+here ships** — these are not part of the PECL package, are not built by
+`make`, and are not loaded by the extension. They exist so that a measured
+claim in a doc or an issue can be re-run instead of taken on trust.
+
+Each subdirectory owns one question and names the artifact it supports.
+
+| Directory | Question | Supports |
+| --------- | -------- | -------- |
+| [`shm-arena/`](shm-arena/) | Can libJudy live in a shared-memory arena, giving an ordered cache shared across FPM workers? | [issue #83](https://github.com/orieg/php-judy/issues/83) — closed, not planned. Five feasibility gates; writer death corrupts the tree 15% of the time (Wilson CI [8.8%, 24.4%]) and macOS has no robust mutexes. `FINDINGS.md` has the per-gate verdicts. |
+| [`iteration-cost/`](iteration-cost/) | Is JudySL's ordered-iteration cost the caller-supplied key buffer, or a stateless re-descend from the root? | [issue #85](https://github.com/orieg/php-judy/issues/85) and [BACKEND_EVALUATION.md](../BACKEND_EVALUATION.md). Refuted the key-reconstruction hypothesis: `JSLN` is flat in key length and flat in working-set size. |
+| [`backend-comparison/`](backend-comparison/) | Should the extension keep libJudy, or move to a modern ordered index? | [BACKEND_EVALUATION.md](../BACKEND_EVALUATION.md). `amdahl.c`/`amdahl.php` bound how much a backend swap could possibly buy through the PHP boundary; `cmp.c` runs ART against JudySL. Verdict: keep Judy. Needs libart cloned alongside — not vendored. |
+
+## Running these
+
+They need libJudy and a C compiler, and they produce timings, so they need an
+**idle machine** — check load average before and between runs and treat
+anything above cores/2 as contaminated. See BENCHMARK.md's *Environment and
+contention* section for why that matters here: a contended sweep of the main
+benchmark suite produced two wrong conclusions before being discarded.
+
+```sh
+# iteration-cost
+gcc -O2 -Wall -Wextra -o iterbench research/iteration-cost/iterbench.c -lJudy
+./iterbench 1000000 16 5        # n, key length, reps
+
+# shm-arena
+cd research/shm-arena && make && make run
+```

--- a/research/backend-comparison/.gitignore
+++ b/research/backend-comparison/.gitignore
@@ -1,0 +1,5 @@
+# Built by hand, not shipped.
+cmp
+amdahl
+libart/
+*.dSYM/

--- a/research/backend-comparison/amdahl.c
+++ b/research/backend-comparison/amdahl.c
@@ -1,0 +1,38 @@
+/* Decompose: how much of a php-judy op is actual Judy work?
+ * Measures raw JudyL point lookup in C, same access pattern the PHP
+ * benchmark uses, so the two are directly comparable per operation. */
+#include <Judy.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+static double now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1e9 + (double)ts.tv_nsec;
+}
+
+int main(int argc, char **argv) {
+    Word_t n = (argc > 1) ? (Word_t)strtoul(argv[1], NULL, 10) : 1000000;
+    Word_t reps = (argc > 2) ? (Word_t)strtoul(argv[2], NULL, 10) : 5000000;
+    Pvoid_t J = (Pvoid_t)NULL;
+    PWord_t pv;
+
+    for (Word_t i = 0; i < n; i++) { JLI(pv, J, i); *pv = i * 3; }
+
+    /* xorshift keeps key generation cheap and identical in shape to the PHP side */
+    unsigned long s = 88172645463325252UL, sink = 0;
+    double t0 = now_ns();
+    for (Word_t r = 0; r < reps; r++) {
+        s ^= s << 13; s ^= s >> 7; s ^= s << 17;
+        Word_t k = (Word_t)(s % n);
+        JLG(pv, J, k);
+        if (pv) sink += *pv;
+    }
+    double t1 = now_ns();
+
+    long freed; (void)freed; JLFA(freed, J);
+    printf("C   JudyLGet   n=%lu reps=%lu  %.2f ns/op  (sink=%lu)\n",
+           (unsigned long)n, (unsigned long)reps, (t1 - t0) / (double)reps, sink);
+    return 0;
+}

--- a/research/backend-comparison/amdahl.php
+++ b/research/backend-comparison/amdahl.php
@@ -1,0 +1,33 @@
+<?php
+// Same access pattern through the PHP extension boundary.
+// Both loops do identical work except the Judy access itself, so the
+// difference isolates (extension boundary + Judy) from interpreter overhead.
+$n    = (int)($argv[1] ?? 1000000);
+$reps = (int)($argv[2] ?? 5000000);
+
+$j = new Judy(Judy::INT_TO_INT);
+for ($i = 0; $i < $n; $i++) { $j[$i] = $i * 3; }
+
+// (a) floor: loop + xorshift key generation, no Judy access
+$s = 88172645463325252; $sink = 0;
+$t0 = hrtime(true);
+for ($r = 0; $r < $reps; $r++) {
+    $s ^= ($s << 13) & PHP_INT_MAX; $s ^= $s >> 7; $s ^= ($s << 17) & PHP_INT_MAX;
+    $sink += $s % $n;
+}
+$t1 = hrtime(true);
+$floor = ($t1 - $t0) / $reps;
+
+// (b) same loop plus one Judy point lookup
+$s = 88172645463325252; $sink2 = 0;
+$t2 = hrtime(true);
+for ($r = 0; $r < $reps; $r++) {
+    $s ^= ($s << 13) & PHP_INT_MAX; $s ^= $s >> 7; $s ^= ($s << 17) & PHP_INT_MAX;
+    $sink2 += $j[$s % $n];
+}
+$t3 = hrtime(true);
+$total = ($t3 - $t2) / $reps;
+
+printf("PHP interpreter floor  %7.2f ns/op\n", $floor);
+printf("PHP floor + \$j[\$k]     %7.2f ns/op\n", $total);
+printf("delta (boundary+judy)  %7.2f ns/op\n", $total - $floor);

--- a/research/backend-comparison/cmp.c
+++ b/research/backend-comparison/cmp.c
@@ -1,0 +1,124 @@
+/* libart (Adaptive Radix Tree) vs libJudy (JudySL) on the workload php-judy
+ * actually competes on: ordered string keys with prefix operations.
+ *
+ * Run as: ./cmp art|judy [n]
+ * One structure per process so peak RSS is attributable.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/resource.h>
+#include <Judy.h>
+#include "art.h"
+
+static double now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1e9 + (double)ts.tv_nsec;
+}
+
+/* ru_maxrss is kilobytes on Linux but BYTES on macOS/BSD. Normalise to KB so
+ * the reported figures mean the same thing on both. */
+static long peak_rss_kb(void) {
+    struct rusage ru;
+    getrusage(RUSAGE_SELF, &ru);
+#if defined(__APPLE__) || defined(BSD)
+    return ru.ru_maxrss / 1024;
+#else
+    return ru.ru_maxrss;
+#endif
+}
+
+#define KEYLEN 40
+
+/* 10 keys per user, so a prefix names a real group of 10. */
+static void make_key(char *buf, unsigned long i) {
+    snprintf(buf, KEYLEN, "user:%08lu:f%lu", i / 10, i % 10);
+}
+
+static int noop_cb(void *data, const unsigned char *k, uint32_t klen, void *val) {
+    (void)k; (void)klen; (void)val;
+    (*(unsigned long *)data)++;
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    const char *which = (argc > 1) ? argv[1] : "judy";
+    unsigned long n = (argc > 2) ? strtoul(argv[2], NULL, 10) : 1000000;
+    int use_art = (strcmp(which, "art") == 0);
+
+    long rss0 = peak_rss_kb();
+    char key[KEYLEN];
+    double t0, t1;
+
+    art_tree at;
+    Pvoid_t sl = (Pvoid_t)NULL;
+    PWord_t pv;
+
+    if (use_art) art_tree_init(&at);
+
+    /* insert */
+    t0 = now_ns();
+    for (unsigned long i = 0; i < n; i++) {
+        make_key(key, i);
+        if (use_art) {
+            art_insert(&at, (unsigned char *)key, (int)strlen(key) + 1, (void *)(i + 1));
+        } else {
+            JSLI(pv, sl, (uint8_t *)key);
+            *pv = i + 1;
+        }
+    }
+    t1 = now_ns();
+    double ins_ns = (t1 - t0) / (double)n;
+    long rss_after_insert = peak_rss_kb();
+
+    /* random point lookup */
+    unsigned long s = 88172645463325252UL, hits = 0, reps = 2000000;
+    t0 = now_ns();
+    for (unsigned long r = 0; r < reps; r++) {
+        s ^= s << 13; s ^= s >> 7; s ^= s << 17;
+        make_key(key, s % n);
+        if (use_art) {
+            if (art_search(&at, (unsigned char *)key, (int)strlen(key) + 1)) hits++;
+        } else {
+            JSLG(pv, sl, (uint8_t *)key);
+            if (pv) hits++;
+        }
+    }
+    t1 = now_ns();
+    double get_ns = (t1 - t0) / (double)reps;
+
+    /* full ordered iteration */
+    unsigned long seen = 0;
+    t0 = now_ns();
+    if (use_art) {
+        art_iter(&at, noop_cb, &seen);
+    } else {
+        uint8_t ik[KEYLEN]; ik[0] = '\0';
+        JSLF(pv, sl, ik);
+        while (pv) { seen++; JSLN(pv, sl, ik); }
+    }
+    t1 = now_ns();
+    double iter_ns = (t1 - t0) / (double)(seen ? seen : 1);
+
+    /* prefix scan: one 'user:00000042' group */
+    const char *pfx = "user:00000042:";
+    unsigned long pfound = 0;
+    t0 = now_ns();
+    if (use_art) {
+        art_iter_prefix(&at, (unsigned char *)pfx, (int)strlen(pfx), noop_cb, &pfound);
+    } else {
+        uint8_t pk[KEYLEN];
+        snprintf((char *)pk, KEYLEN, "%s", pfx);
+        JSLF(pv, sl, pk);
+        while (pv && strncmp((char *)pk, pfx, strlen(pfx)) == 0) { pfound++; JSLN(pv, sl, pk); }
+    }
+    t1 = now_ns();
+    double pfx_us = (t1 - t0) / 1000.0;
+
+    printf("%-5s n=%lu  insert %6.1f ns/op | get %6.1f ns/op | iter %5.1f ns/key | prefix %7.2f us (%lu keys) | peakRSS %6.1f MB (delta %6.1f MB) | hits=%lu seen=%lu\n",
+           use_art ? "ART" : "JUDY", n, ins_ns, get_ns, iter_ns, pfx_us, pfound,
+           rss_after_insert / 1024.0, (rss_after_insert - rss0) / 1024.0, hits, seen);
+    return 0;
+}

--- a/research/iteration-cost/.gitignore
+++ b/research/iteration-cost/.gitignore
@@ -1,0 +1,3 @@
+# Built by hand, not shipped.
+iterbench
+*.dSYM/

--- a/research/iteration-cost/iterbench.c
+++ b/research/iteration-cost/iterbench.c
@@ -1,0 +1,134 @@
+/* Discriminator bench for the "JSLN key-reconstruction is the cost" hypothesis.
+ *
+ * Tests that separate the candidate explanations:
+ *   H1 key reconstruction: JSLN writes the next key into the caller buffer.
+ *      -> cost should scale with key length, and JSLN should be much more
+ *         expensive than JSLG on the same key in the same order.
+ *   H2 memory-bound re-descend: every JSLN/JSLG restarts at the root.
+ *      -> cost should scale with n (working set vs cache), and JSLN ~= JSLG.
+ *
+ * ./iterbench <n> <keylen> <reps>
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <Judy.h>
+
+static double now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1e9 + (double)ts.tv_nsec;
+}
+
+static int cmpd(const void *a, const void *b) {
+    double x = *(const double *)a, y = *(const double *)b;
+    return (x > y) - (x < y);
+}
+static double med(double *v, int k) { qsort(v, k, sizeof(double), cmpd); return v[k / 2]; }
+
+#define MAXK 128
+
+/* keylen = total chars incl. padding, excl. NUL. Prefix structure kept
+ * realistic ("user:00001234:f5"), tail padded with 'x' to hit keylen. */
+static void make_key(char *buf, unsigned long i, int keylen) {
+    int m = snprintf(buf, MAXK, "user:%08lu:f%lu", i / 10, i % 10);
+    while (m < keylen) buf[m++] = 'x';
+    buf[m] = '\0';
+}
+
+int main(int argc, char **argv) {
+    unsigned long n = (argc > 1) ? strtoul(argv[1], NULL, 10) : 1000000;
+    int keylen = (argc > 2) ? atoi(argv[2]) : 16;
+    int reps = (argc > 3) ? atoi(argv[3]) : 5;
+    char key[MAXK];
+
+    Pvoid_t sl = (Pvoid_t)NULL, jl = (Pvoid_t)NULL, hs = (Pvoid_t)NULL;
+    PWord_t pv;
+
+    /* build all three stores over the same n */
+    for (unsigned long i = 0; i < n; i++) {
+        make_key(key, i, keylen);
+        JSLI(pv, sl, (uint8_t *)key); *pv = i + 1;
+        JHSI(pv, hs, key, (Word_t)strlen(key)); *pv = i + 1;
+        JLI(pv, jl, (Word_t)i); *pv = i + 1;
+    }
+
+    /* sorted key list, for replaying iteration order as point lookups */
+    char *keys = malloc((size_t)n * MAXK);
+    {
+        unsigned long c = 0;
+        key[0] = '\0';
+        JSLF(pv, sl, (uint8_t *)key);
+        while (pv != NULL && c < n) {
+            strcpy(keys + (size_t)c * MAXK, key);
+            c++;
+            JSLN(pv, sl, (uint8_t *)key);
+        }
+        if (c != n) { fprintf(stderr, "walk got %lu of %lu\n", c, n); return 1; }
+    }
+
+    double r_jln[64], r_jsln[64], r_jslg_sorted[64], r_jslg_rand[64], r_jhsg_sorted[64];
+    unsigned long sink = 0;
+
+    for (int r = 0; r < reps; r++) {
+        double t0, t1;
+
+        /* JudyL ordered iteration */
+        { Word_t idx = 0; unsigned long c = 0;
+          t0 = now_ns();
+          JLF(pv, jl, idx);
+          while (pv != NULL) { sink += *pv; c++; JLN(pv, jl, idx); }
+          t1 = now_ns(); r_jln[r] = (t1 - t0) / (double)c; }
+
+        /* JudySL ordered iteration (descend + key reconstruction) */
+        { unsigned long c = 0;
+          t0 = now_ns();
+          key[0] = '\0';
+          JSLF(pv, sl, (uint8_t *)key);
+          while (pv != NULL) { sink += *pv; c++; JSLN(pv, sl, (uint8_t *)key); }
+          t1 = now_ns(); r_jsln[r] = (t1 - t0) / (double)c; }
+
+        /* JudySL point lookup, replaying iteration order: same descend, same
+         * locality, NO key reconstruction. JSLN - this = reconstruction cost. */
+        { t0 = now_ns();
+          for (unsigned long i = 0; i < n; i++) {
+              JSLG(pv, sl, (uint8_t *)(keys + (size_t)i * MAXK));
+              if (pv) sink += *pv;
+          }
+          t1 = now_ns(); r_jslg_sorted[r] = (t1 - t0) / (double)n; }
+
+        /* JudySL point lookup, random order (locality control) */
+        { unsigned long s = 88172645463325252UL;
+          t0 = now_ns();
+          for (unsigned long i = 0; i < n; i++) {
+              s ^= s << 13; s ^= s >> 7; s ^= s << 17;
+              JSLG(pv, sl, (uint8_t *)(keys + (size_t)(s % n) * MAXK));
+              if (pv) sink += *pv;
+          }
+          t1 = now_ns(); r_jslg_rand[r] = (t1 - t0) / (double)n; }
+
+        /* JudyHS lookup in sorted order (what *_HASH types pay per element) */
+        { t0 = now_ns();
+          for (unsigned long i = 0; i < n; i++) {
+              const char *k = keys + (size_t)i * MAXK;
+              JHSG(pv, hs, (void *)k, (Word_t)strlen(k));
+              if (pv) sink += *pv;
+          }
+          t1 = now_ns(); r_jhsg_sorted[r] = (t1 - t0) / (double)n; }
+    }
+
+    printf("n=%lu keylen=%d reps=%d (median ns/key; min..max)\n", n, keylen, reps);
+#define REPORT(label, arr) do { \
+        double tmp[64]; memcpy(tmp, arr, sizeof(double) * reps); \
+        double m = med(tmp, reps); \
+        printf("  %-28s %8.2f   [%.2f .. %.2f]\n", label, m, tmp[0], tmp[reps - 1]); \
+    } while (0)
+    REPORT("JLF/JLN iterate", r_jln);
+    REPORT("JSLF/JSLN iterate", r_jsln);
+    REPORT("JSLG sorted (no key recon)", r_jslg_sorted);
+    REPORT("JSLG random", r_jslg_rand);
+    REPORT("JHSG sorted", r_jhsg_sorted);
+    fprintf(stderr, "sink=%lu\n", sink);
+    return 0;
+}

--- a/research/shm-arena/.gitignore
+++ b/research/shm-arena/.gitignore
@@ -1,0 +1,13 @@
+# Compiled gate binaries (built by `make`, not shipped).
+gate1_correctness
+gate2_fork
+gate3_lock
+gate4_profile
+gate5_crash
+gate1_asan
+*.o
+*.dSYM/
+
+# The repo-root .gitignore excludes "Makefile" because phpize generates one
+# there. This spike's Makefile is hand-written source, so re-include it.
+!Makefile

--- a/research/shm-arena/FINDINGS.md
+++ b/research/shm-arena/FINDINGS.md
@@ -1,0 +1,520 @@
+# Step-0 feasibility spike: shared-memory Judy arena (issue #83)
+
+Canonical record for the five Step-0 gates. Feasibility investigation only —
+nothing here is a committed feature, and none of this code ships (the spike is
+deliberately absent from `package.xml` and touches no extension source).
+
+**Overall verdict: `PROCEED_WITH_AMENDMENT` — but the amendments are large
+enough that the honest framing is "this is not a feature, it is a subsystem".**
+All five gates are individually survivable on Linux. The conjunction is what
+hurts. See [§8](#8-recommendation).
+
+---
+
+## 1. How to reproduce
+
+```sh
+cd research/shm-arena
+make            # builds gate1..gate5
+make run        # runs all five
+make asan       # gate 1 under ASan + UBSan
+```
+
+Linux validation (this spike was developed on macOS; Linux is the real target):
+
+```sh
+docker run --rm -v "$PWD":/spike -w /spike debian:bookworm-slim bash -c '
+  apt-get update -qq && apt-get install -y -qq gcc make libjudy-dev valgrind
+  mkdir -p /build && cp shm_arena.* gate*.c Makefile /build/ && cd /build
+  make && make run'
+```
+
+| File | Purpose |
+| --- | --- |
+| `shm_arena.{h,c}` | MAP_SHARED arena + `JudyMalloc`/`JudyFree` override + instrumentation |
+| `gate1_correctness.c` | allocator override correctness (Judy1/JudyL/JudySL) |
+| `gate2_fork.c` | address stability across fork, MAP_FIXED, ASLR |
+| `gate3_lock.c` | pshared/robust lock availability, cost, holder death |
+| `gate4_profile.c` | allocation histogram, fragmentation, bump vs freelist |
+| `gate5_crash.c` | writer-death corruption rate, arena leak, rebuild cost |
+
+## 2. Environment and benchmark hygiene (read before trusting any timing)
+
+- **macOS**: Darwin 25.4.0, Apple M1, 8 cores, 16 GB. libJudy 1.0.5 (Homebrew).
+- **Linux**: Debian bookworm, glibc 2.36, aarch64, in Docker. **The Docker VM
+  reports only 4 CPUs**, so the Linux 8-process contention column is
+  oversubscribed and its absolute values are not comparable to macOS.
+- **Load was NOT clean.** Load average ranged 3.3–5.9 on an 8-core machine
+  during the timing runs; the standing threshold is cores/2 = 4.0. Chrome and
+  WebKit helpers were consuming 25–88% CPU throughout. **Every timing number
+  below is CONTAMINATED and is reported as an upper bound.**
+- Mitigation used: each configuration is run 15x (uncontended) or 5x
+  (contended) and the **minimum** is reported as primary. Interference can only
+  add time, never remove it, so the min is the robust estimator under
+  contamination. The median was visibly corrupted — in the first Gate 3 run the
+  median showed `rwlock rdlock` (73.7 ns) as *faster* than no lock at all
+  (99.0 ns), which is impossible; the min-based ordering was coherent. Spread
+  (min/median/max) is reported so the noise is visible.
+- **Structural findings (symbol interposition, capability probes, corruption
+  counts, allocation histograms) are NOT timing-sensitive and are unaffected.**
+  Judy's allocation counts were byte-identical on macOS and Linux, which is a
+  useful cross-check that the workload is deterministic.
+
+## 3. Premises verified before building anything
+
+Both premises in the issue were checked empirically rather than assumed. One of
+them is materially wrong on macOS.
+
+### 3.1 `JudyMalloc`/`JudyFree` are interposable — platform-dependent
+
+`nm -gU` confirms `_JudyMalloc`/`_JudyFree` are exported (`T`) in both the
+Homebrew dylib and static archive, and every internal caller
+(`JudyLMallocIF.o`, `Judy1MallocIF.o`, `JudySL.o`, `JudyHS.o`) references them
+as undefined (`U`). But exported != interposable:
+
+| Link target | Override honored? | Evidence (measured) |
+| --- | --- | --- |
+| Linux, stock shared `libJudy.so` | **YES** | 57,711 `JudyMalloc` calls captured |
+| Linux, static `libJudy.a` | **YES** | 57,711 calls captured |
+| macOS, static `libJudy.a` | **YES** | 57,711 calls captured |
+| macOS, `libJudy.dylib` | **NO** | **0 calls** — override silently ignored |
+| macOS, `libJudy.dylib` + `-Wl,-flat_namespace` | **NO** | **0 calls** |
+
+**This is a material finding, not a footnote.** macOS's two-level namespace
+binds libJudy's internal calls to its own `JudyMalloc` at build time.
+`-flat_namespace` does not rescue it, and `DYLD_INSERT_LIBRARIES` is restricted
+under SIP. php-judy's `config.m4` uses `PHP_ADD_LIBRARY_WITH_PATH(Judy, ...)`
+-> `-lJudy`, which resolves to the **dylib** on macOS. So a shm-arena build on
+macOS would require linking `libJudy.a` explicitly or vendoring/rebuilding
+libJudy — a build-system change, not a code change.
+
+The silent-failure mode is the dangerous part: the override compiles and links
+cleanly and simply never fires. Any implementation must assert at MINIT that
+its allocator is actually being called, or macOS builds will quietly use the
+process heap while believing they are in shared memory.
+
+### 3.2 Alignment contract — 8 bytes, low 3 bits clear
+
+Determined from Judy-1.0.5 source (tarball sha256
+`d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb`,
+byte-identical to the Homebrew formula's pin), not guessed:
+
+- `src/JudyCommon/JudyMallocIF.c:140-147` — `MALLOCBITS_VALUE 0x3`,
+  `MALLOCBITS_MASK 0x7`, and `assert(((Word_t)(Addr) & MALLOCBITS_MASK) == 0)`
+  before OR-ing the tag bits in.
+- `src/JudyCommon/JudyPrivate.h:365-368` — the low bits are reserved so Judy
+  objects "come from different `malloc()` namespaces".
+
+So **every returned address must have its low 3 bits clear**. Note `MALLOCBITS`
+is only active in DEBUG builds, so a misaligned arena would corrupt trees
+*silently* in a release libJudy. The arena enforces alignment unconditionally
+and aborts on violation (`shm_arena.c`). Stock `JudyMalloc` is a bare `malloc()`
+returning byte counts of `Words * sizeof(Word_t)` — no cache-line alignment is
+required (the 128-byte constant in `JudyPrivate.h` is a performance target for
+node *sizing*, not an allocator constraint).
+
+---
+
+## 4. Gate-by-gate results
+
+### Gate 1 — `JudyMalloc` override with a shm arena -> **PASS_with_caveats**
+
+Caveat is entirely §3.1 (macOS dylib cannot be overridden).
+
+Workload: 200k-key JudyL (dense and sparse), 200k-key Judy1, 50k-string JudySL,
+each with insert -> ordered forward/reverse iterate -> delete half -> verify ->
+re-insert -> verify -> free-array.
+
+| Check | Result (measured) |
+| --- | --- |
+| `JudyMalloc` / `JudyFree` calls | 535,191 / 535,191 — **identical on macOS and Linux** |
+| Overlapping live blocks | **0** (word-granular shadow map over the whole arena) |
+| Double / unknown frees | **0** |
+| **Alloc/free size mismatches** | **0** |
+| Live bytes after all `*FreeArray` | **0** (no leak) |
+| Ordered iteration vs reference model | exact match, forward and reverse |
+| ASan + UBSan | clean |
+| valgrind memcheck (Linux) | **0 errors, 0 bytes definitely/indirectly/possibly lost** |
+
+**The load-bearing result is "alloc/free size mismatches = 0".** Judy always
+frees a block with exactly the word count it allocated it with. That invariant
+is what makes Gate 4's exact-size-class freelist safe; without it the freelist
+design collapses. It is verified, not assumed.
+
+### Gate 2 — address stability under fork -> **PASS_with_caveats**
+
+| Test | macOS | Linux |
+| --- | --- | --- |
+| 2a. 8 children see identical arena base | YES | YES |
+| 2a. Children fully traverse the pre-fork tree | OK | OK |
+| 2b. Child's insert visible to parent (MAP_SHARED write-through) | YES | YES |
+| 2c. `MAP_FIXED` at a reserved address | EXACT | EXACT |
+| 2c. Child inherits fixed mapping at same address | YES | YES |
+
+**Caveat — ASLR across master restart (measured).** The arena base differs on
+every independent run of the same binary:
+
+- macOS: `0x1058d8000`, `0x105794000`, `0x105180000`, `0x107868000`,
+  `0x1089e8000`, `0x1072c8000` (6/6 distinct)
+- Linux: `0xffff78410000`, `0xffff7d160000`, `0xffff783f0000`,
+  `0xffff7cb80000`, `0xffffb2f40000` (5/5 distinct)
+
+**Implication:** absolute pointers are valid only within one master's fork tree.
+A graceful restart / `reload` starts a new master at a new address, so a
+surviving segment is unreadable — the cache is necessarily **cold on every
+reload**, unless `MAP_FIXED` pins a hardcoded address.
+
+`MAP_FIXED` works here, but as a production strategy it is a liability:
+`MAP_FIXED` **silently unmaps whatever already occupies the range**, so a
+hardcoded address that collides with ASLR-placed libraries, the heap, or a JIT
+region corrupts the process. `MAP_FIXED_NOREPLACE` (Linux 4.17+) fails safely
+instead and would be mandatory; macOS has no equivalent. Also note non-fork
+worker models (Windows, some Octane drivers) are unsupported regardless — the
+issue already scoped that out, and this spike confirms it is unavoidable rather
+than an implementation shortcut.
+
+### Gate 3 — process-shared robust rwlock -> **macOS: FAIL / Linux: PASS_with_caveats**
+
+**3a. Capability probe (measured, structural):**
+
+| Primitive | macOS | Linux (glibc) |
+| --- | --- | --- |
+| `pthread_rwlockattr_setpshared` | OK | OK |
+| `pthread_mutexattr_setpshared` | OK | OK |
+| `pthread_mutexattr_setrobust` | **ABSENT** | **OK** |
+| robust *rwlock* | **does not exist in POSIX on any platform** | same |
+
+Two traps worth recording:
+
+1. **Robust rwlocks do not exist anywhere.** POSIX defines robustness only for
+   mutexes. A design that wants both reader parallelism *and* death recovery
+   cannot get them from one primitive.
+2. **Detecting robust support by feature macro is wrong.** glibc declares
+   `PTHREAD_MUTEX_ROBUST` as an **enum constant, not a macro**, so
+   `#if defined(PTHREAD_MUTEX_ROBUST)` is FALSE on Linux even though robust
+   mutexes are fully supported. This spike hit that bug and initially recorded a
+   false "Linux has no robust mutexes" result. Detect by C library (`__GLIBC__`)
+   or a configure-time link test.
+
+**3b. Uncontended per-op cost** — min of 15 reps, ns per JudyL lookup.
+CONTAMINATED (see §2); Linux ran in a quieter container and is the more
+trustworthy column.
+
+| Mode | macOS min | macOS lock cost | Linux min | Linux lock cost |
+| --- | --- | --- | --- | --- |
+| no lock (unsafe baseline) | 34.98 ns | — | 45.40 ns | — |
+| pshared rwlock rdlock | 39.26 ns | +4.28 ns | 104.47 ns | **+59.07 ns** |
+| pshared mutex lock | 50.97 ns | +15.99 ns | 106.73 ns | +61.33 ns |
+| seqlock optimistic read | 30.80 ns | -4.18 ns (noise) | 46.59 ns | **+1.19 ns** |
+
+On Linux a pshared rwlock **more than doubles** the cost of a Judy read.
+
+**3c. N-process contention, read-dominated (99% read / 1% write)** — best-of-5
+aggregate ns/op. Lower is better. macOS, 8 real cores:
+
+| Mode | 1p | 2p | 4p | 8p |
+| --- | --- | --- | --- | --- |
+| no lock (unsafe baseline) | 54.5 | 21.2 | 11.1 | **9.3** |
+| pshared rwlock rdlock | 59.9 | 135.7 | 227.4 | **373.5** |
+| pshared mutex lock | 67.3 | 143.7 | 468.4 | 332.4 |
+| seqlock optimistic read | 91.1 | 25.6 | 14.7 | **14.7** |
+
+**The rwlock is the wrong primitive for a read-dominated cache.** It *degrades*
+6.2x from 1->8 processes while the unlocked baseline *improves* 5.9x (real
+parallelism). At 8 processes the rwlock is **25x slower than the seqlock**
+(373.5 vs 14.7 ns). Cause is not subtle: `rdlock` performs an atomic
+read-modify-write on a shared reader-count cache line, so every reader
+invalidates every other reader's cache line. Linux shows the same shape
+(79.0 -> 358.0 ns for rwlock; 37.2 -> 14.8 ns for seqlock).
+
+**3d. Killing a lock holder mid-critical-section (measured):**
+
+- **macOS**: survivor's `pthread_mutex_lock()` **hung forever** (killed by a 3 s
+  alarm); `trylock` returned EBUSY. **One worker dying inside a write critical
+  section permanently deadlocks the entire pool.** There is no recovery API.
+- **Linux**: survivor got `EOWNERDEAD`, and `pthread_mutex_consistent()`
+  succeeded — **the lock recovers**.
+
+**The critical caveat on the Linux PASS: `EOWNERDEAD` recovers the *lock*, not
+the *data*.** `pthread_mutex_consistent()` is a promise the application makes
+that the protected state is sane. After a writer dies inside `JudyLIns`, it is
+not — see Gate 5. Robust mutexes convert a deadlock into a *corrupt but
+running* system, which is an improvement only if there is a real recovery plan.
+
+**A seqlock is NOT a drop-in fix.** The 3b/3c seqlock numbers measure lock
+*overhead* honestly, but the benchmark's writers only mutate a value in place —
+they never restructure the tree. A seqlock cannot protect a pointer-chasing
+structure whose nodes are being freed and reused: an optimistic reader can
+dereference a node the writer has already freed and the arena has already
+recycled, and the version re-check happens *after* the fault. Gate 5's reader
+crashes are exactly this failure class. Using seqlock reads therefore requires
+**epoch-based / RCU-style deferred reclamation** so freed nodes are not reused
+while any reader may still hold a pointer — which in turn constrains the Gate 4
+freelist (frees must be quarantined, not immediately reusable).
+
+**Portable fallback**, if robust mutexes are unavailable (macOS): `flock`/`fcntl`
+advisory locks are released by the kernel on process death on both platforms.
+Cost is a syscall per operation rather than a userspace atomic — roughly two
+orders of magnitude worse than the numbers above, which is untenable on a cache
+read path. A lease/heartbeat scheme avoids the syscall but adds a liveness
+timeout during which the cache is stalled or bypassed.
+
+### Gate 4 — arena management and fragmentation -> **PASS** (freelist) / **FAIL** (bump-only)
+
+This is the gate the design most clearly survives, and the results are
+**byte-identical on macOS and Linux** (Judy's allocation behavior is
+deterministic).
+
+**4a. Real allocation profile at 1M keys (measured):**
+
+| | dense/sequential | sparse/random |
+| --- | --- | --- |
+| `JudyMalloc` calls | 160,170 | 395,226 |
+| `JudyFree` calls | 140,619 | 329,433 |
+| **churn ratio (free/alloc)** | **0.878** | **0.834** |
+| arena footprint | 8.0 MB | 25.6 MB |
+| live bytes | 7.9 MB | 16.8 MB |
+| distinct size classes | **12** | **12** |
+| largest allocation | 512 words (4096 B) | 512 words (4096 B) |
+
+Two structurally important facts:
+
+- **Only 12 distinct size classes exist, capped at 4096 B** (= `jbu_t`, a
+  256-way uncompressed branch). This is a small, bounded, static set — exactly
+  the shape that makes exact-size-class freelists cheap and removes any need for
+  splitting, coalescing, or best-fit search.
+- **Churn is ~85% even during pure insertion.** Judy constantly frees and
+  reallocates nodes as leaves grow and branches get promoted. Delete-heavy TTL
+  traffic is not the only source of churn — *insert-only* workloads already
+  free ~0.85 blocks per allocation. Any "we mostly just append" reasoning is
+  wrong.
+
+**4b/4c. Bump-only vs size-class freelist under TTL churn (measured):**
+
+Build 500k keys, then 20 rounds x (evict 25k + insert 25k), live population flat:
+
+| Arena mode | allocs | reused | footprint | live | waste |
+| --- | --- | --- | --- | --- | --- |
+| size-class freelist | 656,321 | 546,453 | 11.8 MB | 9.0 MB | **1.31x** |
+| bump-only (no reuse) | 656,321 | 0 | 67.4 MB | 9.0 MB | **7.45x** |
+
+Sustained churn, live population constant at 4.1 MB:
+
+| Arena mode | 10 rounds | 40 rounds | 160 rounds |
+| --- | --- | --- | --- |
+| size-class freelist | 5.2 MB | 5.2 MB | **5.2 MB (flat)** |
+| bump-only | 12.1 MB | 21.4 MB | **58.5 MB (linear growth)** |
+
+**A bump-only arena is fatal, quantified: it grows ~0.31 MB per churn round
+without bound while the live set stays flat.** For a TTL cache that is an
+unbounded leak terminating in segment exhaustion. The size-class freelist
+reaches a **flat steady state** and is the only viable design.
+
+**Derived fragmentation bound (projected, from the measured histogram):** with
+exact-size-class freelists and no splitting or coalescing, the arena's
+high-water mark converges to `sum_c peak_live_blocks[c] * size[c]` — the sum of
+per-class peaks. Measured steady-state waste is **1.27–1.31x live**, consistent
+with that bound. **The residual risk is class stranding**: blocks freed in class
+A can only ever be reused by class A, so a workload whose *shape* shifts (e.g.
+key-length distribution changes, shifting Judy from one node type to another)
+strands the old class's peak permanently. The bound is a sum of peaks, not a
+peak of sums. For a cache with a stable key distribution this is fine; it should
+be monitored rather than assumed, and a segment-level reset is the escape hatch.
+
+### Gate 5 — crash consistency during writer death -> **FAIL as an unmitigated design; tractable only with an explicit recovery strategy**
+
+This gate was measured rather than argued, because the central claim ("a writer
+dying mid-`JudyLIns` corrupts the shared tree") is testable.
+
+**5a. Arena leak per killed writer (measured, 300k inserts):**
+
+| Allocations in one `JudyLIns` | Share |
+| --- | --- |
+| 0 | 42.17% |
+| 1 | 57.70% |
+| 2 | 0.05% |
+| >=7 | 0.09% |
+
+Worst observed single insert: **17 allocations, 4184 bytes**. A writer killed
+mid-insert strands up to that much in the arena — allocated, not yet linked into
+the tree, therefore unreachable and unfreeable. **There is no process teardown
+to reclaim a shared arena**, so this leak is permanent for the segment's
+lifetime and accumulates across every writer death.
+
+**5b. Writer SIGKILLed at a random point mid-insert; a separate reader process
+then traverses the shared tree. 40 trials per platform:**
+
+| Outcome | macOS (run 1) | macOS (run 2) | Linux |
+| --- | --- | --- | --- |
+| traversable | 37 | 35 | 31 |
+| inconsistent (count/order wrong) | 2 | 2 | 3 |
+| **reader process crashed/hung** | 1 | 3 | **6** |
+| traversable but lost/partial update | 0 | 5 | 6 |
+
+Corruption rate (inconsistent + crashed), with Wilson 95% CIs:
+
+- macOS: 3/40 = 7.5%, CI **[2.6%, 19.9%]**
+- Linux: 9/40 = 22.5%, CI **[12.3%, 37.5%]**
+- Pooled (12/80): 15.0%, CI **[8.8%, 24.4%]**
+
+**The CI lower bound is well clear of zero on both platforms: writer death
+corrupts the shared tree, this is established rather than suspected.** And the
+worst outcome is not silent wrongness — on Linux **6/40 (15%, CI [7.1%, 29.1%])
+of writer deaths caused an *unrelated reader process to crash*.** In FPM terms:
+one worker hitting a fatal error inside a write takes healthy workers down with
+it, and they will keep dying on every subsequent read until the segment is
+replaced. This is a cascading-failure mode, not a degraded-cache mode.
+
+Note that "traversable" is a weak pass. It only means a forward iteration
+completed in order; it does not prove the tree is structurally sound, and the
+"lost/partial update" column shows entries silently missing even then.
+
+**5c. Recovery cost — discard the segment and rebuild (measured, contaminated,
+upper bound):**
+
+| Keys | min | median | max |
+| --- | --- | --- | --- |
+| 100,000 | 0.005 s | 0.006 s | 0.007 s |
+| 1,000,000 | 0.156 s | 0.182 s | 0.208 s |
+
+**This is the number that makes Gate 5 survivable.** A cache is reconstructible
+by definition, and a full 1M-key rebuild costs ~0.16 s. "Poison the segment and
+start empty" is a legitimate recovery strategy here in a way it never would be
+for a database.
+
+**Options, with costs:**
+
+| Strategy | Cost | Verdict |
+| --- | --- | --- |
+| Generation counter + rebuild on corruption | cannot *detect* structural corruption cheaply; a reader discovers it by faulting | **insufficient alone** — detection is the hard part, not rebuild |
+| Write-ahead journal | every mutation writes twice; replay on recovery; must journal allocator state too | disproportionate for a cache |
+| **Single-writer-process design** | all mutations serialized through one owner; readers never observe a partial write from a dead peer; writer death is contained | **strongest**, but changes the architecture — no longer "an extension calls JudyLIns" |
+| Copy-on-write double-buffer | 2x memory; publish via one atomic root swap; readers always see a complete tree | clean, viable for read-mostly; write amplification is severe for per-key TTL updates |
+| **Accept corruption + poison + nuke the segment** | one flag check per operation; **~0.16 s to refill 1M keys**; every writer death flushes the whole cache | **most practical** given 5c |
+
+**The design would have to adopt segment poisoning + rebuild, combined with
+robust-mutex `EOWNERDEAD` detection (Linux) to know a death occurred at all.**
+Concretely: a writer sets an "in-flight mutation" flag in the shared header
+before touching the tree and clears it after; any process that acquires the lock
+with `EOWNERDEAD` while that flag is set marks the entire segment poisoned;
+every worker checks the poison flag and rebuilds/bypasses. This bounds the
+damage but means **any writer death flushes the entire cache** — an availability
+characteristic that must be stated up front, because PHP fatal errors, OOM
+kills, and `request_terminate_timeout` kills are routine in FPM, not
+exceptional.
+
+Even this does not recover the 5a arena leak; poisoning discards the whole
+segment, which is the only thing that reclaims it.
+
+---
+
+## 5. Untested / out of scope
+
+Reported as untested, not as passing:
+
+- **Real PHP/FPM integration.** Everything here is standalone C. Whether
+  ZTS/NTS PHP, opcache, or the FPM master's own `fork` timing changes the
+  picture is unmeasured. In particular the arena must be created at MINIT
+  *before* the master forks, which was not exercised.
+- **x86-64.** All Linux testing was aarch64 (Docker on M1). Memory-ordering
+  behavior around the seqlock differs materially on x86-64 (TSO) vs aarch64
+  (weak) — aarch64 is the *stricter* test for correctness, but the *timing*
+  will differ.
+- **8-process contention on Linux.** The Docker VM had only 4 CPUs, so the 8p
+  Linux column is oversubscribed.
+- **Epoch/RCU reclamation.** Identified as required for safe seqlock reads
+  (Gate 3); not prototyped. Its interaction with the Gate 4 freelist
+  (quarantined frees inflating the fragmentation bound) is **underived**.
+- **Contended write-heavy workloads.** Benchmarks used 1% writes. TTL-heavy
+  caches may write far more.
+- **Class stranding under distribution shift** (Gate 4) — bound derived, not
+  measured.
+- **`MAP_FIXED_NOREPLACE`** and hugepage interaction — not tested.
+- **Musl libc** (Alpine) — robust-mutex support not verified.
+
+## 6. What would kill this feature
+
+Ranked by how likely they are to be fatal:
+
+1. **The cascading reader crash (Gate 5b).** 15% of writer deaths on Linux
+   killed an unrelated reader. A cache whose failure mode is "takes down healthy
+   workers" is worse than no cache. This is only acceptable with segment
+   poisoning, and poisoning means a full cache flush on every writer death.
+2. **macOS is a dead end for the locking story (Gate 3d).** No robust mutexes;
+   a killed holder wedges the pool permanently. Combined with §3.1 (dylib
+   override impossible), macOS would be a non-functional or badly degraded
+   development platform for a Linux-only production feature. That is a real
+   maintenance and contributor-experience cost for this repo.
+3. **The read path cannot use the obvious primitive (Gate 3b/3c).** A pshared
+   rwlock costs +59 ns/read and is 25x slower than the alternative at 8
+   processes. The alternative (seqlock) needs epoch reclamation, which is a
+   substantial subsystem in its own right and constrains the allocator.
+4. **Cold cache on every reload (Gate 2).** ASLR moves the mapping on every
+   master restart. `MAP_FIXED` at a hardcoded address is the only fix and
+   carries its own corruption risk.
+
+Not on this list, notably: **the allocator itself.** Gates 1 and 4 came out
+clean and the arena design is sound and bounded. The problems are all in
+concurrency and failure semantics.
+
+## 7. Gate summary
+
+| Gate | Verdict | Single most important measured number |
+| --- | --- | --- |
+| 1. `JudyMalloc` override | **PASS_with_caveats** | 535,191 allocs, **0** size mismatches / overlaps / leaks; but **0 calls captured** against macOS dylib |
+| 2. Address stability | **PASS_with_caveats** | 8/8 children identical base; **6/6 runs differ** across restart (ASLR) |
+| 3. Robust pshared lock | **Linux PASS_with_caveats / macOS FAIL** | rwlock **373.5 ns** vs seqlock **14.7 ns** at 8p; macOS holder death = **permanent deadlock** |
+| 4. Arena management | **PASS** (freelist) / **FAIL** (bump) | freelist **5.2 MB flat** vs bump **58.5 MB and growing**, same 4.1 MB live |
+| 5. Crash consistency | **FAIL unmitigated** | corruption **15%** pooled, CI **[8.8%, 24.4%]**; **15%** of Linux kills crashed a reader; rebuild **0.156 s / 1M keys** |
+
+## 8. Recommendation
+
+**`PROCEED_WITH_AMENDMENT`**, conditional on accepting all of the following. If
+any is unacceptable, the correct answer is REJECT.
+
+1. **Linux-only feature.** macOS gets a compile-time-disabled stub. Requires
+   `__GLIBC__` robust mutexes (verify musl separately). macOS developers cannot
+   test this code path — accept that, or vendor libJudy to at least restore the
+   allocator override for local testing.
+2. **Size-class freelist arena, never bump-only.** Non-negotiable per Gate 4.
+3. **No pshared rwlock on the read path.** Either accept +59 ns/read and 25x
+   contention degradation, or build epoch-based reclamation to make optimistic
+   reads safe. **Prototype the epoch reclaimer before committing** — it is the
+   largest unquantified risk remaining.
+4. **Segment poisoning + rebuild-on-writer-death**, with the availability
+   characteristic stated in the docs: *any* worker dying mid-write flushes the
+   entire cache. Gate 5c shows this costs ~0.16 s per 1M keys, which is
+   acceptable; the surprise factor for users is not, so it must be documented,
+   not discovered.
+5. **Assert at MINIT that the arena allocator is actually installed**, because
+   the macOS failure mode is silent (§3.1).
+6. **Cold cache on reload** is documented as expected behavior, or
+   `MAP_FIXED_NOREPLACE` is adopted with a collision-failure path.
+
+**Strongly consider the single-writer amendment instead.** Routing all mutations
+through one owner process collapses Gates 3 and 5 simultaneously: no
+multi-writer contention, no partial writes from a dead peer, no robust-mutex
+dependency, and the read path can be a genuine seqlock because the single writer
+can drive epoch reclamation itself. It costs an IPC hop per write. Given that
+Gates 3 and 5 are where all the risk lives, and Gates 1 and 4 (the parts unique
+to Judy) are clean, this is the variant most likely to actually ship.
+
+**The blunt version:** the Judy-specific parts of this idea work. The allocator
+hook is real, the arena is bounded and well-behaved, and ordered prefix
+invalidation remains a genuine advantage APCu cannot match. What the spike
+found is that the hard part was never Judy — it is that putting a
+pointer-rich mutable structure in shared memory across processes that can be
+`kill -9`'d at any instant requires a concurrency and failure-recovery
+subsystem (robust locking + epoch reclamation + poison/rebuild) that is larger
+than the feature itself. Scope it as that subsystem, or scope it down to a
+single writer.
+
+**Per the issue's own framing, API design, judy-cache integration, and APCu
+benchmarks remain out of scope** — gates 3 and 5 did not pass cleanly enough to
+open them.
+
+---
+
+*All verdicts are from this spike's own measurements on one machine, under
+acknowledged load contamination for timing figures. No independent review has
+been performed.*

--- a/research/shm-arena/Makefile
+++ b/research/shm-arena/Makefile
@@ -1,0 +1,68 @@
+# Step-0 feasibility spike for issue #83 (shared-memory Judy arena).
+# NOT part of the php-judy build. Nothing here is shipped (absent from package.xml).
+#
+# IMPORTANT (gate 1 finding): overriding JudyMalloc/JudyFree requires that the
+# override be visible to libJudy's own internal calls.
+#   * Linux/ELF : works against the stock shared libJudy.so AND the static .a
+#   * macOS/Mach-O: works ONLY against the static archive libJudy.a. The
+#     two-level namespace binds libJudy.dylib's internal calls to its own
+#     definition; -flat_namespace does not change this.
+# So we link the static archive by default on macOS.
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  JUDY_PREFIX ?= /opt/homebrew
+else
+  JUDY_PREFIX ?= /usr
+endif
+
+CC      ?= cc
+CFLAGS  ?= -std=c11 -O2 -g -Wall -Wextra -Wno-unused-result
+ifeq ($(UNAME_S),Darwin)
+  FEATURE_MACROS = -D_DARWIN_C_SOURCE
+else
+  # glibc hides MAP_ANONYMOUS, robust-mutex constants, etc. under strict -std=c11
+  FEATURE_MACROS = -D_GNU_SOURCE
+endif
+
+CPPFLAGS = -I$(JUDY_PREFIX)/include $(FEATURE_MACROS)
+
+ifeq ($(UNAME_S),Darwin)
+  JUDY_LIB = $(JUDY_PREFIX)/lib/libJudy.a
+else
+  JUDY_LIB = -L$(JUDY_PREFIX)/lib -lJudy
+  # On Linux prefer the static archive when present for a like-for-like link.
+  ifneq ($(wildcard /usr/lib/x86_64-linux-gnu/libJudy.a),)
+    JUDY_LIB = /usr/lib/x86_64-linux-gnu/libJudy.a
+  endif
+  ifneq ($(wildcard /usr/lib/aarch64-linux-gnu/libJudy.a),)
+    JUDY_LIB = /usr/lib/aarch64-linux-gnu/libJudy.a
+  endif
+  LDLIBS_EXTRA = -lpthread -lrt
+endif
+
+GATES = gate1_correctness gate2_fork gate3_lock gate4_profile gate5_crash
+
+all: $(GATES)
+
+gate%: gate%.c shm_arena.c shm_arena.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $< shm_arena.c $(JUDY_LIB) $(LDLIBS_EXTRA)
+
+# Address/UB sanitizer build of the correctness gate.
+gate1_asan: gate1_correctness.c shm_arena.c shm_arena.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) -fsanitize=address,undefined -fno-omit-frame-pointer \
+	  -o $@ $< shm_arena.c $(JUDY_LIB) $(LDLIBS_EXTRA)
+
+.PHONY: all clean run run1 run2 run3 run4 run5 asan
+run: run1 run2 run3 run4 run5
+
+run1: gate1_correctness ; @./gate1_correctness
+run2: gate2_fork        ; @./gate2_fork
+run3: gate3_lock        ; @./gate3_lock
+run4: gate4_profile     ; @./gate4_profile
+run5: gate5_crash       ; @./gate5_crash
+
+asan: gate1_asan ; @./gate1_asan
+
+clean:
+	rm -f $(GATES) gate1_asan *.o

--- a/research/shm-arena/gate1_correctness.c
+++ b/research/shm-arena/gate1_correctness.c
@@ -1,0 +1,305 @@
+/*
+ * gate1_correctness.c - Gate 1: JudyMalloc override + arena correctness.
+ *
+ * Proves:
+ *   (a) Judy1 / JudyL / JudySL insert, delete and ordered iteration are correct
+ *       when every Judy allocation comes from a MAP_SHARED arena.
+ *   (b) Judy's JudyFree(size) always matches the JudyMalloc(size) that produced
+ *       the block. This invariant is what makes an exact-size-class freelist
+ *       safe; without it gate 4's arena design collapses.
+ *   (c) No two live blocks overlap and nothing is freed twice, verified with a
+ *       word-granular shadow map over the whole arena.
+ *   (d) Every address handed to Judy has its low 3 bits clear (MALLOCBITS).
+ */
+
+#include "shm_arena.h"
+
+#include <Judy.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ARENA_BYTES (512ull * 1024 * 1024)
+#define N_KEYS 200000u
+
+static int g_fail = 0;
+#define CHECK(cond, ...)                                                       \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            fprintf(stderr, "  FAIL %s:%d: ", __FILE__, __LINE__);             \
+            fprintf(stderr, __VA_ARGS__);                                      \
+            fprintf(stderr, "\n");                                             \
+            g_fail = 1;                                                        \
+        }                                                                      \
+    } while (0)
+
+/* ---- shadow map: one byte per 8-byte word of the arena ---- */
+static unsigned char *g_shadow;   /* 0 = free, 1..n = live, first word marked */
+static size_t g_shadow_words;
+static arena_hdr_t *g_a;
+static unsigned long g_audit_allocs, g_audit_frees;
+static unsigned long g_overlap, g_dblfree, g_sizemismatch;
+
+/* remembered size (in words) for each live block, indexed by word offset */
+static unsigned int *g_blocksz;
+
+static void auditor(void *addr, size_t words, int is_free) {
+    size_t off = (size_t)((char *)addr - (char *)g_a);
+    size_t w = off / 8;
+    /* payload rounded up to ARENA_ALIGN, same as the arena does */
+    size_t span = ((words * sizeof(Word_t)) + 7) / 8;
+    if (w + span > g_shadow_words) return; /* outside tracked region */
+
+    if (!is_free) {
+        g_audit_allocs++;
+        for (size_t i = 0; i < span; i++) {
+            if (g_shadow[w + i]) {
+                if (g_overlap++ == 0)
+                    fprintf(stderr, "  overlap: alloc %p+%zuw hits live word %zu\n",
+                            addr, span, w + i);
+            }
+            g_shadow[w + i] = 1;
+        }
+        g_blocksz[w] = (unsigned int)words;
+    } else {
+        g_audit_frees++;
+        if (g_shadow[w] == 0) {
+            if (g_dblfree++ == 0)
+                fprintf(stderr, "  double-free/unknown free at %p\n", addr);
+            return;
+        }
+        if (g_blocksz[w] != (unsigned int)words) {
+            if (g_sizemismatch++ == 0)
+                fprintf(stderr,
+                        "  SIZE MISMATCH at %p: alloc'd %u words, freed as %zu words\n",
+                        addr, g_blocksz[w], words);
+        }
+        for (size_t i = 0; i < span; i++) g_shadow[w + i] = 0;
+        g_blocksz[w] = 0;
+    }
+}
+
+/* deterministic pseudo-random key, no libc rand dependency */
+static Word_t mix(Word_t x) {
+    x ^= x >> 33; x *= 0xff51afd7ed558ccdull;
+    x ^= x >> 33; x *= 0xc4ceb9fe1a85ec53ull;
+    x ^= x >> 33;
+    return x;
+}
+
+static int cmp_word(const void *a, const void *b) {
+    Word_t x = *(const Word_t *)a, y = *(const Word_t *)b;
+    return (x > y) - (x < y);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_judyl(const char *label, int sparse) {
+    Pvoid_t L = NULL;
+    Word_t *pv;
+    int rc;
+
+    Word_t *keys = malloc(N_KEYS * sizeof(Word_t));
+    for (Word_t i = 0; i < N_KEYS; i++)
+        keys[i] = sparse ? mix(i) : (Word_t)(i * 3);
+
+    /* dedupe so the reference model matches Judy's set semantics */
+    qsort(keys, N_KEYS, sizeof(Word_t), cmp_word);
+    size_t nk = 0;
+    for (size_t i = 0; i < N_KEYS; i++)
+        if (i == 0 || keys[i] != keys[i - 1]) keys[nk++] = keys[i];
+
+    for (size_t i = 0; i < nk; i++) {
+        JLI(pv, L, keys[i]);
+        CHECK(pv != PJERR, "JLI returned PJERR at %zu", i);
+        *pv = keys[i] ^ 0xa5a5a5a5u;
+    }
+
+    Word_t cnt;
+    JLC(cnt, L, 0, -1);
+    CHECK(cnt == nk, "%s: count %lu != %zu", label, (unsigned long)cnt, nk);
+
+    /* ordered forward iteration must reproduce the sorted key list exactly */
+    Word_t idx = 0;
+    size_t n = 0;
+    JLF(pv, L, idx);
+    while (pv) {
+        CHECK(n < nk && idx == keys[n], "%s: order break at %zu", label, n);
+        CHECK(*pv == (keys[n] ^ 0xa5a5a5a5u), "%s: value corrupt at %zu", label, n);
+        n++;
+        JLN(pv, L, idx);
+    }
+    CHECK(n == nk, "%s: forward iterated %zu of %zu", label, n, nk);
+
+    /* reverse iteration */
+    idx = (Word_t)-1;
+    n = 0;
+    JLL(pv, L, idx);
+    while (pv) {
+        CHECK(idx == keys[nk - 1 - n], "%s: reverse order break at %zu", label, n);
+        n++;
+        JLP(pv, L, idx);
+    }
+    CHECK(n == nk, "%s: reverse iterated %zu of %zu", label, n, nk);
+
+    /* delete every other key, then re-verify */
+    for (size_t i = 0; i < nk; i += 2) { JLD(rc, L, keys[i]); CHECK(rc == 1, "JLD failed"); }
+    JLC(cnt, L, 0, -1);
+    CHECK(cnt == nk - (nk + 1) / 2, "%s: count after delete = %lu", label, (unsigned long)cnt);
+
+    idx = 0; n = 0;
+    JLF(pv, L, idx);
+    while (pv) {
+        size_t want = 1 + 2 * n;
+        CHECK(want < nk && idx == keys[want], "%s: post-delete order break at %zu", label, n);
+        n++;
+        JLN(pv, L, idx);
+    }
+    CHECK(n == nk / 2, "%s: post-delete iterated %zu, want %zu", label, n, nk / 2);
+
+    /* re-insert the deleted half: exercises freelist reuse */
+    for (size_t i = 0; i < nk; i += 2) {
+        JLI(pv, L, keys[i]);
+        *pv = keys[i] ^ 0xa5a5a5a5u;
+    }
+    JLC(cnt, L, 0, -1);
+    CHECK(cnt == nk, "%s: count after reinsert = %lu", label, (unsigned long)cnt);
+
+    idx = 0; n = 0;
+    JLF(pv, L, idx);
+    while (pv) {
+        CHECK(idx == keys[n] && *pv == (keys[n] ^ 0xa5a5a5a5u),
+              "%s: reinsert verify break at %zu", label, n);
+        n++;
+        JLN(pv, L, idx);
+    }
+    CHECK(n == nk, "%s: reinsert iterated %zu of %zu", label, n, nk);
+
+    JLFA(rc, L);
+    (void)rc;
+    free(keys);
+    printf("  [ok] JudyL %-22s keys=%zu\n", label, nk);
+}
+
+static void test_judy1(void) {
+    Pvoid_t J = NULL;
+    int rc;
+    Word_t cnt, idx;
+
+    for (Word_t i = 0; i < N_KEYS; i++) { J1S(rc, J, mix(i)); }
+    J1C(cnt, J, 0, -1);
+
+    size_t n = 0;
+    idx = 0;
+    J1F(rc, J, idx);
+    Word_t prev = 0;
+    while (rc) {
+        if (n) CHECK(idx > prev, "Judy1: order break at %zu", n);
+        prev = idx; n++;
+        J1N(rc, J, idx);
+    }
+    CHECK(n == cnt, "Judy1: iterated %zu != count %lu", n, (unsigned long)cnt);
+
+    for (Word_t i = 0; i < N_KEYS; i += 3) { J1U(rc, J, mix(i)); }
+    Word_t cnt2;
+    J1C(cnt2, J, 0, -1);
+    CHECK(cnt2 < cnt, "Judy1: unset did not reduce count");
+
+    J1FA(rc, J);
+    printf("  [ok] Judy1  %-22s set=%lu after-unset=%lu\n", "sparse",
+           (unsigned long)cnt, (unsigned long)cnt2);
+}
+
+static void test_judysl(void) {
+    Pvoid_t S = NULL;
+    Word_t *pv;
+    int rc;
+    uint8_t buf[64];
+    const size_t NS = 50000;
+
+    for (size_t i = 0; i < NS; i++) {
+        snprintf((char *)buf, sizeof buf, "key:%016llx", (unsigned long long)mix(i));
+        JSLI(pv, S, buf);
+        CHECK(pv != PJERR, "JSLI PJERR");
+        *pv = (Word_t)i;
+    }
+
+    /* ordered traversal must be strictly increasing in strcmp order */
+    uint8_t cur[64];
+    uint8_t prev[64];
+    cur[0] = '\0';
+    size_t n = 0;
+    JSLF(pv, S, cur);
+    while (pv) {
+        if (n) CHECK(strcmp((char *)cur, (char *)prev) > 0,
+                     "JudySL: order break at %zu (%s <= %s)", n, cur, prev);
+        memcpy(prev, cur, sizeof prev);
+        n++;
+        JSLN(pv, S, cur);
+    }
+    CHECK(n == NS, "JudySL: iterated %zu of %zu", n, NS);
+
+    /* delete half, verify lookups */
+    for (size_t i = 0; i < NS; i += 2) {
+        snprintf((char *)buf, sizeof buf, "key:%016llx", (unsigned long long)mix(i));
+        JSLD(rc, S, buf);
+        CHECK(rc == 1, "JSLD failed at %zu", i);
+    }
+    for (size_t i = 1; i < NS; i += 2) {
+        snprintf((char *)buf, sizeof buf, "key:%016llx", (unsigned long long)mix(i));
+        JSLG(pv, S, buf);
+        CHECK(pv != NULL && *pv == (Word_t)i, "JSLG lost key %zu", i);
+    }
+    JSLFA(rc, S);
+    printf("  [ok] JudySL %-22s strings=%zu\n", "mixed", NS);
+}
+
+int main(void) {
+    printf("== Gate 1: JudyMalloc override onto MAP_SHARED arena ==\n");
+
+    g_a = arena_create(ARENA_BYTES, ARENA_MODE_FREELIST);
+    if (!g_a) { fprintf(stderr, "arena_create failed\n"); return 2; }
+
+    g_shadow_words = (size_t)(g_a->size / 8);
+    g_shadow = calloc(g_shadow_words, 1);
+    g_blocksz = calloc(g_shadow_words, sizeof(unsigned int));
+    if (!g_shadow || !g_blocksz) { fprintf(stderr, "shadow alloc failed\n"); return 2; }
+
+    arena_install(g_a);
+    arena_set_audit(auditor);
+
+    printf("  arena base=%p size=%llu MB\n", (void *)g_a,
+           (unsigned long long)(g_a->size / (1024 * 1024)));
+
+    test_judyl("dense/sequential", 0);
+    test_judyl("sparse/random", 1);
+    test_judy1();
+    test_judysl();
+
+    arena_set_audit(NULL);
+
+    printf("\n  allocator audit:\n");
+    printf("    JudyMalloc calls   : %lu\n", g_audit_allocs);
+    printf("    JudyFree   calls   : %lu\n", g_audit_frees);
+    printf("    overlapping blocks : %lu\n", g_overlap);
+    printf("    double/unknown free: %lu\n", g_dblfree);
+    printf("    alloc/free size mismatches: %lu\n", g_sizemismatch);
+    printf("    arena bump high-water: %.2f MB\n", (double)g_a->bump / (1024 * 1024));
+    printf("    live bytes at end  : %llu\n", (unsigned long long)g_a->live_bytes);
+    printf("    oversize allocs (> %u words): %llu\n", ARENA_MAX_WORDS,
+           (unsigned long long)g_a->n_oversize);
+    printf("    OOM               : %llu\n", (unsigned long long)g_a->n_oom);
+
+    CHECK(g_overlap == 0, "arena handed out overlapping blocks");
+    CHECK(g_dblfree == 0, "double free detected");
+    CHECK(g_sizemismatch == 0, "Judy free size != alloc size");
+    CHECK(g_a->n_oom == 0, "arena exhausted");
+    /* after all *FreeArray calls, the tree must have released everything */
+    CHECK(g_a->live_bytes == 0, "leak: %llu live bytes after JLFA/J1FA/JSLFA",
+          (unsigned long long)g_a->live_bytes);
+
+    printf("\nGATE 1: %s\n", g_fail ? "FAIL" : "PASS");
+    arena_destroy(g_a);
+    return g_fail ? 1 : 0;
+}

--- a/research/shm-arena/gate2_fork.c
+++ b/research/shm-arena/gate2_fork.c
@@ -1,0 +1,190 @@
+/*
+ * gate2_fork.c - Gate 2: address stability of a MAP_SHARED arena across fork.
+ *
+ * The whole design rests on absolute pointers inside the Judy tree remaining
+ * valid in every worker. That holds iff the mapping lands at the same address
+ * in every process that touches it.
+ *
+ * Tests:
+ *   2a. Parent builds a tree in the arena, forks N children; each child reports
+ *       its arena base and fully re-traverses the tree.
+ *   2b. A child mutates the shared tree; parent and a later child observe it
+ *       (verifies MAP_SHARED write visibility, not just read inheritance).
+ *   2c. MAP_FIXED at a caller-chosen address: does it remove the dependency on
+ *       fork inheritance, and does the address survive in a child?
+ *   2d. Base address across independent runs of the same binary (ASLR): printed
+ *       so the driver can compare across master restarts.
+ */
+
+#include "shm_arena.h"
+
+#include <Judy.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define ARENA_BYTES (128ull * 1024 * 1024)
+#define N_CHILDREN 8
+#define N_KEYS 100000u
+
+static int g_fail = 0;
+
+static Word_t mix(Word_t x) {
+    x ^= x >> 33; x *= 0xff51afd7ed558ccdull;
+    x ^= x >> 33; x *= 0xc4ceb9fe1a85ec53ull;
+    x ^= x >> 33;
+    return x;
+}
+
+/* The Judy root pointer must itself live in shared memory, otherwise each
+ * process would have its own copy of the root. Park it in the arena. */
+typedef struct {
+    Pvoid_t root;
+    Word_t  n_inserted;
+} shared_state_t;
+
+static shared_state_t *state_slot(arena_hdr_t *a) {
+    /* first allocation out of the arena, reserved by hand */
+    return (shared_state_t *)((char *)a + ((sizeof(arena_hdr_t) + 63) & ~63ull));
+}
+
+/* verify the tree contains exactly keys mix(0..n-1), in sorted order */
+static int verify_tree(Pvoid_t root, Word_t n, const char *who) {
+    Word_t *pv, idx = 0, count = 0, prev = 0;
+    int bad = 0;
+
+    JLF(pv, root, idx);
+    while (pv) {
+        if (count && idx <= prev) { bad++; break; }
+        if (*pv != (idx ^ 0x5a5a5a5aull)) { bad++; break; }
+        prev = idx; count++;
+        JLN(pv, root, idx);
+    }
+    if (count != n) {
+        fprintf(stderr, "  [%s] tree has %lu entries, expected %lu\n",
+                who, (unsigned long)count, (unsigned long)n);
+        return 1;
+    }
+    return bad;
+}
+
+int main(void) {
+    printf("== Gate 2: MAP_SHARED address stability across fork ==\n");
+
+    arena_hdr_t *a = arena_create(ARENA_BYTES, ARENA_MODE_FREELIST);
+    if (!a) { perror("arena_create"); return 2; }
+    arena_install(a);
+
+    shared_state_t *st = state_slot(a);
+    /* keep the hand-reserved slot out of the bump allocator's way */
+    a->bump = (uint64_t)(((char *)st - (char *)a) + sizeof(shared_state_t) + 63) & ~63ull;
+    st->root = NULL;
+    st->n_inserted = 0;
+
+    printf("  parent arena base = %p  (2d: compare across runs for ASLR)\n", (void *)a);
+
+    /* ---- build the tree in the parent, pre-fork ---- */
+    Word_t *pv;
+    for (Word_t i = 0; i < N_KEYS; i++) {
+        Word_t k = mix(i);
+        JLI(pv, st->root, k);
+        *pv = k ^ 0x5a5a5a5aull;
+    }
+    Word_t cnt;
+    JLC(cnt, st->root, 0, -1);
+    st->n_inserted = cnt;
+    printf("  parent built tree: %lu entries, arena footprint %.2f MB\n",
+           (unsigned long)cnt, (double)a->bump / (1024 * 1024));
+
+    /* ---- 2a: fork children, each reports base + re-traverses ---- */
+    int pipefd[2];
+    if (pipe(pipefd) != 0) { perror("pipe"); return 2; }
+
+    for (int i = 0; i < N_CHILDREN; i++) {
+        pid_t p = fork();
+        if (p == 0) {
+            close(pipefd[0]);
+            void *base = (void *)arena_current();
+            int bad = verify_tree(st->root, st->n_inserted, "child");
+            /* report base address + verdict back to parent */
+            struct { void *base; int bad; } msg = { base, bad };
+            ssize_t w = write(pipefd[1], &msg, sizeof msg);
+            (void)w;
+            close(pipefd[1]);
+            _exit(bad ? 1 : 0);
+        } else if (p < 0) { perror("fork"); return 2; }
+    }
+    close(pipefd[1]);
+
+    int same_addr = 1, verify_ok = 1;
+    void *first = NULL;
+    for (int i = 0; i < N_CHILDREN; i++) {
+        struct { void *base; int bad; } msg;
+        ssize_t r = read(pipefd[0], &msg, sizeof msg);
+        if (r != (ssize_t)sizeof msg) { fprintf(stderr, "  short read\n"); g_fail = 1; break; }
+        if (i == 0) first = msg.base;
+        if (msg.base != (void *)a || msg.base != first) same_addr = 0;
+        if (msg.bad) verify_ok = 0;
+    }
+    close(pipefd[0]);
+    for (int i = 0; i < N_CHILDREN; i++) { int s; wait(&s); }
+
+    printf("  2a: %d children, identical arena base: %s; tree traversal: %s\n",
+           N_CHILDREN, same_addr ? "YES" : "NO", verify_ok ? "OK" : "CORRUPT");
+    if (!same_addr || !verify_ok) g_fail = 1;
+
+    /* ---- 2b: child mutates shared tree, parent observes ---- */
+    Word_t extra_key = 0xdeadbeefcafe0001ull;
+    pid_t p = fork();
+    if (p == 0) {
+        JLI(pv, st->root, extra_key);
+        if (pv && pv != PJERR) *pv = extra_key ^ 0x5a5a5a5aull;
+        Word_t c;
+        JLC(c, st->root, 0, -1);
+        st->n_inserted = c;
+        _exit(0);
+    }
+    int status; waitpid(p, &status, 0);
+
+    Word_t *found;
+    JLG(found, st->root, extra_key);
+    int child_write_visible = (found != NULL && *found == (extra_key ^ 0x5a5a5a5aull));
+    printf("  2b: child's insert visible in parent: %s (count now %lu)\n",
+           child_write_visible ? "YES" : "NO", (unsigned long)st->n_inserted);
+    if (!child_write_visible) g_fail = 1;
+
+    /* ---- 2c: MAP_FIXED at a chosen address ---- */
+    /* Reserve a region first so we pick an address the kernel agrees is free. */
+    size_t fixed_len = 16ull * 1024 * 1024;
+    void *probe = mmap(NULL, fixed_len, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (probe == MAP_FAILED) { perror("probe mmap"); return 2; }
+    munmap(probe, fixed_len);
+
+    arena_hdr_t *fa = arena_create_fixed(probe, fixed_len, ARENA_MODE_FREELIST);
+    if (!fa) {
+        printf("  2c: MAP_FIXED at %p FAILED (%s)\n", probe, strerror(errno));
+        g_fail = 1;
+    } else {
+        printf("  2c: MAP_FIXED requested %p, got %p -> %s\n", probe, (void *)fa,
+               (fa == (arena_hdr_t *)probe) ? "EXACT" : "MOVED");
+        if (fa != (arena_hdr_t *)probe) g_fail = 1;
+
+        /* does a child inherit the fixed mapping at the same address? */
+        pid_t q = fork();
+        if (q == 0) { _exit(((void *)fa == probe) ? 0 : 1); }
+        waitpid(q, &status, 0);
+        printf("  2c: child sees fixed mapping at same address: %s\n",
+               (WIFEXITED(status) && WEXITSTATUS(status) == 0) ? "YES" : "NO");
+        arena_destroy(fa);
+    }
+
+    printf("\nGATE 2: %s\n", g_fail ? "FAIL" : "PASS");
+    /* note: arena intentionally not destroyed before the summary above */
+    arena_install(NULL);
+    return g_fail ? 1 : 0;
+}

--- a/research/shm-arena/gate3_lock.c
+++ b/research/shm-arena/gate3_lock.c
@@ -1,0 +1,414 @@
+/*
+ * gate3_lock.c - Gate 3: process-shared locking for the arena.
+ *
+ * Four questions:
+ *   3a. Which primitives actually exist here? pthread_rwlock pshared,
+ *       pthread_mutex pshared, and crucially ROBUST mutexes (Linux-only).
+ *   3b. Per-op overhead, uncontended, for: no lock / pshared rwlock rdlock /
+ *       pshared mutex / seqlock optimistic read.
+ *   3c. Same under N-process contention on a read-dominated workload, which is
+ *       what a cache actually does.
+ *   3d. Kill a lock holder mid-critical-section. What do the survivors see?
+ *
+ * Timing methodology: each configuration is run REPS times; we report
+ * median and min/max across reps, never a single run.
+ */
+
+#include "shm_arena.h"
+
+#include <Judy.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define ARENA_BYTES (128ull * 1024 * 1024)
+#define N_KEYS 200000u
+#define N_OPS 2000000u
+#define REPS 15
+
+/*
+ * Estimator note: on a loaded machine the MEDIAN of wall-clock per-op timings
+ * is badly biased upward by scheduler interference (and can even invert the
+ * ordering of two configurations). Interference can only ADD time, never remove
+ * it, so the MINIMUM across repetitions is the robust estimator for per-op cost
+ * under contamination. We report min as primary and median/max as spread.
+ */
+
+/*
+ * Robust-mutex detection.
+ *
+ * NOTE: glibc declares PTHREAD_MUTEX_ROBUST as an ENUM CONSTANT, not a macro,
+ * so "#if defined(PTHREAD_MUTEX_ROBUST)" is FALSE on Linux even though robust
+ * mutexes are fully supported. Detecting by feature-macro is the trap here;
+ * detect by C library instead.
+ *   glibc  : pthread_mutexattr_setrobust + pthread_mutex_consistent  -> yes
+ *   macOS  : symbols do not exist at all                             -> no
+ */
+#if defined(__GLIBC__)
+#  define HAVE_ROBUST_MUTEX 1
+#else
+#  define HAVE_ROBUST_MUTEX 0
+#endif
+
+static Word_t mix(Word_t x) {
+    x ^= x >> 33; x *= 0xff51afd7ed558ccdull;
+    x ^= x >> 33; x *= 0xc4ceb9fe1a85ec53ull;
+    x ^= x >> 33;
+    return x;
+}
+
+static double now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1e9 + (double)ts.tv_nsec;
+}
+
+static int cmp_dbl(const void *a, const void *b) {
+    double x = *(const double *)a, y = *(const double *)b;
+    return (x > y) - (x < y);
+}
+
+/* shared control block, lives in the arena */
+typedef struct {
+    Pvoid_t root;
+    pthread_rwlock_t rw;
+    pthread_mutex_t  mtx;
+    atomic_uint_least64_t seq;    /* seqlock counter: odd = write in progress */
+    atomic_int start_flag;
+    atomic_int holder_alive;
+    atomic_long total_ops;
+} ctl_t;
+
+/* ------------------------------------------------------------------ */
+/* 3a: capability probe                                                */
+/* ------------------------------------------------------------------ */
+
+static int have_robust = 0;
+
+static void probe_capabilities(void) {
+    printf("-- 3a: primitive availability on this platform --\n");
+
+    pthread_rwlockattr_t ra;
+    int rc = pthread_rwlockattr_init(&ra);
+    rc |= pthread_rwlockattr_setpshared(&ra, PTHREAD_PROCESS_SHARED);
+    printf("   pthread_rwlockattr_setpshared(PROCESS_SHARED) : %s\n",
+           rc == 0 ? "OK" : strerror(rc));
+    pthread_rwlockattr_destroy(&ra);
+
+    pthread_mutexattr_t ma;
+    rc = pthread_mutexattr_init(&ma);
+    rc |= pthread_mutexattr_setpshared(&ma, PTHREAD_PROCESS_SHARED);
+    printf("   pthread_mutexattr_setpshared(PROCESS_SHARED)  : %s\n",
+           rc == 0 ? "OK" : strerror(rc));
+
+#if HAVE_ROBUST_MUTEX
+    {
+        int r2 = pthread_mutexattr_setrobust(&ma, PTHREAD_MUTEX_ROBUST);
+        printf("   pthread_mutexattr_setrobust(ROBUST)           : %s\n",
+               r2 == 0 ? "OK  <-- EOWNERDEAD recovery available" : strerror(r2));
+        have_robust = (r2 == 0);
+    }
+#else
+    printf("   pthread_mutexattr_setrobust(ROBUST)           : "
+           "ABSENT ON THIS PLATFORM  <-- no EOWNERDEAD recovery\n");
+    have_robust = 0;
+#endif
+    pthread_mutexattr_destroy(&ma);
+
+    /* robust RWLOCKS do not exist in POSIX on any platform */
+    printf("   robust *rwlock* (any platform)                : "
+           "DOES NOT EXIST IN POSIX\n");
+    printf("   -> a robust design can only use a robust MUTEX, not a rwlock.\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* lock modes                                                          */
+/* ------------------------------------------------------------------ */
+
+typedef enum { M_NOLOCK, M_RWLOCK, M_MUTEX, M_SEQLOCK } mode_t_;
+static const char *mode_name(mode_t_ m) {
+    switch (m) {
+        case M_NOLOCK:  return "no lock (unsafe baseline)";
+        case M_RWLOCK:  return "pshared rwlock rdlock";
+        case M_MUTEX:   return "pshared mutex lock";
+        case M_SEQLOCK: return "seqlock optimistic read";
+    }
+    return "?";
+}
+
+/* one read op: lookup a key under the given lock discipline */
+static inline int do_read(ctl_t *c, mode_t_ m, Word_t key, Word_t *out) {
+    Word_t *pv;
+    switch (m) {
+        case M_NOLOCK:
+            JLG(pv, c->root, key);
+            *out = pv ? *pv : 0;
+            return 1;
+        case M_RWLOCK:
+            pthread_rwlock_rdlock(&c->rw);
+            JLG(pv, c->root, key);
+            *out = pv ? *pv : 0;
+            pthread_rwlock_unlock(&c->rw);
+            return 1;
+        case M_MUTEX:
+            pthread_mutex_lock(&c->mtx);
+            JLG(pv, c->root, key);
+            *out = pv ? *pv : 0;
+            pthread_mutex_unlock(&c->mtx);
+            return 1;
+        case M_SEQLOCK: {
+            uint64_t s0, s1;
+            int tries = 0;
+            do {
+                s0 = atomic_load_explicit(&c->seq, memory_order_acquire);
+                if (s0 & 1u) { continue; }
+                JLG(pv, c->root, key);
+                *out = pv ? *pv : 0;
+                atomic_thread_fence(memory_order_acquire);
+                s1 = atomic_load_explicit(&c->seq, memory_order_relaxed);
+            } while ((s0 != s1 || (s0 & 1u)) && ++tries < 1000);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* 3b: uncontended per-op cost                                         */
+/* ------------------------------------------------------------------ */
+
+static volatile Word_t g_sink; /* keeps the benchmark loop from being elided */
+
+static double bench_uncontended(ctl_t *c, mode_t_ m, unsigned nops) {
+    Word_t sink = 0, out = 0;
+    double t0 = now_ns();
+    for (unsigned i = 0; i < nops; i++) {
+        do_read(c, m, mix(i % N_KEYS), &out);
+        sink += out;
+    }
+    double t1 = now_ns();
+    g_sink = sink;
+    return (t1 - t0) / nops;
+}
+
+/* ------------------------------------------------------------------ */
+/* 3c: N-process contention, read-dominated                            */
+/* ------------------------------------------------------------------ */
+
+static double bench_contended(ctl_t *c, mode_t_ m, int nproc, unsigned nops,
+                              int writer_permille) {
+    atomic_store(&c->start_flag, 0);
+    atomic_store(&c->total_ops, 0);
+
+    for (int i = 0; i < nproc; i++) {
+        pid_t p = fork();
+        if (p == 0) {
+            while (atomic_load(&c->start_flag) == 0) { /* spin to start together */ }
+            Word_t out = 0, sink = 0;
+            unsigned seed = (unsigned)(i * 7919 + 13);
+            for (unsigned k = 0; k < nops; k++) {
+                seed = seed * 1103515245u + 12345u;
+                int is_write = ((seed >> 16) % 1000) < (unsigned)writer_permille;
+                if (is_write && m != M_NOLOCK) {
+                    /* exclusive section */
+                    if (m == M_RWLOCK) pthread_rwlock_wrlock(&c->rw);
+                    else if (m == M_MUTEX) pthread_mutex_lock(&c->mtx);
+                    else atomic_fetch_add(&c->seq, 1); /* seqlock: make odd */
+
+                    Word_t *pv;
+                    Word_t key = mix(seed % N_KEYS);
+                    JLG(pv, c->root, key);
+                    if (pv) *pv = *pv + 1;
+
+                    if (m == M_RWLOCK) pthread_rwlock_unlock(&c->rw);
+                    else if (m == M_MUTEX) pthread_mutex_unlock(&c->mtx);
+                    else atomic_fetch_add(&c->seq, 1); /* back to even */
+                } else {
+                    do_read(c, m, mix(seed % N_KEYS), &out);
+                    sink += out;
+                }
+            }
+            atomic_fetch_add(&c->total_ops, (long)nops);
+            _exit(sink == 0xdeadbeef ? 1 : 0);
+        }
+    }
+
+    double t0 = now_ns();
+    atomic_store(&c->start_flag, 1);
+    for (int i = 0; i < nproc; i++) { int s; wait(&s); }
+    double t1 = now_ns();
+
+    long total = atomic_load(&c->total_ops);
+    return (t1 - t0) / (double)total; /* ns per op, aggregate throughput */
+}
+
+/* ------------------------------------------------------------------ */
+/* 3d: kill a lock holder mid-critical-section                         */
+/* ------------------------------------------------------------------ */
+
+static void test_holder_death(ctl_t *c) {
+    printf("-- 3d: lock holder killed inside the critical section --\n");
+
+    atomic_store(&c->holder_alive, 0);
+
+    pid_t victim = fork();
+    if (victim == 0) {
+        /* take the write lock, announce, then die while still holding it */
+        pthread_mutex_lock(&c->mtx);
+        atomic_store(&c->holder_alive, 1);
+        for (;;) pause();     /* never unlocks */
+        _exit(0);
+    }
+
+    while (atomic_load(&c->holder_alive) == 0) { /* wait until lock is held */ }
+    usleep(50000);
+    kill(victim, SIGKILL);
+    int st; waitpid(victim, &st, 0);
+    printf("   victim killed with SIGKILL while holding the pshared mutex\n");
+
+    /* survivor tries to acquire it (blocking, with an alarm so we cannot hang) */
+    pid_t survivor = fork();
+    if (survivor == 0) {
+        alarm(3);
+        int rc = pthread_mutex_lock(&c->mtx);
+        if (rc == EOWNERDEAD) {
+#if HAVE_ROBUST_MUTEX
+            /* robust path: the lock IS acquired, but the data it protected is
+             * in an unknown state. Declaring it consistent is a promise the
+             * application must actually keep -- see gate 5. */
+            int rc2 = pthread_mutex_consistent(&c->mtx);
+            pthread_mutex_unlock(&c->mtx);
+            _exit(rc2 == 0 ? 2 : 3);
+#else
+            _exit(2);
+#endif
+        }
+        if (rc == 0) { pthread_mutex_unlock(&c->mtx); _exit(0); }
+        _exit(1);
+    }
+    waitpid(survivor, &st, 0);
+
+    if (WIFSIGNALED(st) && WTERMSIG(st) == SIGALRM) {
+        printf("   survivor pthread_mutex_lock() -> HUNG FOREVER "
+               "(killed by alarm after 3s)\n");
+        printf("   ==> the whole pool is permanently deadlocked by one dead worker\n");
+    } else {
+        int code = WIFEXITED(st) ? WEXITSTATUS(st) : -1;
+        switch (code) {
+            case 0:
+                printf("   survivor pthread_mutex_lock() -> ACQUIRED "
+                       "(lock auto-released on death)\n");
+                break;
+            case 2:
+                printf("   survivor pthread_mutex_lock() -> EOWNERDEAD, "
+                       "pthread_mutex_consistent() OK\n");
+                printf("   ==> LOCK recovers. The DATA it guarded does not "
+                       "(see gate 5).\n");
+                break;
+            case 3:
+                printf("   survivor got EOWNERDEAD but "
+                       "pthread_mutex_consistent() FAILED\n");
+                break;
+            default:
+                printf("   survivor pthread_mutex_lock() -> failed (code %d)\n", code);
+        }
+    }
+
+    /* flock(2) comparison: kernel releases on process death, unconditionally */
+    printf("   [reference] flock/fcntl advisory locks are released by the kernel\n"
+           "               on process death on BOTH platforms -- the portable\n"
+           "               fallback when robust mutexes are unavailable.\n");
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(void) {
+    printf("== Gate 3: process-shared locking ==\n");
+    probe_capabilities();
+
+    arena_hdr_t *a = arena_create(ARENA_BYTES, ARENA_MODE_FREELIST);
+    if (!a) { perror("arena_create"); return 2; }
+    arena_install(a);
+
+    ctl_t *c = (ctl_t *)((char *)a + ((sizeof(arena_hdr_t) + 63) & ~63ull));
+    a->bump = (uint64_t)((((char *)c - (char *)a) + sizeof(ctl_t) + 63) & ~63ull);
+    memset(c, 0, sizeof(*c));
+
+    pthread_rwlockattr_t ra;
+    pthread_rwlockattr_init(&ra);
+    pthread_rwlockattr_setpshared(&ra, PTHREAD_PROCESS_SHARED);
+    if (pthread_rwlock_init(&c->rw, &ra) != 0) { perror("rwlock_init"); return 2; }
+
+    pthread_mutexattr_t ma;
+    pthread_mutexattr_init(&ma);
+    pthread_mutexattr_setpshared(&ma, PTHREAD_PROCESS_SHARED);
+#if HAVE_ROBUST_MUTEX
+    pthread_mutexattr_setrobust(&ma, PTHREAD_MUTEX_ROBUST);
+#endif
+    if (pthread_mutex_init(&c->mtx, &ma) != 0) { perror("mutex_init"); return 2; }
+
+    /* build the tree */
+    Word_t *pv;
+    for (Word_t i = 0; i < N_KEYS; i++) {
+        Word_t k = mix(i);
+        JLI(pv, c->root, k);
+        *pv = k;
+    }
+    printf("\n   tree: %u keys, arena footprint %.2f MB\n\n",
+           N_KEYS, (double)a->bump / (1024 * 1024));
+
+    /* ---- 3b ---- */
+    printf("-- 3b: uncontended per-op cost, single process (%u ops x %d reps) --\n",
+           N_OPS / 10, REPS);
+    printf("   %-28s %10s %10s %10s %14s\n", "mode", "MIN", "median", "max",
+           "lock cost");
+    mode_t_ modes[] = { M_NOLOCK, M_RWLOCK, M_MUTEX, M_SEQLOCK };
+    double base_min = 0;
+    for (size_t mi = 0; mi < sizeof modes / sizeof modes[0]; mi++) {
+        double r[REPS];
+        for (int k = 0; k < REPS; k++) r[k] = bench_uncontended(c, modes[mi], N_OPS / 10);
+        qsort(r, REPS, sizeof(double), cmp_dbl);
+        if (mi == 0) base_min = r[0];
+        printf("   %-28s %8.2fns %8.2fns %8.2fns %+10.2fns\n",
+               mode_name(modes[mi]), r[0], r[REPS / 2], r[REPS - 1],
+               r[0] - base_min);
+    }
+
+    /* ---- 3c ---- */
+    printf("\n-- 3c: N-process contention, read-dominated (99%% read / 1%% write) --\n");
+    printf("   best-of-5 aggregate ns per op (lower = better throughput)\n");
+    int procs[] = { 1, 2, 4, 8 };
+    printf("   %-28s", "mode");
+    for (size_t pi = 0; pi < sizeof procs / sizeof procs[0]; pi++)
+        printf(" %8dp", procs[pi]);
+    printf("\n");
+    for (size_t mi = 0; mi < sizeof modes / sizeof modes[0]; mi++) {
+        printf("   %-28s", mode_name(modes[mi]));
+        for (size_t pi = 0; pi < sizeof procs / sizeof procs[0]; pi++) {
+            double r[5];
+            for (int k = 0; k < 5; k++)
+                r[k] = bench_contended(c, modes[mi], procs[pi], 200000, 10);
+            qsort(r, 5, sizeof(double), cmp_dbl);
+            printf(" %7.1fns", r[0]); /* min: robust under interference */
+        }
+        printf("\n");
+    }
+
+    /* ---- 3d ---- */
+    printf("\n");
+    test_holder_death(c);
+
+    printf("\nGATE 3: see FINDINGS.md (verdict is platform-dependent; "
+           "robust=%s here)\n", have_robust ? "YES" : "NO");
+    arena_install(NULL);
+    return 0;
+}

--- a/research/shm-arena/gate4_profile.c
+++ b/research/shm-arena/gate4_profile.c
@@ -1,0 +1,199 @@
+/*
+ * gate4_profile.c - Gate 4: arena management / fragmentation at 1M-key scale.
+ *
+ * Measures the REAL Judy allocation pattern rather than assuming one:
+ *   4a. size-class histogram + alloc/free churn ratio, for dense/sequential and
+ *       sparse/random key distributions (they build very different node types).
+ *   4b. bump-only arena vs size-class-freelist arena under TTL-style delete
+ *       churn: peak mapped bytes vs live bytes = the fragmentation bound.
+ *   4c. steady-state churn (the judy-cache case: insert with expiry, so the
+ *       live set stays flat while allocations keep flowing).
+ *
+ * The number that decides the gate is 4b/4c: a bump-only arena that never
+ * reuses freed blocks grows without bound under delete churn.
+ */
+
+#include "shm_arena.h"
+
+#include <Judy.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ARENA_BYTES (3072ull * 1024 * 1024)
+#define N_KEYS 1000000u
+
+static Word_t mix(Word_t x) {
+    x ^= x >> 33; x *= 0xff51afd7ed558ccdull;
+    x ^= x >> 33; x *= 0xc4ceb9fe1a85ec53ull;
+    x ^= x >> 33;
+    return x;
+}
+
+static Word_t keygen(unsigned i, int sparse) {
+    return sparse ? mix(i) : (Word_t)i;
+}
+
+/* ------------------------------------------------------------------ */
+/* 4a: size-class histogram                                            */
+/* ------------------------------------------------------------------ */
+
+static void report_histogram(arena_hdr_t *a, const char *label) {
+    printf("\n   size-class histogram [%s] (words -> allocs, %% of total):\n", label);
+    uint64_t total = 0;
+    for (unsigned w = 0; w <= ARENA_MAX_WORDS; w++) total += a->alloc_calls[w];
+    if (!total) { printf("     (none)\n"); return; }
+
+    /* print classes accounting for >=0.5% of allocations, plus the largest */
+    unsigned shown = 0;
+    for (unsigned w = 0; w <= ARENA_MAX_WORDS; w++) {
+        if (!a->alloc_calls[w]) continue;
+        double pct = 100.0 * (double)a->alloc_calls[w] / (double)total;
+        if (pct < 0.5) continue;
+        printf("     %4u w (%5u B) : %10llu  %5.1f%%   peak-live %lld\n",
+               w, (unsigned)(w * sizeof(Word_t)),
+               (unsigned long long)a->alloc_calls[w], pct,
+               (long long)a->peak_blocks[w]);
+        shown++;
+    }
+    unsigned distinct = 0;
+    unsigned maxw = 0;
+    for (unsigned w = 0; w <= ARENA_MAX_WORDS; w++)
+        if (a->alloc_calls[w]) { distinct++; maxw = w; }
+    printf("     ... %u distinct size classes in use, largest = %u words (%u B)\n",
+           distinct, maxw, (unsigned)(maxw * sizeof(Word_t)));
+    printf("     (%u classes shown at >=0.5%%)\n", shown);
+}
+
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    uint64_t allocs, frees, reused, bumped;
+    uint64_t peak_live_bytes, footprint, live_bytes_end;
+} run_stats_t;
+
+/* Build a tree of n keys, then delete a fraction, then re-insert fresh keys.
+ * `churn_rounds` models TTL expiry: each round evicts `evict` keys and inserts
+ * the same number of new ones, so the live population is flat. */
+static run_stats_t run_workload(arena_mode_t mode, int sparse, unsigned n,
+                                int churn_rounds, unsigned evict_per_round,
+                                arena_hdr_t **keep, const char *hist_label) {
+    arena_hdr_t *a = arena_create(ARENA_BYTES, mode);
+    if (!a) { fprintf(stderr, "arena_create failed\n"); exit(2); }
+    arena_install(a);
+
+    Pvoid_t L = NULL;
+    Word_t *pv;
+    int rc;
+
+    for (unsigned i = 0; i < n; i++) {
+        Word_t k = keygen(i, sparse);
+        JLI(pv, L, k);
+        if (pv == PJERR) { fprintf(stderr, "PJERR (arena OOM?)\n"); break; }
+        *pv = k;
+    }
+
+    if (hist_label) report_histogram(a, hist_label);
+
+    /* TTL-style churn: steady live population, continuous alloc/free traffic */
+    unsigned next_new = n;
+    for (int r = 0; r < churn_rounds; r++) {
+        unsigned base = (unsigned)r * evict_per_round;
+        for (unsigned j = 0; j < evict_per_round; j++) {
+            JLD(rc, L, keygen(base + j, sparse));
+        }
+        for (unsigned j = 0; j < evict_per_round; j++) {
+            Word_t k = keygen(next_new++, sparse);
+            JLI(pv, L, k);
+            if (pv == PJERR) break;
+            *pv = k;
+        }
+    }
+
+    run_stats_t s;
+    s.allocs = a->n_alloc;
+    s.frees = a->n_free;
+    s.reused = a->n_reused;
+    s.bumped = a->n_bumped;
+    s.peak_live_bytes = a->peak_live_bytes;
+    s.footprint = a->bump;
+    s.live_bytes_end = a->live_bytes;
+
+    if (keep) { *keep = a; }
+    else { JLFA(rc, L); (void)rc; arena_install(NULL); arena_destroy(a); }
+    return s;
+}
+
+int main(void) {
+    printf("== Gate 4: arena management & fragmentation at %u keys ==\n", N_KEYS);
+
+    /* ---- 4a: allocation profile, no churn ---- */
+    printf("\n-- 4a: Judy allocation profile, %u keys, build-only --\n", N_KEYS);
+
+    arena_hdr_t *a = NULL;
+    run_stats_t dense = run_workload(ARENA_MODE_FREELIST, 0, N_KEYS, 0, 0, &a,
+                                     "dense/sequential");
+    printf("\n   dense : allocs=%llu frees=%llu  churn(free/alloc)=%.3f  "
+           "footprint=%.1f MB live=%.1f MB\n",
+           (unsigned long long)dense.allocs, (unsigned long long)dense.frees,
+           (double)dense.frees / (double)dense.allocs,
+           (double)dense.footprint / (1024 * 1024),
+           (double)dense.live_bytes_end / (1024 * 1024));
+    { int rc; Pvoid_t dummy = NULL; JLFA(rc, dummy); (void)rc; }
+    arena_install(NULL); arena_destroy(a); a = NULL;
+
+    run_stats_t sparse = run_workload(ARENA_MODE_FREELIST, 1, N_KEYS, 0, 0, &a,
+                                      "sparse/random");
+    printf("\n   sparse: allocs=%llu frees=%llu  churn(free/alloc)=%.3f  "
+           "footprint=%.1f MB live=%.1f MB\n",
+           (unsigned long long)sparse.allocs, (unsigned long long)sparse.frees,
+           (double)sparse.frees / (double)sparse.allocs,
+           (double)sparse.footprint / (1024 * 1024),
+           (double)sparse.live_bytes_end / (1024 * 1024));
+    arena_install(NULL); arena_destroy(a); a = NULL;
+
+    /* ---- 4b/4c: bump-only vs freelist under TTL churn ---- */
+    printf("\n-- 4b/4c: TTL-style churn, live population held flat --\n");
+    printf("   workload: build %u keys, then %d rounds x evict+insert %u keys\n",
+           N_KEYS / 2, 20, N_KEYS / 40);
+    printf("   (total churn traffic ~= %u insert+delete pairs)\n",
+           20 * (N_KEYS / 40));
+
+    struct { arena_mode_t m; const char *name; } modes[] = {
+        { ARENA_MODE_FREELIST, "size-class freelist" },
+        { ARENA_MODE_BUMP,     "bump-only (no reuse)" },
+    };
+
+    printf("\n   %-22s %12s %12s %12s %10s %10s\n", "arena mode", "allocs",
+           "reused", "footprint", "live", "waste x");
+    for (size_t i = 0; i < 2; i++) {
+        run_stats_t s = run_workload(modes[i].m, 1, N_KEYS / 2, 20, N_KEYS / 40,
+                                     NULL, NULL);
+        double fp = (double)s.footprint / (1024 * 1024);
+        double live = (double)s.live_bytes_end / (1024 * 1024);
+        printf("   %-22s %12llu %12llu %9.1f MB %7.1f MB %9.2fx\n",
+               modes[i].name, (unsigned long long)s.allocs,
+               (unsigned long long)s.reused, fp, live,
+               live > 0 ? fp / live : 0.0);
+    }
+
+    /* ---- 4c-extended: sustained churn, how far does bump-only run? ---- */
+    printf("\n-- 4c: sustained churn scaling (freelist vs bump-only) --\n");
+    printf("   %-22s %8s %12s %12s %10s\n", "arena mode", "rounds", "allocs",
+           "footprint", "live");
+    int rounds[] = { 10, 40, 160 };
+    for (size_t i = 0; i < 2; i++) {
+        for (size_t r = 0; r < sizeof rounds / sizeof rounds[0]; r++) {
+            run_stats_t s = run_workload(modes[i].m, 1, 200000, rounds[r], 5000,
+                                         NULL, NULL);
+            printf("   %-22s %8d %12llu %9.1f MB %7.1f MB\n",
+                   modes[i].name, rounds[r], (unsigned long long)s.allocs,
+                   (double)s.footprint / (1024 * 1024),
+                   (double)s.live_bytes_end / (1024 * 1024));
+        }
+    }
+
+    printf("\nGATE 4: see FINDINGS.md\n");
+    return 0;
+}

--- a/research/shm-arena/gate5_crash.c
+++ b/research/shm-arena/gate5_crash.c
@@ -1,0 +1,267 @@
+/*
+ * gate5_crash.c - Gate 5: what a reader sees when a writer dies mid-mutation.
+ *
+ * Gate 5 is mostly analysis, but two of its load-bearing claims are measurable
+ * rather than assumable, so we measure them:
+ *
+ *   5a. Allocation burst per single JudyLIns. This bounds the arena leak when a
+ *       writer is killed mid-insert: blocks already handed out but not yet
+ *       linked into the tree are unreachable and unfreeable forever (there is
+ *       no process teardown to reclaim a shared arena).
+ *   5b. Kill writers at random points inside a bulk insert and have a separate
+ *       reader process traverse the resulting shared tree. Record how often the
+ *       tree is intact / silently wrong / fatal to the reader.
+ *
+ * Readers run in their own forked process precisely because a corrupt Judy tree
+ * can fault the traversing process -- which is itself the finding.
+ */
+
+#include "shm_arena.h"
+
+#include <Judy.h>
+
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define ARENA_BYTES (512ull * 1024 * 1024)
+#define TRIALS 40
+#define PRELOAD 20000u
+
+static Word_t mix(Word_t x) {
+    x ^= x >> 33; x *= 0xff51afd7ed558ccdull;
+    x ^= x >> 33; x *= 0xc4ceb9fe1a85ec53ull;
+    x ^= x >> 33;
+    return x;
+}
+
+typedef struct {
+    Pvoid_t root;
+    atomic_uint_least64_t inserted;   /* writer's progress counter */
+    atomic_uint_least64_t in_flight;  /* 1 while inside a JLI call */
+} shm_state_t;
+
+/* ---- 5a: allocations per single insert ---- */
+static unsigned g_cur_allocs, g_max_allocs;
+static unsigned long g_cur_bytes, g_max_bytes;
+static int g_counting;
+
+static void audit(void *addr, size_t words, int is_free) {
+    (void)addr;
+    if (!g_counting || is_free) return;
+    g_cur_allocs++;
+    g_cur_bytes += words * sizeof(Word_t);
+    if (g_cur_allocs > g_max_allocs) g_max_allocs = g_cur_allocs;
+    if (g_cur_bytes > g_max_bytes) g_max_bytes = g_cur_bytes;
+}
+
+static void measure_alloc_burst(void) {
+    arena_hdr_t *a = arena_create(ARENA_BYTES, ARENA_MODE_FREELIST);
+    if (!a) { perror("arena_create"); exit(2); }
+    arena_install(a);
+
+    Pvoid_t L = NULL;
+    Word_t *pv;
+    unsigned long long hist[8] = { 0 };
+    unsigned n = 300000;
+
+    arena_set_audit(audit);
+    g_counting = 1;
+    for (unsigned i = 0; i < n; i++) {
+        g_cur_allocs = 0; g_cur_bytes = 0;
+        JLI(pv, L, mix(i));
+        if (pv != PJERR && pv) *pv = i;
+        unsigned b = g_cur_allocs < 7 ? g_cur_allocs : 7;
+        hist[b]++;
+    }
+    g_counting = 0;
+    arena_set_audit(NULL);
+
+    printf("-- 5a: allocations issued by ONE JudyLIns (%u inserts) --\n", n);
+    for (int i = 0; i < 8; i++) {
+        if (!hist[i]) continue;
+        printf("     %s%d alloc(s): %10llu  (%5.2f%%)\n",
+               i == 7 ? ">=" : " ", i, hist[i], 100.0 * (double)hist[i] / n);
+    }
+    printf("     worst case: %u allocations, %lu bytes in a single insert\n",
+           g_max_allocs, g_max_bytes);
+    printf("     => a writer killed mid-insert strands up to %lu bytes in the\n"
+           "        arena, unreachable and unfreeable (no teardown reclaims it).\n",
+           g_max_bytes);
+
+    int rc; JLFA(rc, L); (void)rc;
+    arena_install(NULL);
+    arena_destroy(a);
+}
+
+/* ---- 5b: kill a writer mid-mutation, then have a reader traverse ---- */
+
+/* Returns: 0 = consistent, 1 = wrong count/order, 2 = crashed */
+static int reader_verdict(shm_state_t *st, Word_t *out_count) {
+    int fds[2];
+    if (pipe(fds) != 0) return 2;
+
+    pid_t r = fork();
+    if (r == 0) {
+        close(fds[0]);
+        alarm(10); /* a corrupt tree can also send the reader into a long loop */
+        Word_t *pv, idx = 0, count = 0, prev = 0;
+        int order_ok = 1;
+        JLF(pv, st->root, idx);
+        while (pv) {
+            if (count && idx <= prev) { order_ok = 0; break; }
+            prev = idx; count++;
+            if (count > 100000000ull) { order_ok = 0; break; } /* runaway */
+            JLN(pv, st->root, idx);
+        }
+        ssize_t w = write(fds[1], &count, sizeof count);
+        (void)w;
+        close(fds[1]);
+        _exit(order_ok ? 0 : 1);
+    }
+    close(fds[1]);
+    Word_t cnt = 0;
+    ssize_t got = read(fds[0], &cnt, sizeof cnt);
+    close(fds[0]);
+    int st_;
+    waitpid(r, &st_, 0);
+    *out_count = (got == (ssize_t)sizeof cnt) ? cnt : 0;
+
+    if (WIFSIGNALED(st_)) return 2;
+    if (WIFEXITED(st_) && WEXITSTATUS(st_) == 0) return 0;
+    return 1;
+}
+
+static void crash_trials(void) {
+    printf("\n-- 5b: writer SIGKILLed mid-insert, reader then traverses --\n");
+
+    int intact = 0, inconsistent = 0, fatal = 0, lost_updates = 0;
+
+    for (int t = 0; t < TRIALS; t++) {
+        arena_hdr_t *a = arena_create(ARENA_BYTES, ARENA_MODE_FREELIST);
+        if (!a) { perror("arena_create"); exit(2); }
+        arena_install(a);
+
+        shm_state_t *st = (shm_state_t *)((char *)a +
+                          ((sizeof(arena_hdr_t) + 63) & ~63ull));
+        a->bump = (uint64_t)((((char *)st - (char *)a) + sizeof(*st) + 63) & ~63ull);
+        memset(st, 0, sizeof(*st));
+
+        /* preload a stable tree */
+        Word_t *pv;
+        for (Word_t i = 0; i < PRELOAD; i++) {
+            JLI(pv, st->root, mix(i));
+            if (pv && pv != PJERR) *pv = i;
+        }
+        Word_t before;
+        JLC(before, st->root, 0, -1);
+
+        pid_t w = fork();
+        if (w == 0) {
+            /* writer: keep inserting until killed */
+            for (Word_t i = PRELOAD; ; i++) {
+                atomic_store(&st->in_flight, 1);
+                Word_t *p;
+                JLI(p, st->root, mix(i));
+                if (p && p != PJERR) *p = i;
+                atomic_store(&st->in_flight, 0);
+                atomic_fetch_add(&st->inserted, 1);
+            }
+            _exit(0);
+        }
+
+        /* let the writer get going, then kill at a pseudo-random offset */
+        struct timespec ts = { 0, (long)(200000 + (t * 137331) % 3000000) };
+        nanosleep(&ts, NULL);
+        kill(w, SIGKILL);
+        int s; waitpid(w, &s, 0);
+
+        unsigned long long done = atomic_load(&st->inserted);
+        int was_in_flight = (int)atomic_load(&st->in_flight);
+
+        Word_t seen = 0;
+        int v = reader_verdict(st, &seen);
+
+        if (v == 2) fatal++;
+        else if (v == 1) inconsistent++;
+        else {
+            intact++;
+            /* even "intact" can silently lose the in-flight insert */
+            if (seen != before + done) lost_updates++;
+        }
+
+        if (t < 5 || v != 0) {
+            printf("     trial %2d: killed after %llu inserts (in_flight=%d) -> "
+                   "%s, reader saw %lu entries (expected >= %lu)\n",
+                   t, done, was_in_flight,
+                   v == 0 ? "traversable" : v == 1 ? "INCONSISTENT" : "READER CRASHED",
+                   (unsigned long)seen, (unsigned long)(before + done));
+        }
+
+        arena_install(NULL);
+        arena_destroy(a);
+    }
+
+    printf("\n     over %d kill trials:\n", TRIALS);
+    printf("       traversable          : %d\n", intact);
+    printf("       inconsistent/ordering: %d\n", inconsistent);
+    printf("       reader crashed/hung  : %d\n", fatal);
+    printf("       traversable but with a lost/partial update: %d\n", lost_updates);
+}
+
+/* ---- 5c: cost of the "poison the segment and rebuild" recovery ---- */
+static double now_s(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
+}
+
+static int cmp_d(const void *a, const void *b) {
+    double x = *(const double *)a, y = *(const double *)b;
+    return (x > y) - (x < y);
+}
+
+static void measure_rebuild_cost(void) {
+    printf("\n-- 5c: cost of discarding a corrupt segment and rebuilding --\n");
+    printf("   (this is the recovery cost of the accept-corruption strategy;\n"
+           "    a cache is reconstructible, so 'nuke and refill' is legal)\n");
+
+    const unsigned sizes[] = { 100000, 1000000 };
+    for (size_t si = 0; si < sizeof sizes / sizeof sizes[0]; si++) {
+        unsigned n = sizes[si];
+        double r[5];
+        for (int k = 0; k < 5; k++) {
+            arena_hdr_t *a = arena_create(ARENA_BYTES, ARENA_MODE_FREELIST);
+            if (!a) { perror("arena_create"); exit(2); }
+            arena_install(a);
+            Pvoid_t L = NULL;
+            Word_t *pv;
+            double t0 = now_s();
+            for (unsigned i = 0; i < n; i++) {
+                JLI(pv, L, mix(i));
+                if (pv && pv != PJERR) *pv = i;
+            }
+            r[k] = now_s() - t0;
+            arena_install(NULL);
+            arena_destroy(a);
+        }
+        qsort(r, 5, sizeof(double), cmp_d);
+        printf("     rebuild %8u keys: min %.3fs  median %.3fs  max %.3fs\n",
+               n, r[0], r[2], r[4]);
+    }
+    printf("     NOTE: measured on a LOADED machine; treat as an upper bound.\n");
+}
+
+int main(void) {
+    printf("== Gate 5: crash consistency (writer death) ==\n\n");
+    measure_alloc_burst();
+    crash_trials();
+    measure_rebuild_cost();
+    printf("\nGATE 5: see FINDINGS.md\n");
+    return 0;
+}

--- a/research/shm-arena/shm_arena.c
+++ b/research/shm-arena/shm_arena.c
@@ -1,0 +1,196 @@
+/*
+ * shm_arena.c - shared-memory arena allocator for libJudy (Step-0 spike, issue #83)
+ *
+ * NOT production code. See shm_arena.h for the alignment contract.
+ */
+
+#include "shm_arena.h"
+
+#include <Judy.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define ARENA_MAGIC 0x4A554459414E4131ull /* "JUDYANA1" */
+
+/* The installed arena. Deliberately process-local: each forked worker inherits
+ * a copy of this pointer, and (gate 2) it must point at the same address in
+ * every worker for the shared tree to be traversable. */
+static arena_hdr_t *g_arena = NULL;
+
+/* Free-block link: stored in the first word of a free block, as a byte offset
+ * from the arena base. 0 terminates the list (offset 0 is the header, so it can
+ * never be a real block). */
+typedef struct {
+    uint64_t next;
+} free_link_t;
+
+static inline size_t align_up(size_t v, size_t a) { return (v + (a - 1)) & ~(a - 1); }
+
+static inline void *off2ptr(arena_hdr_t *a, uint64_t off) {
+    return off ? (void *)((char *)a + off) : NULL;
+}
+static inline uint64_t ptr2off(arena_hdr_t *a, void *p) {
+    return p ? (uint64_t)((char *)p - (char *)a) : 0;
+}
+
+static arena_hdr_t *arena_init_mapping(void *base, size_t bytes, arena_mode_t mode) {
+    arena_hdr_t *a = (arena_hdr_t *)base;
+    memset(a, 0, sizeof(*a));
+    a->magic     = ARENA_MAGIC;
+    a->size      = bytes;
+    a->hdr_bytes = align_up(sizeof(arena_hdr_t), ARENA_ALIGN);
+    a->bump      = a->hdr_bytes;
+    a->mode      = (uint32_t)mode;
+    return a;
+}
+
+arena_hdr_t *arena_create(size_t bytes, arena_mode_t mode) {
+    long pg = sysconf(_SC_PAGESIZE);
+    if (pg <= 0) pg = 4096;
+    bytes = align_up(bytes, (size_t)pg);
+
+    void *base = mmap(NULL, bytes, PROT_READ | PROT_WRITE,
+                      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (base == MAP_FAILED) return NULL;
+    return arena_init_mapping(base, bytes, mode);
+}
+
+arena_hdr_t *arena_create_fixed(void *at, size_t bytes, arena_mode_t mode) {
+    long pg = sysconf(_SC_PAGESIZE);
+    if (pg <= 0) pg = 4096;
+    bytes = align_up(bytes, (size_t)pg);
+
+    void *base = mmap(at, bytes, PROT_READ | PROT_WRITE,
+                      MAP_SHARED | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    if (base == MAP_FAILED) return NULL;
+    return arena_init_mapping(base, bytes, mode);
+}
+
+void arena_destroy(arena_hdr_t *a) {
+    if (!a) return;
+    size_t n = (size_t)a->size;
+    if (g_arena == a) g_arena = NULL;
+    munmap((void *)a, n);
+}
+
+void arena_install(arena_hdr_t *a) { g_arena = a; }
+arena_hdr_t *arena_current(void) { return g_arena; }
+
+static arena_audit_fn g_audit = NULL;
+void arena_set_audit(arena_audit_fn fn) { g_audit = fn; }
+
+void arena_stats_reset(arena_hdr_t *a) {
+    if (!a) return;
+    memset(a->alloc_calls, 0, sizeof(a->alloc_calls));
+    memset(a->free_calls, 0, sizeof(a->free_calls));
+    memset(a->peak_blocks, 0, sizeof(a->peak_blocks));
+    a->n_alloc = a->n_free = a->n_reused = a->n_bumped = 0;
+    a->n_oversize = a->n_oom = 0;
+    a->peak_live_bytes = a->live_bytes;
+}
+
+/* ------------------------------------------------------------------ */
+/* Core allocate / release                                             */
+/* ------------------------------------------------------------------ */
+
+static void *arena_alloc(arena_hdr_t *a, size_t words) {
+    size_t payload = align_up(words * sizeof(Word_t), ARENA_ALIGN);
+
+    a->n_alloc++;
+    if (words <= ARENA_MAX_WORDS) {
+        a->alloc_calls[words]++;
+        a->live_blocks[words]++;
+        if (a->live_blocks[words] > a->peak_blocks[words])
+            a->peak_blocks[words] = a->live_blocks[words];
+    } else {
+        a->n_oversize++;
+    }
+
+    /* 1. exact-size freelist (freelist mode only) */
+    if (a->mode == ARENA_MODE_FREELIST && words <= ARENA_MAX_WORDS &&
+        a->free_head[words] != 0) {
+        uint64_t off = a->free_head[words];
+        free_link_t *fl = (free_link_t *)off2ptr(a, off);
+        a->free_head[words] = fl->next;
+        a->free_bytes -= payload;
+        a->n_reused++;
+        a->live_bytes += payload;
+        if (a->live_bytes > a->peak_live_bytes) a->peak_live_bytes = a->live_bytes;
+        return (void *)fl;
+    }
+
+    /* 2. fresh bump space */
+    if (a->bump + payload > a->size) {
+        a->n_oom++;
+        if (words <= ARENA_MAX_WORDS) a->live_blocks[words]--;
+        return NULL;
+    }
+    void *p = (char *)a + a->bump;
+    a->bump += payload;
+    a->n_bumped++;
+    a->live_bytes += payload;
+    if (a->live_bytes > a->peak_live_bytes) a->peak_live_bytes = a->live_bytes;
+    return p;
+}
+
+static void arena_release(arena_hdr_t *a, void *p, size_t words) {
+    if (!p) return;
+    size_t payload = align_up(words * sizeof(Word_t), ARENA_ALIGN);
+
+    a->n_free++;
+    if (words <= ARENA_MAX_WORDS) {
+        a->free_calls[words]++;
+        a->live_blocks[words]--;
+    }
+    a->live_bytes -= payload;
+
+    /* Bump-only mode models "never reuse": the block is simply abandoned. */
+    if (a->mode == ARENA_MODE_BUMP || words > ARENA_MAX_WORDS) return;
+
+    free_link_t *fl = (free_link_t *)p;
+    fl->next = a->free_head[words];
+    a->free_head[words] = ptr2off(a, p);
+    a->free_bytes += payload;
+}
+
+/* ------------------------------------------------------------------ */
+/* Judy link-time hooks                                                */
+/* ------------------------------------------------------------------ */
+
+Word_t JudyMalloc(Word_t Words) {
+    arena_hdr_t *a = g_arena;
+    void *p;
+
+    if (a == NULL) {
+        /* baseline path: stock heap, matching Judy's own JudyMalloc.c */
+        p = malloc((size_t)Words * sizeof(Word_t));
+    } else {
+        p = arena_alloc(a, (size_t)Words);
+    }
+
+    /* Judy requires the low 3 bits clear (MALLOCBITS_MASK 0x7). Enforce loudly:
+     * a violation here is silent tree corruption in a DEBUG libJudy build. */
+    if (p && ((uintptr_t)p & 0x7u) != 0) {
+        fprintf(stderr, "FATAL: arena returned misaligned address %p\n", p);
+        abort();
+    }
+    if (p && g_audit) g_audit(p, (size_t)Words, 0);
+    return (Word_t)p;
+}
+
+void JudyFree(void *p, Word_t Words) {
+    arena_hdr_t *a = g_arena;
+    if (p && g_audit) g_audit(p, (size_t)Words, 1);
+    if (a == NULL) {
+        free(p);
+        return;
+    }
+    arena_release(a, p, (size_t)Words);
+}
+
+Word_t JudyMallocVirtual(Word_t Words) { return JudyMalloc(Words); }
+void JudyFreeVirtual(void *p, Word_t Words) { JudyFree(p, Words); }

--- a/research/shm-arena/shm_arena.h
+++ b/research/shm-arena/shm_arena.h
@@ -1,0 +1,105 @@
+/*
+ * shm_arena.h - shared-memory arena allocator for libJudy (Step-0 spike, issue #83)
+ *
+ * NOT production code. NOT part of the shipping php-judy extension.
+ *
+ * Judy's allocator is a link-time hook: libJudy calls the global symbols
+ * JudyMalloc/JudyFree/JudyMallocVirtual/JudyFreeVirtual. Defining them in the
+ * final link unit replaces the stock malloc-backed implementation.
+ *
+ * Alignment contract (verified against Judy-1.0.5 sources, sha256
+ * d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb):
+ *   src/JudyCommon/JudyMallocIF.c:140-147 defines
+ *       MALLOCBITS_VALUE 0x3, MALLOCBITS_MASK 0x7
+ *   and asserts ((addr & 0x7) == 0) before OR-ing the tag bits in.
+ *   JudyPrivate.h:365-368 documents the low bits as reserved so that "Judy
+ *   mallocd objects [can] come from different malloc() namespaces".
+ *   => every returned address MUST have its low 3 bits clear (8-byte aligned).
+ */
+
+#ifndef SHM_ARENA_H
+#define SHM_ARENA_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+/* Judy allocates in words. Largest single Judy node on 64-bit is jbu_t
+ * (256 * sizeof(jp_t) = 4096 bytes = 512 words). 1024 covers it with headroom;
+ * anything larger falls into the oversize path and is counted separately. */
+#define ARENA_MAX_WORDS 1024u
+
+/* Minimum alignment demanded by Judy (low 3 bits clear). */
+#define ARENA_ALIGN 8u
+
+typedef enum {
+    ARENA_MODE_FREELIST = 0, /* size-class freelist + bump for fresh memory */
+    ARENA_MODE_BUMP     = 1  /* bump only; JudyFree is a no-op (never reuses) */
+} arena_mode_t;
+
+/*
+ * Arena header. Lives at offset 0 of the shared mapping.
+ *
+ * All internal links are BYTE OFFSETS from the arena base, never pointers, so
+ * the arena's own metadata is position-independent. Only the Judy tree itself
+ * stores absolute pointers -- that is the fork-inheritance dependency this
+ * spike exists to test (gate 2).
+ */
+typedef struct {
+    uint64_t magic;
+    uint64_t size;      /* total bytes of the mapping */
+    uint64_t bump;      /* offset of next never-yet-allocated byte */
+    uint64_t hdr_bytes; /* offset of first allocatable byte */
+    uint32_t mode;      /* arena_mode_t */
+    uint32_t _pad;
+
+    /* free_head[w] = byte offset of first free block of exactly w words, or 0 */
+    uint64_t free_head[ARENA_MAX_WORDS + 1];
+
+    /* ---- instrumentation (gate 4) ---- */
+    uint64_t alloc_calls[ARENA_MAX_WORDS + 1];
+    uint64_t free_calls[ARENA_MAX_WORDS + 1];
+    int64_t  live_blocks[ARENA_MAX_WORDS + 1]; /* currently-live count per class */
+    int64_t  peak_blocks[ARENA_MAX_WORDS + 1]; /* high-water live count per class */
+
+    uint64_t n_alloc;        /* total JudyMalloc calls */
+    uint64_t n_free;         /* total JudyFree calls */
+    uint64_t n_reused;       /* allocations satisfied from a freelist */
+    uint64_t n_bumped;       /* allocations satisfied from fresh bump space */
+    uint64_t n_oversize;     /* allocations above ARENA_MAX_WORDS */
+    uint64_t n_oom;          /* allocations that failed (arena exhausted) */
+
+    uint64_t live_bytes;     /* payload bytes currently allocated */
+    uint64_t peak_live_bytes;/* high-water of live_bytes */
+    uint64_t free_bytes;     /* payload bytes sitting on freelists */
+} arena_hdr_t;
+
+/* Create a fresh MAP_SHARED anonymous arena of `bytes`. Returns base or NULL. */
+arena_hdr_t *arena_create(size_t bytes, arena_mode_t mode);
+
+/* Create at a caller-chosen address with MAP_FIXED semantics (gate 2 variant).
+ * `at` must be page-aligned. Returns base (== at on success) or NULL. */
+arena_hdr_t *arena_create_fixed(void *at, size_t bytes, arena_mode_t mode);
+
+void arena_destroy(arena_hdr_t *a);
+
+/* Install `a` as the arena backing JudyMalloc/JudyFree for this process.
+ * Must be called before any Judy operation. Passing NULL routes Judy back to
+ * the process heap (used for the malloc baseline in gate 4). */
+void arena_install(arena_hdr_t *a);
+
+arena_hdr_t *arena_current(void);
+
+/* Audit hook (gate 1). Called after every successful allocation and before
+ * every release. `is_free` is 0 for alloc, 1 for free. Used to verify Judy's
+ * alloc/free size symmetry and to detect overlapping or double-freed blocks. */
+typedef void (*arena_audit_fn)(void *addr, size_t words, int is_free);
+void arena_set_audit(arena_audit_fn fn);
+
+/* Reset statistics without discarding allocations. */
+void arena_stats_reset(arena_hdr_t *a);
+
+/* Bytes of the mapping actually touched (bump high-water). */
+static inline uint64_t arena_footprint(const arena_hdr_t *a) { return a->bump; }
+
+#endif /* SHM_ARENA_H */


### PR DESCRIPTION
Docs-and-research-only. No extension sources touched, no behavior change.

## 1. `BACKEND_EVALUATION.md` — should php-judy still be built on libJudy?

Judy is a ~2002 design and the ordered-index literature has moved on (ART, Masstree, HOT, Wormhole), so "are we carrying a legacy dependency for no reason?" deserved measuring rather than arguing.

**Method was cheapest-first**, because step 1 can make step 2 unnecessary:

**Step 1 — bound the achievable win before implementing anything.** If the PHP boundary dominated an operation, no backend could help.

| Layer | ns/op |
| --- | --- |
| Raw C `JudyLGet` (incl. loop) | 17.39 |
| PHP interpreter floor | 15.97 |
| PHP loop + `$j[$k]` | 39.30 |
| Marginal cost of the Judy access | 23.33 |

The boundary is ~6–8 ns and the C structure is ~65–75% of marginal op cost, so a swap *could* show through — but an infinitely fast replacement caps at ~39% on a tight loop, and ~19% for a realistic 2× structure.

**Step 2 — pure-C head-to-head.** No extension written: a candidate that can't win in C can't win through a binding. 1M ordered string keys, dedicated idle 24-core x86_64, load 0.00–0.04, 3 runs.

| Metric | JudySL | ART | Winner |
| --- | --- | --- | --- |
| Insert | ~124 ns/op | ~110 ns/op | ART 1.13× |
| **Point lookup** | ~179 ns/op | ~174 ns/op | **tie (3%)** |
| Prefix scan (10-key group) | ~1.34 µs | ~0.54 µs | ART 2.5× |
| **Peak RSS** | **51.8 MB** | 65.8 MB | **Judy 1.27×** |

**Verdict: keep Judy.** ART ties where it's supposed to shine and regresses memory 27% — the axis this project sells hardest.

**Masstree/HOT/Wormhole are excluded on argued design-intent grounds, not measured** — the doc says so explicitly. They spend complexity on multicore concurrency and long-key asymptotics; php-judy is single-threaded per process with short keys, and the shared-structure case that would make Masstree relevant is #83, closed.

The doc also corrects itself on one point: the 25× ordered-iteration gap against ART is **not** the API artifact it first appeared to be. #85 measured `JSLN` as flat in key length (+10% for 4× the bytes) and flat in working-set size (+6% for 10×), so the cost is JudySL's stateless per-call root descend — and `Judy.h` exposes no cursor primitive, making it a genuine backend property php-judy cannot optimise away. More significant than first written, not less. It doesn't change the verdict.

Six caveats are stated plainly (one ART implementation, one key shape, string keys only, no churn workload, `void *` values both sides, three structures excluded by argument).

## 2. `research/` — harnesses that back measured claims

Standalone C, indexed by `research/README.md` against the issue or doc each one supports. **Nothing here ships or builds with the extension** — not in the PECL package, not touched by `make`.

| Directory | Supports |
| --- | --- |
| `shm-arena/` | #83 Step-0 spike (closed not-planned) — five feasibility gates |
| `iteration-cost/` | #85 — the discriminator that refuted the key-reconstruction hypothesis |
| `backend-comparison/` | BACKEND_EVALUATION.md — the ART and Amdahl harnesses above |

**Two defects found by re-running these from their committed paths, both fixed here:**

- `cmp.c` reported peak RSS **1024× too high on macOS** — `ru_maxrss` is bytes there and kilobytes on Linux. The published figures were measured on Linux and are unaffected, but anyone re-running on a Mac would have seen 5472 MB instead of 5.3 MB.
- `amdahl.c` tripped `-Wsign-compare` through libJudy's `JLFA` macro.

That is the argument for committing them rather than describing them in prose.

## 3. README roadmap

Replaced *"C-level `forEach()`/`filter()`/`map()` performance tuning (vtable dispatch)"* — #85 measured that as targeting a few ns inside a 6–15 ns glue bucket, with userland dispatch only ~10 ns and `Judy::forEach()` on `INT_TO_INT` already beating `array_map()`. The addressable cost was elsewhere: the `filter()` half shipped in #86, and the per-element second lookup on `*_HASH`/`*_ADAPTIVE` is now listed instead. The retired item is recorded with its reason rather than silently dropped.

## Indexing

`BACKEND_EVALUATION.md` and `research/` are linked from README (roadmap + directory listing), BENCHMARK.md, AGENTS.md, and llms.txt — no orphans. `BACKEND_EVALUATION.md` declares an explicit superseded-when. AGENTS.md gains a "backend choice is settled, don't relitigate it" entry, since a future agent proposing an ART rewrite is the failure mode this doc exists to prevent.

`package.xml` updated and re-validated; all internal links verified to resolve; `baselines/latest.json` untouched.
