### PR TITLE
perf(#85): preconditions for the key_index mirror — one write path, JUDY_DEBUG_MIRROR, write-path benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,84 @@ jobs:
           docker run --rm -w /usr/src/php-judy php-judy-alpine \
             make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
 
+  debug-mirror-assertions:
+    # The four *_HASH / *_ADAPTIVE types keep the key set in a JudySL
+    # key_index and the values in a separate store. A path that updates one
+    # and not the other produces two valid pointers holding different answers:
+    # no crash, no leak, nothing valgrind can see. This job builds with
+    # --enable-judy-debug-mirror, which compiles in a checker that walks both
+    # stores and aborts on disagreement, and runs the whole suite under it.
+    #
+    # The last step is a negative control. An assertion that has never fired
+    # is not known to work, and a harness that silently stops checking is
+    # worse than none — so CI deletes one line the checker depends on and
+    # requires the abort to happen.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Judy library
+        run: sudo apt-get update && sudo apt-get install -y libjudy-dev
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+
+      - name: Build with the consistency assertions
+        run: |
+          phpize
+          ./configure --with-judy=/usr --enable-judy-debug-mirror
+          make 2>&1 | tee /tmp/build-debug-mirror.log
+
+      - name: Fail on compiler warnings
+        run: |
+          if grep -E '(php_judy|judy_handlers|judy_arrayaccess|judy_iterator)\.[ch]:[0-9]+:[0-9]+: warning:' /tmp/build-debug-mirror.log; then
+            echo "::error::Compiler warnings detected with JUDY_DEBUG_MIRROR enabled"
+            exit 1
+          fi
+          echo "No compiler warnings in extension sources."
+
+      - name: Confirm the assertions are compiled in
+        # Without this the job degrades silently into a duplicate of
+        # build-linux the moment the configure flag stops taking effect.
+        run: |
+          nm -D --defined-only modules/judy.so | grep -q judy_debug_check_mirror \
+            || { echo "::error::--enable-judy-debug-mirror produced a build with no checker in it"; exit 1; }
+
+      - name: Run the full suite under the assertions
+        run: make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+
+      - name: Negative control — break the invariant, require the abort
+        run: |
+          # Delete the counter bump that accompanies a new key in the
+          # key_index-backed types. The stores stay individually valid; only
+          # their agreement breaks, which is exactly what the checker is for.
+          sed -i 's|intern->counter++; /\* judy-mirror-negative-control \*/|/* deleted by the CI negative control */|' php_judy.c
+          grep -q 'deleted by the CI negative control' php_judy.c \
+            || { echo "::error::negative control did not apply — the anchor line in php_judy.c moved"; exit 1; }
+          make
+
+          set +e
+          php -d extension="$(pwd)/modules/judy.so" \
+            -r '$j = new Judy(Judy::STRING_TO_INT_HASH); $j["a"] = 1;' \
+            > /tmp/negative-control.log 2>&1
+          rc=$?
+          set -e
+          cat /tmp/negative-control.log
+
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::a deliberately broken invariant ran to completion — the assertions are not working"
+            exit 1
+          fi
+          grep -q 'MIRROR INVARIANT VIOLATED' /tmp/negative-control.log \
+            || { echo "::error::process failed but not via the mirror assertion — check the log above"; exit 1; }
+          echo "Negative control passed: the assertions caught the broken invariant."
+
+          git checkout -- php_judy.c
+
   validate-pecl:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,29 @@ A failing test leaves `tests/<name>.diff` / `.out` / `.exp` files behind for
 inspection. Please add a `.phpt` test for every behavior change or bug fix —
 regression tests are what keep a C extension safe to evolve.
 
+### Internal consistency assertions
+
+The four `*_HASH` / `*_ADAPTIVE` types keep the key set in a JudySL
+`key_index` and the values in a separate store. A path that updates one and
+not the other leaves two valid pointers holding different answers: no crash,
+no leak, nothing valgrind can see. When touching a write, mutate or delete
+path on those types, rebuild with the assertions on and run the suite:
+
+```sh
+phpize --clean && phpize
+./configure --with-judy=/usr --enable-judy-debug-mirror
+make
+make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+```
+
+The checker walks both stores at object teardown and after `clone`, and
+aborts with a `MIRROR INVARIANT VIOLATED` banner naming the offending key.
+Without the flag it compiles to nothing — the linked `judy.so` is
+byte-identical either way — so this is a development and CI build, never a
+release one. CI runs it as the `debug-mirror-assertions` job, which ends with
+a negative control that deliberately breaks the invariant and requires the
+abort, so the harness cannot rot into a no-op.
+
 ## Code conventions
 
 - **Zero compiler warnings.** CI fails on any warning in the extension source

--- a/config.m4
+++ b/config.m4
@@ -6,6 +6,13 @@ PHP_ARG_WITH(judy, for Judy support,
 [  --with-judy[=DIR]       Include Judy support.
                           DIR is the Judy install prefix [default=BUNDLED]])
 
+PHP_ARG_ENABLE(judy-debug-mirror, whether to enable Judy consistency assertions,
+[  --enable-judy-debug-mirror
+                          Compile the internal key_index/value-store
+                          consistency assertions. Aborts on violation; for
+                          development and CI only, never for a release
+                          build. [default=no]], no, no)
+
 judy_sources="judy_handlers.c judy_arrayaccess.c judy_iterator.c"
 
 if test "$PHP_JUDY" != "no"; then
@@ -48,7 +55,13 @@ if test "$PHP_JUDY" != "no"; then
   ])
 
   PHP_INSTALL_HEADERS([ext/judy], [php_judy.h judy_handlers.h judy_arrayaccess.h judy_iterator.h])
-  
+
+  dnl # Opt-in internal consistency assertions (see JUDY_ASSERT_MIRROR).
+  if test "$PHP_JUDY_DEBUG_MIRROR" = "yes"; then
+    AC_MSG_NOTICE([Judy mirror consistency assertions enabled])
+    CFLAGS="$CFLAGS -DJUDY_DEBUG_MIRROR"
+  fi
+
   dnl # Performance optimizations for production builds
   if test "$PHP_DEBUG" != "yes"; then
     dnl # Add optimization flags for production

--- a/examples/benchmarks/judy-bench-writepath.php
+++ b/examples/benchmarks/judy-bench-writepath.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Write-path microbenchmark: string-keyed insert, overwrite and increment.
+ *
+ * The suites in judy-bench.php cover reads, iteration and bulk operations. This
+ * one isolates the *write* path on string-keyed types — `offsetSet` insert and
+ * overwrite across all six, `increment()` on the three that support it, and the
+ * ADAPTIVE short-string (SSO) branch, which has the shortest write path and is
+ * therefore the most sensitive to added indirection. Point lookup is included
+ * as a control: it should not move.
+ *
+ * Why it exists: any change that touches key registration is invisible to an
+ * iteration-only benchmark. It was written for the issue #85 B1 refactor
+ * (routing every string-keyed value write through one slot-acquisition path)
+ * and is kept because the remaining #85 work adds a `key_index` lookup to the
+ * overwrite path, which needs exactly this gate. It caught a real +3.0%
+ * regression on ADAPTIVE SSO overwrite that a code review had passed.
+ *
+ * Usage — one build per process, emitting JSON:
+ *
+ *   PHP_INI_SCAN_DIR= php -d extension=/path/to/modules/judy.so \
+ *       examples/benchmarks/judy-bench-writepath.php --size 200000 > arm.json
+ *
+ * `PHP_INI_SCAN_DIR=` is not optional. If any conf.d ini already loads judy.so
+ * — a Docker image built with `docker-php-ext-enable judy`, a PIE or system
+ * install — that copy wins, `-d extension=` is ignored with only a
+ * "Module judy is already loaded" warning, and the run silently measures the
+ * wrong build. `judy_version()` will not reveal it; both report the same
+ * version. See BENCHMARK.md.
+ *
+ * Comparing two builds: run the arms **interleaved**, alternating order round
+ * by round (ABBA), and compare per-round ratios rather than two aggregate
+ * numbers. Sequential arms minutes apart is the exact shape that produced the
+ * false regressions in issue #87. `scripts/bench-compare.php` implements that
+ * treatment — including the bootstrap CIs and the instability guard — for the
+ * judy-bench.php groups; reuse its methodology rather than eyeballing medians.
+ *
+ * Timings are only meaningful from an idle machine: check load average before
+ * and between runs and treat anything above cores/2 as contaminated.
+ */
+
+$opts = getopt('', ['size:', 'iterations:', 'keylen:']);
+$size = (int)($opts['size'] ?? 200000);
+$iters = (int)($opts['iterations'] ?? 5);
+$keylen = (int)($opts['keylen'] ?? 16);
+
+if (!extension_loaded('judy')) {
+    fwrite(STDERR, "judy not loaded\n");
+    exit(1);
+}
+
+// Keys shaped like the issue's: a shared prefix every 10 keys, padded to
+// $keylen. Precomputed so key construction never lands inside a timed region.
+$keys = [];
+for ($i = 0; $i < $size; $i++) {
+    $k = sprintf('user:%08d:f%d', intdiv($i, 10), $i % 10);
+    $keys[] = strlen($k) >= $keylen ? substr($k, 0, $keylen) : str_pad($k, $keylen, 'x');
+}
+// Short keys for the ADAPTIVE SSO path (< 8 bytes).
+$short = [];
+for ($i = 0; $i < $size; $i++) {
+    $short[] = base_convert((string)$i, 10, 36);
+}
+
+/** Run $body $iters times, returning the median ns/op. $setup runs untimed. */
+function bench(string $name, int $ops, callable $setup, callable $body, int $iters): array {
+    $runs = [];
+    for ($r = 0; $r < $iters; $r++) {
+        $state = $setup();
+        $t0 = hrtime(true);
+        $body($state);
+        $runs[] = (hrtime(true) - $t0) / $ops;
+    }
+    sort($runs);
+    return [
+        'ns' => $runs[intdiv(count($runs), 2)],
+        'min' => $runs[0],
+        'max' => $runs[count($runs) - 1],
+    ];
+}
+
+$results = [];
+function record(string $name, array $r): void {
+    global $results;
+    $results[$name] = $r;
+}
+
+$types = [
+    'str_int'            => Judy::STRING_TO_INT,
+    'str_mixed'          => Judy::STRING_TO_MIXED,
+    'str_int_hash'       => Judy::STRING_TO_INT_HASH,
+    'str_mixed_hash'     => Judy::STRING_TO_MIXED_HASH,
+    'str_int_adaptive'   => Judy::STRING_TO_INT_ADAPTIVE,
+    'str_mixed_adaptive' => Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+foreach ($types as $tname => $type) {
+    $mixed = str_contains($tname, 'mixed');
+
+    // insert: a fresh array each iteration, filled once
+    record("$tname.insert", bench("$tname.insert", $size,
+        fn() => new Judy($type),
+        function ($j) use ($keys, $size, $mixed) {
+            for ($i = 0; $i < $size; $i++) { $j[$keys[$i]] = $mixed ? $i : $i; }
+        }, $iters));
+
+    // overwrite: the array is already full before the timer starts
+    record("$tname.overwrite", bench("$tname.overwrite", $size,
+        function () use ($type, $keys, $size, $mixed) {
+            $j = new Judy($type);
+            for ($i = 0; $i < $size; $i++) { $j[$keys[$i]] = $i; }
+            return $j;
+        },
+        function ($j) use ($keys, $size) {
+            for ($i = 0; $i < $size; $i++) { $j[$keys[$i]] = $i + 1; }
+        }, $iters));
+
+    // control: point lookup, an untouched path
+    record("$tname.get", bench("$tname.get", $size,
+        function () use ($type, $keys, $size) {
+            $j = new Judy($type);
+            for ($i = 0; $i < $size; $i++) { $j[$keys[$i]] = $i; }
+            return $j;
+        },
+        function ($j) use ($keys, $size) {
+            $s = 0;
+            for ($i = 0; $i < $size; $i++) { $s += (int)$j[$keys[$i]]; }
+        }, $iters));
+}
+
+// ADAPTIVE short keys exercise the SSO (JudyL) half of the acquire helper.
+foreach (['str_int_adaptive' => Judy::STRING_TO_INT_ADAPTIVE,
+          'str_mixed_adaptive' => Judy::STRING_TO_MIXED_ADAPTIVE] as $tname => $type) {
+    record("$tname.insert_sso", bench("$tname.insert_sso", $size,
+        fn() => new Judy($type),
+        function ($j) use ($short, $size) {
+            for ($i = 0; $i < $size; $i++) { $j[$short[$i]] = $i; }
+        }, $iters));
+    record("$tname.overwrite_sso", bench("$tname.overwrite_sso", $size,
+        function () use ($type, $short, $size) {
+            $j = new Judy($type);
+            for ($i = 0; $i < $size; $i++) { $j[$short[$i]] = $i; }
+            return $j;
+        },
+        function ($j) use ($short, $size) {
+            for ($i = 0; $i < $size; $i++) { $j[$short[$i]] = $i + 1; }
+        }, $iters));
+}
+
+// increment(): the method B1 rerouted. `_new` creates every key, `_hot` is the
+// existing-key path that used to write the value word on its own.
+foreach (['str_int' => Judy::STRING_TO_INT, 'str_int_hash' => Judy::STRING_TO_INT_HASH] as $tname => $type) {
+    record("$tname.increment_new", bench("$tname.increment_new", $size,
+        fn() => new Judy($type),
+        function ($j) use ($keys, $size) {
+            for ($i = 0; $i < $size; $i++) { $j->increment($keys[$i]); }
+        }, $iters));
+    record("$tname.increment_hot", bench("$tname.increment_hot", $size,
+        function () use ($type, $keys, $size) {
+            $j = new Judy($type);
+            for ($i = 0; $i < $size; $i++) { $j->increment($keys[$i]); }
+            return $j;
+        },
+        function ($j) use ($keys, $size) {
+            for ($i = 0; $i < $size; $i++) { $j->increment($keys[$i]); }
+        }, $iters));
+}
+
+// control: increment() on INT_TO_INT, which B1 did not touch at all
+record('int_int.increment_hot', bench('int_int.increment_hot', $size,
+    function () use ($size) {
+        $j = new Judy(Judy::INT_TO_INT);
+        for ($i = 0; $i < $size; $i++) { $j->increment($i); }
+        return $j;
+    },
+    function ($j) use ($size) {
+        for ($i = 0; $i < $size; $i++) { $j->increment($i); }
+    }, $iters));
+
+echo json_encode([
+    'version' => judy_version(),
+    'size' => $size,
+    'keylen' => $keylen,
+    'iterations' => $iters,
+    'results' => $results,
+], JSON_PRETTY_PRINT), "\n";

--- a/judy_handlers.c
+++ b/judy_handlers.c
@@ -284,6 +284,12 @@ zend_object *judy_object_clone(zend_object *this_ptr)
 		new_obj->key_scratch = emalloc(PHP_JUDY_MAX_LENGTH);
 	}
 
+	/* Clone builds a second copy of both stores by hand rather than going
+	 * through the shared write path, so it is the other place they can drift.
+	 * Compiles to nothing without --enable-judy-debug-mirror. */
+	JUDY_ASSERT_MIRROR(old_obj, "clone (source)");
+	JUDY_ASSERT_MIRROR(new_obj, "clone (result)");
+
 	return &new_obj->std;
 }
 /* }}} */

--- a/package.xml
+++ b/package.xml
@@ -70,6 +70,7 @@
          <file name="examples/benchmarks/iterator_performance_analysis.md" role="doc" />
          <file name="examples/benchmarks/judy-bench-all-types.php" role="doc" />
          <file name="examples/benchmarks/judy-bench-alternatives.php" role="doc" />
+         <file name="examples/benchmarks/judy-bench-writepath.php" role="doc" />
          <file name="examples/benchmarks/judy-bench-batch-operations.php" role="doc" />
          <file name="examples/benchmarks/judy-bench-bitset.php" role="doc" />
          <file name="examples/benchmarks/judy-bench-compare.php" role="doc" />

--- a/package.xml
+++ b/package.xml
@@ -134,6 +134,7 @@
          <file name="tests/get_all_001.phpt" role="test" />
          <file name="tests/increment_int_to_int_001.phpt" role="test" />
          <file name="tests/increment_string_to_int_001.phpt" role="test" />
+         <file name="tests/increment_string_to_int_hash_001.phpt" role="test" />
          <file name="tests/increment_type_error_001.phpt" role="test" />
          <file name="tests/judy_memuse_001.phpt" role="test" />
          <file name="tests/judy_memuse_002.phpt" role="test" />
@@ -171,6 +172,7 @@
          <file name="tests/batch_empty_input_001.phpt" role="test" />
          <file name="tests/batch_large_001.phpt" role="test" />
          <file name="tests/increment_boundary_001.phpt" role="test" />
+         <file name="tests/mirror_value_agreement_001.phpt" role="test" />
          <file md5sum="3022d615e01248b9aedcc07d53f9d298" name="tests/clone_bitset_001.phpt" role="test" />
          <file md5sum="ebf5a62bedc4d0100256bc6db614cac0" name="tests/int_to_int_001.phpt" role="test" />
          <file md5sum="293c4e8f37490390abeaac289e8d4ee7" name="tests/int_to_int_002.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -50,6 +50,11 @@ static Word_t judy_free_array_internal(judy_object *intern)
 {
 	Word_t Rc_word = 0;
 
+	/* Teardown is the one point every object reaches, whatever it was used
+	 * for, and it is already O(n) — so it is where the consistency check earns
+	 * its keep. Compiles to nothing without --enable-judy-debug-mirror. */
+	JUDY_ASSERT_MIRROR(intern, "free_array_internal");
+
 	/* key_index must be in the guard too: a partially-failed clone can leave
 	 * key_index non-NULL while array/hs_array are NULL, and skipping the free
 	 * here would leak the JudySL key_index. */
@@ -619,7 +624,11 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 				JHSD(rc_tmp, intern->array, (uint8_t *)key, klen);
 				return FAILURE;
 			}
-			intern->counter++;
+			/* The key_index registration above and this counter bump are what
+			   the JUDY_DEBUG_MIRROR checker cross-examines. ci.yml's negative
+			   control deletes this exact line and requires the assertions to
+			   fire, so that the harness cannot rot into a no-op. */
+			intern->counter++; /* judy-mirror-negative-control */
 		}
 		break;
 
@@ -1523,6 +1532,146 @@ static inline Pvoid_t *judy_string_value_slot(judy_object *intern, const uint8_t
 	return slot;
 }
 /* }}} */
+
+#ifdef JUDY_DEBUG_MIRROR
+/* {{{ judy_debug_check_mirror — internal consistency check.
+
+   The four *_HASH / *_ADAPTIVE types answer "which keys exist, in what order?"
+   from a JudySL key_index and "what is the value?" from a separate JudyHS (plus
+   a JudyL for the short keys ADAPTIVE packs inline). Nothing ties the two
+   together at the type level: a path that updates one and not the other leaves
+   two valid pointers holding different answers. There is no crash and no leak,
+   so valgrind cannot see it — only a check that walks both stores can.
+
+   What is checked:
+
+     1. Population agrees with intern->counter, for every type. That counter is
+        the bookkeeping every write branch maintains, and it is the cheapest
+        cross-examination of the two stores available.
+     2. Every key in key_index resolves to a live value slot, and for the MIXED
+        variants to a non-NULL zval*.
+     3. The reverse direction, as far as it is enumerable. JudyHS exposes no
+        enumeration primitive — the whole API is JHSG/JHSI/JHSD/JHSFA — so a
+        JudyHS entry that no key_index entry points at cannot be reached
+        directly. It is caught by (1) whenever the counter was bumped, and
+        shows up as a leak under valgrind otherwise. ADAPTIVE's short-key half
+        is an ordinary JudyL and *is* enumerable, so that half is checked in
+        both directions.
+
+   #85 step 1 (payload mirroring) extends (2) with "and the payload mirrored
+   into the key_index slot equals the one in the value store": the same walk,
+   one more comparison per key.
+
+   O(n). Call it only from operations that are already O(n) — object teardown,
+   clone — never once per element. */
+static void judy_debug_mirror_fail(const judy_object *intern, const char *where,
+	const char *what, const char *key)
+{
+	fprintf(stderr, "\n[judy] MIRROR INVARIANT VIOLATED at %s\n", where);
+	fprintf(stderr, "[judy]   %s\n", what);
+	fprintf(stderr, "[judy]   type=%ld counter=" ZEND_LONG_FMT "\n",
+		(long)intern->type, intern->counter);
+	if (key != NULL) {
+		fprintf(stderr, "[judy]   key=\"%s\"\n", key);
+	}
+	fflush(stderr);
+	abort();
+}
+
+void judy_debug_check_mirror(judy_object *intern, const char *where)
+{
+	zend_long seen = 0;
+
+	if (intern->array == NULL && intern->hs_array == NULL && intern->key_index == NULL) {
+		if (intern->counter != 0) {
+			judy_debug_mirror_fail(intern, where,
+				"object holds no store at all but the counter is non-zero", NULL);
+		}
+		return;
+	}
+
+	if (intern->type == TYPE_BITSET) {
+		Word_t count = 0;
+		J1C(count, intern->array, 0, (Word_t)-1);
+		seen = (zend_long)count;
+	} else if (JUDY_IS_INTEGER_KEYED(intern)) {
+		Word_t count = 0;
+		JLC(count, intern->array, 0, (Word_t)-1);
+		seen = (zend_long)count;
+	} else if (intern->type == TYPE_STRING_TO_INT || intern->type == TYPE_STRING_TO_MIXED) {
+		/* Single store: the JudySL trie holds the values itself. */
+		uint8_t *cursor = emalloc(PHP_JUDY_MAX_LENGTH);
+		Pvoid_t *PValue;
+
+		cursor[0] = '\0';
+		JSLF(PValue, intern->array, cursor);
+		while (PValue != NULL && PValue != PJERR) {
+			seen++;
+			JSLN(PValue, intern->array, cursor);
+		}
+		efree(cursor);
+	} else {
+		/* The four key_index-backed types. A private cursor rather than
+		 * intern->key_scratch: a manual rewind()/next() iteration may be
+		 * holding that shared buffer. */
+		uint8_t *cursor = emalloc(PHP_JUDY_MAX_LENGTH);
+		Pvoid_t *KValue;
+
+		cursor[0] = '\0';
+		JSLF(KValue, intern->key_index, cursor);
+		while (KValue != NULL && KValue != PJERR) {
+			Word_t klen = (Word_t)strlen((char *)cursor);
+			Pvoid_t *VValue = judy_string_value_slot(intern, cursor, klen);
+
+			if (VValue == NULL) {
+				judy_debug_mirror_fail(intern, where,
+					"key listed in key_index has no entry in the value store",
+					(const char *)cursor);
+			}
+			if (JUDY_IS_MIXED_VALUE(intern) && JUDY_MVAL_READ(VValue) == NULL) {
+				judy_debug_mirror_fail(intern, where,
+					"key listed in key_index has a NULL zval in the value store",
+					(const char *)cursor);
+			}
+			seen++;
+			JSLN(KValue, intern->key_index, cursor);
+		}
+		efree(cursor);
+
+		if (JUDY_IS_ADAPTIVE(intern)) {
+			/* Reverse direction for the enumerable half: keys shorter than 8
+			 * bytes are packed into a JudyL index. */
+			Word_t sso_idx = 0;
+			Pvoid_t *PValue;
+
+			JLF(PValue, intern->array, sso_idx);
+			while (PValue != NULL && PValue != PJERR) {
+				uint8_t unpacked[9];
+				Pvoid_t *KFound;
+
+				memcpy(unpacked, &sso_idx, sizeof(Word_t));
+				unpacked[8] = '\0';
+				JSLG(KFound, intern->key_index, unpacked);
+				if (KFound == NULL || KFound == PJERR) {
+					judy_debug_mirror_fail(intern, where,
+						"short key present in the value store is missing from key_index",
+						(const char *)unpacked);
+				}
+				JLN(PValue, intern->array, sso_idx);
+			}
+		}
+	}
+
+	if (seen != intern->counter) {
+		char msg[128];
+		snprintf(msg, sizeof(msg),
+			"population %ld disagrees with counter %ld",
+			(long)seen, (long)intern->counter);
+		judy_debug_mirror_fail(intern, where, msg, NULL);
+	}
+}
+/* }}} */
+#endif /* JUDY_DEBUG_MIRROR */
 
 /* {{{ proto mixed Judy::first([mixed index])
    Search (inclusive) for the first index present that is equal to or greater than the passed Index */

--- a/php_judy.c
+++ b/php_judy.c
@@ -526,6 +526,224 @@ static zval *judy_object_read_dimension(zend_object *obj, zval *offset, int type
     return judy_object_read_dimension_helper(&object_zv, offset, rv);
 }
 
+/* {{{ judy_string_slot_acquire — write-side twin of judy_string_value_slot().
+
+   Locates — creating it if absent — the value slot for `key` in a string-keyed
+   Judy object, and owns every side effect that must accompany the creation of
+   a new key:
+
+     - the embedded-NUL precondition of the four key_index-backed types (a NUL
+       truncates the JudySL key and would desynchronise the two stores),
+     - registering the key in the JudySL key_index,
+     - rolling the value-store insert back if that registration fails,
+     - the intern->counter bump.
+
+   Callers are left with exactly one job: write the payload through *slot_out.
+   That split is the point. The *_HASH and *_ADAPTIVE types hold the key set in
+   two structures at once, and a value write that reached the value store
+   without coming through here is precisely where the two would drift apart.
+   Route every string-keyed value write through this function.
+
+   Returns SUCCESS with *slot_out set to the value slot. A slot that was just
+   created reads 0 for the _INT variants / NULL for the _MIXED variants, so a
+   caller that cares can still tell an insert from an overwrite by inspecting
+   it; the counter is maintained here either way.
+
+   Returns FAILURE having made no net change. An exception is thrown only for
+   the NUL precondition — an allocation failure is reported silently so each
+   caller keeps its own wording. A caller adding a message of its own must
+   therefore check EG(exception) first.
+
+   Not valid for the integer-keyed types: they have no key_index, and their
+   index derivation (append, negative offsets) belongs to the caller. */
+static zend_always_inline int judy_string_slot_acquire(judy_object *intern, const uint8_t *key,
+	Word_t klen, Pvoid_t **slot_out)
+{
+	Pvoid_t *slot = NULL;
+	Pvoid_t *existing = NULL;
+	Pvoid_t *kslot = NULL;
+	Word_t sso_idx = 0;
+	int rc_tmp = 0;
+
+	*slot_out = NULL;
+
+	switch (intern->type) {
+
+	case TYPE_STRING_TO_INT:
+		/* Plain JudySL: the trie is itself the value store, so there is no
+		   mirror to keep and no NUL restriction. 0 is a legal stored value,
+		   hence the separate existence probe. */
+		JSLG(existing, intern->array, (uint8_t *)key);
+		JSLI(slot, intern->array, (uint8_t *)key);
+		if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
+			return FAILURE;
+		}
+		if (existing == NULL) {
+			intern->counter++;
+		}
+		break;
+
+	case TYPE_STRING_TO_MIXED:
+		JSLI(slot, intern->array, (uint8_t *)key);
+		if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
+			return FAILURE;
+		}
+		/* A MIXED slot holds a zval*, so NULL unambiguously means "new". */
+		if (JUDY_MVAL_READ(slot) == NULL) {
+			intern->counter++;
+		}
+		break;
+
+	/* The four key_index-backed types get one case each rather than a shared
+	   body with runtime `intern->type ==` tests inside it: those tests cost a
+	   measurable ~3% on the shortest write (ADAPTIVE SSO overwrite), which a
+	   refactor is not allowed to spend. The repetition stays inside this one
+	   function, so nothing outside it learns about the key_index. */
+	case TYPE_STRING_TO_INT_HASH:
+		if (JUDY_UNLIKELY(memchr(key, '\0', (size_t)klen) != NULL)) {
+			zend_throw_exception(NULL,
+				"Judy STRING_TO_INT_HASH keys must not contain embedded null bytes", 0);
+			return FAILURE;
+		}
+		/* 0 is a legal stored value, so probe rather than read the slot. */
+		JHSG(existing, intern->array, (uint8_t *)key, klen);
+		JHSI(slot, intern->array, (uint8_t *)key, klen);
+		if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
+			return FAILURE;
+		}
+		if (existing == NULL) {
+			JSLI(kslot, intern->key_index, (uint8_t *)key);
+			if (JUDY_UNLIKELY(kslot == PJERR)) {
+				/* Roll the value-store insert back rather than leave a key
+				   that key_index — and so iteration and free() — never sees. */
+				JHSD(rc_tmp, intern->array, (uint8_t *)key, klen);
+				return FAILURE;
+			}
+			intern->counter++;
+		}
+		break;
+
+	case TYPE_STRING_TO_MIXED_HASH:
+		if (JUDY_UNLIKELY(memchr(key, '\0', (size_t)klen) != NULL)) {
+			zend_throw_exception(NULL,
+				"Judy STRING_TO_MIXED_HASH keys must not contain embedded null bytes", 0);
+			return FAILURE;
+		}
+		JHSI(slot, intern->array, (uint8_t *)key, klen);
+		if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
+			return FAILURE;
+		}
+		if (JUDY_MVAL_READ(slot) == NULL) {
+			JSLI(kslot, intern->key_index, (uint8_t *)key);
+			if (JUDY_UNLIKELY(kslot == PJERR)) {
+				JHSD(rc_tmp, intern->array, (uint8_t *)key, klen);
+				return FAILURE;
+			}
+			intern->counter++;
+		}
+		break;
+
+	case TYPE_STRING_TO_INT_ADAPTIVE:
+		if (JUDY_UNLIKELY(memchr(key, '\0', (size_t)klen) != NULL)) {
+			zend_throw_exception(NULL,
+				"Judy adaptive keys must not contain embedded null bytes", 0);
+			return FAILURE;
+		}
+		if (judy_pack_short_string_internal((const char *)key, (size_t)klen, &sso_idx)) {
+			JLG(existing, intern->array, sso_idx);
+			JLI(slot, intern->array, sso_idx);
+			if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
+				return FAILURE;
+			}
+			if (existing == NULL) {
+				JSLI(kslot, intern->key_index, (uint8_t *)key);
+				if (JUDY_UNLIKELY(kslot == PJERR)) {
+					JLD(rc_tmp, intern->array, sso_idx);
+					return FAILURE;
+				}
+				intern->counter++;
+			}
+		} else {
+			JHSG(existing, intern->hs_array, (uint8_t *)key, klen);
+			JHSI(slot, intern->hs_array, (uint8_t *)key, klen);
+			if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
+				return FAILURE;
+			}
+			if (existing == NULL) {
+				JSLI(kslot, intern->key_index, (uint8_t *)key);
+				if (JUDY_UNLIKELY(kslot == PJERR)) {
+					JHSD(rc_tmp, intern->hs_array, (uint8_t *)key, klen);
+					return FAILURE;
+				}
+				intern->counter++;
+			}
+		}
+		break;
+
+	case TYPE_STRING_TO_MIXED_ADAPTIVE:
+		if (JUDY_UNLIKELY(memchr(key, '\0', (size_t)klen) != NULL)) {
+			zend_throw_exception(NULL,
+				"Judy adaptive keys must not contain embedded null bytes", 0);
+			return FAILURE;
+		}
+		if (judy_pack_short_string_internal((const char *)key, (size_t)klen, &sso_idx)) {
+			JLI(slot, intern->array, sso_idx);
+			if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
+				return FAILURE;
+			}
+			if (JUDY_MVAL_READ(slot) == NULL) {
+				JSLI(kslot, intern->key_index, (uint8_t *)key);
+				if (JUDY_UNLIKELY(kslot == PJERR)) {
+					JLD(rc_tmp, intern->array, sso_idx);
+					return FAILURE;
+				}
+				intern->counter++;
+			}
+		} else {
+			JHSI(slot, intern->hs_array, (uint8_t *)key, klen);
+			if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
+				return FAILURE;
+			}
+			if (JUDY_MVAL_READ(slot) == NULL) {
+				JSLI(kslot, intern->key_index, (uint8_t *)key);
+				if (JUDY_UNLIKELY(kslot == PJERR)) {
+					JHSD(rc_tmp, intern->hs_array, (uint8_t *)key, klen);
+					return FAILURE;
+				}
+				intern->counter++;
+			}
+		}
+		break;
+
+	default:
+		return FAILURE;
+	}
+
+	*slot_out = slot;
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ judy_slot_store_zval — publish a MIXED value into an acquired slot.
+
+   The new pointer is written into the slot BEFORE the old one is destroyed:
+   the old value's destructor can run arbitrary PHP that re-enters and
+   restructures this array, invalidating `slot`. Writing first leaves the slot
+   consistent no matter what the destructor does. */
+static zend_always_inline void judy_slot_store_zval(Pvoid_t *slot, zval *value)
+{
+	zval *old_value = JUDY_MVAL_READ(slot);
+	zval *new_value = emalloc(sizeof(zval));
+
+	ZVAL_COPY(new_value, value);
+	JUDY_MVAL_WRITE(slot, new_value);
+	if (old_value != NULL) {
+		zval_ptr_dtor(old_value);
+		efree(old_value);
+	}
+}
+/* }}} */
+
 int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) /* {{{ */
 {
 	zend_long index;
@@ -688,240 +906,32 @@ int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value) 
 			efree(packed);
 			return FAILURE;
 		}
-	} else if (intern->type == TYPE_STRING_TO_INT) {
-		PWord_t     *PValue;
-		PWord_t     *PExisting;
-		zend_long lval = zval_get_long(value);
-		int res;
+	} else if (JUDY_IS_STRING_KEYED(intern)) {
+		/* All six string-keyed types share one slot-acquisition path; see
+		   judy_string_slot_acquire() for why nothing may bypass it. */
+		Pvoid_t *slot;
 
-		/* Check if key already exists before insert to track count correctly */
-		JSLG(PExisting, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key));
-
-		JSLI(PValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key));
-		if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-			if (PExisting == NULL) {
-				intern->counter++;
+		if (JUDY_IS_MIXED_VALUE(intern)) {
+			if (JUDY_UNLIKELY(judy_string_slot_acquire(intern,
+					(uint8_t *)Z_STRVAL_P(pstring_key),
+					(Word_t)Z_STRLEN_P(pstring_key), &slot) == FAILURE)) {
+				return FAILURE;
 			}
-			JUDY_LVAL_WRITE(PValue, lval);
-			res = SUCCESS;
+			judy_slot_store_zval(slot, value);
 		} else {
-			res = FAILURE;
-		}
-		return res;
-	} else if (intern->type == TYPE_STRING_TO_MIXED) {
-		Pvoid_t *PValue;
-		int res;
+			/* Convert before acquiring the slot: zval_get_long() can run a
+			   userland cast handler that re-enters and restructures this
+			   array, which would invalidate a slot taken first. */
+			zend_long lval = zval_get_long(value);
 
-		JSLI(PValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key));
-		if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-			zval *old_value = JUDY_MVAL_READ(PValue);
-			zval *new_value = emalloc(sizeof(zval));
-			ZVAL_COPY(new_value, value);
-			/* Write new value before destroying old (see INT_TO_MIXED note):
-			 * old_value's destructor may re-enter and invalidate PValue. */
-			JUDY_MVAL_WRITE(PValue, new_value);
-			if (old_value != NULL) {
-				zval_ptr_dtor(old_value);
-				efree(old_value);
-			} else {
-				intern->counter++;
+			if (JUDY_UNLIKELY(judy_string_slot_acquire(intern,
+					(uint8_t *)Z_STRVAL_P(pstring_key),
+					(Word_t)Z_STRLEN_P(pstring_key), &slot) == FAILURE)) {
+				return FAILURE;
 			}
-			res = SUCCESS;
-		} else {
-			res = FAILURE;
+			JUDY_LVAL_WRITE(slot, lval);
 		}
-		return res;
-	} else if (intern->type == TYPE_STRING_TO_MIXED_HASH) {
-		Pvoid_t *HValue;
-		Pvoid_t *KValue;
-		int res;
-		Word_t key_len = (Word_t)Z_STRLEN_P(pstring_key);
-
-		/* JudySL key_index uses null-terminated strings; reject embedded NULs */
-		if (memchr(Z_STRVAL_P(pstring_key), '\0', Z_STRLEN_P(pstring_key)) != NULL) {
-			zend_throw_exception(NULL,
-				"Judy STRING_TO_MIXED_HASH keys must not contain embedded null bytes", 0);
-			return FAILURE;
-		}
-
-		JHSI(HValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-		if (JUDY_LIKELY(HValue != NULL && HValue != PJERR)) {
-			zval *old_value = JUDY_MVAL_READ(HValue);
-			if (old_value == NULL) {
-				/* Register key in JudySL key_index for iteration support */
-				JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
-				if (JUDY_UNLIKELY(KValue == PJERR)) {
-					/* Rollback the JudyHS insertion */
-					int Rc_tmp = 0;
-					JHSD(Rc_tmp, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-					return FAILURE;
-				}
-				intern->counter++;
-			}
-			zval *new_value = ecalloc(1, sizeof(zval));
-			ZVAL_COPY(new_value, value);
-			/* Write new value before destroying old (see INT_TO_MIXED note). */
-			JUDY_MVAL_WRITE(HValue, new_value);
-			if (old_value != NULL) {
-				zval_ptr_dtor(old_value);
-				efree(old_value);
-			}
-			res = SUCCESS;
-		} else {
-			res = FAILURE;
-		}
-		return res;
-	} else if (intern->type == TYPE_STRING_TO_INT_HASH) {
-		Pvoid_t *HExisting;
-		Pvoid_t *HValue;
-		Pvoid_t *KValue;
-		int res;
-		Word_t key_len = (Word_t)Z_STRLEN_P(pstring_key);
-
-		/* JudySL key_index uses null-terminated strings; reject embedded NULs */
-		if (JUDY_UNLIKELY(memchr(Z_STRVAL_P(pstring_key), '\0', Z_STRLEN_P(pstring_key)) != NULL)) {
-			zend_throw_exception(NULL,
-				"Judy STRING_TO_INT_HASH keys must not contain embedded null bytes", 0);
-			return FAILURE;
-		}
-
-		/* Check if key already exists before insert to track count correctly */
-		JHSG(HExisting, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-
-		JHSI(HValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-		if (JUDY_LIKELY(HValue != NULL && HValue != PJERR)) {
-			if (HExisting == NULL) {
-				/* New key — register in key_index for iteration */
-				JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
-				if (JUDY_UNLIKELY(KValue == PJERR)) {
-					int Rc_tmp = 0;
-					JHSD(Rc_tmp, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-					return FAILURE;
-				}
-				intern->counter++;
-			}
-			JUDY_LVAL_WRITE(HValue, zval_get_long(value));
-			res = SUCCESS;
-		} else {
-			res = FAILURE;
-		}
-		return res;
-	} else if (intern->type == TYPE_STRING_TO_INT_ADAPTIVE) {
-		if (UNEXPECTED(memchr(Z_STRVAL_P(pstring_key), '\0', Z_STRLEN_P(pstring_key)) != NULL)) {
-			zend_throw_exception(NULL, "Judy adaptive keys must not contain embedded null bytes", 0);
-			return FAILURE;
-		}
-		Pvoid_t *PValue;
-		Pvoid_t *PExisting;
-		Pvoid_t *KValue;
-		int res;
-		Word_t key_len = (Word_t)Z_STRLEN_P(pstring_key);
-		Word_t sso_idx;
-
-		zend_long lval = zval_get_long(value);
-
-		if (judy_pack_short_string_internal(Z_STRVAL_P(pstring_key), key_len, &sso_idx)) {
-			/* Probe existence before insert: value 0 is a legal stored value,
-			 * so a zero slot must not be mistaken for a brand-new key. */
-			JLG(PExisting, intern->array, sso_idx);
-			JLI(PValue, intern->array, sso_idx);
-			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				if (PExisting == NULL) {
-					/* New key — register in key_index for iteration */
-					JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
-					if (JUDY_UNLIKELY(KValue == PJERR)) {
-						JLD(res, intern->array, sso_idx);
-						return FAILURE;
-					}
-					intern->counter++;
-				}
-				JUDY_LVAL_WRITE(PValue, lval);
-				res = SUCCESS;
-			} else {
-				res = FAILURE;
-			}
-		} else {
-			JHSG(PExisting, intern->hs_array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-			JHSI(PValue, intern->hs_array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				if (PExisting == NULL) {
-					JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
-					if (JUDY_UNLIKELY(KValue == PJERR)) {
-						int Rc_tmp;
-						JHSD(Rc_tmp, intern->hs_array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-						return FAILURE;
-					}
-					intern->counter++;
-				}
-				JUDY_LVAL_WRITE(PValue, lval);
-				res = SUCCESS;
-			} else {
-				res = FAILURE;
-			}
-		}
-		return res;
-	} else if (intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE) {
-		if (UNEXPECTED(memchr(Z_STRVAL_P(pstring_key), '\0', Z_STRLEN_P(pstring_key)) != NULL)) {
-			zend_throw_exception(NULL, "Judy adaptive keys must not contain embedded null bytes", 0);
-			return FAILURE;
-		}
-		Pvoid_t *PValue;
-		Pvoid_t *KValue;
-		int res;
-		Word_t key_len = (Word_t)Z_STRLEN_P(pstring_key);
-		Word_t sso_idx;
-
-		if (judy_pack_short_string_internal(Z_STRVAL_P(pstring_key), key_len, &sso_idx)) {
-			JLI(PValue, intern->array, sso_idx);
-			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				zval *old_value = JUDY_MVAL_READ(PValue);
-				if (old_value == NULL) {
-					JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
-					if (JUDY_UNLIKELY(KValue == PJERR)) {
-						JLD(res, intern->array, sso_idx);
-						return FAILURE;
-					}
-					intern->counter++;
-				}
-				zval *new_value = emalloc(sizeof(zval));
-				ZVAL_COPY(new_value, value);
-				/* Write new value before destroying old (see INT_TO_MIXED note). */
-				JUDY_MVAL_WRITE(PValue, new_value);
-				if (old_value != NULL) {
-					zval_ptr_dtor(old_value);
-					efree(old_value);
-				}
-				res = SUCCESS;
-			} else {
-				res = FAILURE;
-			}
-		} else {
-			JHSI(PValue, intern->hs_array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-			if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-				zval *old_value = JUDY_MVAL_READ(PValue);
-				if (old_value == NULL) {
-					JSLI(KValue, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
-					if (JUDY_UNLIKELY(KValue == PJERR)) {
-						int Rc_tmp;
-						JHSD(Rc_tmp, intern->hs_array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-						return FAILURE;
-					}
-					intern->counter++;
-				}
-				zval *new_value = emalloc(sizeof(zval));
-				ZVAL_COPY(new_value, value);
-				/* Write new value before destroying old (see INT_TO_MIXED note). */
-				JUDY_MVAL_WRITE(PValue, new_value);
-				if (old_value != NULL) {
-					zval_ptr_dtor(old_value);
-					efree(old_value);
-				}
-				res = SUCCESS;
-			} else {
-				res = FAILURE;
-			}
-		}
-		return res;
+		return SUCCESS;
 	}
 	return FAILURE;
 }
@@ -4685,9 +4695,11 @@ PHP_METHOD(Judy, getAll)
 /* }}} */
 
 /* {{{ proto int Judy::increment(mixed $key, int $amount = 1)
-   Atomic increment for INT_TO_INT (single-traversal via JLI) and
-   STRING_TO_INT (two traversals: JSLG for counter tracking + JSLI).
-   Returns the new value. Creates the key with value $amount if it doesn't exist. */
+   Atomic increment for INT_TO_INT, STRING_TO_INT and STRING_TO_INT_HASH.
+   Returns the new value. Creates the key with value $amount if it doesn't
+   exist. The string-keyed types share judy_string_slot_acquire() with
+   offsetSet(), so an increment cannot register a key differently from a
+   plain write. */
 PHP_METHOD(Judy, increment)
 {
 	zval *zkey;
@@ -4717,10 +4729,11 @@ PHP_METHOD(Judy, increment)
 		JUDY_LVAL_WRITE(PValue, old_val + amount);
 		RETURN_LONG(old_val + amount);
 
-	} else if (intern->type == TYPE_STRING_TO_INT) {
+	} else if (intern->type == TYPE_STRING_TO_INT
+			|| intern->type == TYPE_STRING_TO_INT_HASH) {
 		zend_string *skey = zval_get_string(zkey);
-		Pvoid_t *PExisting;
-		Pvoid_t *PValue;
+		Pvoid_t *slot;
+		zend_long new_val;
 
 		if (ZSTR_LEN(skey) >= PHP_JUDY_MAX_LENGTH) {
 			zend_string_release(skey);
@@ -4730,74 +4743,24 @@ PHP_METHOD(Judy, increment)
 			return;
 		}
 
-		/* Check if key exists for counter tracking (requires JSLG + JSLI) */
-		JSLG(PExisting, intern->array, (uint8_t *)ZSTR_VAL(skey));
-
-		JSLI(PValue, intern->array, (uint8_t *)ZSTR_VAL(skey));
-		if (PValue == NULL || PValue == PJERR) {
+		/* Same acquisition path as offsetSet(): the embedded-NUL check, the
+		   key_index registration, its rollback and the counter all live in
+		   one place, so increment() cannot drift from a plain write. */
+		if (judy_string_slot_acquire(intern, (uint8_t *)ZSTR_VAL(skey),
+				(Word_t)ZSTR_LEN(skey), &slot) == FAILURE) {
 			zend_string_release(skey);
-			zend_throw_exception(NULL, "Judy: memory allocation failed during increment", 0);
-			return;
-		}
-
-		if (PExisting == NULL) {
-			intern->counter++;
-		}
-
-		zend_long old_val = JUDY_LVAL_READ(PValue);
-		JUDY_LVAL_WRITE(PValue, old_val + amount);
-		zend_string_release(skey);
-		RETURN_LONG(old_val + amount);
-
-	} else if (intern->type == TYPE_STRING_TO_INT_HASH) {
-		zend_string *skey = zval_get_string(zkey);
-		Pvoid_t *HExisting;
-		Pvoid_t *HValue;
-		Word_t key_len = (Word_t)ZSTR_LEN(skey);
-
-		if (ZSTR_LEN(skey) >= PHP_JUDY_MAX_LENGTH) {
-			zend_string_release(skey);
-			zend_throw_exception_ex(NULL, 0,
-				"Judy string key length (%zu) exceeds maximum of %d bytes",
-				ZSTR_LEN(skey), PHP_JUDY_MAX_LENGTH - 1);
-			return;
-		}
-
-		if (memchr(ZSTR_VAL(skey), '\0', ZSTR_LEN(skey)) != NULL) {
-			zend_string_release(skey);
-			zend_throw_exception(NULL,
-				"Judy STRING_TO_INT_HASH keys must not contain embedded null bytes", 0);
-			return;
-		}
-
-		/* Check if key exists for counter tracking */
-		JHSG(HExisting, intern->array, (uint8_t *)ZSTR_VAL(skey), key_len);
-
-		JHSI(HValue, intern->array, (uint8_t *)ZSTR_VAL(skey), key_len);
-		if (HValue == NULL || HValue == PJERR) {
-			zend_string_release(skey);
-			zend_throw_exception(NULL, "Judy: memory allocation failed during increment", 0);
-			return;
-		}
-
-		if (HExisting == NULL) {
-			/* New key — register in key_index for iteration */
-			Pvoid_t *KValue;
-			JSLI(KValue, intern->key_index, (uint8_t *)ZSTR_VAL(skey));
-			if (KValue == PJERR) {
-				int Rc_tmp = 0;
-				JHSD(Rc_tmp, intern->array, (uint8_t *)ZSTR_VAL(skey), key_len);
-				zend_string_release(skey);
+			/* The helper throws for the NUL precondition and stays silent on
+			   allocation failure, which is the case that wants our wording. */
+			if (!EG(exception)) {
 				zend_throw_exception(NULL, "Judy: memory allocation failed during increment", 0);
-				return;
 			}
-			intern->counter++;
+			return;
 		}
 
-		zend_long old_val = JUDY_LVAL_READ(HValue);
-		JUDY_LVAL_WRITE(HValue, old_val + amount);
+		new_val = JUDY_LVAL_READ(slot) + amount;
+		JUDY_LVAL_WRITE(slot, new_val);
 		zend_string_release(skey);
-		RETURN_LONG(old_val + amount);
+		RETURN_LONG(new_val);
 
 	} else {
 		zend_throw_exception(NULL, "Judy::increment() is only supported for INT_TO_INT, STRING_TO_INT and STRING_TO_INT_HASH types", 0);

--- a/php_judy.h
+++ b/php_judy.h
@@ -248,6 +248,25 @@ static inline void judy_init_type_flags(judy_object *intern, zend_long jtype)
 zend_object *judy_object_new(zend_class_entry *ce);
 zend_object *judy_object_new_ex(zend_class_entry *ce, judy_object **ptr);
 
+/* {{{ JUDY_ASSERT_MIRROR — internal consistency assertions.
+
+   Compiled in only by `./configure --enable-judy-debug-mirror`, which defines
+   JUDY_DEBUG_MIRROR. In a normal build the macro expands to nothing and
+   judy_debug_check_mirror() is not compiled at all, so the shipped extension
+   carries no cost and no extra symbol.
+
+   The check is O(n) in the population, so it belongs only at call sites that
+   are already O(n) — object teardown, clone — never per element. `where` names
+   the call site and is printed on violation. On violation the process aborts;
+   it never alters behaviour otherwise. */
+#ifdef JUDY_DEBUG_MIRROR
+void judy_debug_check_mirror(judy_object *intern, const char *where);
+#define JUDY_ASSERT_MIRROR(intern, where) judy_debug_check_mirror((intern), (where))
+#else
+#define JUDY_ASSERT_MIRROR(intern, where) ((void)0)
+#endif
+/* }}} */
+
 zval *judy_object_read_dimension_helper(zval *object, zval *offset, zval *rv);
 int judy_object_write_dimension_helper(zval *object, zval *offset, zval *value);
 int judy_object_has_dimension_helper(zval *object, zval *offset, int check_empty);

--- a/tests/increment_string_to_int_hash_001.phpt
+++ b/tests/increment_string_to_int_hash_001.phpt
@@ -1,0 +1,98 @@
+--TEST--
+Judy increment for STRING_TO_INT_HASH: shares offsetSet's slot path (key_index, counter, preconditions)
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// STRING_TO_INT_HASH keeps two stores: a JudyHS value store and a JudySL
+// key_index that drives ordered traversal. increment() writes a value in
+// place, so it must register keys exactly the way offsetSet() does or
+// iteration and point lookup will disagree.
+$j = new Judy(Judy::STRING_TO_INT_HASH);
+
+// New keys via increment() only.
+echo "increment('pear'): " . $j->increment("pear") . "\n";
+echo "increment('apple', 5): " . $j->increment("apple", 5) . "\n";
+echo "Count: " . $j->count() . "\n";
+
+// Every key created by increment() must be reachable by ordered traversal,
+// in sorted order, with the value point lookup reports.
+foreach ($j as $k => $v) {
+    echo "iter $k => $v (offsetGet " . $j[$k] . ")\n";
+}
+
+// Overwrite path: increment() on an existing key must not touch the count
+// and must stay visible to traversal.
+echo "increment('pear', 10): " . $j->increment("pear", 10) . "\n";
+echo "Count: " . $j->count() . "\n";
+foreach ($j as $k => $v) {
+    echo "iter $k => $v\n";
+}
+
+// Mixed with offsetSet on the same keys, both directions.
+$j["pear"] = 100;
+echo "after offsetSet: increment('pear') = " . $j->increment("pear") . "\n";
+$j->increment("cherry", 3);
+$j["cherry"] = $j["cherry"] + 1;
+echo "Count: " . $j->count() . "\n";
+var_dump($j->toArray());
+
+// Negative amounts and zero-valued keys: 0 is a legal stored value and must
+// not be mistaken for an absent key on the next increment.
+$j->increment("zero", 0);
+echo "zero present: " . var_export(isset($j["zero"]), true) . "\n";
+echo "Count: " . $j->count() . "\n";
+echo "increment('zero', -4): " . $j->increment("zero", -4) . "\n";
+echo "Count: " . $j->count() . "\n";
+
+// Delete then recreate via increment().
+unset($j["apple"]);
+echo "Count after unset: " . $j->count() . "\n";
+echo "increment('apple', 7): " . $j->increment("apple", 7) . "\n";
+echo "Count: " . $j->count() . "\n";
+echo "keys: " . implode(",", array_keys($j->toArray())) . "\n";
+
+// Preconditions are the same ones offsetSet() enforces.
+try {
+    $j->increment("a\0b");
+} catch (Exception $e) {
+    echo "NUL: " . $e->getMessage() . "\n";
+}
+try {
+    $j->increment(str_repeat("x", 65536));
+} catch (Exception $e) {
+    echo "LONG: " . $e->getMessage() . "\n";
+}
+echo "Count unchanged: " . $j->count() . "\n";
+?>
+--EXPECT--
+increment('pear'): 1
+increment('apple', 5): 5
+Count: 2
+iter apple => 5 (offsetGet 5)
+iter pear => 1 (offsetGet 1)
+increment('pear', 10): 11
+Count: 2
+iter apple => 5
+iter pear => 11
+after offsetSet: increment('pear') = 101
+Count: 3
+array(3) {
+  ["apple"]=>
+  int(5)
+  ["cherry"]=>
+  int(4)
+  ["pear"]=>
+  int(101)
+}
+zero present: true
+Count: 4
+increment('zero', -4): -4
+Count: 4
+Count after unset: 3
+increment('apple', 7): 7
+Count: 4
+keys: apple,cherry,pear,zero
+NUL: Judy STRING_TO_INT_HASH keys must not contain embedded null bytes
+LONG: Judy string key length (65536) exceeds maximum of 65535 bytes
+Count unchanged: 4

--- a/tests/mirror_value_agreement_001.phpt
+++ b/tests/mirror_value_agreement_001.phpt
@@ -1,0 +1,167 @@
+--TEST--
+Judy *_HASH / *_ADAPTIVE: ordered traversal and point lookup agree after mixed writes
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// The four key_index-backed types answer "what keys are there, in order?"
+// from a JudySL index and "what is the value?" from a separate store. Any
+// write path that updates one and not the other produces two valid pointers
+// holding different answers — no crash, no leak, only a wrong result. This
+// test pins the agreement across every write shape the extension has.
+//
+// ADAPTIVE keys are split deliberately across the 8-byte SSO boundary, since
+// short and long keys land in different value stores.
+$types = [
+    'STRING_TO_INT_HASH'       => Judy::STRING_TO_INT_HASH,
+    'STRING_TO_MIXED_HASH'     => Judy::STRING_TO_MIXED_HASH,
+    'STRING_TO_INT_ADAPTIVE'   => Judy::STRING_TO_INT_ADAPTIVE,
+    'STRING_TO_MIXED_ADAPTIVE' => Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+// Keys straddling the SSO boundary: "k00".."k07" are 3 bytes, the "long_"
+// ones are 8+.
+function keys_for(int $n): array {
+    $keys = [];
+    for ($i = 0; $i < $n; $i++) {
+        $keys[] = sprintf('k%02d', $i);
+        $keys[] = sprintf('long_key_%04d', $i);
+    }
+    return $keys;
+}
+
+function check(string $label, Judy $j, array $expected): void {
+    $seen = [];
+    $problems = [];
+
+    foreach ($j as $k => $v) {
+        $seen[$k] = $v;
+        // The value ordered traversal reports must be the value a point
+        // lookup reports for the same key.
+        if ($j[$k] !== $v) {
+            $problems[] = "traversal/lookup disagree at '$k': " .
+                var_export($v, true) . " vs " . var_export($j[$k], true);
+        }
+    }
+
+    if (count($seen) !== $j->count()) {
+        $problems[] = "count() " . $j->count() . " != iterated " . count($seen);
+    }
+    if (array_keys($seen) !== array_keys($j->toArray())) {
+        $problems[] = "toArray() key set differs from foreach";
+    }
+
+    $sorted = array_keys($seen);
+    $want = $sorted;
+    sort($want, SORT_STRING);
+    if ($sorted !== $want) {
+        $problems[] = "keys not in sorted order";
+    }
+
+    ksort($expected, SORT_STRING);
+    if ($seen !== $expected) {
+        $problems[] = "contents differ from the model";
+    }
+
+    echo $label . ": " . ($problems ? implode("; ", $problems) : "ok") . "\n";
+}
+
+foreach ($types as $name => $type) {
+    $mixed = str_contains($name, 'MIXED');
+    $j = new Judy($type);
+    $model = [];
+
+    // 1. plain inserts
+    foreach (keys_for(8) as $i => $k) {
+        $v = $mixed ? "v$i" : $i;
+        $j[$k] = $v;
+        $model[$k] = $v;
+    }
+    check("$name insert", $j, $model);
+
+    // 2. overwrite every key in place
+    foreach (array_keys($model) as $i => $k) {
+        $v = $mixed ? "over$i" : ($i + 1000);
+        $j[$k] = $v;
+        $model[$k] = $v;
+    }
+    check("$name overwrite", $j, $model);
+
+    // 3. increment() where the type supports it — the one in-place mutator
+    //    that is not offsetSet
+    if (!$mixed && $type === Judy::STRING_TO_INT_HASH) {
+        foreach (array_keys($model) as $k) {
+            $model[$k] = $j->increment($k, 7);
+        }
+        check("$name increment", $j, $model);
+    }
+
+    // 4. putAll / fromArray over a mix of new and existing keys
+    $batch = [];
+    foreach (['k03', 'k99', 'long_key_0003', 'long_key_9999'] as $i => $k) {
+        $batch[$k] = $mixed ? "batch$i" : ($i + 2000);
+    }
+    $j->putAll($batch);
+    $model = array_merge($model, $batch);
+    check("$name putAll", $j, $model);
+
+    // 5. deletes, then re-insert some of the deleted keys
+    foreach (['k00', 'k03', 'long_key_0000', 'long_key_9999'] as $k) {
+        unset($j[$k]);
+        unset($model[$k]);
+    }
+    check("$name unset", $j, $model);
+    foreach (['k00', 'long_key_9999'] as $i => $k) {
+        $v = $mixed ? "again$i" : ($i + 3000);
+        $j[$k] = $v;
+        $model[$k] = $v;
+    }
+    check("$name reinsert", $j, $model);
+
+    // 6. clone must carry both stores across intact
+    $c = clone $j;
+    check("$name clone", $c, $model);
+
+    // 7. serialize round trip
+    $u = unserialize(serialize($j));
+    check("$name unserialize", $u, $model);
+
+    // 8. mutating the clone must not disturb the original
+    $c["only_on_clone"] = $mixed ? "x" : 42;
+    check("$name original after clone write", $j, $model);
+}
+?>
+--EXPECT--
+STRING_TO_INT_HASH insert: ok
+STRING_TO_INT_HASH overwrite: ok
+STRING_TO_INT_HASH increment: ok
+STRING_TO_INT_HASH putAll: ok
+STRING_TO_INT_HASH unset: ok
+STRING_TO_INT_HASH reinsert: ok
+STRING_TO_INT_HASH clone: ok
+STRING_TO_INT_HASH unserialize: ok
+STRING_TO_INT_HASH original after clone write: ok
+STRING_TO_MIXED_HASH insert: ok
+STRING_TO_MIXED_HASH overwrite: ok
+STRING_TO_MIXED_HASH putAll: ok
+STRING_TO_MIXED_HASH unset: ok
+STRING_TO_MIXED_HASH reinsert: ok
+STRING_TO_MIXED_HASH clone: ok
+STRING_TO_MIXED_HASH unserialize: ok
+STRING_TO_MIXED_HASH original after clone write: ok
+STRING_TO_INT_ADAPTIVE insert: ok
+STRING_TO_INT_ADAPTIVE overwrite: ok
+STRING_TO_INT_ADAPTIVE putAll: ok
+STRING_TO_INT_ADAPTIVE unset: ok
+STRING_TO_INT_ADAPTIVE reinsert: ok
+STRING_TO_INT_ADAPTIVE clone: ok
+STRING_TO_INT_ADAPTIVE unserialize: ok
+STRING_TO_INT_ADAPTIVE original after clone write: ok
+STRING_TO_MIXED_ADAPTIVE insert: ok
+STRING_TO_MIXED_ADAPTIVE overwrite: ok
+STRING_TO_MIXED_ADAPTIVE putAll: ok
+STRING_TO_MIXED_ADAPTIVE unset: ok
+STRING_TO_MIXED_ADAPTIVE reinsert: ok
+STRING_TO_MIXED_ADAPTIVE clone: ok
+STRING_TO_MIXED_ADAPTIVE unserialize: ok
+STRING_TO_MIXED_ADAPTIVE original after clone write: ok


### PR DESCRIPTION
The two preconditions from #85's Part B plan. **The payload mirroring itself (B3/B4) is deliberately not here** — this is the groundwork that makes it safe to attempt, plus the benchmark that will gate it.

Part B's danger is specific: once a value lives in two stores, any path that writes, mutates or deletes must update both or they silently diverge. **A divergence is two valid pointers holding different values — valgrind sees nothing, no crash, no leak.** Only a test that thought to check that exact path catches it.

## B1 — one slot path for every string-keyed value write

`increment()` was the only in-place value mutator that did not go through `judy_object_write_dimension_helper`, and on its hot path it wrote the value alone, touching `key_index` only for new keys. That is the site most likely to make `increment()` and `foreach` disagree once B3 lands.

Extracted `judy_string_slot_acquire()` — the write-side twin of the existing `judy_string_value_slot()`, same signature style, sitting beside it. It locates (creating if absent) the value slot for a string key and owns everything that must accompany creating a key: the embedded-NUL precondition of the four `key_index` types, the `JSLI` registration, its rollback, and the `counter` bump. Callers are left with one job — write the payload through the returned slot.

That collapsed the six string branches of `write_dimension_helper` (~230 lines → ~25) and merged `increment()`'s two arms into one. Also extracted `judy_slot_store_zval()`, the publish-new-before-freeing-old sequence that was copy-pasted four times.

**Effect on B3's risk surface:** all six live-mutation `key_index` `JSLI` sites now sit inside one function. The rest are fresh-array builders — `slice()` ×3 and `clone()` ×3 — which never mutate a live object. The audit for #85 counted 24 mutation sites; most of that surface is now one place.

**Behaviour unchanged.** Both new tests pass *identically against the pre-refactor build* — they pin existing behaviour rather than describing the refactor. Exception wording and check ordering preserved verbatim. Two deliberate, disclosed changes: `zval_get_long()` on the `_INT` types now runs before slot acquisition (matching what `STRING_TO_INT` already did, so a userland cast handler can no longer re-enter and invalidate a slot taken first), and `STRING_TO_MIXED_HASH`'s `ecalloc` became `emalloc`, unifying with the other three MIXED types.

## B2 — `JUDY_DEBUG_MIRROR` assertions + CI job

A build flag turning on internal consistency checks, and a CI job running the full suite under it. The invariant:

1. Population agrees with `intern->counter`, every type.
2. Every key in `key_index` resolves to a live value slot, and for MIXED to a non-NULL `zval*`.
3. The reverse direction **only as far as it is enumerable**.

**On (3) — a limitation worth stating plainly: JudyHS has no enumeration primitive.** The API is `JHSI/JHSG/JHSD/JHSFA` and nothing else, so value-store → `key_index` cannot be walked for the `*_HASH` types; an orphaned JudyHS entry is reachable only through (1) or as a valgrind leak. ADAPTIVE's short-key half is a JudyL and *is* checked both ways. Documented in the code, not glossed — and B3's gate should repeat it rather than claim coverage it cannot have.

This is validated against an invariant that is already true today (it guards B1's counter bookkeeping, the delete paths, clone and slice), rather than waiting for B3 to give it something to check — the harness should not be commissioned by the change it exists to police. The forward walk is also the right shape for B3: payload divergence is a value mismatch on keys present in both stores, so `key_index` → value store suffices, and B3 adds one comparison inside the existing loop.

**Proof it catches things** — three deliberate breaks, all `SIGABRT`:

| break | assertion |
| --- | --- |
| counter bump removed on new HASH key | `population 1 disagrees with counter 0` |
| `key_index` entry left behind on MIXED_HASH unset | `key listed in key_index has no entry in the value store` |
| SSO value entry retained on ADAPTIVE unset | `short key present in the value store is missing from key_index` |

The first is wired into CI as a permanent **negative control**: the job strips a marked line, rebuilds, and requires the abort. It also asserts `nm -D` finds `judy_debug_check_mirror`, so the job cannot silently decay into a duplicate of `build-linux` if the configure flag stops taking effect.

**Zero cost when off — verified, not asserted.** Macro is `((void)0)`, checker not compiled, and the linked `judy.so` is byte-identical to a build of the parent commit: `2497544ad30206c2` both ways, built in the same directory (path differences alone change the hash, so this comparison only means anything same-directory). Checks run at teardown and clone, both already O(n) — never per element. Suite time under the flag: 3.36 s vs 3.36 s.

## Write-path benchmark

`examples/benchmarks/judy-bench-writepath.php`. The existing suites cover reads, iteration and bulk ops, so a change to key registration is invisible to them.

It is not decoration: B1's first version was consistently **+3.0% on ADAPTIVE SSO overwrite**. Splitting the grouped `switch` did not fix it — the cost was the call boundary, and `zend_always_inline` removed it. Without this benchmark that ships as an unnoticed regression on the shortest write path.

Ships the benchmark only, not a driver — `scripts/bench-compare.php` already does ABBA interleaving, per-round ratios, bootstrap CIs and the instability guard.

## Measured

`honeycomb`, dedicated 24-core x86_64, PHP 8.4.24, `PHP_INI_SCAN_DIR=` on every invocation, `/proc/loadavg` 0.41–0.92 before and after every run (threshold 12.0). ABBA-interleaved, 9 rounds × 5 iterations × 200 K ops, per-round `after/base` ratios, median reported. 27 benchmarks including point lookup and `INT_TO_INT increment` as untouched controls.

Run-wide drift **−0.05%**. Everything within ±1.4%, except `str_mixed_hash.*` which got **1.3–3.3% faster** (the `ecalloc`→`emalloc` unification). Largest nominal slowdown `str_int_hash.increment_new` +0.91%, per-round range 0.9964–1.0159 — straddles 1.0, no measured separation.

## Verification

- **192/192 pass** on macOS/arm64 and Linux/x86_64.
- Two new `.phpt`, both in `package.xml` (192 on disk == 192 listed; #90's guard passes). `mirror_value_agreement_001` is the generic divergence canary: for all four mirror types it asserts traversal value === point-lookup value across insert/overwrite/increment/putAll/unset/reinsert/clone/unserialize, straddling the 8-byte SSO boundary.
- `USE_ZEND_ALLOC=0` valgrind over the **full 192-test suite**: 0 failed, 0 leaked.
- Zero compiler warnings with and without the flag, both toolchains.
- `API.md` fresh; `baselines/latest.json` untouched.

## What this changes about B3

1. **B3 costs writes, and #85's gate does not measure that.** Mirroring means locating the `key_index` slot on the overwrite path, which today it never touches. #85's gate is iteration-only. That is what the new benchmark is for.
2. **B1 may make that free.** The existence probe is now one site, so B3 can *replace* `JHSG` with a `JSLG` on `key_index` — answering "does this key exist?" and handing back the mirror slot — rather than adding a third lookup. **Caveat: #85 only measured `JHSG` replayed in iteration order.** Random-order `JSLG` is 184–198 ns there and the random-order JudyHS figure was never taken, so the comparison for random-order writes is unknown. Measuring it is a B3 prerequisite, not an afterthought.
3. **The reverse direction stays unverifiable for `*_HASH`** — see B2 above.
