### PR TITLE
ci(benchmark): interleave the release-comparison arms and test them statistically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,26 +94,34 @@ jobs:
           php -d "extension=$BASELINE_SO" -r \
             'echo "Baseline loaded: judy " . judy_version() . "\n";'
 
-      - name: Run baseline benchmarks
+      - name: Run interleaved release comparison
         if: matrix.php-version == '8.4'
         run: |
-          mkdir -p /tmp/php-judy-baseline-ini
-          echo "extension=$BASELINE_SO" > /tmp/php-judy-baseline-ini/judy.ini
+          # Interleaved A/B/A/B comparison against the previous release. The
+          # arms alternate per benchmark group and repeat over several rounds,
+          # so runner drift hits both arms and cancels in the paired ratio —
+          # see scripts/bench-compare.php and issue #87 for why running the
+          # two suites back to back reported false regressions instead.
+          #
+          # Deliberately smaller than the headline benchmark below: this job
+          # needs to detect *changes* reliably, not produce publishable
+          # absolute numbers (those come from a dedicated host, see
+          # BENCHMARK.md). Rounds buy more than element count here.
+          php scripts/bench-compare.php \
+            --baseline-so "$BASELINE_SO" \
+            --current-so "$(pwd)/modules/judy.so" \
+            --size 300000 --iterations 3 --rounds 5 \
+            --out bench-compare.json \
+            2>&1 | tee bench-compare-output.txt
 
-          # v2.4.1 has all types + API, so run the full suite for a complete
-          # release-over-release comparison.
-          PHP_INI_SCAN_DIR=/tmp/php-judy-baseline-ini php examples/benchmarks/judy-bench.php \
-            --json baseline-bench.json --size 500000 --iterations 7 --suite all \
-            2>&1 | tee baseline-benchmark-output.txt
-
-      - name: Upload baseline benchmark results
+      - name: Upload release comparison results
         if: always() && matrix.php-version == '8.4'
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-baseline-linux-php${{ matrix.php-version }}
           path: |
-            baseline-bench.json
-            baseline-benchmark-output.txt
+            bench-compare.json
+            bench-compare-output.txt
           if-no-files-found: ignore
 
       - name: Run benchmarks
@@ -973,25 +981,229 @@ jobs:
                   lines.append("</details>\n")
 
               # ── Cross-release baseline comparison ──
-              # Prefer CI-generated baseline (same runner = no arch noise)
+              # Preferred: the interleaved A/B comparison produced on the same
+              # runner by scripts/bench-compare.php. Running the two suites
+              # back to back put the arms minutes apart and reported runner
+              # drift as regressions (issue #87); this artifact instead carries
+              # paired per-round ratios with confidence intervals.
+              compare = None
+              for cf in sorted(glob.glob(
+                  "benchmarks/benchmark-baseline-*/bench-compare.json"
+              )):
+                  with open(cf) as f:
+                      try:
+                          compare = json.load(f)
+                      except json.JSONDecodeError:
+                          compare = None
+                  break
+
+              if compare and compare.get("benchmarks"):
+                  meta = compare.get("metadata", {})
+                  drift = compare.get("drift", {})
+                  counts = compare.get("counts", {})
+                  rows = compare["benchmarks"]
+
+                  lines.append(
+                      f"### Release Comparison "
+                      f"({meta.get('baseline_version', '?')} → "
+                      f"{meta.get('current_version', '?')})\n"
+                  )
+                  lines.append(
+                      f"> Interleaved A/B comparison against v"
+                      f"{meta.get('baseline_version', '?')} "
+                      f"(`pie install`) on the **same CI runner**: "
+                      f"{len(meta.get('groups', []))} benchmark groups × "
+                      f"{meta.get('rounds', '?')} rounds × 2 arms, "
+                      f"{meta.get('size', 0):,} elements, "
+                      f"median of {meta.get('iterations', '?')} per child. "
+                      f"Each row is the median of the paired "
+                      f"current/baseline ratios with a 95% "
+                      f"percentile-bootstrap CI; it is flagged only when the "
+                      f"whole drift-adjusted CI clears "
+                      f"±{meta.get('threshold_pct', 10):.0f}%. "
+                      f"Advisory — benchmarks never gate a merge.\n"
+                  )
+
+                  php_ctl = drift.get("php_control_median_delta_pct")
+                  drift_note = (
+                      f"Run-wide median delta "
+                      f"{drift.get('median_delta_pct', 0):+.2f}% "
+                      f"(PHP-array control "
+                      + ("n/a" if php_ctl is None else f"{php_ctl:+.2f}%")
+                      + "), divided out of every row."
+                  )
+                  if drift.get("contaminated"):
+                      lines.append(
+                          f"> ⚠️ **Comparison contaminated.** "
+                          f"{drift_note} That is past the "
+                          f"±{meta.get('drift_threshold_pct', 5):.0f}% "
+                          f"threshold: the whole suite moved together, which "
+                          f"is a slower runner rather than slower code. "
+                          f"Individual flags are suppressed — re-run the "
+                          f"job for a usable comparison.\n"
+                      )
+                  else:
+                      lines.append(f"> {drift_note}\n")
+
+                  parts = []
+                  if counts.get("faster"):
+                      parts.append(f"{counts['faster']} faster")
+                  if counts.get("slower"):
+                      parts.append(
+                          f"⚠️ **{counts['slower']} regressions**"
+                      )
+                  else:
+                      parts.append("0 regressions")
+                  if counts.get("same"):
+                      parts.append(f"{counts['same']} unchanged")
+                  if counts.get("unstable"):
+                      parts.append(
+                          f"{counts['unstable']} not evaluated (unstable)"
+                      )
+                  if counts.get("new"):
+                      parts.append(f"{counts['new']} new")
+                  if counts.get("removed"):
+                      parts.append(f"{counts['removed']} removed")
+                  lines.append("**Summary**: " + ", ".join(parts) + "\n")
+
+                  def cmp_row(name, r):
+                      d = r.get("adj_delta_pct", 0.0)
+                      ci = r.get("adj_ci_delta_pct", [0.0, 0.0])
+                      d_str = "0.0%" if abs(d) < 0.05 else f"{d:+.1f}%"
+                      ci_str = f"[{ci[0]:+.1f}%, {ci[1]:+.1f}%]"
+                      st = r.get("status", "~same")
+                      if st == "FASTER":
+                          s_str = "✅ **FASTER**"
+                      elif st == "SLOWER":
+                          s_str = "⚠️ **SLOWER**"
+                      elif st == "unstable":
+                          s_str = "— unstable"
+                      else:
+                          s_str = "~same"
+                      return (
+                          f"| {name} | {fmt_ms(r.get('baseline_ms'))} "
+                          f"| {fmt_ms(r.get('current_ms'))} | {d_str} "
+                          f"| {ci_str} | {s_str} |"
+                      )
+
+                  header = [
+                      "| Benchmark | Baseline | Current | Delta | 95% CI "
+                      "| Status |",
+                      "|-----------|----------|---------|------:|--------:"
+                      "|--------|",
+                  ]
+                  evaluated = [
+                      (n, r) for n, r in sorted(rows.items())
+                      if r.get("status") != "unstable"
+                  ]
+                  unstable = [
+                      (n, r) for n, r in sorted(rows.items())
+                      if r.get("status") == "unstable"
+                  ]
+                  if evaluated:
+                      lines.extend(header)
+                      for n, r in evaluated:
+                          lines.append(cmp_row(n, r))
+                      lines.append("")
+                  if unstable:
+                      lines.append(
+                          f"<details><summary>{len(unstable)} benchmarks not "
+                          f"evaluated (within-arm scatter exceeded the effect "
+                          f"being claimed)</summary>\n"
+                      )
+                      lines.extend(header)
+                      for n, r in unstable:
+                          lines.append(cmp_row(n, r))
+                      lines.append("")
+                      lines.append("</details>\n")
+
+                  # ── Memory Comparison ──
+                  type_label_map = dict(all_types)
+                  mem_rows = []
+                  mem_counts = {"better": 0, "worse": 0, "same": 0}
+                  for mid, m in sorted(compare.get("memory", {}).items()):
+                      mid_parts = mid.split(".")
+                      if len(mid_parts) < 2:
+                          continue
+                      name = type_label_map.get(mid_parts[1], mid_parts[1])
+                      b_heap = m.get("baseline_bytes") or 0
+                      c_heap = m.get("current_bytes") or 0
+                      if b_heap <= 0:
+                          delta, status = 0.0, "~same"
+                          mem_counts["same"] += 1
+                      else:
+                          delta = ((c_heap - b_heap) / b_heap) * 100
+                          if delta < -1.0:
+                              status = "BETTER"
+                              mem_counts["better"] += 1
+                          elif delta > 1.0:
+                              status = "WORSE"
+                              mem_counts["worse"] += 1
+                          else:
+                              status = "~same"
+                              mem_counts["same"] += 1
+                      mem_rows.append((name, b_heap, c_heap, delta, status))
+
+                  if mem_rows:
+                      lines.append("#### Memory Comparison\n")
+                      mparts = []
+                      if mem_counts["better"]:
+                          mparts.append(f"{mem_counts['better']} improved")
+                      if mem_counts["worse"]:
+                          mparts.append(
+                              f"⚠️ **{mem_counts['worse']} "
+                              f"regressions**"
+                          )
+                      else:
+                          mparts.append("0 regressions")
+                      if mem_counts["same"]:
+                          mparts.append(f"{mem_counts['same']} unchanged")
+                      lines.append("**Memory**: " + ", ".join(mparts) + "\n")
+                      lines.append(
+                          "| Type | Baseline | Current | Delta | Status |"
+                      )
+                      lines.append(
+                          "|------|----------|---------|------:|--------|"
+                      )
+                      for name, b_heap, c_heap, delta, status in mem_rows:
+                          if abs(delta) < 0.05:
+                              d_str = "0.0%"
+                          else:
+                              d_str = f"{delta:+.1f}%"
+                          if status == "BETTER":
+                              s_str = "✅ **BETTER**"
+                          elif status == "WORSE":
+                              s_str = "⚠️ **WORSE**"
+                          else:
+                              s_str = "~same"
+                          lines.append(
+                              f"| {name} | {fmt_bytes(b_heap)} "
+                              f"| {fmt_bytes(c_heap)} | {d_str} | {s_str} |"
+                          )
+                      lines.append("")
+
+                  for label, entries in (
+                      ("new benchmarks (not in baseline)", compare.get("new", {})),
+                      ("removed benchmarks", compare.get("removed", {})),
+                  ):
+                      if entries:
+                          lines.append(
+                              f"<details><summary>{len(entries)} {label}"
+                              f"</summary>\n"
+                          )
+                          lines.append("| Benchmark | Median |")
+                          lines.append("|-----------|--------|")
+                          for n, ms in sorted(entries.items()):
+                              lines.append(f"| {n} | {fmt_ms(ms)} |")
+                          lines.append("")
+                          lines.append("</details>\n")
+
+              # Fallback: committed baseline file. Only reached when the
+              # interleaved comparison artifact is missing (e.g. the 8.4 job
+              # failed before producing it).
               baseline = None
               baseline_source = None
-
-              for bdir in sorted(glob.glob(
-                  "benchmarks/benchmark-baseline-*"
-              )):
-                  bf = os.path.join(bdir, "baseline-bench.json")
-                  if os.path.isfile(bf):
-                      with open(bf) as f:
-                          try:
-                              baseline = json.load(f)
-                              baseline_source = "same-runner"
-                          except json.JSONDecodeError:
-                              pass
-                      break
-
-              # Fallback: committed baseline file
-              if baseline is None:
+              if compare is None:
                   fallback = "baselines/latest.json"
                   if os.path.isfile(fallback):
                       with open(fallback) as f:
@@ -1086,23 +1298,16 @@ jobs:
                           f"### Release Comparison "
                           f"({base_ver} \u2192 {cur_ver})\n"
                       )
-                      if baseline_source == "same-runner":
-                          lines.append(
-                              f"> Baseline: v{base_ver} via "
-                              f"`pie install` on **same CI "
-                              f"runner**. "
-                              f"Comparing {primary} PHP {latest}. "
-                              f"Threshold: \u00b1{threshold:.0f}% "
-                              f"(entries < {min_ms:.0f} ms ignored).\n"
-                          )
-                      else:
-                          lines.append(
-                              f"> \u26a0\ufe0f Baseline: v{base_ver} "
-                              f"from committed file "
-                              f"(cross-architecture — deltas may "
-                              f"be unreliable). "
-                              f"Threshold: \u00b1{threshold:.0f}%.\n"
-                          )
+                      lines.append(
+                          f"> \u26a0\ufe0f Fallback comparison — the "
+                          f"interleaved same-runner artifact was missing, so "
+                          f"this is v{base_ver} from the committed baseline "
+                          f"file: cross-architecture, one sample per arm, no "
+                          f"confidence intervals. Treat the deltas as "
+                          f"unreliable. "
+                          f"Threshold: \u00b1{threshold:.0f}% "
+                          f"(entries < {min_ms:.0f} ms ignored).\n"
+                      )
                       # Summary line
                       parts = []
                       if counts["faster"]:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,39 @@ release checklist.
 
 ## Benchmarks
 
-Benchmark scripts live in `examples/benchmarks/`. CI compares each PR against the
-committed baseline in `baselines/latest.json`. If your change legitimately
-shifts performance, mention it in the PR description; do not update the
-baseline in a feature PR.
+Benchmark scripts live in `examples/benchmarks/`. Benchmarks are **advisory** —
+they never gate a merge.
+
+CI compares each PR against the previous release, installed onto the same runner
+via `pie`. The comparison is driven by `scripts/bench-compare.php`, which
+interleaves the two extension builds per benchmark group (A/B/A/B) and repeats
+the pair over several rounds in ABBA order. Each row in the report is the median
+of the paired current/baseline ratios with a 95% percentile-bootstrap CI, and is
+flagged only when the whole drift-adjusted CI clears ±10%. Running the two
+suites back to back instead put the arms minutes apart, so runner drift showed
+up as a page of regressions on code the diff could not reach (issue #87).
+
+Reading the report:
+
+- **`~same`** — either the difference is inside ±10%, or the CI straddles the
+  threshold, i.e. there is no measured separation.
+- **`unstable`** — the benchmark's own arms scattered by more than the effect
+  being claimed, so it was not evaluated. Expect a few on a busy runner.
+- **"Comparison contaminated"** — the run-wide median delta moved past ±5%,
+  meaning the whole suite shifted together. That is a slower runner, not slower
+  code; individual flags are suppressed and the job should be re-run.
+
+To reproduce a comparison locally:
+
+```sh
+php scripts/bench-compare.php \
+    --baseline-so /path/to/previous/judy.so \
+    --current-so "$PWD/modules/judy.so" \
+    --size 300000 --iterations 3 --rounds 5
+```
+
+If your change legitimately shifts performance, mention it in the PR
+description; do not update `baselines/latest.json` in a feature PR.
 
 ## Submitting a pull request
 

--- a/examples/benchmarks/judy-bench.php
+++ b/examples/benchmarks/judy-bench.php
@@ -25,21 +25,59 @@ ini_set('memory_limit', '2G');
 
 // ── CLI argument parsing ────────────────────────────────────────────────────
 
-$opts = getopt('', ['json:', 'size:', 'iterations:', 'suite:']);
+$opts = getopt('', ['json:', 'size:', 'iterations:', 'suite:', 'group:', 'list-groups']);
 $size       = isset($opts['size'])       ? (int)$opts['size']       : 500000;
 $iterations = isset($opts['iterations']) ? (int)$opts['iterations'] : 5;
 $suite      = isset($opts['suite'])      ? $opts['suite']           : 'all';
 $json_file  = isset($opts['json'])       ? $opts['json']            : null;
 
-$valid_suites = ['core', 'api', 'advanced', 'all'];
+// Groups are the finest unit the runner can execute on its own. Each one owns
+// its setup, so running a group in isolation costs only that group's work —
+// which is what lets an external driver interleave two extension builds at
+// group granularity instead of whole-suite granularity (see
+// scripts/bench-compare.php).
+$suite_groups = [
+    'core'     => ['core.int', 'core.str'],
+    'api'      => ['api.batch', 'api.setops'],
+    'advanced' => ['adv.iter', 'adv.sso'],
+];
+$suite_groups['all'] = array_merge(...array_values($suite_groups));
+
+if (isset($opts['list-groups'])) {
+    foreach ($suite_groups['all'] as $g) {
+        echo "$g\n";
+    }
+    exit(0);
+}
+
+$valid_suites = array_keys($suite_groups);
 if (!in_array($suite, $valid_suites, true)) {
     fwrite(STDERR, "Invalid suite: $suite. Choose from: " . implode(', ', $valid_suites) . "\n");
     exit(1);
 }
 
-$run_core     = ($suite === 'all' || $suite === 'core');
-$run_api      = ($suite === 'all' || $suite === 'api');
-$run_advanced = ($suite === 'all' || $suite === 'advanced');
+$active_groups = $suite_groups[$suite];
+if (isset($opts['group'])) {
+    $requested = array_filter(array_map('trim', explode(',', (string)$opts['group'])), 'strlen');
+    $unknown   = array_diff($requested, $suite_groups['all']);
+    if ($unknown) {
+        fwrite(STDERR, "Unknown group(s): " . implode(', ', $unknown)
+            . ". Choose from: " . implode(', ', $suite_groups['all']) . "\n");
+        exit(1);
+    }
+    $active_groups = array_values($requested);
+}
+$active_group_set = array_flip($active_groups);
+
+/** Is this benchmark group selected for this run? */
+function bench_group(string $group): bool {
+    global $active_group_set;
+    return isset($active_group_set[$group]);
+}
+
+$run_core     = bench_group('core.int')  || bench_group('core.str');
+$run_api      = bench_group('api.batch') || bench_group('api.setops');
+$run_advanced = bench_group('adv.iter')  || bench_group('adv.sso');
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -116,6 +154,7 @@ $json_results = [
         'size'         => $size,
         'iterations'   => $iterations,
         'suite'        => $suite,
+        'groups'       => $active_groups,
     ],
     'benchmarks' => [],
 ];
@@ -149,7 +188,7 @@ $div = str_repeat('═', 90);
 echo "$div\n";
 echo "  php-judy Benchmark Suite — " . number_format($size) . " elements, $iterations iterations (median)\n";
 echo "  PHP " . phpversion() . " | Judy ext " . judy_version() . " | " . PHP_OS . " " . php_uname('m') . "\n";
-echo "  Suite: $suite\n";
+echo "  Suite: $suite | Groups: " . implode(',', $active_groups) . "\n";
 echo "$div\n\n";
 
 // ╔═══════════════════════════════════════════════════════════════════════════╗
@@ -220,9 +259,12 @@ function bench_core_type(
     ];
 }
 
+$col = [24, 12, 12, 12, 12, 12, 12];
+
+if (bench_group('core.int')) {
+
 echo "── Core: Integer-Keyed Types ────────────────────────────────────────────────\n\n";
 
-$col = [24, 12, 12, 12, 12, 12, 12];
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
     'Type', 'Write(ms)', 'Read(ms)', 'Iter(ms)', 'Free(ms)', 'Heap');
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
@@ -363,7 +405,11 @@ if ($has_packed) {
 unset($mixed_data, $mixed_keys);
 echo "\n";
 
+} // end core.int group
+
 // ── Core: String-Keyed Types ────────────────────────────────────────────────
+
+if (bench_group('core.str')) {
 
 echo "── Core: String-Keyed Types ────────────────────────────────────────────────\n\n";
 
@@ -444,6 +490,8 @@ if ($has_adaptive) {
 unset($str_int_data, $str_keys, $str_mixed_data, $str_mix_keys);
 echo "\n";
 
+} // end core.str group
+
 } // end core suite
 
 // ╔═══════════════════════════════════════════════════════════════════════════╗
@@ -452,9 +500,12 @@ echo "\n";
 
 if ($run_api) {
 
+$col_api = [30, 12, 12, 10];
+
+if (bench_group('api.batch')) {
+
 echo "── API: Batch Operations (INT_TO_INT) ────────────────────────────────────────\n\n";
 
-$col_api = [30, 12, 12, 10];
 printf("  %-{$col_api[0]}s  %{$col_api[1]}s  %{$col_api[2]}s  %{$col_api[3]}s\n",
     'Operation', 'Judy(ms)', 'PHP(ms)', 'Speedup');
 printf("  %-{$col_api[0]}s  %{$col_api[1]}s  %{$col_api[2]}s  %{$col_api[3]}s\n",
@@ -647,7 +698,11 @@ printf("  %-{$col_api[0]}s  %{$col_api[1]}s  %{$col_api[2]}s  %{$col_api[3]}s\n"
 unset($j_int, $j_str, $j_int_b);
 echo "\n";
 
+} // end api.batch group
+
 // ── API: Set Operations ─────────────────────────────────────────────────────
+
+if (bench_group('api.setops')) {
 
 echo "── API: Set Operations (BITSET, 50% overlap) ────────────────────────────────\n\n";
 
@@ -846,6 +901,8 @@ foreach (['union', 'intersect', 'diff'] as $op) {
 unset($judy_a, $judy_b, $php_a, $php_b, $j_a, $j_b, $js_a, $js_b);
 echo "\n";
 
+} // end api.setops group
+
 } // end api suite
 
 // ╔═══════════════════════════════════════════════════════════════════════════╗
@@ -857,6 +914,8 @@ if ($run_advanced) {
 $col_adv = [30, 12, 12, 10];
 
 // ── Advanced: C-level forEach/filter/map ────────────────────────────────────
+
+if (bench_group('adv.iter')) {
 
 echo "── Advanced: C-Level forEach/filter/map ──────────────────────────────────────\n\n";
 
@@ -960,9 +1019,11 @@ printf("  %-{$col_adv[0]}s  %{$col_adv[1]}s  %{$col_adv[2]}s  %{$col_adv[3]}s\n"
 unset($j_int, $j_str);
 echo "\n";
 
+} // end adv.iter group
+
 // ── Advanced: Adaptive SSO comparison ───────────────────────────────────────
 
-if ($has_adaptive) {
+if ($has_adaptive && bench_group('adv.sso')) {
 
 echo "── Advanced: Adaptive SSO — short keys (<8 bytes) via JudyL ─────────────────\n\n";
 

--- a/package.xml
+++ b/package.xml
@@ -284,6 +284,7 @@
          <file md5sum="af4d88a4da7b16aaf4f92d7fe619e6be" name="BENCHMARK.md" role="doc" />
          <file name="API.md" role="doc" />
          <file name="scripts/api-metadata.php" role="doc" />
+         <file name="scripts/bench-compare.php" role="doc" />
          <file name="scripts/generate-api-docs.php" role="doc" />
          <file md5sum="513b0c0813de66e8cba534d4fa1b0eb2" name="MIGRATION_2.2.0.md" role="doc" />
          <file md5sum="366b0129d18f1e9b38f1712590805903" name="Dockerfile" role="doc" />

--- a/scripts/bench-compare.php
+++ b/scripts/bench-compare.php
@@ -1,0 +1,492 @@
+<?php
+/**
+ * Interleaved A/B benchmark comparison driver.
+ *
+ * Problem this solves
+ * -------------------
+ * Running the whole baseline suite to completion and *then* the whole current
+ * suite puts the two arms minutes apart. Taking a median inside an arm removes
+ * fast jitter but nothing removes drift *between* arms, so when a shared CI
+ * runner slows down during the second arm every current number inflates at
+ * once and the comparison reports a wall of false regressions.
+ *
+ * What this driver does instead
+ * -----------------------------
+ *  1. Interleaves the arms per benchmark *group* rather than per suite. Each
+ *     group's baseline and current measurements are taken adjacent in time
+ *     (seconds apart, not minutes), so slow drift affects both arms about
+ *     equally and largely cancels in the delta.
+ *  2. Repeats the interleaved pair over R rounds in ABBA order (round 1 runs
+ *     baseline-then-current, round 2 current-then-baseline, ...). ABBA makes
+ *     the two arms symmetric in time, which cancels the linear component of
+ *     drift exactly instead of loading it onto whichever arm ran second.
+ *  3. Treats each round as a *pair* and works on the per-round ratio
+ *     current/baseline, summarised as a median with a 95% percentile-bootstrap
+ *     CI (same method as examples/benchmarks/judy-bench-alternatives.php).
+ *     Pairing is what makes the interleaving pay: whatever the machine was
+ *     doing during round r hits both members of that round's pair, so it
+ *     divides out of the ratio instead of accumulating into a delta between
+ *     two independently-estimated medians.
+ *  4. Computes the run-wide median delta as a contamination estimate. A clean
+ *     run centres near 0%; a run-wide median past the threshold means the
+ *     runner state moved under the measurement, and the whole comparison is
+ *     marked contaminated rather than emitting a page of individual flags.
+ *  5. Divides each benchmark's ratio by that run-wide median, so a benchmark is
+ *     only flagged when it moved differently from everything else in the run.
+ *
+ * A benchmark is flagged only when the *whole* drift-adjusted CI clears the
+ * threshold — a point estimate past the threshold with a CI straddling it is
+ * reported as "no measured separation", not as a regression — and both arms
+ * are above the minimum-duration floor.
+ *
+ * Usage:
+ *   php scripts/bench-compare.php \
+ *       --baseline-so /path/to/baseline/judy.so \
+ *       --current-so  /path/to/modules/judy.so \
+ *       [--rounds 5] [--size 300000] [--iterations 3] \
+ *       [--groups core.int,core.str,api.batch,api.setops,adv.iter] \
+ *       [--threshold 10.0] [--min-ms 2.0] [--drift-threshold 5.0] \
+ *       [--out bench-compare.json]
+ *
+ * Output: a JSON document (see $result at the bottom) consumed by the
+ * "Release Comparison" section of the CI report.
+ */
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+$opts = getopt('', [
+    'baseline-so:', 'current-so:', 'bench:', 'rounds:', 'size:', 'iterations:',
+    'groups:', 'threshold:', 'min-ms:', 'drift-threshold:', 'max-spread:',
+    'out:', 'quiet',
+]);
+
+$baseline_so = $opts['baseline-so'] ?? null;
+$current_so  = $opts['current-so']  ?? null;
+if ($baseline_so === null || $current_so === null) {
+    fwrite(STDERR, "Usage: bench-compare.php --baseline-so <path> --current-so <path> [options]\n");
+    exit(2);
+}
+foreach (['baseline' => $baseline_so, 'current' => $current_so] as $arm => $so) {
+    if (!is_file($so)) {
+        fwrite(STDERR, "No such $arm extension: $so\n");
+        exit(2);
+    }
+}
+
+$bench_script = $opts['bench'] ?? __DIR__ . '/../examples/benchmarks/judy-bench.php';
+if (!is_file($bench_script)) {
+    fwrite(STDERR, "No such benchmark script: $bench_script\n");
+    exit(2);
+}
+
+$rounds     = max(3, (int)($opts['rounds']     ?? 5));
+$size       = max(1, (int)($opts['size']       ?? 300000));
+$iterations = max(1, (int)($opts['iterations'] ?? 3));
+$threshold  = (float)($opts['threshold']       ?? 10.0);
+$min_ms     = (float)($opts['min-ms']          ?? 2.0);
+$drift_max  = (float)($opts['drift-threshold'] ?? 5.0);
+$max_spread = (float)($opts['max-spread']      ?? 30.0);
+$out_file   = $opts['out'] ?? 'bench-compare.json';
+$quiet      = isset($opts['quiet']);
+
+// adv.sso is excluded by default: its entries do not end in `.judy`, so the
+// release comparison never looks at them, and running them would cost wall
+// clock for nothing.
+$groups = array_values(array_filter(array_map(
+    'trim',
+    explode(',', (string)($opts['groups'] ?? 'core.int,core.str,api.batch,api.setops,adv.iter'))
+), 'strlen'));
+
+function say(string $msg): void {
+    global $quiet;
+    if (!$quiet) {
+        fwrite(STDERR, $msg);
+    }
+}
+
+// ── Per-arm ini scan dirs ───────────────────────────────────────────────────
+// Children get exactly one judy build via PHP_INI_SCAN_DIR, so the baseline
+// and the current build can never end up loaded in the same process.
+
+$tmp_root = sys_get_temp_dir() . '/judy-bench-compare-' . getmypid();
+$arm_ini  = [];
+foreach (['baseline' => $baseline_so, 'current' => $current_so] as $arm => $so) {
+    $dir = "$tmp_root/$arm-ini";
+    if (!is_dir($dir) && !mkdir($dir, 0700, true)) {
+        fwrite(STDERR, "Cannot create $dir\n");
+        exit(2);
+    }
+    file_put_contents("$dir/judy.ini", 'extension=' . realpath($so) . "\n");
+    $arm_ini[$arm] = $dir;
+}
+register_shutdown_function(static function () use ($tmp_root): void {
+    foreach (glob("$tmp_root/*/*") ?: [] as $f) { @unlink($f); }
+    foreach (glob("$tmp_root/*") ?: [] as $d) { @rmdir($d); }
+    @rmdir($tmp_root);
+});
+
+// ── Child execution ─────────────────────────────────────────────────────────
+
+/**
+ * Run one benchmark group under one arm. Returns the child's `benchmarks` map.
+ *
+ * @return array<string,array<string,mixed>>
+ */
+function run_group(string $arm, string $group): array {
+    global $arm_ini, $bench_script, $size, $iterations, $tmp_root;
+
+    $json = "$tmp_root/out.json";
+    @unlink($json);
+    $cmd = 'PHP_INI_SCAN_DIR=' . escapeshellarg($arm_ini[$arm]) . ' '
+        . escapeshellarg(PHP_BINARY) . ' -d memory_limit=-1 '
+        . escapeshellarg($bench_script)
+        . ' --group ' . escapeshellarg($group)
+        . ' --size ' . $size
+        . ' --iterations ' . $iterations
+        . ' --json ' . escapeshellarg($json)
+        . ' > /dev/null 2>&1';
+
+    exec($cmd, $_, $status);
+    if ($status !== 0 || !is_file($json)) {
+        fwrite(STDERR, "Child failed (arm=$arm group=$group status=$status)\n");
+        exit(1);
+    }
+    $data = json_decode((string)file_get_contents($json), true);
+    if (!is_array($data) || !isset($data['benchmarks'])) {
+        fwrite(STDERR, "Child produced unusable JSON (arm=$arm group=$group)\n");
+        exit(1);
+    }
+    $GLOBALS['arm_meta'][$arm] = $data['metadata'] ?? [];
+
+    return $data['benchmarks'];
+}
+
+// ── Statistics ──────────────────────────────────────────────────────────────
+
+function median(array $xs): float {
+    sort($xs);
+    $c = count($xs);
+    if ($c === 0) {
+        return 0.0;
+    }
+
+    return $c % 2 ? (float)$xs[intdiv($c, 2)] : ((float)$xs[$c / 2 - 1] + (float)$xs[$c / 2]) / 2;
+}
+
+/**
+ * 95% percentile-bootstrap CI for the median. Seeded, so re-deriving the stats
+ * from the same samples reproduces the same interval.
+ *
+ * @return array{0:float,1:float}
+ */
+function median_ci(array $xs, int $resamples = 2000): array {
+    $n = count($xs);
+    if ($n < 3) {
+        return [(float)min($xs), (float)max($xs)];
+    }
+    mt_srand(20260817);
+    $meds = [];
+    for ($b = 0; $b < $resamples; $b++) {
+        $s = [];
+        for ($i = 0; $i < $n; $i++) {
+            $s[] = $xs[mt_rand(0, $n - 1)];
+        }
+        $meds[] = median($s);
+    }
+    sort($meds);
+
+    return [$meds[(int)floor(0.025 * $resamples)], $meds[(int)ceil(0.975 * $resamples) - 1]];
+}
+
+
+/**
+ * Within-arm spread as a percentage of the median: (max - min) / median * 100.
+ *
+ * A benchmark whose own arm scatters this much was not measured cleanly, so
+ * neither is the ratio built from it. The run-wide drift statistic only sees
+ * contamination that hits everything at once; this catches the localized kind
+ * that lands on one benchmark's window.
+ */
+function spread_pct(array $xs): float {
+    $m = median($xs);
+    if ($m <= 0.0) {
+        return 0.0;
+    }
+
+    return (max($xs) - min($xs)) / $m * 100.0;
+}
+
+// ── Interleaved execution ───────────────────────────────────────────────────
+
+$arm_meta = [];
+/** @var array<string,array<string,array<float>>> $samples arm => id => ms[] */
+$samples  = ['baseline' => [], 'current' => []];
+/** @var array<string,array<string,array<int>>> $heaps */
+$heaps    = ['baseline' => [], 'current' => []];
+
+$started = microtime(true);
+$total   = count($groups) * $rounds * 2;
+$done    = 0;
+
+foreach ($groups as $group) {
+    for ($r = 1; $r <= $rounds; $r++) {
+        // ABBA: alternate which arm goes first so the two arms are symmetric
+        // in time. Linear drift then cancels instead of being charged to
+        // whichever arm always runs second.
+        $order = ($r % 2 === 1) ? ['baseline', 'current'] : ['current', 'baseline'];
+        foreach ($order as $arm) {
+            $bm = run_group($arm, $group);
+            foreach ($bm as $id => $entry) {
+                if (array_key_exists('heap_bytes', $entry)) {
+                    $heaps[$arm][$id][] = (int)$entry['heap_bytes'];
+                    continue;
+                }
+                $samples[$arm][$id][] = (float)$entry['median_ms'];
+            }
+            $done++;
+            say(sprintf("  [%2d/%2d] %-12s %-10s round %d\n", $done, $total, $group, $arm, $r));
+        }
+    }
+}
+$wall = microtime(true) - $started;
+
+// ── Per-benchmark comparison ────────────────────────────────────────────────
+
+$ids = array_unique(array_merge(
+    array_keys($samples['baseline']),
+    array_keys($samples['current'])
+));
+sort($ids);
+
+$rows     = [];   // id => stats (only .judy entries)
+$new      = [];
+$removed  = [];
+$raw_deltas = [];         // .judy point deltas, for the run-wide median
+$php_deltas = [];         // .php control deltas, reported as a diagnostic
+
+foreach ($ids as $id) {
+    $b = $samples['baseline'][$id] ?? null;
+    $c = $samples['current'][$id]  ?? null;
+
+    if ($b === null || $c === null) {
+        if (!str_ends_with($id, '.judy')) {
+            continue;
+        }
+        $name = substr($id, 0, -5);
+        if ($b === null) {
+            $new[$name] = round(median($c), 4);
+        } else {
+            $removed[$name] = round(median($b), 4);
+        }
+        continue;
+    }
+
+    $b_med = median($b);
+    $c_med = median($c);
+    if ($b_med <= 0.0) {
+        continue;
+    }
+
+    // Per-round pairing. Sample r of each arm came from the same round, i.e.
+    // from two child processes run back to back, so the pair shares a machine
+    // state and the ratio cancels it.
+    $pairs = [];
+    $n     = min(count($b), count($c));
+    for ($r = 0; $r < $n; $r++) {
+        if ($b[$r] > 0.0) {
+            $pairs[] = $c[$r] / $b[$r];
+        }
+    }
+    if (!$pairs) {
+        continue;
+    }
+    $ratio = median($pairs);
+
+    if (str_ends_with($id, '.php')) {
+        // PHP-array control work. It shares a process and a moment with the
+        // matching .judy measurement, so its delta is a second, independent
+        // read on how much the machine moved between the arms.
+        if ($b_med >= $min_ms && $c_med >= $min_ms) {
+            $php_deltas[] = ($ratio - 1.0) * 100.0;
+        }
+        continue;
+    }
+    if (!str_ends_with($id, '.judy')) {
+        continue;
+    }
+
+    $rows[substr($id, 0, -5)] = [
+        'baseline_ms'   => round($b_med, 4),
+        'current_ms'    => round($c_med, 4),
+        'baseline_runs' => array_map(static fn($v) => round($v, 4), $b),
+        'current_runs'  => array_map(static fn($v) => round($v, 4), $c),
+        'paired_ratios' => array_map(static fn($v) => round($v, 4), $pairs),
+        'ratio'         => $ratio,
+        'ratio_ci'      => median_ci($pairs),
+        'delta_pct'     => round(($ratio - 1.0) * 100.0, 2),
+        'spread_pct'    => [round(spread_pct($b), 1), round(spread_pct($c), 1)],
+    ];
+    if ($b_med >= $min_ms || $c_med >= $min_ms) {
+        $raw_deltas[] = ($ratio - 1.0) * 100.0;
+    }
+}
+
+// ── Run-wide drift / contamination ──────────────────────────────────────────
+
+$drift        = $raw_deltas ? median($raw_deltas) : 0.0;
+$php_drift    = $php_deltas ? median($php_deltas) : null;
+$contaminated = abs($drift) > $drift_max;
+$scale        = 1.0 + $drift / 100.0;   // multiplicative common-mode factor
+
+$counts = ['faster' => 0, 'slower' => 0, 'same' => 0, 'unstable' => 0,
+           'new' => count($new), 'removed' => count($removed)];
+
+$hi_bound = 1.0 + $threshold / 100.0;
+$lo_bound = 1.0 - $threshold / 100.0;
+
+foreach ($rows as $name => &$row) {
+    $b_med = $row['baseline_ms'];
+    $c_med = $row['current_ms'];
+
+    // Divide out the run-wide common-mode factor.
+    $adj_ratio = $row['ratio'] / $scale;
+    $adj_ci    = [$row['ratio_ci'][0] / $scale, $row['ratio_ci'][1] / $scale];
+
+    $row['adj_delta_pct']    = round(($adj_ratio - 1.0) * 100.0, 2);
+    $row['adj_ci_delta_pct'] = [round(($adj_ci[0] - 1.0) * 100.0, 2),
+                                round(($adj_ci[1] - 1.0) * 100.0, 2)];
+    $row['ratio']            = round($row['ratio'], 4);
+    $row['ratio_ci']         = array_map(static fn($v) => round($v, 4), $row['ratio_ci']);
+
+    if ($b_med < $min_ms && $c_med < $min_ms) {
+        $row['status'] = '~same';
+        $row['reason'] = 'below min-ms floor';
+        $counts['same']++;
+        continue;
+    }
+
+    // Refuse to evaluate a benchmark whose own arms scattered by more than the
+    // difference being claimed: within-arm noise that large explains the
+    // between-arm gap on its own. The guard is relative on purpose — an effect
+    // that dwarfs the scatter is still reported, so this suppresses noise
+    // without suppressing signal.
+    $worst_spread = max($row['spread_pct'][0], $row['spread_pct'][1]);
+    if ($worst_spread > $max_spread && $worst_spread > abs($row['adj_delta_pct'])) {
+        $row['status'] = 'unstable';
+        $row['reason'] = sprintf(
+            'not evaluated: within-arm spread %.0f%% exceeds both the %.0f%% floor '
+            . 'and the %.1f%% effect',
+            $worst_spread, $max_spread, abs($row['adj_delta_pct'])
+        );
+        $counts['unstable']++;
+        continue;
+    }
+
+    // The whole interval has to clear the threshold. A point estimate past the
+    // threshold whose CI straddles it is not a measured regression.
+    if ($adj_ci[0] > $hi_bound) {
+        $row['status'] = 'SLOWER';
+        $counts['slower']++;
+    } elseif ($adj_ci[1] < $lo_bound) {
+        $row['status'] = 'FASTER';
+        $counts['faster']++;
+    } else {
+        $row['status'] = '~same';
+        $row['reason'] = abs($row['adj_delta_pct']) > $threshold
+            ? 'no measured separation (CI straddles the threshold)'
+            : sprintf("within \u{00b1}%.0f%%", $threshold);
+        $counts['same']++;
+    }
+}
+unset($row);
+
+// A contaminated run keeps its numbers but stops asserting anything about
+// them: suppressing the flags is the honest outcome, not silently reporting
+// a page of regressions the machine caused.
+if ($contaminated) {
+    $counts['same'] += $counts['slower'] + $counts['faster'];
+    $counts['slower'] = 0;
+    $counts['faster'] = 0;
+    foreach ($rows as &$row) {
+        if ($row['status'] === 'SLOWER' || $row['status'] === 'FASTER') {
+            $row['status'] = '~same';
+            $row['reason'] = 'suppressed: run flagged contaminated';
+        }
+    }
+    unset($row);
+}
+
+// ── Memory (heap) ───────────────────────────────────────────────────────────
+
+$memory = [];
+foreach (array_keys($heaps['baseline']) as $id) {
+    if (!str_ends_with($id, '.judy') || !isset($heaps['current'][$id])) {
+        continue;
+    }
+    $memory[substr($id, 0, -5)] = [
+        'baseline_bytes' => (int)median($heaps['baseline'][$id]),
+        'current_bytes'  => (int)median($heaps['current'][$id]),
+    ];
+}
+
+// ── Emit ────────────────────────────────────────────────────────────────────
+
+$result = [
+    'metadata' => [
+        'php_version'      => phpversion(),
+        'baseline_version' => $arm_meta['baseline']['judy_version'] ?? '?',
+        'current_version'  => $arm_meta['current']['judy_version'] ?? '?',
+        'platform'         => PHP_OS . ' ' . php_uname('m'),
+        'date'             => date('Y-m-d\TH:i:sP'),
+        'size'             => $size,
+        'iterations'       => $iterations,
+        'rounds'           => $rounds,
+        'groups'           => $groups,
+        'threshold_pct'    => $threshold,
+        'min_ms'           => $min_ms,
+        'drift_threshold_pct' => $drift_max,
+        'max_spread_pct'   => $max_spread,
+        'wall_seconds'     => round($wall, 1),
+        'schema'           => 'judy-bench-compare/1',
+    ],
+    'drift' => [
+        'median_delta_pct'             => round($drift, 2),
+        'php_control_median_delta_pct' => $php_drift === null ? null : round($php_drift, 2),
+        'contaminated'                 => $contaminated,
+        'sample_count'                 => count($raw_deltas),
+    ],
+    'counts'     => $counts,
+    'benchmarks' => $rows,
+    'memory'     => $memory,
+    'new'        => $new,
+    'removed'    => $removed,
+];
+
+file_put_contents($out_file, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+printf(
+    "Interleaved comparison: %s -> %s | %d groups x %d rounds x 2 arms | %.0fs\n",
+    $result['metadata']['baseline_version'],
+    $result['metadata']['current_version'],
+    count($groups), $rounds, $wall
+);
+printf(
+    "Run-wide median delta: %+.2f%% (PHP-array control %s) -> %s\n",
+    $drift,
+    $php_drift === null ? 'n/a' : sprintf('%+.2f%%', $php_drift),
+    $contaminated ? 'CONTAMINATED, flags suppressed' : 'clean'
+);
+printf(
+    "Summary: %d faster, %d regressions, %d unchanged, %d unstable, %d new, %d removed\n",
+    $counts['faster'], $counts['slower'], $counts['same'], $counts['unstable'],
+    $counts['new'], $counts['removed']
+);
+foreach ($rows as $name => $row) {
+    if ($row['status'] === 'SLOWER' || $row['status'] === 'FASTER') {
+        printf("  %-8s %-40s %+.1f%% [%+.1f%%, %+.1f%%] (drift-adjusted; raw %+.1f%%)\n",
+            $row['status'], $name, $row['adj_delta_pct'],
+            $row['adj_ci_delta_pct'][0], $row['adj_ci_delta_pct'][1],
+            $row['delta_pct']);
+    }
+}
+echo "Wrote $out_file\n";

--- a/scripts/bench-compare.php
+++ b/scripts/bench-compare.php
@@ -127,28 +127,136 @@ register_shutdown_function(static function () use ($tmp_root): void {
 
 // ── Child execution ─────────────────────────────────────────────────────────
 
+/** Build the `PHP_INI_SCAN_DIR=... php ...` prefix for one arm's child. */
+function arm_php(string $arm): string {
+    global $arm_ini;
+
+    // PHP_INI_SCAN_DIR points at a directory holding exactly one judy.ini, so
+    // no other ini file on the machine can also load the extension. The whole
+    // comparison is worthless if an arm silently runs the other build: an
+    // image that pre-enables judy in its own conf.d makes `-d extension=...`
+    // a no-op and PHP only whispers "Module already loaded" about it. Hence
+    // the scan-dir override here and verify_arm() below.
+    return 'PHP_INI_SCAN_DIR=' . escapeshellarg($arm_ini[$arm]) . ' '
+        . escapeshellarg(PHP_BINARY) . ' -d memory_limit=-1 ';
+}
+
+/**
+ * Fail loudly unless this arm's children load exactly the extension we asked
+ * for. A benchmark that silently measures the wrong binary is worse than a
+ * noisy one: it reports a near-zero delta, which reads as success.
+ */
+function verify_arm(string $arm, string $so): void {
+    global $tmp_root;
+
+    $probe = <<<'PROBE'
+$out = ['loaded' => extension_loaded('judy'), 'paths' => [], 'proc' => false];
+$maps = @file_get_contents('/proc/self/maps');
+if ($maps !== false) {
+    $out['proc'] = true;
+    if (preg_match_all('#/\S*judy\S*\.so#', $maps, $m)) {
+        $out['paths'] = array_values(array_unique($m[0]));
+    }
+}
+$inis = php_ini_scanned_files();
+$out['ini_files'] = $inis === false ? [] : array_values(array_filter(
+    array_map('trim', explode(',', $inis)), 'strlen'
+));
+$loaded_ini = php_ini_loaded_file();
+$out['main_ini_loads_judy'] = $loaded_ini !== false
+    && preg_match('#^\s*(zend_)?extension\s*=.*judy#mi', (string)@file_get_contents($loaded_ini)) === 1;
+echo json_encode($out);
+PROBE;
+
+    $err = "$tmp_root/probe.err";
+    $cmd = arm_php($arm) . '-r ' . escapeshellarg($probe) . ' 2> ' . escapeshellarg($err);
+    $raw = (string)shell_exec($cmd);
+    $stderr = is_file($err) ? trim((string)file_get_contents($err)) : '';
+    @unlink($err);
+
+    $fail = static function (string $why) use ($arm, $so, $stderr): void {
+        fwrite(STDERR, "Extension preflight failed for the $arm arm.\n");
+        fwrite(STDERR, "  wanted: $so\n");
+        fwrite(STDERR, "  reason: $why\n");
+        if ($stderr !== '') {
+            fwrite(STDERR, "  child stderr: $stderr\n");
+        }
+        exit(1);
+    };
+
+    if (stripos($stderr, 'already loaded') !== false) {
+        $fail('another ini file had already loaded judy, so this arm would '
+            . 'have measured whichever build that ini points at');
+    }
+    if (stripos($stderr, 'Unable to load dynamic library') !== false) {
+        $fail('the extension could not be loaded');
+    }
+
+    $info = json_decode(trim($raw), true);
+    if (!is_array($info)) {
+        $fail('the probe produced no usable output: ' . trim($raw));
+    }
+    if (empty($info['loaded'])) {
+        $fail('the judy extension was not loaded at all');
+    }
+    if (!empty($info['main_ini_loads_judy'])) {
+        $fail('the main php.ini also loads judy; PHP_INI_SCAN_DIR cannot '
+            . 'override that, so run this on a PHP whose php.ini does not '
+            . 'enable the extension');
+    }
+    if (count($info['ini_files']) > 1) {
+        $fail('more than one scanned ini file is in effect: '
+            . implode(', ', $info['ini_files']));
+    }
+
+    // Linux gives us the authoritative answer: which file is actually mapped.
+    if (!empty($info['proc'])) {
+        $want  = realpath($so);
+        $paths = array_map(static fn($p) => realpath($p) ?: $p, $info['paths']);
+        $paths = array_values(array_unique($paths));
+        if (count($paths) !== 1 || $paths[0] !== $want) {
+            $fail('the mapped extension is ' . (
+                $paths ? implode(', ', $paths) : 'not identifiable'
+            ));
+        }
+    }
+}
+
 /**
  * Run one benchmark group under one arm. Returns the child's `benchmarks` map.
  *
  * @return array<string,array<string,mixed>>
  */
 function run_group(string $arm, string $group): array {
-    global $arm_ini, $bench_script, $size, $iterations, $tmp_root;
+    global $bench_script, $size, $iterations, $tmp_root;
 
     $json = "$tmp_root/out.json";
+    $err  = "$tmp_root/child.err";
     @unlink($json);
-    $cmd = 'PHP_INI_SCAN_DIR=' . escapeshellarg($arm_ini[$arm]) . ' '
-        . escapeshellarg(PHP_BINARY) . ' -d memory_limit=-1 '
+    $cmd = arm_php($arm)
         . escapeshellarg($bench_script)
         . ' --group ' . escapeshellarg($group)
         . ' --size ' . $size
         . ' --iterations ' . $iterations
         . ' --json ' . escapeshellarg($json)
-        . ' > /dev/null 2>&1';
+        . ' > /dev/null 2> ' . escapeshellarg($err);
 
     exec($cmd, $_, $status);
+    $stderr = is_file($err) ? trim((string)file_get_contents($err)) : '';
+    @unlink($err);
+
+    // Never measure through a warning that means the wrong build is loaded.
+    if (stripos($stderr, 'already loaded') !== false
+        || stripos($stderr, 'Unable to load dynamic library') !== false) {
+        fwrite(STDERR, "Extension loading went wrong mid-run (arm=$arm "
+            . "group=$group): $stderr\n");
+        exit(1);
+    }
     if ($status !== 0 || !is_file($json)) {
         fwrite(STDERR, "Child failed (arm=$arm group=$group status=$status)\n");
+        if ($stderr !== '') {
+            fwrite(STDERR, "  stderr: $stderr\n");
+        }
         exit(1);
     }
     $data = json_decode((string)file_get_contents($json), true);
@@ -223,6 +331,17 @@ $arm_meta = [];
 $samples  = ['baseline' => [], 'current' => []];
 /** @var array<string,array<string,array<int>>> $heaps */
 $heaps    = ['baseline' => [], 'current' => []];
+
+// Preflight before spending any wall clock: prove each arm loads the build it
+// was given, and say plainly when the two arms are the same file.
+verify_arm('baseline', $baseline_so);
+verify_arm('current', $current_so);
+$same_build = hash_file('sha256', $baseline_so) === hash_file('sha256', $current_so);
+if ($same_build) {
+    say("Note: both arms are byte-identical builds — this is a self-comparison,\n"
+        . "      so any flagged difference is measurement error by construction.\n");
+}
+say("Preflight OK: baseline and current arms load their own build.\n");
 
 $started = microtime(true);
 $total   = count($groups) * $rounds * 2;
@@ -447,6 +566,9 @@ $result = [
         'drift_threshold_pct' => $drift_max,
         'max_spread_pct'   => $max_spread,
         'wall_seconds'     => round($wall, 1),
+        'baseline_so'      => realpath($baseline_so),
+        'current_so'       => realpath($current_so),
+        'identical_builds' => $same_build,
         'schema'           => 'judy-bench-compare/1',
     ],
     'drift' => [


### PR DESCRIPTION
Closes #87.

The release comparison ran the whole baseline suite to completion and then the
whole current suite, so the two arms sat minutes apart. `--iterations 7`
medians *within* an arm but nothing cancels drift *between* arms, and on a
shared runner that drift is systematic: PR #86 was flagged with 21 regressions,
almost all on paths its diff cannot reach, and a re-run of the identical commit
flagged 1.

## What changed

- `examples/benchmarks/judy-bench.php` gains `--group`. Each suite is split
  into groups that own their setup (`core.int`, `core.str`, `api.batch`,
  `api.setops`, `adv.iter`, `adv.sso`), so a group can be run in isolation for
  only that group's cost. `--suite` keeps its old meaning and the 178 benchmark
  ids are unchanged.
- `scripts/bench-compare.php` (new) drives the comparison:
  1. **Interleaves per group, not per suite** — each arm's measurement of a
     group is taken seconds after the other's, not minutes.
  2. **Repeats the pair over 5 rounds in ABBA order**, then treats each round
     as a *pair* and works on the current/baseline ratio. Pairing is what makes
     the interleaving pay: whatever the machine was doing during round *r* hits
     both members of that round's pair and divides out. Reported as the median
     paired ratio with a 95% percentile-bootstrap CI, the same method
     `judy-bench-alternatives.php` already uses.
  3. **Contamination detector** — the run-wide median delta. A clean run
     centres near 0%; past ±5% the whole comparison is marked contaminated and
     the individual flags are suppressed with an explanation.
  4. **Deltas relative to the run-wide median**, so a benchmark is flagged only
     when it moved differently from the rest of that run.
  Plus a guard the issue does not list: a benchmark whose own arms scattered by
  more than the effect being claimed is reported as `unstable` rather than
  evaluated. The run-wide statistic only sees contamination that hits
  everything at once; this catches the localized kind. It is relative on
  purpose, so an effect that dwarfs the scatter is still reported.
- A benchmark is flagged only when the **whole** drift-adjusted CI clears ±10%.
  A point estimate past the threshold with a CI straddling it is reported as
  "no measured separation", not as a regression.
- `.github/workflows/ci.yml` replaces the two full-suite steps with one
  comparison step and renders the new artifact.

## Cost

The comparison runs at `--size 300000 --iterations 3 --rounds 5` instead of one
500k/7 pass per arm. This job needs to detect *changes* reliably, not publish
absolute numbers — those come from a dedicated host (BENCHMARK.md). The
headline 500k/7 run feeding the cross-version tables is untouched.

## Not done

- No dedicated/self-hosted runner (issue item 5). Out of scope here, and the
  shared-runner path has to be trustworthy either way.

Benchmarks stay advisory. `baselines/latest.json` and the
`pie install orieg/judy:X.Y.Z` baseline policy are untouched.