### PR TITLE
fix(delete-range): delete entries before running value destructors

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -253,6 +253,7 @@
          <file name="tests/count_int_to_mixed_overwrite_001.phpt" role="test" />
          <file name="tests/count_int_to_packed_overwrite_001.phpt" role="test" />
          <file name="tests/delete_range_001.phpt" role="test" />
+         <file name="tests/regression_delete_range_destructor_reentrancy_001.phpt" role="test" />
          <file name="tests/equals_001.phpt" role="test" />
          <file name="tests/foreach_string_key_stress_001.phpt" role="test" />
          <file name="tests/adaptive_clone_isset_unset_empty_slice.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -3662,27 +3662,40 @@ PHP_METHOD(Judy, deleteRange)
 			JLF(PValue, intern->array, index);
 			while (JUDY_LIKELY(PValue != NULL && PValue != PJERR) && index <= index_end) {
 				int Rc_del;
+				zval *value = NULL;
+				judy_packed_value *packed = NULL;
+
 				if (intern->type == TYPE_INT_TO_MIXED) {
-					zval *value = JUDY_MVAL_READ(PValue);
-					zval_ptr_dtor(value);
-					efree(value);
+					value = JUDY_MVAL_READ(PValue);
 				} else if (intern->type == TYPE_INT_TO_PACKED) {
-					judy_packed_value *packed = JUDY_PVAL_READ(PValue);
-					if (packed) efree(packed);
+					packed = JUDY_PVAL_READ(PValue);
 				}
+				/* Delete before free (destructor re-entrancy guard): a user
+				 * destructor can unset the same key, which would otherwise
+				 * find this slot still populated and free `value` twice.
+				 * The counter must also be settled before the destructor
+				 * runs, since it can observe count(). */
 				JLD(Rc_del, intern->array, index);
 				if (Rc_del) {
 					deleted++;
 					intern->counter--;
 				}
-				/* Re-seek after mutation — JLF is safe after JLD */
-				JLF(PValue, intern->array, index);
+				if (value != NULL) {
+					zval_ptr_dtor(value);
+					efree(value);
+				} else if (packed != NULL) {
+					efree(packed);
+				}
+				/* Re-seek strictly past `index`: the destructor may have
+				 * re-inserted this very key, and JLF would hand it back
+				 * forever. JLN also stops cleanly at the Word_t maximum. */
+				JLN(PValue, intern->array, index);
 			}
 		}
 	} else if (intern->is_adaptive) {
 		char *str_start, *str_end;
 		size_t str_start_len, str_end_len;
-		uint8_t *key = intern->key_scratch;
+		uint8_t *key;
 		Pvoid_t *PValue;
 
 		ZEND_PARSE_PARAMETERS_START(2, 2)
@@ -3691,6 +3704,12 @@ PHP_METHOD(Judy, deleteRange)
 		ZEND_PARSE_PARAMETERS_END();
 
 		if (strcmp(str_start, str_end) > 0) RETURN_LONG(0);
+
+		/* Private cursor rather than intern->key_scratch: a stored value's
+		 * destructor can re-enter and run an operation that owns that shared
+		 * buffer (iteration, first()/next()), which would corrupt this walk.
+		 * Same rationale as judy_object_get_gc(). */
+		key = emalloc(PHP_JUDY_MAX_LENGTH);
 
 		size_t key_len = str_start_len >= PHP_JUDY_MAX_LENGTH ? PHP_JUDY_MAX_LENGTH - 1 : str_start_len;
 		memcpy(key, str_start, key_len);
@@ -3702,15 +3721,19 @@ PHP_METHOD(Judy, deleteRange)
 			Word_t klen = (Word_t)strlen((char *)key);
 			Word_t sso_idx;
 			int Rc_del;
+			int Rc_idx_del;
+			zval *value = NULL;
 
+			/* Capture the value, then remove both the value slot and the
+			 * key_index entry, and only then run the destructor: it can
+			 * re-enter and unset the same key, which would otherwise find
+			 * the entry still present and free `value` a second time. */
 			if (judy_pack_short_string_internal((char *)key, klen, &sso_idx)) {
 				Pvoid_t *VValue;
 				JLG(VValue, intern->array, sso_idx);
 				if (JUDY_LIKELY(VValue != NULL && VValue != PJERR)) {
 					if (intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE) {
-						zval *value = JUDY_MVAL_READ(VValue);
-						zval_ptr_dtor(value);
-						efree(value);
+						value = JUDY_MVAL_READ(VValue);
 					}
 					JLD(Rc_del, intern->array, sso_idx);
 				}
@@ -3719,28 +3742,34 @@ PHP_METHOD(Judy, deleteRange)
 				JHSG(VValue, intern->hs_array, key, klen);
 				if (JUDY_LIKELY(VValue != NULL && VValue != PJERR)) {
 					if (intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE) {
-						zval *value = JUDY_MVAL_READ(VValue);
-						zval_ptr_dtor(value);
-						efree(value);
+						value = JUDY_MVAL_READ(VValue);
 					}
 					JHSD(Rc_del, intern->hs_array, key, klen);
 				}
 			}
-			
+
 			/* Delete from key_index */
-			int Rc_idx_del;
 			JSLD(Rc_idx_del, intern->key_index, key);
 			if (Rc_idx_del) {
 				deleted++;
 				intern->counter--;
 			}
-			
-			JSLF(PValue, intern->key_index, key);
+
+			if (value != NULL) {
+				zval_ptr_dtor(value);
+				efree(value);
+			}
+
+			/* Re-seek strictly past `key`: the destructor may have
+			 * re-inserted it, and JSLF would hand it back forever. */
+			JSLN(PValue, intern->key_index, key);
 		}
+
+		efree(key);
 	} else { /* string keyed */
 		char *str_start, *str_end;
 		size_t str_start_len, str_end_len;
-		uint8_t *key = intern->key_scratch;
+		uint8_t *key;
 		Pvoid_t *PValue;
 
 		ZEND_PARSE_PARAMETERS_START(2, 2)
@@ -3749,6 +3778,9 @@ PHP_METHOD(Judy, deleteRange)
 		ZEND_PARSE_PARAMETERS_END();
 
 		if (strcmp(str_start, str_end) > 0) RETURN_LONG(0);
+
+		/* Private cursor — see the adaptive branch above. */
+		key = emalloc(PHP_JUDY_MAX_LENGTH);
 
 		size_t key_len = str_start_len >= PHP_JUDY_MAX_LENGTH ? PHP_JUDY_MAX_LENGTH - 1 : str_start_len;
 		memcpy(key, str_start, key_len);
@@ -3761,44 +3793,58 @@ PHP_METHOD(Judy, deleteRange)
 		}
 
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR) && strcmp((const char *)key, str_end) <= 0) {
+			zval *value = NULL;
+
+			/* Delete before free (destructor re-entrancy guard) — see the
+			 * adaptive branch above. */
 			if (intern->is_hash_keyed) {
+				Word_t klen = (Word_t)strlen((char *)key);
 				Pvoid_t *HValue;
-				JHSG(HValue, intern->array, key, (Word_t)strlen((char *)key));
+				int Rc_idx_del;
+
+				JHSG(HValue, intern->array, key, klen);
 				if (JUDY_LIKELY(HValue != NULL && HValue != PJERR)) {
-					if (intern->type == TYPE_STRING_TO_MIXED_HASH) {
-						zval *value = JUDY_MVAL_READ(HValue);
-						zval_ptr_dtor(value);
-						efree(value);
-					}
 					int Rc_del;
-					JHSD(Rc_del, intern->array, key, (Word_t)strlen((char *)key));
+					if (intern->type == TYPE_STRING_TO_MIXED_HASH) {
+						value = JUDY_MVAL_READ(HValue);
+					}
+					JHSD(Rc_del, intern->array, key, klen);
 					(void)Rc_del; /* JUDYERROR_NOTEST: delete cannot partially fail */
 				}
 				/* Delete from key_index too */
-				int Rc_idx_del;
 				JSLD(Rc_idx_del, intern->key_index, key);
 				if (Rc_idx_del) {
 					deleted++;
 					intern->counter--;
 				}
-				/* We must use JSLF again because key_index was modified */
-				JSLF(PValue, intern->key_index, key);
-			} else {
-				if (intern->type == TYPE_STRING_TO_MIXED) {
-					zval *value = JUDY_MVAL_READ(PValue);
+				if (value != NULL) {
 					zval_ptr_dtor(value);
 					efree(value);
 				}
+				/* Re-seek strictly past `key` — the destructor may have
+				 * re-inserted it, and JSLF would hand it back forever. */
+				JSLN(PValue, intern->key_index, key);
+			} else {
 				int Rc_str_del;
+
+				if (intern->type == TYPE_STRING_TO_MIXED) {
+					value = JUDY_MVAL_READ(PValue);
+				}
 				JSLD(Rc_str_del, intern->array, key);
 				if (Rc_str_del) {
 					deleted++;
 					intern->counter--;
 				}
-				/* We must use JSLF again because array was modified */
-				JSLF(PValue, intern->array, key);
+				if (value != NULL) {
+					zval_ptr_dtor(value);
+					efree(value);
+				}
+				/* Re-seek strictly past `key` — see above. */
+				JSLN(PValue, intern->array, key);
 			}
 		}
+
+		efree(key);
 	}
 	RETURN_LONG(deleted);
 }

--- a/tests/regression_delete_range_destructor_reentrancy_001.phpt
+++ b/tests/regression_delete_range_destructor_reentrancy_001.phpt
@@ -1,0 +1,148 @@
+--TEST--
+Regression: deleteRange() survives a stored value's destructor re-entering the same array
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// deleteRange() used to run a stored value's destructor BEFORE removing its
+// entry from the Judy store. A userland destructor can re-enter and unset (or
+// overwrite) the same key, which then found the entry still present and freed
+// the same zval a second time. It also walked with the shared
+// intern->key_scratch cursor, which a re-entrant destructor can move.
+// Every branch must now delete first, free second, and walk a private cursor.
+
+class UnsetKey {
+    public $j; public $k;
+    function __construct($j, $k) { $this->j = $j; $this->k = $k; }
+    function __destruct() { unset($this->j[$this->k]); }
+}
+
+class Reinsert {
+    public $j; public $k;
+    function __construct($j, $k) { $this->j = $j; $this->k = $k; }
+    function __destruct() { $this->j[$this->k] = "reborn"; }
+}
+
+class Iterate {
+    public $j;
+    function __construct($j) { $this->j = $j; }
+    function __destruct() { foreach ($this->j as $k => $v) { /* walk */ } }
+}
+
+class SeekCursor {
+    public $j; public $k;
+    function __construct($j, $k) { $this->j = $j; $this->k = $k; }
+    // Moves the shared key_scratch cursor to the far end of the range.
+    function __destruct() { $this->j->first($this->k); }
+}
+
+function run($label, $type, $mk, $lo, $hi, $string_keyed) {
+    echo "== $label ==\n";
+
+    // 1. Destructor unsets the very key deleteRange is deleting (double free).
+    $j = new Judy($type);
+    $j[$mk(5)] = new UnsetKey($j, $mk(5));
+    $n = $j->deleteRange($lo, $hi);
+    echo "  self:     deleted=$n count=" . count($j) . "\n";
+    unset($j);
+
+    // 2. Destructor unsets a different key still ahead in the range.
+    $j = new Judy($type);
+    $j[$mk(1)] = "a";
+    $j[$mk(5)] = new UnsetKey($j, $mk(7));
+    $j[$mk(7)] = "c";
+    $j[$mk(9)] = "d";
+    $n = $j->deleteRange($lo, $hi);
+    echo "  other:    deleted=$n count=" . count($j) . "\n";
+    unset($j);
+
+    // 3. Destructor re-inserts the same key: must not free the new value and
+    //    must not hand the same key back to the walk forever.
+    $j = new Judy($type);
+    $j[$mk(1)] = "a";
+    $j[$mk(5)] = new Reinsert($j, $mk(5));
+    $n = $j->deleteRange($lo, $hi);
+    echo "  reinsert: deleted=$n count=" . count($j)
+        . " val=" . var_export($j[$mk(5)], true) . "\n";
+    unset($j);
+
+    // 4. Destructor iterates the same array.
+    $j = new Judy($type);
+    $it = new Iterate($j);
+    $j[$mk(1)] = $it;
+    unset($it);
+    foreach ([2, 3, 4, 5] as $i) { $j[$mk($i)] = "v$i"; }
+    $n = $j->deleteRange($lo, $hi);
+    echo "  iterate:  deleted=$n count=" . count($j) . "\n";
+    unset($j);
+
+    // 5. Destructor seeks the shared key cursor past the rest of the range.
+    //    Only string-keyed types use intern->key_scratch.
+    if ($string_keyed) {
+        $j = new Judy($type);
+        $j[$mk(1)] = new SeekCursor($j, $mk(9));
+        foreach ([2, 3, 4, 5, 6, 7, 8, 9] as $i) { $j[$mk($i)] = "v$i"; }
+        $n = $j->deleteRange($lo, $hi);
+        echo "  cursor:   deleted=$n count=" . count($j) . "\n";
+        foreach ($j as $k => $v) { echo "    leftover: "; var_dump($v); }
+        unset($j);
+    }
+}
+
+$long = str_repeat("k", 40);
+
+run("INT_TO_MIXED",       Judy::INT_TO_MIXED,             fn($n) => $n,        0, 10, false);
+run("STRING_TO_MIXED",    Judy::STRING_TO_MIXED,          fn($n) => "k$n",     "k0", "k9", true);
+run("STRING_TO_MIXED_HASH", Judy::STRING_TO_MIXED_HASH,   fn($n) => "k$n",     "k0", "k9", true);
+run("ADAPTIVE (sso)",     Judy::STRING_TO_MIXED_ADAPTIVE, fn($n) => "k$n",     "k0", "k9", true);
+run("ADAPTIVE (long)",    Judy::STRING_TO_MIXED_ADAPTIVE, fn($n) => "$long$n", "{$long}0", "{$long}9", true);
+
+// The non-MIXED branches were reordered too; check they still delete cleanly.
+$p = new Judy(Judy::INT_TO_PACKED);
+for ($i = 0; $i < 10; $i++) { $p[$i] = [$i, "v$i"]; }
+echo "PACKED deleted=" . $p->deleteRange(2, 7) . " count=" . count($p) . "\n";
+
+$a = new Judy(Judy::STRING_TO_INT_ADAPTIVE);
+foreach (["a", "b", "c", "d"] as $i => $s) { $a[$s] = $i; $a[$long . $s] = $i; }
+echo "ADAPTIVE_INT deleted=" . $a->deleteRange("a", "c") . " count=" . count($a) . "\n";
+
+$h = new Judy(Judy::STRING_TO_INT_HASH);
+foreach (["a", "b", "c", "d"] as $i => $s) { $h[$s] = $i; }
+echo "HASH_INT deleted=" . $h->deleteRange("a", "c") . " count=" . count($h) . "\n";
+
+echo "done\n";
+?>
+--EXPECT--
+== INT_TO_MIXED ==
+  self:     deleted=1 count=0
+  other:    deleted=3 count=0
+  reinsert: deleted=2 count=1 val='reborn'
+  iterate:  deleted=5 count=0
+== STRING_TO_MIXED ==
+  self:     deleted=1 count=0
+  other:    deleted=3 count=0
+  reinsert: deleted=2 count=1 val='reborn'
+  iterate:  deleted=5 count=0
+  cursor:   deleted=9 count=0
+== STRING_TO_MIXED_HASH ==
+  self:     deleted=1 count=0
+  other:    deleted=3 count=0
+  reinsert: deleted=2 count=1 val='reborn'
+  iterate:  deleted=5 count=0
+  cursor:   deleted=9 count=0
+== ADAPTIVE (sso) ==
+  self:     deleted=1 count=0
+  other:    deleted=3 count=0
+  reinsert: deleted=2 count=1 val='reborn'
+  iterate:  deleted=5 count=0
+  cursor:   deleted=9 count=0
+== ADAPTIVE (long) ==
+  self:     deleted=1 count=0
+  other:    deleted=3 count=0
+  reinsert: deleted=2 count=1 val='reborn'
+  iterate:  deleted=5 count=0
+  cursor:   deleted=9 count=0
+PACKED deleted=6 count=4
+ADAPTIVE_INT deleted=3 count=5
+HASH_INT deleted=3 count=1
+done


### PR DESCRIPTION
## Problem

`Judy::deleteRange()` ran a stored value's destructor **before** removing its entry from the Judy store. A userland destructor can re-enter and unset the same key, which found the entry still present and freed the same zval a second time.

`judy_object_unset_dimension_helper()` was already hardened against exactly this ("Delete before free (destructor re-entrancy guard)" at php_judy.c:1074, 1094, 1139, 1155); `deleteRange` was not. All five value-bearing branches had the free-then-delete ordering:

- `INT_TO_MIXED` and `INT_TO_PACKED`
- `STRING_TO_MIXED_ADAPTIVE`, SSO branch
- `STRING_TO_MIXED_ADAPTIVE`, JudyHS branch
- `STRING_TO_MIXED_HASH`
- `STRING_TO_MIXED`

For the `*_HASH` / `*_ADAPTIVE` types the `JSLD` on `intern->key_index` also happened after the destructor, so that entry was live over the same window.

Reproducer (pure PHP, no extension internals):

```php
class D {
    public $j; public $k;
    function __construct($j, $k) { $this->j = $j; $this->k = $k; }
    function __destruct() { unset($this->j[$this->k]); }
}
$j = new Judy(Judy::INT_TO_MIXED);
$j[5] = new D($j, 5);
$j->deleteRange(0, 10);
```

## Fix

Each branch now captures the value pointer, removes the entry (and, for `*_HASH`/`*_ADAPTIVE`, the `key_index` entry), settles the counter, and only then runs `zval_ptr_dtor` + `efree` — matching the pattern in `judy_object_unset_dimension_helper()`. The counter bookkeeping had to move ahead of the destructor too, since a destructor can observe `count()`.

Two supporting changes, both of which the reorder needs:

**Re-seek with `JLN`/`JSLN` instead of `JLF`/`JSLF`.** Once the entry is deleted first, a destructor that *re-inserts* the same key would make `JLF` hand that key back forever. `JLN`/`JSLN` advance strictly past the current key, and `JLN` also stops cleanly at the `Word_t` maximum. This case already crashed on `main` for all five types — the write path frees the old value, then `deleteRange` freed it again.

**A private cursor instead of the shared `intern->key_scratch`** in the two string branches, same rationale as `judy_object_get_gc()` (php_judy.c:341). `next()` writes into `key_scratch` (php_judy.c:1769), so a destructor calling `first()`/`next()` moves the walk's own cursor. With a destructor doing `$j->first("k9")` mid-range, `main` returned `deleted=1 count=8`, left a dangling zval in the `k1` slot, and segfaulted on the next read. The reorder alone downgrades that to a silent wrong answer (`deleted=1`, 8 undeleted entries); only the private cursor makes it correct — confirmed by building that intermediate variant.

## Verification

- **Previous code reproduces the report** under `USE_ZEND_ALLOC=0 valgrind` on Linux/PHP 8.4 (`php-judy-bench`): invalid read of size 4, invalid write, and two `Invalid free()` at php_judy.c:3667 and :3668.
- **This branch**: `ERROR SUMMARY: 0 errors from 0 contexts`, no definite leaks, on both the new test and the existing `delete_range_001`.
- **Zero compiler warnings** on clang/macOS and gcc/Linux.
- **189/189 tests pass** on both platforms.
- The new test **fails on `main`** (crashes at the first scenario, no output) — it is a real regression guard.

## Test

`tests/regression_delete_range_destructor_reentrancy_001.phpt` covers five scenarios — destructor unsets the same key, unsets a different in-range key, re-inserts the same key, iterates the array, seeks the shared cursor — across `INT_TO_MIXED`, `STRING_TO_MIXED`, `STRING_TO_MIXED_HASH`, and `STRING_TO_MIXED_ADAPTIVE` in both its SSO and JudyHS regimes. Plus `INT_TO_PACKED`, `STRING_TO_INT_ADAPTIVE`, and `STRING_TO_INT_HASH` coverage, since those branches were reordered too. Added to `package.xml`.

No API change, so `API.md` is unchanged. `baselines/latest.json` untouched.

## Out of scope

12 other `regression_*.phpt` files are on disk but absent from `package.xml`, so the PECL package ships without them and CI's `validate-pecl` does not catch the drift. Tracked separately rather than widening this diff.
