### PR TITLE
fix(pecl): ship the 12 missing regression tests + guard package.xml drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,22 @@ jobs:
             exit 1
           fi
 
+      - name: Verify package.xml lists every tests/*.phpt
+        # The test run below executes tests/*.phpt from the checkout, not from
+        # the built tarball, so a .phpt missing from package.xml still passes
+        # CI while being absent from the shipped package. Compare explicitly.
+        run: |
+          ls tests/*.phpt | sort > /tmp/tests-on-disk.txt
+          grep -oP '(?<=name=")tests/[^"]+(?=")' package.xml | sort > /tmp/tests-in-package.txt
+          if ! diff -u --label package.xml --label tests/ \
+               /tmp/tests-in-package.txt /tmp/tests-on-disk.txt; then
+            echo "ERROR: package.xml and tests/ have diverged."
+            echo "  '+' lines: on disk but not in package.xml — add"
+            echo '            <file name="tests/<name>.phpt" role="test" />'
+            echo "  '-' lines: in package.xml but not on disk — remove the entry"
+            exit 1
+          fi
+
       - name: Install Judy library
         run: sudo apt-get update && sudo apt-get install -y libjudy-dev
 

--- a/package.xml
+++ b/package.xml
@@ -265,6 +265,18 @@
          <file name="tests/population_count_001.phpt" role="test" />
          <file name="tests/sum_values_001.phpt" role="test" />
          <file name="tests/unserialize_counter_001.phpt" role="test" />
+         <file name="tests/regression_adaptive_counter_zero_value_001.phpt" role="test" />
+         <file name="tests/regression_adaptive_iteration_001.phpt" role="test" />
+         <file name="tests/regression_adaptive_navigation_001.phpt" role="test" />
+         <file name="tests/regression_adaptive_setops_001.phpt" role="test" />
+         <file name="tests/regression_append_after_bulk_clone_001.phpt" role="test" />
+         <file name="tests/regression_bulk_exception_stop_001.phpt" role="test" />
+         <file name="tests/regression_callback_reentrancy_001.phpt" role="test" />
+         <file name="tests/regression_gc_cycle_001.phpt" role="test" />
+         <file name="tests/regression_int_keyed_string_key_001.phpt" role="test" />
+         <file name="tests/regression_mixed_destructor_reentrancy_001.phpt" role="test" />
+         <file name="tests/regression_packed_equals_001.phpt" role="test" />
+         <file name="tests/regression_unserialize_reinit_leak_001.phpt" role="test" />
          <file md5sum="f4c1dde3511c574eef8fbf6a99f9d27b" name="config.m4" role="src" />
          <file md5sum="14c238115fee50dfe70b13bc8da311d3" name="config.w32" role="src" />
          <file name="Judy.stub.php" role="src" />


### PR DESCRIPTION
## Problem

12 `tests/regression_*.phpt` files exist on disk but were never listed in `package.xml`, so they are absent from the shipped PECL package.

```
comm -23 <(ls tests/*.phpt | sort) <(grep -oE 'name="tests/[^"]+"' package.xml | sed 's/name="//;s/"//' | sort)
```

CI did not catch it. The `validate-pecl` job's final step runs `tests/*.phpt` from the **checkout**, not from the installed tarball, so an unpackaged test still executes and passes.

## Changes

- **`package.xml`** — added the 12 missing `<file … role="test" />` entries.
- **`.github/workflows/ci.yml`** — new `Verify package.xml lists every tests/*.phpt` step in `validate-pecl`, placed before the apt/PHP/pecl setup so it fails fast. Diffs disk against `package.xml` and fails in both directions (missing entry, or stale entry with no file), printing the exact `<file …/>` line to add.

## Verification

- `xmllint --noout package.xml` → OK
- disk vs `package.xml` → no divergence, 188 == 188
- `pecl package package.xml` builds; `tar tzf` confirms all 188 tests including the 12 regression files
- CI YAML parses; step order confirmed
- failure path exercised on a copy with one entry stripped — diff exits non-zero and names the missing file

## Notes

- The 12th file is `tests/regression_mixed_destructor_reentrancy_001.phpt`; no `regression_delete_range_destructor_reentrancy_001.phpt` exists on disk.
- `examples/*.php` has no drift. `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` / `SECURITY.md` are unlisted, which looks deliberate — the guard is scoped to `tests/*.phpt` only.