### PR TITLE
docs: warn that an ini-loaded judy.so silently shadows -d extension=

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,17 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   proposing a backend swap.
 - **Benchmarks**: suite in `examples/benchmarks/`; CI compares PRs against
   `baselines/latest.json`. Don't update the baseline in a feature PR.
+- **Verify you are testing the build you think you are.** If any ini file
+  under `conf.d/` already loads `judy.so` (a Docker image built with
+  `docker-php-ext-enable judy`, a system install, a PIE install), that copy
+  wins and your `-d extension=/path/to/modules/judy.so` is **ignored** — the
+  only signal is `Module "judy" is already loaded in Unknown on line 0`.
+  Always use `PHP_INI_SCAN_DIR= php -d extension=...` (or `php -n -d ...`)
+  when measuring or valgrinding a build you just compiled. `judy_version()`
+  will not save you: the stale and fresh builds report the same version. This
+  has already produced one wrong conclusion — a memory-safety fix was measured
+  as ineffective while the container re-ran the pre-fix binary, and the
+  isolated re-run reversed the result.
 - **Runnable demos**: `examples/` (index + type-per-demo table in
   `examples/README.md`). Reach for these before writing a pattern from
   scratch — each is the idiomatic shape for its problem:

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -281,17 +281,47 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pecl install apcu && docker-php-ext-enable apcu
 COPY . /usr/src/php-judy
 WORKDIR /usr/src/php-judy
-RUN phpize && ./configure --with-judy=/usr && make -j"$(nproc)" && make install \
-    && docker-php-ext-enable judy
+# Build only — deliberately NOT `docker-php-ext-enable judy`. See the warning
+# below: an ini-enabled copy silently wins over `-d extension=`.
+RUN phpize && ./configure --with-judy=/usr && make -j"$(nproc)"
 ```
 
 ```bash
 cat /proc/loadavg                      # confirm < cores/2 BEFORE and AFTER
 docker build -f Dockerfile.bench -t php-judy-bench .
 docker run --rm -w /usr/src/php-judy php-judy-bench \
-    php -d apc.enable_cli=1 -d apc.shm_size=2048M \
+    env PHP_INI_SCAN_DIR= php \
+        -d extension=apcu \
+        -d extension=/usr/src/php-judy/modules/judy.so \
+        -d apc.enable_cli=1 -d apc.shm_size=2048M \
         examples/benchmarks/judy-bench-alternatives.php
 ```
+
+`PHP_INI_SCAN_DIR=` disables **every** `conf.d` ini, APCu's included, so APCu
+has to be loaded explicitly too or the harness will skip its rows with a
+notice. Confirm both are present before trusting a run:
+
+```bash
+env PHP_INI_SCAN_DIR= php -d extension=apcu -d extension=.../modules/judy.so \
+    -r 'printf("judy=%s apcu=%s\n", extension_loaded("judy")?"yes":"no",
+                                     extension_loaded("apcu")?"yes":"no");'
+```
+
+> **Do not bake the extension into the image with `docker-php-ext-enable
+> judy`.** If an ini file in `conf.d/` loads `judy.so`, that copy wins and a
+> later `-d extension=/path/to/your/build.so` is **ignored** — PHP emits only
+> `Module "judy" is already loaded in Unknown on line 0` and carries on with
+> the baked-in build. Every measurement then silently describes the image's
+> extension rather than the one under test.
+>
+> This is easy to miss and expensive when missed: a verification round during
+> the #85 work concluded a memory-safety fix was ineffective, when in fact the
+> container was re-running the pre-fix binary. Re-measuring with
+> `PHP_INI_SCAN_DIR=` reversed the result outright.
+>
+> Build the extension in the image but load it explicitly at run time, with
+> `PHP_INI_SCAN_DIR=` (or `php -n`) so nothing is inherited. `judy_version()`
+> will **not** catch the mistake — both builds report the same version.
 
 ### 1. Prefix invalidation — a complexity-class difference
 


### PR DESCRIPTION
Docs only. Closes a documented footgun that already produced one wrong conclusion.

## The problem

BENCHMARK.md's benchmark reproduction recipe built its image with `docker-php-ext-enable judy`. That writes an ini into `conf.d/`, and **an ini-loaded copy wins over a later `-d extension=/path/to/your/build.so`**. PHP does not error — it emits `Module "judy" is already loaded in Unknown on line 0` and carries on with the baked-in build.

So anyone following the recipe to measure a build they just compiled is measuring the image's extension instead. `judy_version()` cannot detect it: both builds report the same version.

## Why this is worth a doc change

It is not hypothetical. While verifying the #89 `deleteRange` fix, a container built from this exact recipe re-ran the pre-fix binary, and the fix measured as **completely ineffective** — same 28 valgrind errors from 7 contexts as before, same wrong `deleted=0` return.

Re-running the identical reproducer with `PHP_INI_SCAN_DIR=` reversed it outright:

| Build | `deleted` | valgrind |
| --- | --- | --- |
| `main~1` (pre-#89) | 0 | 28 errors / 7 contexts |
| `main` (post-#89) | 4 | **0 errors / 0 contexts** |

Same host, same reproducer, same method. #89 works; the measurement was wrong. Given this repo verifies memory-safety fixes under valgrind, a recipe that can silently test the wrong binary is a real hazard.

## What changed

**BENCHMARK.md** — the Dockerfile builds the extension but no longer enables it; the run command loads it explicitly under `PHP_INI_SCAN_DIR=`; a warning block explains the failure mode and its signal.

One subtlety, found by actually running the corrected recipe rather than assuming it: `PHP_INI_SCAN_DIR=` disables **every** `conf.d` ini, APCu's included, so the harness would have silently skipped its APCu rows. The recipe now loads `apcu` explicitly too, and includes a both-extensions-present check:

```bash
env PHP_INI_SCAN_DIR= php -d extension=apcu -d extension=.../modules/judy.so \
    -r 'printf("judy=%s apcu=%s\n", extension_loaded("judy")?"yes":"no",
                                     extension_loaded("apcu")?"yes":"no");'
```

Verified end-to-end against the real image: `PHP 8.4.24 | judy 2.4.2 | apcu 5.1.28`, APCu column present in the output.

**AGENTS.md** — the same warning as a repo pitfall, since this traps anyone measuring or valgrinding a freshly compiled build, and the tell (`already loaded`) is easy to miss when grepping for benchmark output.

## Related

Relevant to #87 (CI benchmark noise): if a comparison ever loads the extension via an ini while also passing one explicitly, the "current" arm can silently measure the baseline build — producing a near-zero delta, the failure mode that looks like success. `.github/workflows/ci.yml` already does the right thing today, using a per-arm `PHP_INI_SCAN_DIR=/tmp/php-judy-ini`; that property is load-bearing and should be preserved if those steps are restructured.
