### PR TITLE
feat(debug): make Judy observable to debuggers, and add coverage/test-impact examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,5 +134,7 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   `ip-range-lookup.php` (floor lookup via `last()` — CIDR, tariff bands),
   `sliding-window-rate-limit.php` (time-bucket expiry via `deleteRange()`),
   `prefix-invalidation.php` (namespace drop via `first()` + `searchNext()`),
+  `coverage-index.php` (nested `file -> line -> ids` maps flattened into one
+  `BITSET` over packed keys, merged with `union()`/`mergeWith()`),
   `autocomplete-trie.php` (prefix search), `worker-counters.php` (atomic
   `increment()`), `quickstart.php` (API tour).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,11 +61,23 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
 - **`next()` is the Iterator method** (returns void, advances the cursor).
   The ordered *search* is `searchNext($index)`. Pre-2.x code and old stubs
   (php.net manual, outdated IDE stubs) show `next($index)` — that API is gone.
-- **`memoryUsage()` returns `null` for string-keyed types** (JudySL/JudyHS
-  provide no accounting). Only integer-keyed types report bytes.
+- **`memoryUsage()` returns two different kinds of number.** Integer-keyed
+  types report libJudy's EXACT total (`Judy1MemUsed`/`JudyLMemUsed`).
+  String-keyed types report an APPROXIMATION the extension maintains itself,
+  because JudySL/JudyHS expose no accounting: it counts payload only — stored
+  key bytes (twice for the `_HASH` types, which hold each key in the value
+  store and in the key index), one word per value slot, and the `zval` box per
+  `_MIXED` value — and excludes everything libJudy allocates for its trie and
+  hash nodes. It is a LOWER BOUND: useful for tracking growth within one array,
+  wrong to compare against an integer-keyed array's exact figure. Both are
+  O(1) and both return `0` for a new or emptied array. For the true
+  string-keyed footprint measure peak RSS in a separate process, or Massif via
+  `examples/benchmarks/judy-bench-memory.php`. Details: BENCHMARK.md
+  "Understanding `Judy::memoryUsage()`".
 - **`var_dump()`/`print_r()` show a synthetic, TRUNCATED view.** A Judy object
-  dumps as `type` (the name, e.g. `INT_TO_INT`), `count`, `memoryUsage` (null
-  for string-keyed types, as above), `firstKey`, `lastKey`, and `preview` —
+  dumps as `type` (the name, e.g. `INT_TO_INT`), `count`, `memoryUsage` (plus
+  `memoryUsageIsApproximate => true` for string-keyed types, as above),
+  `firstKey`, `lastKey`, and `preview` —
   plus `previewTruncated` whenever fewer elements are shown than the array
   holds. `preview` is capped at `judy.debug_preview_size` (default 16,
   `PHP_INI_ALL`, so `ini_set()` works mid-session); `0` disables the element

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,8 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
 - **`var_dump()`/`print_r()` show a synthetic, TRUNCATED view.** A Judy object
   dumps as `type` (the name, e.g. `INT_TO_INT`), `count`, `memoryUsage` (plus
   `memoryUsageIsApproximate => true` for string-keyed types, as above),
-  `firstKey`, `lastKey`, and `preview` —
-  plus `previewTruncated` whenever fewer elements are shown than the array
+  `firstKey`, `lastKey`, and `preview` — plus
+  `previewTruncated` whenever fewer elements are shown than the array
   holds. `preview` is capped at `judy.debug_preview_size` (default 16,
   `PHP_INI_ALL`, so `ini_set()` works mid-session); `0` disables the element
   preview and leaves metadata only, and negatives clamp to 0. The cap exists
@@ -89,8 +89,9 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   carry the true total, `preview` is a sample. For the real contents use
   `toArray()`/`keys()`/`values()`, which are unaffected by the INI.
 - **Judy memory is invisible to `memory_get_usage()`** — it allocates outside
-  PHP's memory manager. Measure peak RSS (`getrusage()['ru_maxrss']`) in a
-  separate process for honest comparisons.
+  PHP's memory manager, and Xdebug's memory column inherits that blindness.
+  Measure peak RSS (`getrusage()['ru_maxrss']`) in a separate process for
+  honest comparisons; see "Debugging and profiling Judy code" below.
 - **`*_HASH` and `*_ADAPTIVE` types DO iterate in key order** — they keep a
   sorted key index alongside the value store, so `foreach`, `first()` +
   `searchNext()` and prefix walks all work and return lexicographic order.
@@ -115,6 +116,41 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
 - Keys are `int` (platform word) or binary-safe `string` depending on type;
   mixing categories in set ops (`union` etc.) with a different key category
   throws.
+
+### Debugging and profiling Judy code
+
+- **Judy and Xdebug coexist; load order does not matter.** Judy is a module
+  extension that registers a class and object handlers and does not hook the
+  executor; Xdebug is a zend_extension that does. Verified empirically, not
+  argued: `php:8.4-cli` with judy built from source + Xdebug 3.5.3 from PECL,
+  both `extension_loaded()` true, `var_dump()` of a Judy object correct under
+  `xdebug.mode=develop` (Xdebug overrides `var_dump()` and goes through the
+  same `get_debug_info` handler), iteration correct, and swapping
+  `-d extension=judy.so` / `-d zend_extension=xdebug.so` changes nothing.
+- **Do NOT diagnose Judy memory with a profiler.** Xdebug's memory column is
+  `memory_get_usage()` underneath, and Judy allocates outside PHP's memory
+  manager. Measured: a function filling `STRING_TO_INT` with 50K keys traced at
+  `xdebug.mode=trace` shows a 65,696-byte delta — PHP-side overhead only, none
+  of the ~1.24 MB of trie it actually allocated — while the equivalent PHP
+  array shows its full 4,941,520 bytes. Judy looks free exactly where a user is
+  hunting a memory-limit crash. Use `memoryUsage()` (in-process; exact for
+  integer-keyed types, an approximate lower bound for string-keyed ones) and
+  peak RSS via `getrusage()['ru_maxrss']` measured in a **separate process**.
+- **The signal profilers DO give is call counts.** `$j[$key]` dispatches
+  straight to the extension's dimension handler, so it does not appear in a
+  trace or cachegrind profile at all — the cost lands in the enclosing
+  function. Explicit `$j->offsetGet($key)` calls do appear one per lookup
+  (5,000 lookups = 5,000 entries) against a single entry for the bulk call.
+  Either way the fix is the bulk API: `getAll()` 1.9x faster than individual
+  lookups (int keys, 10K lookups over 100K elements) and `toArray()` 2.8x
+  faster than a manual `foreach` (100K int-keyed; 3.1x string-keyed) — measured,
+  BENCHMARK.md Tables 5 and 6. `forEach()`/`filter()`/`map()` are the same
+  trade for callback loops.
+- **What an IDE variable pane shows** is the `get_debug_info` output described
+  in the `var_dump()` pitfall above: whole-array `count`/`firstKey`/`lastKey`,
+  a `preview` sample bounded by `judy.debug_preview_size` (0 = metadata only),
+  a `previewTruncated` note carrying the true total whenever the preview is
+  short, and `memoryUsageIsApproximate` on the string-keyed types.
 
 ## Modifying the extension (working in this repo)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,8 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   `sliding-window-rate-limit.php` (time-bucket expiry via `deleteRange()`),
   `prefix-invalidation.php` (namespace drop via `first()` + `searchNext()`),
   `coverage-index.php` (nested `file -> line -> ids` maps flattened into one
-  `BITSET` over packed keys, merged with `union()`/`mergeWith()`),
+  `BITSET` over packed keys, merged with `union()`/`mergeWith()`, then queried
+  for test-impact selection — the contiguous-block walk, and why an uncovered
+  changed line must widen rather than select nothing),
   `autocomplete-trie.php` (prefix search), `worker-counters.php` (atomic
   `increment()`), `quickstart.php` (API tour).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,19 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   (php.net manual, outdated IDE stubs) show `next($index)` — that API is gone.
 - **`memoryUsage()` returns `null` for string-keyed types** (JudySL/JudyHS
   provide no accounting). Only integer-keyed types report bytes.
+- **`var_dump()`/`print_r()` show a synthetic, TRUNCATED view.** A Judy object
+  dumps as `type` (the name, e.g. `INT_TO_INT`), `count`, `memoryUsage` (null
+  for string-keyed types, as above), `firstKey`, `lastKey`, and `preview` —
+  plus `previewTruncated` whenever fewer elements are shown than the array
+  holds. `preview` is capped at `judy.debug_preview_size` (default 16,
+  `PHP_INI_ALL`, so `ini_set()` works mid-session); `0` disables the element
+  preview and leaves metadata only, and negatives clamp to 0. The cap exists
+  because a debug dump has to stay cheap enough to be safe at a breakpoint —
+  Xdebug and the PhpStorm/VS Code variable panels read the same handler over
+  DBGp, and serializing millions of elements there would hang the session.
+  **Never read element counts off a dump**: `count` and `previewTruncated`
+  carry the true total, `preview` is a sample. For the real contents use
+  `toArray()`/`keys()`/`values()`, which are unaffected by the INI.
 - **Judy memory is invisible to `memory_get_usage()`** — it allocates outside
   PHP's memory manager. Measure peak RSS (`getrusage()['ru_maxrss']`) in a
   separate process for honest comparisons.

--- a/API.md
+++ b/API.md
@@ -102,12 +102,12 @@ Frees all memory used by the Judy array and resets the element count. Returns th
 public function memoryUsage(): ?int
 ```
 
-Returns the number of bytes used by the internal Judy structure. Returns `null` for string-keyed types (JudySL and JudyHS do not provide memory accounting).
+Returns the number of bytes used by the internal Judy structure. **The number means two different things depending on the key category, and callers must know which.** Integer-keyed types return libJudy's *exact* figure. String-keyed types return an *approximate* figure the extension maintains itself, because JudySL/JudyHS expose no accounting: it counts only the payload — stored key bytes (counted twice for the `_HASH` types, which hold each key in both the value store and the key index), one machine word per value slot, and the `zval` box allocated for each `_MIXED` value — and excludes everything libJudy allocates for its own trie and hash nodes. Treat it as a **lower bound**, good for tracking growth within one array, not for comparing against the exact figure. Both variants are O(1) and return `0` for a newly constructed or emptied array.
 
-| Supported Types                                 | Returns       |
-| ----------------------------------------------- | ------------- |
-| BITSET, INT_TO_INT, INT_TO_MIXED, INT_TO_PACKED | `int` (bytes) |
-| All string-keyed types                          | `null`        |
+| Supported Types                                 | Returns                                                                       |
+| ----------------------------------------------- | ----------------------------------------------------------------------------- |
+| BITSET, INT_TO_INT, INT_TO_MIXED, INT_TO_PACKED | `int` (bytes, exact — `Judy1MemUsed`/`JudyLMemUsed`)                          |
+| All string-keyed types                          | `int` (bytes, **approximate** — payload only, excludes libJudy node overhead) |
 
 ### size()
 
@@ -580,7 +580,7 @@ Summary of which methods are available for each type. Methods not listed here wo
 
 | Method                     | BITSET | INT_TO_INT | INT_TO_MIXED | INT_TO_PACKED | STR_INT | STR_MIXED | STR_INT_HASH | STR_MIX_HASH | STR_INT_ADAPT | STR_MIX_ADAPT |
 | -------------------------- | ------ | ---------- | ------------ | ------------- | ------- | --------- | ------------ | ------------ | ------------- | ------------- |
-| `memoryUsage()`            | int    | int        | int          | int           | null    | null      | null         | null         | null          | null          |
+| `memoryUsage()`            | int    | int        | int          | int           | approx  | approx    | approx       | approx       | approx        | approx        |
 | `union/intersect/diff/xor` | yes    | yes        | -            | -             | yes     | -         | yes          | -            | -             | -             |
 | `populationCount()`        | yes    | yes        | yes          | yes           | -       | -         | -            | -            | -             | -             |
 | `sumValues()`              | yes    | yes        | -            | -             | yes     | -         | yes          | -            | yes           | -             |
@@ -589,6 +589,6 @@ Summary of which methods are available for each type. Methods not listed here wo
 | `byCount()`                | yes    | yes        | yes          | yes           | null    | null      | null         | null         | null          | null          |
 | `firstEmpty()` etc.        | yes    | yes        | yes          | yes           | null    | null      | null         | null         | null          | null          |
 
-**Legend**: `yes` = supported, `-` = throws exception, `null` = silently returns null, `int` = returns integer value.
+**Legend**: `yes` = supported, `-` = throws exception, `null` = silently returns null, `int` = returns an exact integer value, `approx` = returns an approximate integer value (see the method entry).
 
 All other methods (`slice`, `deleteRange`, `forEach`, `filter`, `map`, `keys`, `values`, `equals`, `mergeWith`, `toArray`, `fromArray`, `putAll`, `getAll`) work with all 10 types.

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -628,7 +628,9 @@ foreach ($random_keys as $key) {
 
 ## Understanding `Judy::memoryUsage()`
 
-The `memoryUsage()` method reports internal Judy C library memory consumption for the array. Its behavior varies by Judy type because the underlying C library provides different memory-accounting macros for each array family.
+The `memoryUsage()` method reports the memory a Judy array occupies outside PHP's memory manager — memory that `memory_get_usage()` and Xdebug's memory profiler are both blind to, so this method is the only in-process view of it.
+
+**It returns two different kinds of number.** Integer-keyed types return libJudy's own exact accounting. String-keyed types return an approximation the extension maintains itself, because libJudy ships no accounting macro for JudySL or JudyHS. Read the type table before comparing two figures.
 
 ### Return Values by Type
 
@@ -638,20 +640,32 @@ The `memoryUsage()` method reports internal Judy C library memory consumption fo
 | `INT_TO_INT`               | JudyL                   | `JudyLMemUsed` (JLMU) | `int` — bytes used                                              |
 | `INT_TO_MIXED`             | JudyL                   | `JudyLMemUsed` (JLMU) | `int` — bytes used (Judy storage only, excludes PHP zvals)      |
 | `INT_TO_PACKED`            | JudyL                   | `JudyLMemUsed` (JLMU) | `int` — bytes used (Judy storage only, excludes packed buffers) |
-| `STRING_TO_INT`            | JudySL                  | *(no macro)*          | `NULL`                                                          |
-| `STRING_TO_MIXED`          | JudySL                  | *(no macro)*          | `NULL`                                                          |
-| `STRING_TO_INT_HASH`       | JudyHS + JudySL         | *(no macro)*          | `NULL`                                                          |
-| `STRING_TO_MIXED_HASH`     | JudyHS + JudySL         | *(no macro)*          | `NULL`                                                          |
-| `STRING_TO_INT_ADAPTIVE`   | JudyL + JudyHS + JudySL | *(no macro)*          | `NULL`                                                          |
-| `STRING_TO_MIXED_ADAPTIVE` | JudyL + JudyHS + JudySL | *(no macro)*          | `NULL`                                                          |
+| `STRING_TO_INT`            | JudySL                  | *(no macro)*          | `int` — **approximate**, payload only                           |
+| `STRING_TO_MIXED`          | JudySL                  | *(no macro)*          | `int` — **approximate**, payload only                           |
+| `STRING_TO_INT_HASH`       | JudyHS + JudySL         | *(no macro)*          | `int` — **approximate**, payload only (keys counted twice)      |
+| `STRING_TO_MIXED_HASH`     | JudyHS + JudySL         | *(no macro)*          | `int` — **approximate**, payload only (keys counted twice)      |
+| `STRING_TO_INT_ADAPTIVE`   | JudyL + JudyHS + JudySL | *(no macro)*          | `int` — **approximate**, payload only                           |
+| `STRING_TO_MIXED_ADAPTIVE` | JudyL + JudyHS + JudySL | *(no macro)*          | `int` — **approximate**, payload only                           |
 
-**Why STRING types return NULL**: The Judy C library does not provide a `JudySLMemUsed` macro. JudySL is internally a chain of JudyL arrays (one per byte of the key), making a single memory total impractical at the C level. Use `memory_get_usage()` deltas as an alternative for string-keyed types.
+**What the string-keyed approximation counts**: the Judy C library provides no `JudySLMemUsed` macro (JudySL is internally a chain of JudyL arrays, one per key byte, and JudyHS exposes only get/insert/delete/free-all), so the extension keeps its own running total instead. Per live entry it counts:
+
+- the **stored key bytes**, once per structure that holds a copy. The `_HASH` types hold every key twice — once in the JudyHS value store, once in the JudySL key index that makes ordered iteration possible — so their figure is roughly twice the key bytes. `_ADAPTIVE` packs keys shorter than 8 bytes into the index word and only copies longer ones into JudyHS.
+- one **machine word per value slot** (8 bytes on 64-bit).
+- the **`zval` box** (`sizeof(zval)`, 16 bytes on 64-bit) allocated for each `_MIXED` value.
+
+**What it excludes** — and therefore why it is only an approximation: every byte libJudy allocates for its own trie branches, leaves and JudyHS hash structures; allocator rounding; and the PHP heap reachable from a stored `zval` (the string or array it points at, which `memory_get_usage()` *does* see). The figure is a **lower bound on the true footprint**. How far below depends on the key distribution: keys with heavy prefix sharing compress well in the trie and land close to the reported figure, while random keys leave the real footprint a small multiple of it. Use it to track growth and to compare populations of the same type, not to compare a string-keyed array against the exact figure an integer-keyed one reports.
+
+**For the exact string-keyed footprint**, measure outside the extension: peak RSS via `getrusage()['ru_maxrss']` in a separate process, or Valgrind Massif (`examples/benchmarks/judy-bench-memory.php`), which attributes libJudy's `malloc` traffic directly.
+
+**Debug dumps carry the caveat too**: `var_dump()` of a string-keyed Judy shows a `memoryUsageIsApproximate => true` entry beside `memoryUsage`, so the distinction is visible in an IDE variable pane without consulting this table.
 
 **INT_TO_MIXED note**: The value returned is only the JudyL trie memory. The PHP `zval` pointers stored in each slot consume additional PHP heap memory not reflected in `memoryUsage()`.
 
 ### How `memoryUsage()` Works Internally
 
 For `BITSET` and `INT_TO_*` types, the Judy library maintains a `TotalMemWords` counter in the root JPM (Judy Population/Memory) structure. `memoryUsage()` reads this counter and multiplies by `sizeof(Word_t)` — an O(1) operation with no traversal.
+
+For the string-keyed types the extension maintains its own counter in the object, adjusted on the same insert and delete paths that maintain the element count — so that call is O(1) as well, and it is safe to read at a breakpoint. It survives `clone`, `serialize()`/`unserialize()`, `slice()`, `deleteRange()`, `mergeWith()`, the set operations and the bulk writers, and returns to exactly `0` for a newly constructed array, after `free()`, and after the last key is unset.
 
 ```php
 $j = new Judy(Judy::INT_TO_INT);

--- a/Judy.stub.php
+++ b/Judy.stub.php
@@ -50,10 +50,30 @@ class Judy implements ArrayAccess, Countable, Iterator, JsonSerializable
     public function free(): int {}
 
     /**
-     * Return the memory used by the internal Judy structure.
+     * Return the memory used by the internal Judy structure, in bytes.
      *
-     * Returns null for string-keyed types (JudySL/JudyHS do not provide
-     * memory accounting).
+     * The number means two different things, and callers relying on it must
+     * know which they are looking at:
+     *
+     * - Integer-keyed types (BITSET, INT_TO_INT, INT_TO_MIXED, INT_TO_PACKED)
+     *   return libJudy's EXACT figure (Judy1MemUsed/JudyLMemUsed): every byte
+     *   the library allocated for the array. It excludes the PHP heap used by
+     *   the values themselves (zvals for INT_TO_MIXED, buffers for
+     *   INT_TO_PACKED).
+     * - String-keyed types (STRING_TO_INT, STRING_TO_MIXED and their _HASH and
+     *   _ADAPTIVE variants) return an APPROXIMATE figure maintained by the
+     *   extension, because JudySL/JudyHS expose no accounting of their own. It
+     *   counts only the payload: the stored key bytes (twice for the _HASH
+     *   types, which hold each key in both the value store and the key index),
+     *   one machine word per value slot, and the zval box allocated for each
+     *   _MIXED value. It EXCLUDES everything libJudy allocates for its trie and
+     *   hash nodes, so it is a LOWER BOUND on the real footprint — usually a
+     *   large one — and must not be compared against the exact figure the
+     *   integer-keyed types return. It is well suited to tracking growth and
+     *   comparing populations within one array type.
+     *
+     * Both are O(1). Returns 0 for a newly constructed or emptied array, and
+     * null only for an array whose type was never initialised.
      */
     public function memoryUsage(): ?int {}
 

--- a/Judy_arginfo.h
+++ b/Judy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2c3d6e08ad8d66c9985ad460a5b801aecb4e3398 */
+ * Stub hash: 1067f736ceecd1551388388a1c84bcc518dade11 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_judy_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@
 2. [Directory Contents](#directory-contents)
 3. [Installation](#installation)
 4. [Usage Examples](#usage-examples)
-5. [Ecosystem](#ecosystem)
-6. [Reporting Bugs](#reporting-bugs)
-7. [Roadmap](#roadmap)
-8. [Releasing](#releasing)
-9. [License](#license)
-10. [Contributing](#contributing)
-11. [Support](#support)
+5. [Debugging and Profiling](#debugging-and-profiling)
+6. [Ecosystem](#ecosystem)
+7. [Reporting Bugs](#reporting-bugs)
+8. [Roadmap](#roadmap)
+9. [Releasing](#releasing)
+10. [License](#license)
+11. [Contributing](#contributing)
+12. [Support](#support)
 
 ## Introduction
 
@@ -472,6 +473,119 @@ Beyond basic array access, Judy provides a rich API including:
 - **Comparison**: `equals()`
 
 For complete method signatures, parameter details, and type compatibility, see [API.md](API.md).
+
+## Debugging and Profiling
+
+### Judy and Xdebug coexist
+
+Judy is an ordinary **module** extension: it registers a class and a set of
+object handlers and does not hook the executor. Xdebug is a **zend_extension**
+that does hook the executor. The two do not overlap, and load order is
+irrelevant.
+
+That was verified rather than assumed: in a container with both loaded
+(`php:8.4-cli`, judy built from source, Xdebug 3.5.3 from PECL), both report
+loaded, `var_dump()` of a Judy object renders correctly under
+`xdebug.mode=develop` (Xdebug replaces `var_dump()`, and it goes through the
+same handler), iteration works, and swapping the order of `-d extension=judy.so`
+and `-d zend_extension=xdebug.so` changes nothing.
+
+### The blind spot: Judy memory is invisible to memory profiling
+
+Judy allocates through the C allocator, outside PHP's memory manager. So
+`memory_get_usage()` does not see it — and neither does anything built on top
+of it, including Xdebug's per-function memory column. Filling a
+`STRING_TO_INT` with 50,000 keys inside a function, traced with
+`xdebug.mode=trace`:
+
+| Function                       | Xdebug memory delta | Actually allocated             |
+| ------------------------------ | ------------------- | ------------------------------ |
+| `fill_judy(50000)`             | 65,696 bytes        | ~1.24 MB (`memoryUsage()`)     |
+| `fill_php_array(50000)`        | 4,941,520 bytes     | 4,941,520 bytes                |
+
+The 65 KB charged to `fill_judy()` is PHP-side overhead (the object, the key
+zvals); not one byte of the ~1.24 MB of trie the call actually allocated
+appears anywhere in the trace, while the PHP array is reported in full. A
+memory-limit investigation driven by those numbers concludes the Judy array is
+nearly free — the opposite of what is happening.
+
+Two things do see it:
+
+- **`Judy::memoryUsage()`** — the only in-process view. Exact for
+  integer-keyed types, approximate (payload bytes, a lower bound) for
+  string-keyed ones; see [BENCHMARK.md](BENCHMARK.md#understanding-judymemoryusage).
+- **Peak RSS**, `getrusage()['ru_maxrss']`, measured in a **separate process**
+  per configuration — the honest way to compare Judy against a PHP array,
+  since only one of the two is visible to PHP's own accounting.
+
+```php
+// Run each variant in its own process; comparing them in one process is
+// meaningless because neither allocation is released to the OS on time.
+$judy = new Judy(Judy::STRING_TO_INT);
+for ($i = 0; $i < 1_000_000; $i++) { $judy["key_$i"] = $i; }
+printf("memoryUsage: %d bytes (approximate)\n", $judy->memoryUsage());
+printf("peak RSS:    %d\n", getrusage()['ru_maxrss']);
+```
+
+### What profilers do tell you: dispatch cost
+
+The signal Xdebug gives accurately is **call counts**, and that is what usually
+points at the real fix. With bracket syntax (`$judy[$key]`) the engine calls the
+extension's dimension handler directly, so nothing named `Judy` appears in the
+trace at all and the cost lands in the enclosing function. Explicit
+`$judy->offsetGet($key)` calls do appear, one line per lookup — 5,000 lookups
+show up as 5,000 `Judy->offsetGet` entries in both the trace and the cachegrind
+profile, while the bulk equivalent is a single `Judy->getAll` entry.
+
+Either way, a hot loop doing one lookup per element is the thing to replace:
+
+```php
+// Per-element dispatch
+foreach ($keys as $k) { $sum += $judy[$k]; }
+$copy = []; foreach ($judy as $k => $v) { $copy[$k] = $v; }
+
+// One C-level call instead
+$sum  = array_sum($judy->getAll($keys));
+$copy = $judy->toArray();
+```
+
+Measured (BENCHMARK.md Tables 5 and 6): `getAll()` is **1.9x** faster than
+individual lookups for integer keys on 10K lookups over 100K elements, and
+`toArray()` is **2.8x** faster than a manual `foreach` for 100K integer-keyed
+elements (**3.1x** for string keys). `forEach()`, `filter()` and `map()` are the
+same trade for callback-driven loops.
+
+### What a debugger shows
+
+`var_dump()`, `print_r()` and IDE variable panes (PhpStorm/VS Code over DBGp)
+all read the same `get_debug_info` handler, which renders a Judy object as
+(condensed — `var_dump()` prints each value on its own line):
+
+```
+object(Judy)#1 (7) {
+  ["type"]=>                      string(20) "STRING_TO_MIXED_HASH"
+  ["count"]=>                     int(2)
+  ["memoryUsage"]=>               int(68)
+  ["memoryUsageIsApproximate"]=>  bool(true)
+  ["firstKey"]=>                  string(5) "alpha"
+  ["lastKey"]=>                   string(4) "beta"
+  ["preview"]=>                   array(2) { ... }
+}
+```
+
+- `count`, `firstKey` and `lastKey` always describe the **whole** array.
+- `preview` is a **sample**, capped at `judy.debug_preview_size` (default 16,
+  `PHP_INI_ALL`, so `ini_set()` works mid-session). `0` disables the element
+  preview and leaves metadata only; negative values clamp to 0. The cap exists
+  because a dump has to stay cheap enough to be safe at a breakpoint —
+  serializing millions of elements over DBGp would hang the session.
+- Whenever fewer elements are shown than the array holds — including the `0`
+  case — a `previewTruncated` entry states the true total, e.g.
+  `showing 16 of 1000000 elements (judy.debug_preview_size=16)`. **Never read
+  element counts off a preview**; use `count()`, `toArray()`, `keys()` or
+  `values()`, which the INI does not affect.
+- `memoryUsageIsApproximate` appears only for string-keyed types, marking the
+  `memoryUsage` figure on the line above as a payload-only lower bound.
 
 ## Ecosystem
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ php examples/quickstart.php
 | [ip-range-lookup.php](ip-range-lookup.php) | Floor lookup (`last()`) over range tables — IPs, tariffs, time buckets | `INT_TO_MIXED` |
 | [sliding-window-rate-limit.php](sliding-window-rate-limit.php) | Sliding-window rate limiting / rolling metrics — `deleteRange()` expiry that visits only aged-out buckets | `INT_TO_INT` |
 | [prefix-invalidation.php](prefix-invalidation.php) | Namespace invalidation (`user:123:*`) walking only the matching key slice, with a keys-visited comparison against a hash table | `STRING_TO_MIXED` |
-| [coverage-index.php](coverage-index.php) | Line-coverage index (`file -> line -> tests`) as one BITSET over packed keys, plus test-impact selection ("which tests must this diff run?"): interning, `union()`/`mergeWith()` merge of per-worker indexes, range-walk queries, sound escalation for changed lines with no recorded coverage, honest peak-RSS **and selection wall-time** comparison against the nested-array shape | `BITSET`, `STRING_TO_INT_HASH`, `INT_TO_MIXED` |
+| [coverage-index.php](coverage-index.php) | Line-coverage index (`file -> line -> tests`) as one BITSET over packed keys, plus test-impact selection ("which tests must this diff run?"): interning, `union()`/`mergeWith()` merge of per-worker indexes, range-walk queries, sound escalation for changed lines with no recorded coverage, and an honest peak-RSS **and selection wall-time** comparison against the nested-array shape — with selection written both as a per-id `first()`/`searchNext()` walk and as bulk `populationCount()`/`slice()`/`keys()`, since the usual "prefer bulk" rule does not transfer cleanly to a bounded range read | `BITSET`, `STRING_TO_INT_HASH`, `INT_TO_MIXED` |
 
 ## Choosing a type
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ php examples/quickstart.php
 | [ip-range-lookup.php](ip-range-lookup.php) | Floor lookup (`last()`) over range tables — IPs, tariffs, time buckets | `INT_TO_MIXED` |
 | [sliding-window-rate-limit.php](sliding-window-rate-limit.php) | Sliding-window rate limiting / rolling metrics — `deleteRange()` expiry that visits only aged-out buckets | `INT_TO_INT` |
 | [prefix-invalidation.php](prefix-invalidation.php) | Namespace invalidation (`user:123:*`) walking only the matching key slice, with a keys-visited comparison against a hash table | `STRING_TO_MIXED` |
+| [coverage-index.php](coverage-index.php) | Line-coverage index (`file -> line -> tests`) as one BITSET over packed keys: interning, `union()`/`mergeWith()` merge of per-worker indexes, range-walk queries, honest peak-RSS comparison against the nested-array shape | `BITSET`, `STRING_TO_INT_HASH`, `INT_TO_MIXED` |
 
 ## Choosing a type
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ php examples/quickstart.php
 | [ip-range-lookup.php](ip-range-lookup.php) | Floor lookup (`last()`) over range tables — IPs, tariffs, time buckets | `INT_TO_MIXED` |
 | [sliding-window-rate-limit.php](sliding-window-rate-limit.php) | Sliding-window rate limiting / rolling metrics — `deleteRange()` expiry that visits only aged-out buckets | `INT_TO_INT` |
 | [prefix-invalidation.php](prefix-invalidation.php) | Namespace invalidation (`user:123:*`) walking only the matching key slice, with a keys-visited comparison against a hash table | `STRING_TO_MIXED` |
-| [coverage-index.php](coverage-index.php) | Line-coverage index (`file -> line -> tests`) as one BITSET over packed keys: interning, `union()`/`mergeWith()` merge of per-worker indexes, range-walk queries, honest peak-RSS comparison against the nested-array shape | `BITSET`, `STRING_TO_INT_HASH`, `INT_TO_MIXED` |
+| [coverage-index.php](coverage-index.php) | Line-coverage index (`file -> line -> tests`) as one BITSET over packed keys, plus test-impact selection ("which tests must this diff run?"): interning, `union()`/`mergeWith()` merge of per-worker indexes, range-walk queries, sound escalation for changed lines with no recorded coverage, honest peak-RSS **and selection wall-time** comparison against the nested-array shape | `BITSET`, `STRING_TO_INT_HASH`, `INT_TO_MIXED` |
 
 ## Choosing a type
 

--- a/examples/benchmarks/judy-bench-all-types.php
+++ b/examples/benchmarks/judy-bench-all-types.php
@@ -22,7 +22,8 @@
  *   INT_TO_INT       — JudyLMemUsed via memoryUsage()
  *   INT_TO_MIXED     — JudyLMemUsed via memoryUsage() (ecalloc'd zvals not counted)
  *   INT_TO_PACKED    — JudyLMemUsed via memoryUsage() (emalloc'd packed bufs not counted)
- *   STRING_TO_*      — memoryUsage() returns NULL (no C-level accounting macro)
+ *   STRING_TO_*      — memoryUsage() is approximate (payload bytes only; libJudy
+ *                      exposes no accounting macro for JudySL/JudyHS)
  *
  * Usage:
  *   php examples/judy-bench-all-types.php [size] [iterations]
@@ -564,8 +565,9 @@ $results['STRING_TO_INT'] = [
         foreach ($str_int_data as $k => $v) { $j[$k] = $v; }
         return $j;
     }, $iterations),
-    'internal' => null,  // JudySL has no C-level memory accounting
-    'note'   => 'memoryUsage()=null (JudySL)',
+    'internal' => null,  // libJudy exposes no accounting for JudySL; the extension's
+                         // memoryUsage() approximation is deliberately not used here
+    'note'   => 'memoryUsage() approximate (JudySL)',
 ];
 
 // PHP string array — mixed values
@@ -632,8 +634,9 @@ $results['STRING_TO_MIXED'] = [
         foreach ($str_mixed_data as $k => $v) { $j[$k] = $v; }
         return $j;
     }, $iterations),
-    'internal' => null,  // JudySL has no C-level memory accounting
-    'note'   => 'memoryUsage()=null (JudySL)',
+    'internal' => null,  // libJudy exposes no accounting for JudySL; the extension's
+                         // memoryUsage() approximation is deliberately not used here
+    'note'   => 'memoryUsage() approximate (JudySL)',
 ];
 
 // STRING_TO_MIXED_HASH
@@ -666,8 +669,9 @@ $results['STRING_TO_MIXED_HASH'] = [
         foreach ($str_mixed_data as $k => $v) { $j[$k] = $v; }
         return $j;
     }, $iterations),
-    'internal' => null,  // JudyHS has no C-level memory accounting
-    'note'   => 'memoryUsage()=null (JudyHS)',
+    'internal' => null,  // libJudy exposes no accounting for JudyHS; the extension's
+                         // memoryUsage() approximation is deliberately not used here
+    'note'   => 'memoryUsage() approximate (JudyHS)',
 ];
 
 // STRING_TO_INT_HASH
@@ -700,8 +704,9 @@ $results['STRING_TO_INT_HASH'] = [
         foreach ($str_int_data as $k => $v) { $j[$k] = $v; }
         return $j;
     }, $iterations),
-    'internal' => null,  // JudyHS has no C-level memory accounting
-    'note'   => 'memoryUsage()=null (JudyHS)',
+    'internal' => null,  // libJudy exposes no accounting for JudyHS; the extension's
+                         // memoryUsage() approximation is deliberately not used here
+    'note'   => 'memoryUsage() approximate (JudyHS)',
 ];
 
 // ── Long-key string subjects (JudyHS O(1) vs JudySL O(k) demo) ────────

--- a/examples/benchmarks/judy-bench-memory-patterns.php
+++ b/examples/benchmarks/judy-bench-memory-patterns.php
@@ -9,10 +9,12 @@
  * internal Judy memory via JudyLMemUsed / Judy1MemUsed (O(1) lookup of the
  * JPM TotalMemWords counter).
  *
- * For JudySL (STRING_TO_INT, STRING_TO_MIXED), memoryUsage() returns NULL
- * because the Judy C library provides no JSLMU macro, and JudySL allocates
- * via C malloc (invisible to PHP's memory_get_usage()).  These types are
- * included in the insertion throughput comparison but not memory footprint.
+ * For JudySL (STRING_TO_INT, STRING_TO_MIXED) the C library provides no JSLMU
+ * macro, so memoryUsage() returns an APPROXIMATION maintained by the extension:
+ * payload bytes only (stored key bytes, value slots, zval boxes), excluding the
+ * trie nodes libJudy mallocs — which are invisible to PHP's memory_get_usage()
+ * as well. Treat the string-keyed figures below as a lower bound; the exact
+ * footprint needs Massif (judy-bench-memory.php) or peak RSS.
  *
  * All timings are median of N iterations using hrtime(true).
  */
@@ -221,9 +223,10 @@ foreach ($sizes as $size) {
 echo "\n";
 
 echo "  Note: STRING_TO_INT / STRING_TO_MIXED memory cannot be measured\n";
-echo "  directly. Judy::memoryUsage() returns NULL for these types (no\n";
-echo "  JudySL memory-accounting macro in the C library), and JudySL\n";
-echo "  allocates via C malloc — invisible to PHP's memory_get_usage().\n\n";
+echo "  exactly. Judy::memoryUsage() reports an approximation for these types\n";
+echo "  (payload bytes only — no JudySL memory-accounting macro exists), and\n";
+echo "  JudySL node memory goes through C malloc, invisible to\n";
+echo "  memory_get_usage(). Use Massif or peak RSS for the true figure.\n\n";
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // 2. memoryUsage() API details
@@ -267,7 +270,7 @@ foreach ($types as $name => $type) {
     $macro = match($type) {
         Judy::BITSET     => "J1MU",
         Judy::INT_TO_INT, Judy::INT_TO_MIXED => "JLMU",
-        default          => "(none)",
+        default          => "approx",
     };
 
     printf("  %-20s  %-12s  %-18s  %-12s\n", $name, $macro, $empty_str, $full_str);

--- a/examples/benchmarks/judy-bench-memory.php
+++ b/examples/benchmarks/judy-bench-memory.php
@@ -6,8 +6,9 @@
  * Massif. Each type is tested in an isolated sub-process so peak heap
  * measurements are per-type.
  *
- * This specifically measures libJudy.so's malloc allocations — the metric
- * that is missing for STRING_TO_* types where memoryUsage() returns null.
+ * This specifically measures libJudy.so's malloc allocations — the node
+ * overhead that the STRING_TO_* memoryUsage() approximation deliberately
+ * excludes (it counts payload only: key bytes, value slots, zval boxes).
  * PHP arrays use emalloc (mmap'd) and won't appear here; see the 'Heap delta'
  * column in judy-bench-all-types.php for PHP-level memory comparison.
  *
@@ -242,8 +243,8 @@ echo "  • Per element: net / $size\n";
 echo "  • Baseline: " . ($baseline !== null ? fmt($baseline) : '?') . "\n";
 echo "  • PHP array shows ~0 because PHP uses emalloc (mmap'd), not malloc — see\n";
 echo "    judy-bench-all-types.php 'Heap delta' column for PHP-level memory comparison\n";
-echo "  • Judy types show libJudy.so malloc overhead — this fills the gap for\n";
-echo "    STRING_TO_* types where memoryUsage() returns null\n";
+echo "  • Judy types show libJudy.so malloc overhead — the part the STRING_TO_*\n";
+echo "    memoryUsage() approximation excludes (it counts payload bytes only)\n";
 echo "  • MIXED types (INT_TO_MIXED, STRING_TO_MIXED) may undercount at large N:\n";
 echo "    PHP GC fires mid-loop, temporarily lowering tracked malloc heap; Massif\n";
 echo "    peak can be captured before loop completion. Use <=100K for reliable results.\n";

--- a/examples/benchmarks/judy-bench-realistic-judy.php
+++ b/examples/benchmarks/judy-bench-realistic-judy.php
@@ -41,7 +41,8 @@ foreach ($element_counts as $element_count) {
     $start_time = microtime(true);
     $judy = new Judy(Judy::STRING_TO_INT); foreach ($keys as $k) $judy[$k] = 1;
     $results[$scenario]['Judy']['Write Time'] = microtime(true) - $start_time;
-    // For string-based Judy arrays, memoryUsage() returns NULL, so we use size() as approximation
+    // For string-based Judy arrays memoryUsage() is only an approximation of the
+    // payload, so we use size() here instead
     $memory_usage = $judy->memoryUsage();
     if ($memory_usage === null) {
         // Estimate memory usage based on size and average string length

--- a/examples/coverage-index.php
+++ b/examples/coverage-index.php
@@ -1,0 +1,453 @@
+<?php
+/**
+ * Line-coverage index: "which tests executed this file:line?"
+ *
+ * Code-coverage tooling keeps, in memory, a structure shaped roughly like
+ *
+ *     file -> line -> [test identifier, test identifier, ...]
+ *
+ * with the test identifiers as strings. Over a large suite that is tens of
+ * millions of live zvals, which is why coverage runs are the thing that
+ * exhausts memory_limit. (The shape above is a *representative* model used
+ * for this demo, not a claim about any specific tool's current internals.)
+ *
+ * Four Judy properties line up on that workload at once:
+ *
+ *   1. line numbers are sparse integer keys;
+ *   2. intern the test names once, and "which tests cover this line" becomes
+ *      a set of small integers instead of a PHP array of strings;
+ *   3. merging per-worker indexes (ParaTest, --process-isolation) is one
+ *      set-union call running in C rather than a recursive array merge in
+ *      PHP — though see the notes at the bottom: an in-place nested-array
+ *      merge moves whole test lists by refcount, so the merge column is the
+ *      one to check rather than assume;
+ *   4. Judy allocates outside PHP's memory manager, so the index does not
+ *      count against memory_limit.
+ *
+ * The representation here is a single BITSET whose key packs the whole
+ * triple:
+ *
+ *     [ file id | line | test id ]   62 bits, always positive
+ *
+ * Because the key is ordered file-major, every test id for one file:line is
+ * a contiguous block, so a query is a range walk and a per-file report is a
+ * block-to-block walk. No nested containers, one Judy object per index.
+ *
+ * Judy memory is invisible to memory_get_usage(), so the comparison at the
+ * bottom re-executes this script once per variant and reads peak RSS from
+ * getrusage() in each child.
+ *
+ * Run: php examples/coverage-index.php [files] [linesPerFile] [tests]
+ * Set JUDY_SO=/path/to/judy.so if the extension is not enabled in php.ini.
+ *
+ * Numbers are only meaningful on an idle machine: check the load average
+ * before believing any row of the table.
+ */
+
+if (!extension_loaded('judy')) {
+    fwrite(STDERR, "The judy extension is not loaded.\n");
+    exit(1);
+}
+
+/* ── Key packing ─────────────────────────────────────────────────────── */
+
+const TEST_BITS = 22;                        // up to 4,194,304 distinct tests
+const LINE_BITS = 20;                        // up to 1,048,576 lines per file
+const FILE_BITS = 20;                        // up to 1,048,576 files
+const TEST_MASK = (1 << TEST_BITS) - 1;
+const LINE_MASK = (1 << LINE_BITS) - 1;
+
+function covKey(int $fileId, int $line, int $testId): int
+{
+    return ($fileId << (LINE_BITS + TEST_BITS)) | ($line << TEST_BITS) | $testId;
+}
+
+/** Interns strings to dense integer ids, and back. */
+final class Interner
+{
+    private Judy $ids;                       // name -> id
+    private Judy $names;                     // id   -> name
+    private int $next = 0;
+
+    public function __construct()
+    {
+        $this->ids   = new Judy(Judy::STRING_TO_INT_HASH); // point lookups only
+        $this->names = new Judy(Judy::INT_TO_MIXED);
+    }
+
+    public function intern(string $name): int
+    {
+        if (isset($this->ids[$name])) {
+            return $this->ids[$name];
+        }
+        $id = $this->next++;
+        $this->ids[$name]  = $id;
+        $this->names[$id]  = $name;
+        return $id;
+    }
+
+    public function name(int $id): ?string
+    {
+        return isset($this->names[$id]) ? $this->names[$id] : null;
+    }
+
+    public function count(): int
+    {
+        return $this->next;
+    }
+}
+
+/* ── Accumulate, merge, query ────────────────────────────────────────── */
+
+/** @param iterable<array{0:string,1:string,2:int[]}> $stream */
+function accumulateJudy(iterable $stream, Interner $files, Interner $tests): Judy
+{
+    $cov = new Judy(Judy::BITSET);
+    foreach ($stream as [$test, $path, $lines]) {
+        $fileId = $files->intern($path);
+        $testId = $tests->intern($test);
+        if ($fileId >> FILE_BITS !== 0 || $testId >> TEST_BITS !== 0) {
+            throw new RangeException('id space exhausted: widen the key layout');
+        }
+        // file id and test id are constant for the whole run of lines
+        $base = covKey($fileId, 0, $testId);
+        foreach ($lines as $line) {
+            $cov[$base | ($line << TEST_BITS)] = true;
+        }
+    }
+    return $cov;
+}
+
+/** The equivalent nested-array structure: file -> line -> list of test names. */
+function accumulateArray(iterable $stream): array
+{
+    $cov = [];
+    foreach ($stream as [$test, $path, $lines]) {
+        foreach ($lines as $line) {
+            $cov[$path][$line][] = $test;    // $test is one shared zend_string
+        }
+    }
+    return $cov;
+}
+
+/** Merge a worker's array index into $into, in place (the array's best case). */
+function mergeArray(array &$into, array $from): void
+{
+    foreach ($from as $path => $lines) {
+        foreach ($lines as $line => $tests) {
+            if (isset($into[$path][$line])) {
+                foreach ($tests as $t) {
+                    $into[$path][$line][] = $t;
+                }
+            } else {
+                $into[$path][$line] = $tests;
+            }
+        }
+    }
+}
+
+/** Test ids covering one file:line — a range walk over the id block. */
+function testsCovering(Judy $cov, int $fileId, int $line): array
+{
+    $hi  = covKey($fileId, $line, TEST_MASK);
+    $out = [];
+    for ($k = $cov->first(covKey($fileId, $line, 0)); $k !== null && $k <= $hi; $k = $cov->searchNext($k)) {
+        $out[] = $k & TEST_MASK;
+    }
+    return $out;
+}
+
+/** Executed lines of one file, jumping block to block instead of scanning. */
+function coveredLines(Judy $cov, int $fileId): array
+{
+    $end   = covKey($fileId, LINE_MASK, TEST_MASK);
+    $lines = [];
+    $k     = $cov->first(covKey($fileId, 0, 0));
+    while ($k !== null && $k <= $end) {
+        $line    = ($k >> TEST_BITS) & LINE_MASK;
+        $lines[] = $line;
+        if ($line >= LINE_MASK) {
+            break;
+        }
+        $k = $cov->first(covKey($fileId, $line + 1, 0)); // skip this line's test ids
+    }
+    return $lines;
+}
+
+/* ── Synthetic workload ──────────────────────────────────────────────── */
+
+const HOT_FILES    = 8;     // bootstrap/framework files nearly every test loads
+const HOT_PER_TEST = 3;
+const OWN_PER_TEST = 2;     // files a test exercises on its own
+const HIT_RATIO    = 0.10;  // fraction of a file's lines one test executes
+
+function filePath(int $f): string
+{
+    return sprintf('/app/src/Module%02d/Class%05d.php', intdiv($f, 100), $f);
+}
+
+/**
+ * Yields [testName, filePath, lines[]] — one item per (test, file) pair, so
+ * each name is built once and both variants see the same shared strings.
+ *
+ * @return Generator<array{0:string,1:string,2:int[]}>
+ */
+function coverageStream(int $files, int $linesPerFile, int $tests, int $worker, int $workers): Generator
+{
+    $hot = min(HOT_FILES, $files);
+    $run = max(1, (int) round($linesPerFile * HIT_RATIO));
+    mt_srand(20260817 + $worker);
+
+    for ($t = $worker; $t < $tests; $t += $workers) {
+        $test   = sprintf('App\\Tests\\Feature%dTest::testCase%d', intdiv($t, 20), $t % 20);
+        $picked = [];
+        for ($i = 0; $i < HOT_PER_TEST; $i++) {
+            $picked[mt_rand(0, $hot - 1)] = true;
+        }
+        for ($i = 0; $i < OWN_PER_TEST; $i++) {
+            $picked[mt_rand(0, $files - 1)] = true;
+        }
+        foreach (array_keys($picked) as $f) {
+            $path  = filePath($f);
+            $start = mt_rand(1, max(1, $linesPerFile - $run));
+            $lines = [];
+            for ($i = 0; $i < $run; $i++) {
+                if ($i % 3 !== 2) {          // roughly one line in three is a branch not taken
+                    $lines[] = $start + $i;
+                }
+            }
+            yield [$test, $path, $lines];
+        }
+    }
+}
+
+/** Fixed probe set both variants answer, so their answers can be compared. */
+function probeSet(int $files, int $linesPerFile): array
+{
+    $step   = max(1, intdiv($linesPerFile, 12));
+    $probes = [];
+    foreach ([0, 1, 2, 3, intdiv($files, 2), $files - 1] as $f) {
+        for ($l = 1; $l <= $linesPerFile; $l += $step) {
+            $probes[] = [$f, $l];
+        }
+    }
+    return $probes;
+}
+
+/* ── Child: run one variant, report peak RSS ─────────────────────────── */
+
+$files        = (int) ($argv[1] ?? 800);
+$linesPerFile = (int) ($argv[2] ?? 300);
+$tests        = (int) ($argv[3] ?? 2000);
+$mode         = $argv[4] ?? null;
+
+if ($mode !== null) {
+    $probes  = probeSet($files, $linesPerFile);
+    $answers = [];
+    $t0      = $t1 = $t2 = $t3 = hrtime(true);
+    $triples = 0;
+    $indexBytes = null;
+
+    if ($mode === 'floor') {
+        // An otherwise identical process that builds no index: the PHP runtime's
+        // own footprint, which both variants below pay before storing anything.
+    } elseif ($mode === 'union' || $mode === 'mergeWith') {
+        $fileIds = new Interner();
+        $testIds = new Interner();
+
+        $t0 = hrtime(true);
+        $a  = accumulateJudy(coverageStream($files, $linesPerFile, $tests, 0, 2), $fileIds, $testIds);
+        $b  = accumulateJudy(coverageStream($files, $linesPerFile, $tests, 1, 2), $fileIds, $testIds);
+        $t1 = hrtime(true);
+
+        // One C call for a whole worker index. Both indexes must share the same
+        // id space for this to be free — here the interners are shared; across
+        // real worker processes the coordinator must hand out the ids (or the
+        // ids must be remapped before the merge).
+        if ($mode === 'union') {
+            $cov = $a->union($b);     // new index; both inputs stay alive
+        } else {
+            $a->mergeWith($b);        // in place, like the array merge below
+            $cov = $a;
+        }
+        $t2 = hrtime(true);
+
+        foreach ($probes as [$f, $l]) {
+            // probes address files by path; the index addresses them by id
+            $names = array_map($testIds->name(...), testsCovering($cov, $fileIds->intern(filePath($f)), $l));
+            sort($names);
+            $answers[] = implode(',', $names);
+        }
+        $t3 = hrtime(true);
+
+        $triples   = count($cov);
+        $indexBytes = $cov->memoryUsage();
+    } else {
+        $t0 = hrtime(true);
+        $a  = accumulateArray(coverageStream($files, $linesPerFile, $tests, 0, 2));
+        $b  = accumulateArray(coverageStream($files, $linesPerFile, $tests, 1, 2));
+        $t1 = hrtime(true);
+
+        mergeArray($a, $b);
+        $cov = $a;
+        $t2  = hrtime(true);
+
+        foreach ($probes as [$f, $l]) {
+            $names = $cov[filePath($f)][$l] ?? [];
+            sort($names);
+            $answers[] = implode(',', $names);
+        }
+        $t3 = hrtime(true);
+
+        $triples = 0;
+        foreach ($cov as $lines) {
+            foreach ($lines as $list) {
+                $triples += count($list);
+            }
+        }
+        $indexBytes = null;
+    }
+
+    // ru_maxrss is bytes on macOS, kilobytes on Linux.
+    echo json_encode([
+        'variant'    => $mode,
+        'triples'    => $triples,
+        'accumulate' => ($t1 - $t0) / 1e9,
+        'merge'      => ($t2 - $t1) / 1e9,
+        'query'      => ($t3 - $t2) / 1e9,
+        'peak'       => getrusage()['ru_maxrss'] * (PHP_OS_FAMILY === 'Darwin' ? 1 : 1024),
+        'indexBytes' => $indexBytes,
+        'digest'     => md5(implode("\n", $answers)),
+    ]), "\n";
+    exit(0);
+}
+
+/* ── Parent: narrated demo, then the side-by-side ────────────────────── */
+
+echo "1. Accumulate, merge, query\n\n";
+
+$fileIds = new Interner();
+$testIds = new Interner();
+
+// Two "workers", as ParaTest or --process-isolation would produce.
+$worker1 = accumulateJudy([
+    ['SuiteA::testLogin',  '/app/src/Auth.php', [10, 11, 12, 40]],
+    ['SuiteA::testLogout', '/app/src/Auth.php', [10, 11, 55]],
+], $fileIds, $testIds);
+$worker2 = accumulateJudy([
+    ['SuiteB::testExpiry', '/app/src/Auth.php', [10, 60, 61]],
+    ['SuiteB::testExpiry', '/app/src/Clock.php', [7]],
+], $fileIds, $testIds);
+
+$merged = $worker1->union($worker2);          // whole-index merge, in C
+printf(
+    "   worker 1: %d line/test pairs, worker 2: %d, merged: %d\n",
+    count($worker1),
+    count($worker2),
+    count($merged),
+);
+
+$auth = $fileIds->intern('/app/src/Auth.php');
+printf("   lines covered in Auth.php: %s\n", implode(', ', coveredLines($merged, $auth)));
+
+foreach ([10, 55] as $line) {
+    $names = array_map($testIds->name(...), testsCovering($merged, $auth, $line));
+    printf("   Auth.php:%-3d covered by %d test(s): %s\n", $line, count($names), implode(', ', $names));
+}
+// Counting needs no materialisation at all.
+printf(
+    "   populationCount over the Auth.php:10 block: %d\n",
+    $merged->populationCount(covKey($auth, 10, 0), covKey($auth, 10, TEST_MASK)),
+);
+printf(
+    "   %d test names and %d paths are stored once, as ids everywhere else\n\n",
+    $testIds->count(),
+    $fileIds->count(),
+);
+
+echo "2. Peak RSS and wall time, one process per variant\n\n";
+printf(
+    "   workload: %s files x %s lines, %s tests (%d hot files every test loads)\n\n",
+    number_format($files),
+    number_format($linesPerFile),
+    number_format($tests),
+    min(HOT_FILES, $files),
+);
+
+// A child gets an explicit -n so an already-enabled judy.so in conf.d cannot
+// silently shadow the build under test, and memory_limit=-1 so the array
+// variant is not the one that dies (that it needs this and the Judy variant
+// does not is itself part of the story).
+$so = getenv('JUDY_SO') ?: (is_file(__DIR__ . '/../modules/judy.so') ? __DIR__ . '/../modules/judy.so' : null);
+$flags = $so !== null
+    ? '-n -d memory_limit=-1 -d extension=' . escapeshellarg($so)
+    : '-d memory_limit=-1';
+$self = escapeshellarg(__FILE__);
+
+$rows = [];
+foreach (['floor', 'array', 'union', 'mergeWith'] as $variant) {
+    $out  = shell_exec(sprintf('%s %s %s %d %d %d %s', PHP_BINARY, $flags, $self, $files, $linesPerFile, $tests, $variant));
+    $last = trim(strrchr("\n" . trim((string) $out), "\n") ?: '');
+    $row  = json_decode($last, true);
+    if (!is_array($row)) {
+        fwrite(STDERR, "child run failed for '$variant':\n$out\n");
+        exit(1);
+    }
+    $rows[$variant] = $row;
+
+    if ($variant === 'floor') {
+        printf("   %-20s %-33s peak RSS: %8.1f MB\n", 'floor', '(empty process, no index)', $row['peak'] / 1048576);
+        continue;
+    }
+    printf(
+        "   %-20s pairs: %-12s index: %8.1f MB   peak RSS: %8.1f MB   accumulate: %6.2fs   merge: %6.3fs   query: %6.3fs\n",
+        $variant === 'array' ? 'array (nested)' : "judy ($variant)",
+        number_format($row['triples']),
+        ($row['peak'] - $rows['floor']['peak']) / 1048576,
+        $row['peak'] / 1048576,
+        $row['accumulate'],
+        $row['merge'],
+        $row['query'],
+    );
+}
+
+echo "\n";
+$digests = array_unique([$rows['array']['digest'], $rows['union']['digest'], $rows['mergeWith']['digest']]);
+if (count($digests) !== 1) {
+    echo "   WARNING: the variants disagree on the probe queries.\n";
+} else {
+    printf("   every variant answers every probe query identically (%s)\n", $rows['array']['digest']);
+}
+printf("   Judy::memoryUsage() for the merged index: %.1f MB\n", $rows['union']['indexBytes'] / 1048576);
+
+echo "\n   array / judy  (>1 favours Judy)\n";
+foreach (['union', 'mergeWith'] as $variant) {
+    printf(
+        "     %-10s %5.2fx peak RSS   %5.2fx index   %5.2fx merge time\n",
+        $variant,
+        $rows['array']['peak'] / max(1, $rows[$variant]['peak']),
+        ($rows['array']['peak'] - $rows['floor']['peak']) / max(1, $rows[$variant]['peak'] - $rows['floor']['peak']),
+        $rows['array']['merge'] / max(1e-9, $rows[$variant]['merge']),
+    );
+}
+
+echo "\n";
+echo "Notes:\n";
+echo "  - peak RSS includes the PHP runtime, so the ratio understates the index\n";
+echo "    difference; the 'index' column is peak RSS minus the floor row.\n";
+echo "  - the array merge is measured in place, its best case: where a line is new\n";
+echo "    to the target it moves the whole test list by refcount, so its work is\n";
+echo "    O(distinct lines) plus the overlap. union() and mergeWith() are O(keys)\n";
+echo "    in C. Which side wins the merge column therefore depends on how much\n";
+echo "    the two workers overlap, not on Judy alone.\n";
+echo "  - union() builds a third index, so that row pays a transient copy of the\n";
+echo "    result; mergeWith() is the like-for-like in-place comparison.\n";
+echo "  - either merge is only free when both indexes share one test-id space.\n";
+echo "    Workers that intern independently must be remapped first.\n";
+echo "  - both merges here happen in one process. Real per-process workers must\n";
+echo "    also ship their index to the coordinator: the nested array serialises to\n";
+echo "    a structure as large as itself, while a BITSET's keys are a flat run of\n";
+echo "    integers (pack('J*', ...) over keys(), or one packed key per line).\n";
+echo "  - the Judy index does not count against memory_limit at all; the array\n";
+echo "    one does, which is what turns a large coverage run into a fatal error.\n";
+echo "  - a loaded machine invalidates every number above. Re-run when idle.\n";

--- a/examples/coverage-index.php
+++ b/examples/coverage-index.php
@@ -33,6 +33,18 @@
  * a contiguous block, so a query is a range walk and a per-file report is a
  * block-to-block walk. No nested containers, one Judy object per index.
  *
+ * The user-visible payoff of that index is test-impact selection: given the
+ * file:line pairs a diff touched, run the 40 tests that reach them instead of
+ * the whole 12,000-test suite. Section 2 does exactly that, and section 3
+ * times it against the nested array, because for this query it is *selection
+ * wall time* that matters rather than the memory story.
+ *
+ * Selection is only sound while the index is current, and the failure mode is
+ * silent: a changed line with no recorded coverage must mean "cannot prove
+ * safe, run more", never "no tests affected". Getting that backwards is how a
+ * test-selection tool quietly stops catching regressions, so the selector
+ * below escalates instead of returning an empty set.
+ *
  * Judy memory is invisible to memory_get_usage(), so the comparison at the
  * bottom re-executes this script once per variant and reads peak RSS from
  * getrusage() in each child.
@@ -84,6 +96,12 @@ final class Interner
         $this->ids[$name]  = $id;
         $this->names[$id]  = $name;
         return $id;
+    }
+
+    /** Lookup without interning: a query must not invent ids for unknown names. */
+    public function id(string $name): ?int
+    {
+        return isset($this->ids[$name]) ? $this->ids[$name] : null;
     }
 
     public function name(int $id): ?string
@@ -174,6 +192,128 @@ function coveredLines(Judy $cov, int $fileId): array
     return $lines;
 }
 
+/* ── Test-impact selection ───────────────────────────────────────────── */
+
+/*
+ * Both selectors answer the same question — "which tests must run for this
+ * set of changed file:line pairs?" — and must answer it identically, which
+ * the digest check at the bottom enforces.
+ *
+ * Three outcomes per changed line, and only the first is the happy path:
+ *
+ *   covered      the line has recorded coverage: select exactly its tests.
+ *   line-unknown the file is tracked but nothing ever executed this line --
+ *                new code, or code the last coverage run never reached. The
+ *                index cannot bound the blast radius, so widen to every test
+ *                that touches the file. Returning an empty set here is the
+ *                bug that makes a selection tool stop catching regressions.
+ *   file-unknown the file is absent from the index entirely. Nothing about
+ *                the suite can be proven, so the selection is *unbounded*:
+ *                the honest answer is "run everything".
+ *
+ * The tiering is a policy choice, not a Judy detail; the array selector below
+ * implements the identical policy so the comparison is like for like.
+ */
+
+/** @param list<array{0:string,1:int}> $changed */
+function selectJudy(Judy $cov, Interner $fileIds, Interner $testIds, array $changed): array
+{
+    $hits      = new Judy(Judy::BITSET);   // union of selected test ids
+    $covered   = 0;
+    $widened   = 0;
+    $unbounded = 0;
+
+    foreach ($changed as [$path, $line]) {
+        $fileId = $fileIds->id($path);
+        if ($fileId === null) {
+            $unbounded++;                  // no coverage recorded for this file
+            continue;
+        }
+
+        $lo = covKey($fileId, $line, 0);
+        $hi = covKey($fileId, $line, TEST_MASK);
+        $k  = $cov->first($lo);
+        if ($k === null || $k > $hi) {
+            // Nothing in this line's block. Widen to the whole file's block:
+            // still one contiguous range, just a much longer walk.
+            $widened++;
+            $hi = covKey($fileId, LINE_MASK, TEST_MASK);
+            $k  = $cov->first(covKey($fileId, 0, 0));
+        } else {
+            $covered++;
+        }
+
+        for (; $k !== null && $k <= $hi; $k = $cov->searchNext($k)) {
+            $hits[$k & TEST_MASK] = true;
+        }
+    }
+
+    $names = [];
+    for ($id = $hits->first(); $id !== null; $id = $hits->searchNext($id)) {
+        $names[] = $testIds->name($id);
+    }
+    sort($names);                          // ids are dense, names are not
+
+    return [
+        'tests'     => $names,
+        'covered'   => $covered,
+        'widened'   => $widened,
+        'unbounded' => $unbounded,
+    ];
+}
+
+/** The same policy over the nested array. @param list<array{0:string,1:int}> $changed */
+function selectArray(array $cov, array $changed): array
+{
+    $hits      = [];
+    $covered   = 0;
+    $widened   = 0;
+    $unbounded = 0;
+
+    foreach ($changed as [$path, $line]) {
+        if (!isset($cov[$path])) {
+            $unbounded++;
+            continue;
+        }
+        if (isset($cov[$path][$line])) {
+            $covered++;
+            foreach ($cov[$path][$line] as $t) {
+                $hits[$t] = true;
+            }
+        } else {
+            $widened++;
+            foreach ($cov[$path] as $list) {
+                foreach ($list as $t) {
+                    $hits[$t] = true;
+                }
+            }
+        }
+    }
+
+    $names = array_keys($hits);
+    sort($names);
+
+    return [
+        'tests'     => $names,
+        'covered'   => $covered,
+        'widened'   => $widened,
+        'unbounded' => $unbounded,
+    ];
+}
+
+/** How a runner should read a selection result. */
+function selectionVerdict(array $sel, int $suiteSize): string
+{
+    if ($sel['unbounded'] > 0) {
+        return sprintf(
+            'UNBOUNDED - %d changed file(s) absent from the index; run all %s tests',
+            $sel['unbounded'],
+            number_format($suiteSize),
+        );
+    }
+    return sprintf('%s of %s tests', number_format(count($sel['tests'])), number_format($suiteSize));
+}
+
 /* ── Synthetic workload ──────────────────────────────────────────────── */
 
 const HOT_FILES    = 8;     // bootstrap/framework files nearly every test loads
@@ -234,6 +374,51 @@ function probeSet(int $files, int $linesPerFile): array
     return $probes;
 }
 
+const CHANGED_FILES = 24;   // file:line pairs in the synthetic diff
+
+/**
+ * A synthetic diff: the file:line pairs a change touched.
+ *
+ * Drawn from the same deterministic stream both variants index, so these are
+ * genuinely executed lines — a real diff mostly touches code that runs. Hot
+ * files are skipped on purpose: a diff in framework bootstrap selects the
+ * whole suite and there is nothing to demonstrate. Two pairs are appended
+ * that the index deliberately cannot answer, to exercise both escalations.
+ *
+ * @return list<array{0:string,1:int}>
+ */
+function changedLines(int $files, int $linesPerFile, int $tests): array
+{
+    $hot = [];
+    for ($f = 0; $f < min(HOT_FILES, $files); $f++) {
+        $hot[filePath($f)] = true;
+    }
+
+    $changed = [];
+    $seen    = 0;
+    foreach (coverageStream($files, $linesPerFile, $tests, 0, 2) as [, $path, $lines]) {
+        if ($lines === [] || isset($hot[$path])) {
+            continue;
+        }
+        if ($seen++ % 37 !== 0) {          // spread the diff across the suite
+            continue;
+        }
+        $changed[] = [$path, $lines[intdiv(count($lines), 2)]];
+        if (count($changed) >= CHANGED_FILES) {
+            break;
+        }
+    }
+
+    // A line inside a tracked file that no test has ever executed. Deliberately
+    // not a hot file: widening one of those selects the suite and hides the
+    // difference between "widened" and "unbounded".
+    $changed[] = [$changed[0][0] ?? filePath($files - 1), $linesPerFile + 7];
+    // A file the index has never seen: added by this very diff.
+    $changed[] = ['/app/src/BrandNewClass.php', 12];
+
+    return $changed;
+}
+
 /* ── Child: run one variant, report peak RSS ─────────────────────────── */
 
 $files        = (int) ($argv[1] ?? 800);
@@ -241,12 +426,16 @@ $linesPerFile = (int) ($argv[2] ?? 300);
 $tests        = (int) ($argv[3] ?? 2000);
 $mode         = $argv[4] ?? null;
 
+const SELECT_ROUNDS = 25;   // selection is fast; average over a few rounds
+
 if ($mode !== null) {
     $probes  = probeSet($files, $linesPerFile);
+    $changed = changedLines($files, $linesPerFile, $tests);
     $answers = [];
-    $t0      = $t1 = $t2 = $t3 = hrtime(true);
+    $t0      = $t1 = $t2 = $t3 = $t4 = hrtime(true);
     $triples = 0;
     $indexBytes = null;
+    $sel        = ['tests' => [], 'covered' => 0, 'widened' => 0, 'unbounded' => 0];
 
     if ($mode === 'floor') {
         // An otherwise identical process that builds no index: the PHP runtime's
@@ -280,6 +469,11 @@ if ($mode !== null) {
         }
         $t3 = hrtime(true);
 
+        for ($r = 0; $r < SELECT_ROUNDS; $r++) {
+            $sel = selectJudy($cov, $fileIds, $testIds, $changed);
+        }
+        $t4 = hrtime(true);
+
         $triples   = count($cov);
         $indexBytes = $cov->memoryUsage();
     } else {
@@ -299,6 +493,11 @@ if ($mode !== null) {
         }
         $t3 = hrtime(true);
 
+        for ($r = 0; $r < SELECT_ROUNDS; $r++) {
+            $sel = selectArray($cov, $changed);
+        }
+        $t4 = hrtime(true);
+
         $triples = 0;
         foreach ($cov as $lines) {
             foreach ($lines as $list) {
@@ -315,9 +514,15 @@ if ($mode !== null) {
         'accumulate' => ($t1 - $t0) / 1e9,
         'merge'      => ($t2 - $t1) / 1e9,
         'query'      => ($t3 - $t2) / 1e9,
+        'select'     => ($t4 - $t3) / 1e9 / SELECT_ROUNDS,
         'peak'       => getrusage()['ru_maxrss'] * (PHP_OS_FAMILY === 'Darwin' ? 1 : 1024),
         'indexBytes' => $indexBytes,
         'digest'     => md5(implode("\n", $answers)),
+        'selected'   => count($sel['tests']),
+        'covered'    => $sel['covered'],
+        'widened'    => $sel['widened'],
+        'unbounded'  => $sel['unbounded'],
+        'selDigest'  => md5(implode("\n", $sel['tests'])),
     ]), "\n";
     exit(0);
 }
@@ -365,7 +570,54 @@ printf(
     $fileIds->count(),
 );
 
-echo "2. Peak RSS and wall time, one process per variant\n\n";
+echo "2. Test-impact selection: which tests must this diff run?\n\n";
+
+// A diff against the tiny index above: one covered line, one line in a tracked
+// file that no test reaches, one file the index has never seen.
+$diff = [
+    ['/app/src/Auth.php', 10],
+    ['/app/src/Auth.php', 99],
+    ['/app/src/Clock.php', 7],
+];
+$suiteSize = $testIds->count();
+
+$sel = selectJudy($merged, $fileIds, $testIds, $diff);
+foreach ($diff as [$path, $line]) {
+    $id  = $fileIds->id($path);
+    $lo  = $id === null ? 0 : covKey($id, $line, 0);
+    $hi  = $id === null ? 0 : covKey($id, $line, TEST_MASK);
+    // populationCount answers "is this line covered, and by how many tests?"
+    // over the block without materialising a single test id.
+    $n   = $id === null ? 0 : $merged->populationCount($lo, $hi);
+    printf(
+        "   %-22s %-24s -> %s\n",
+        $path . ':' . $line,
+        $id === null ? 'file not in index' : $n . ' test(s) recorded',
+        $id === null
+            ? 'UNBOUNDED: run the whole suite'
+            : ($n === 0 ? 'no coverage: widen to every test touching the file' : 'select those tests'),
+    );
+}
+printf("   selection: %s\n", selectionVerdict($sel, $suiteSize));
+printf("   tests: %s\n", implode(', ', $sel['tests']));
+printf(
+    "   %d line(s) covered, %d widened to file scope, %d file(s) not indexed\n\n",
+    $sel['covered'],
+    $sel['widened'],
+    $sel['unbounded'],
+);
+
+// The same diff without the unindexed file: now the selection is bounded.
+$bounded = selectJudy($merged, $fileIds, $testIds, [['/app/src/Auth.php', 55]]);
+printf("   Auth.php:55 alone selects %s\n\n", selectionVerdict($bounded, $suiteSize));
+
+echo "   A changed line with no recorded coverage is NOT 'no tests affected'.\n";
+echo "   It is 'this index cannot prove which tests reach it', and the only\n";
+echo "   safe response is to widen — to the file, or to the whole suite when\n";
+echo "   the file is unknown. A selector that returns the empty set there\n";
+echo "   stops catching regressions without ever reporting a failure.\n\n";
+
+echo "3. Peak RSS and wall time, one process per variant\n\n";
 printf(
     "   workload: %s files x %s lines, %s tests (%d hot files every test loads)\n\n",
     number_format($files),
@@ -400,7 +652,7 @@ foreach (['floor', 'array', 'union', 'mergeWith'] as $variant) {
         continue;
     }
     printf(
-        "   %-20s pairs: %-12s index: %8.1f MB   peak RSS: %8.1f MB   accumulate: %6.2fs   merge: %6.3fs   query: %6.3fs\n",
+        "   %-20s pairs: %-12s index: %8.1f MB   peak RSS: %8.1f MB   accumulate: %6.2fs   merge: %6.3fs   query: %6.3fs   select: %8.3f ms\n",
         $variant === 'array' ? 'array (nested)' : "judy ($variant)",
         number_format($row['triples']),
         ($row['peak'] - $rows['floor']['peak']) / 1048576,
@@ -408,6 +660,7 @@ foreach (['floor', 'array', 'union', 'mergeWith'] as $variant) {
         $row['accumulate'],
         $row['merge'],
         $row['query'],
+        $row['select'] * 1000,
     );
 }
 
@@ -418,16 +671,45 @@ if (count($digests) !== 1) {
 } else {
     printf("   every variant answers every probe query identically (%s)\n", $rows['array']['digest']);
 }
+$selDigests = array_unique([$rows['array']['selDigest'], $rows['union']['selDigest'], $rows['mergeWith']['selDigest']]);
+if (count($selDigests) !== 1) {
+    echo "   WARNING: the variants select different test sets for the same diff.\n";
+} else {
+    printf("   every variant selects the identical test set for the diff (%s)\n", $rows['array']['selDigest']);
+}
 printf("   Judy::memoryUsage() for the merged index: %.1f MB\n", $rows['union']['indexBytes'] / 1048576);
+
+$sel = $rows['union'];
+printf(
+    "\n   diff of %d file:line pairs -> %s selected of %s tests in the suite\n",
+    $sel['covered'] + $sel['widened'] + $sel['unbounded'],
+    number_format($sel['selected']),
+    number_format($tests),
+);
+printf(
+    "   %d covered exactly, %d widened to file scope (line not in the index),\n   %d file(s) absent from the index\n",
+    $sel['covered'],
+    $sel['widened'],
+    $sel['unbounded'],
+);
+if ($sel['unbounded'] > 0) {
+    printf(
+        "   -> the selection is UNBOUNDED: a correct runner ignores the %s above\n"
+        . "      and runs all %s tests until the index covers those files.\n",
+        number_format($sel['selected']),
+        number_format($tests),
+    );
+}
 
 echo "\n   array / judy  (>1 favours Judy)\n";
 foreach (['union', 'mergeWith'] as $variant) {
     printf(
-        "     %-10s %5.2fx peak RSS   %5.2fx index   %5.2fx merge time\n",
+        "     %-10s %5.2fx peak RSS   %5.2fx index   %5.2fx merge time   %5.2fx selection time\n",
         $variant,
         $rows['array']['peak'] / max(1, $rows[$variant]['peak']),
         ($rows['array']['peak'] - $rows['floor']['peak']) / max(1, $rows[$variant]['peak'] - $rows['floor']['peak']),
         $rows['array']['merge'] / max(1e-9, $rows[$variant]['merge']),
+        $rows['array']['select'] / max(1e-9, $rows[$variant]['select']),
     );
 }
 
@@ -450,4 +732,25 @@ echo "    a structure as large as itself, while a BITSET's keys are a flat run o
 echo "    integers (pack('J*', ...) over keys(), or one packed key per line).\n";
 echo "  - the Judy index does not count against memory_limit at all; the array\n";
 echo "    one does, which is what turns a large coverage run into a fatal error.\n";
+echo "  - do not expect Judy to win the selection column, and do not read it as a\n";
+echo "    broken build if it does not. The array reaches a line's whole test list\n";
+echo "    in two hash lookups and then iterates it inside the VM; the block walk\n";
+echo "    crosses PHP into C once per test id (one first(), then one searchNext()\n";
+echo "    each). Per changed line the array does O(1) boundary crossings and Judy\n";
+echo "    does O(tests on that line), so the array can be ahead on a small diff\n";
+echo "    even though both walk the same number of entries.\n";
+echo "  - what Judy actually buys on this query is that the index still exists at\n";
+echo "    suite scale (section 3's memory columns), that populationCount() prices\n";
+echo "    a block without materialising it (section 2 uses it to ask 'is this line\n";
+echo "    covered at all, and how widely?' before deciding what to do), and that a\n";
+echo "    BITSET accumulator returns the union deduplicated and already in order.\n";
+echo "    Selection speed is the payoff of having the index, not of the walk.\n";
+echo "  - a widened line walks the file's whole block, which for a hot file is\n";
+echo "    most of the suite. Both shapes pay that; it is the price of being\n";
+echo "    sound rather than the price of the representation.\n";
+echo "  - selection is only as good as the index is fresh. Every line the last\n";
+echo "    coverage run did not reach widens, so a stale index degrades toward\n";
+echo "    'run everything' — which is safe. The dangerous variant is a selector\n";
+echo "    that treats an unrecorded line as 'no tests affected': it degrades\n";
+echo "    toward running nothing, silently, and no test failure ever reports it.\n";
 echo "  - a loaded machine invalidates every number above. Re-run when idle.\n";

--- a/examples/coverage-index.php
+++ b/examples/coverage-index.php
@@ -45,6 +45,12 @@
  * test-selection tool quietly stops catching regressions, so the selector
  * below escalates instead of returning an empty set.
  *
+ * That selection is written twice — a per-id first()/searchNext() walk and a
+ * bulk populationCount()+slice()+keys() shape — because which one is cheaper
+ * is genuinely not obvious here, and the usual "prefer bulk operations" rule
+ * turns out not to transfer cleanly to a bounded range read. Both are timed;
+ * see the notes at the bottom.
+ *
  * Judy memory is invisible to memory_get_usage(), so the comparison at the
  * bottom re-executes this script once per variant and reads peak RSS from
  * getrusage() in each child.
@@ -262,6 +268,86 @@ function selectJudy(Judy $cov, Interner $fileIds, Interner $testIds, array $chan
     ];
 }
 
+/**
+ * The same policy, same answer, bulk operations instead of a per-id walk.
+ *
+ * selectJudy() above crosses from PHP into C once per test id in the block:
+ * one first(), then one searchNext() each. That is the per-element-dispatch
+ * shape BENCHMARK.md's bulk-operation tables warn about, and it is not the
+ * only tool available. Here each block is lifted whole:
+ *
+ *   populationCount($lo, $hi)  is the block empty, and how big? No allocation.
+ *   slice($lo, $hi)            the whole block as a new Judy, one C call.
+ *   keys()                     that block as a PHP array, one more C call.
+ *
+ * Three crossings per changed line regardless of how many tests cover it,
+ * and the mask then runs at VM speed over a plain array — the same kind of
+ * work the array baseline does when it iterates a line's test list.
+ *
+ * Fewer crossings is not automatically less work, though, and this is the
+ * interesting part. getAll() and toArray() are fast because they make ONE
+ * traversal and write straight into the destination PHP array. There is no
+ * range-limited equivalent — no keys($lo, $hi) — so bounding a read to one
+ * block has to go through slice(), and slice() is a copy constructor, not a
+ * projection: Judy::slice in php_judy.c runs the same J1F/J1N traversal the
+ * walk does, but J1S-inserts every key into a freshly allocated Judy, which
+ * keys() then traverses a second time to build the array. The bulk route
+ * therefore pays two traversals, an insert per key and an allocation per
+ * changed line in order to avoid a PHP method dispatch per key.
+ *
+ * So the bulk-operations rule of thumb does not transfer to a range read the
+ * way it does to getAll()/toArray(), and neither shape is obviously right.
+ * Both are kept, and section 3 times both, so the example measures the
+ * question instead of asserting an answer. Check the two columns on an idle
+ * machine for your own block sizes rather than trusting either story here.
+ *
+ * @param list<array{0:string,1:int}> $changed
+ */
+function selectJudyBulk(Judy $cov, Interner $fileIds, Interner $testIds, array $changed): array
+{
+    $hits      = [];                       // test id => true, deduped by the VM
+    $covered   = 0;
+    $widened   = 0;
+    $unbounded = 0;
+
+    foreach ($changed as [$path, $line]) {
+        $fileId = $fileIds->id($path);
+        if ($fileId === null) {
+            $unbounded++;
+            continue;
+        }
+
+        $lo = covKey($fileId, $line, 0);
+        $hi = covKey($fileId, $line, TEST_MASK);
+        // Prices the block without materialising it, so the empty case costs
+        // one call and allocates nothing.
+        if ($cov->populationCount($lo, $hi) === 0) {
+            $widened++;
+            $lo = covKey($fileId, 0, 0);
+            $hi = covKey($fileId, LINE_MASK, TEST_MASK);
+        } else {
+            $covered++;
+        }
+
+        foreach ($cov->slice($lo, $hi)->keys() as $k) {
+            $hits[$k & TEST_MASK] = true;
+        }
+    }
+
+    $names = [];
+    foreach (array_keys($hits) as $id) {
+        $names[] = $testIds->name($id);
+    }
+    sort($names);
+
+    return [
+        'tests'     => $names,
+        'covered'   => $covered,
+        'widened'   => $widened,
+        'unbounded' => $unbounded,
+    ];
+}
+
 /** The same policy over the nested array. @param list<array{0:string,1:int}> $changed */
 function selectArray(array $cov, array $changed): array
 {
@@ -436,6 +522,8 @@ if ($mode !== null) {
     $triples = 0;
     $indexBytes = null;
     $sel        = ['tests' => [], 'covered' => 0, 'widened' => 0, 'unbounded' => 0];
+    $bulkTime   = null;                    // judy variants only: the slice() shape
+    $bulkDigest = null;
 
     if ($mode === 'floor') {
         // An otherwise identical process that builds no index: the PHP runtime's
@@ -469,10 +557,18 @@ if ($mode !== null) {
         }
         $t3 = hrtime(true);
 
+        // Shape 1: the per-id first()/searchNext() walk.
         for ($r = 0; $r < SELECT_ROUNDS; $r++) {
             $sel = selectJudy($cov, $fileIds, $testIds, $changed);
         }
         $t4 = hrtime(true);
+
+        // Shape 2: bulk slice() + keys(). Same answer, different cost profile.
+        for ($r = 0; $r < SELECT_ROUNDS; $r++) {
+            $bulkSel = selectJudyBulk($cov, $fileIds, $testIds, $changed);
+        }
+        $bulkTime   = (hrtime(true) - $t4) / 1e9 / SELECT_ROUNDS;
+        $bulkDigest = md5(implode("\n", $bulkSel['tests']));
 
         $triples   = count($cov);
         $indexBytes = $cov->memoryUsage();
@@ -515,6 +611,8 @@ if ($mode !== null) {
         'merge'      => ($t2 - $t1) / 1e9,
         'query'      => ($t3 - $t2) / 1e9,
         'select'     => ($t4 - $t3) / 1e9 / SELECT_ROUNDS,
+        'selectBulk' => $bulkTime,
+        'bulkDigest' => $bulkDigest,
         'peak'       => getrusage()['ru_maxrss'] * (PHP_OS_FAMILY === 'Darwin' ? 1 : 1024),
         'indexBytes' => $indexBytes,
         'digest'     => md5(implode("\n", $answers)),
@@ -607,6 +705,14 @@ printf(
     $sel['unbounded'],
 );
 
+// Same policy, same answer, bulk ops: one populationCount() + slice() + keys()
+// per changed line instead of a first()/searchNext() dispatch per test id.
+$bulk = selectJudyBulk($merged, $fileIds, $testIds, $diff);
+printf(
+    "   the slice()+keys() bulk shape selects the same set: %s\n\n",
+    $bulk['tests'] === $sel['tests'] ? 'yes' : 'NO — the two shapes disagree',
+);
+
 // The same diff without the unindexed file: now the selection is bounded.
 $bounded = selectJudy($merged, $fileIds, $testIds, [['/app/src/Auth.php', 55]]);
 printf("   Auth.php:55 alone selects %s\n\n", selectionVerdict($bounded, $suiteSize));
@@ -652,7 +758,7 @@ foreach (['floor', 'array', 'union', 'mergeWith'] as $variant) {
         continue;
     }
     printf(
-        "   %-20s pairs: %-12s index: %8.1f MB   peak RSS: %8.1f MB   accumulate: %6.2fs   merge: %6.3fs   query: %6.3fs   select: %8.3f ms\n",
+        "   %-20s pairs: %-12s index: %8.1f MB   peak RSS: %8.1f MB   accumulate: %6.2fs   merge: %6.3fs   query: %6.3fs   select: %8.3f ms%s\n",
         $variant === 'array' ? 'array (nested)' : "judy ($variant)",
         number_format($row['triples']),
         ($row['peak'] - $rows['floor']['peak']) / 1048576,
@@ -661,6 +767,7 @@ foreach (['floor', 'array', 'union', 'mergeWith'] as $variant) {
         $row['merge'],
         $row['query'],
         $row['select'] * 1000,
+        $row['selectBulk'] === null ? '' : sprintf('  (bulk slice()+keys(): %8.3f ms)', $row['selectBulk'] * 1000),
     );
 }
 
@@ -671,11 +778,24 @@ if (count($digests) !== 1) {
 } else {
     printf("   every variant answers every probe query identically (%s)\n", $rows['array']['digest']);
 }
-$selDigests = array_unique([$rows['array']['selDigest'], $rows['union']['selDigest'], $rows['mergeWith']['selDigest']]);
+// Every shape — nested array, per-id walk, bulk slice()+keys() — must select
+// byte-identically. This assertion is the one thing here machine load cannot
+// invalidate, so it is the one thing worth trusting on a busy box.
+$selDigests = array_unique([
+    $rows['array']['selDigest'],
+    $rows['union']['selDigest'],
+    $rows['union']['bulkDigest'],
+    $rows['mergeWith']['selDigest'],
+    $rows['mergeWith']['bulkDigest'],
+]);
 if (count($selDigests) !== 1) {
     echo "   WARNING: the variants select different test sets for the same diff.\n";
 } else {
-    printf("   every variant selects the identical test set for the diff (%s)\n", $rows['array']['selDigest']);
+    printf(
+        "   array, per-id walk and bulk slice()+keys() select the identical test\n"
+        . "   set for the diff (%s)\n",
+        $rows['array']['selDigest'],
+    );
 }
 printf("   Judy::memoryUsage() for the merged index: %.1f MB\n", $rows['union']['indexBytes'] / 1048576);
 
@@ -704,12 +824,13 @@ if ($sel['unbounded'] > 0) {
 echo "\n   array / judy  (>1 favours Judy)\n";
 foreach (['union', 'mergeWith'] as $variant) {
     printf(
-        "     %-10s %5.2fx peak RSS   %5.2fx index   %5.2fx merge time   %5.2fx selection time\n",
+        "     %-10s %5.2fx peak RSS   %5.2fx index   %5.2fx merge time   %5.2fx selection (walk)   %5.2fx selection (bulk)\n",
         $variant,
         $rows['array']['peak'] / max(1, $rows[$variant]['peak']),
         ($rows['array']['peak'] - $rows['floor']['peak']) / max(1, $rows[$variant]['peak'] - $rows['floor']['peak']),
         $rows['array']['merge'] / max(1e-9, $rows[$variant]['merge']),
         $rows['array']['select'] / max(1e-9, $rows[$variant]['select']),
+        $rows['array']['select'] / max(1e-9, $rows[$variant]['selectBulk']),
     );
 }
 
@@ -732,19 +853,27 @@ echo "    a structure as large as itself, while a BITSET's keys are a flat run o
 echo "    integers (pack('J*', ...) over keys(), or one packed key per line).\n";
 echo "  - the Judy index does not count against memory_limit at all; the array\n";
 echo "    one does, which is what turns a large coverage run into a fatal error.\n";
-echo "  - do not expect Judy to win the selection column, and do not read it as a\n";
-echo "    broken build if it does not. The array reaches a line's whole test list\n";
-echo "    in two hash lookups and then iterates it inside the VM; the block walk\n";
-echo "    crosses PHP into C once per test id (one first(), then one searchNext()\n";
-echo "    each). Per changed line the array does O(1) boundary crossings and Judy\n";
-echo "    does O(tests on that line), so the array can be ahead on a small diff\n";
-echo "    even though both walk the same number of entries.\n";
-echo "  - what Judy actually buys on this query is that the index still exists at\n";
-echo "    suite scale (section 3's memory columns), that populationCount() prices\n";
-echo "    a block without materialising it (section 2 uses it to ask 'is this line\n";
-echo "    covered at all, and how widely?' before deciding what to do), and that a\n";
-echo "    BITSET accumulator returns the union deduplicated and already in order.\n";
-echo "    Selection speed is the payoff of having the index, not of the walk.\n";
+echo "  - the two selection columns are the same query written two ways: a per-id\n";
+echo "    first()/searchNext() walk, and bulk populationCount()+slice()+keys().\n";
+echo "    The walk crosses PHP into C once per test id; the bulk shape crosses a\n";
+echo "    fixed three times per changed line and masks at VM speed.\n";
+echo "  - fewer crossings is not automatically less work, and this is the case\n";
+echo "    where the usual 'prefer bulk operations' advice does not carry over.\n";
+echo "    getAll() and toArray() win because they make one traversal straight\n";
+echo "    into the destination PHP array. There is no range-limited equivalent,\n";
+echo "    so a bounded read has to go through slice() — and slice() copies the\n";
+echo "    range into a newly allocated Judy (a J1S insert per key) before keys()\n";
+echo "    traverses it a second time. Two traversals plus an allocation, to save\n";
+echo "    one method dispatch per key. Read both columns before choosing.\n";
+echo "  - measure this one for your own diff shape rather than reasoning about\n";
+echo "    it: the crossover depends on how many tests cover a changed line, and\n";
+echo "    a diff mixes tiny exactly-covered blocks with whole-file widenings.\n";
+echo "  - either way, do not conclude anything about the representation from the\n";
+echo "    selection columns alone. What Judy buys here is that the index still\n";
+echo "    exists at suite scale (the memory columns above), and that\n";
+echo "    populationCount() prices a block without materialising it, so 'is this\n";
+echo "    line covered at all?' costs one call and no allocation even when the\n";
+echo "    honest answer is a hot file covered by most of the suite.\n";
 echo "  - a widened line walks the file's whole block, which for a hot file is\n";
 echo "    most of the suite. Both shapes pay that; it is the price of being\n";
 echo "    sound rather than the price of the representation.\n";

--- a/judy_handlers.c
+++ b/judy_handlers.c
@@ -274,6 +274,10 @@ zend_object *judy_object_clone(zend_object *this_ptr)
 
 	new_obj->array = newJArray;
 	new_obj->counter = old_obj->counter;
+	/* The approximate payload total is a pure function of the key set and the
+	   value shape, and a clone reproduces both — so it carries over with the
+	   population count rather than being re-derived by a second O(n) walk. */
+	new_obj->approx_payload_bytes = old_obj->approx_payload_bytes;
 	/* Do not trust a copied append watermark: force the next `$j[] =` to
 	 * recompute the empty slot, otherwise a cloned array would append at
 	 * index 0 and overwrite an existing element. */

--- a/package.xml
+++ b/package.xml
@@ -61,6 +61,7 @@
          <file name="examples/ip-range-lookup.php" role="doc" />
          <file name="examples/sliding-window-rate-limit.php" role="doc" />
          <file name="examples/prefix-invalidation.php" role="doc" />
+        <file name="examples/coverage-index.php" role="doc" />
          <file name="examples/benchmarks/benchmark_ordered_data.php" role="doc" />
          <file name="examples/benchmarks/benchmark_ordered_data_demo.php" role="doc" />
          <file name="examples/benchmarks/benchmark_range_queries.php" role="doc" />

--- a/package.xml
+++ b/package.xml
@@ -143,6 +143,8 @@
          <file name="tests/judy_memuse_003.phpt" role="test" />
          <file name="tests/judy_memuse_004.phpt" role="test" />
          <file name="tests/judy_memuse_005.phpt" role="test" />
+         <file name="tests/judy_memuse_string_approx_001.phpt" role="test" />
+         <file name="tests/judy_memuse_string_approx_002.phpt" role="test" />
          <file name="tests/int_to_packed_001.phpt" role="test" />
          <file name="tests/int_to_packed_002.phpt" role="test" />
          <file name="tests/int_to_packed_003.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -244,7 +244,12 @@
          <file md5sum="b0cc6ab42f008869e910866de849b69d" name="tests/count_method_loop_int_to_int_001.phpt" role="test" />
          <file md5sum="8f9c1801c661a32ef99b82a580f371a6" name="tests/count_method_loop_string_to_mixed_001.phpt" role="test" />
          <file md5sum="5b661d339be8f777c72c752df9266a18" name="tests/foreach_negative_indices_int_to_int_001.phpt" role="test" />
-         <file md5sum="fc98800804890cf1e121d123107267fd" name="tests/foreach_with_vardump_int_to_int_001.phpt" role="test" />
+         <file name="tests/foreach_with_vardump_int_to_int_001.phpt" role="test" />
+         <file name="tests/debug_info_var_dump_001.phpt" role="test" />
+         <file name="tests/debug_info_empty_001.phpt" role="test" />
+         <file name="tests/debug_info_truncation_001.phpt" role="test" />
+         <file name="tests/debug_info_preview_size_ini_001.phpt" role="test" />
+         <file name="tests/debug_info_dynamic_property_001.phpt" role="test" />
          <file md5sum="cc7b8b87898284e32df206f2d13b0992" name="tests/strings_as_keys.phpt" role="test" />
          <file md5sum="8b18c913476fa203cf3d6d23bb3a1272" name="tests/strings_as_values.phpt" role="test" />
          <file name="tests/bulk_insert_counter_001.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -170,6 +170,7 @@ static Word_t judy_free_array_internal(judy_object *intern)
 
 	intern->array = NULL;
 	intern->counter = 0;
+	intern->approx_payload_bytes = 0;
 
 	return Rc_word;
 }
@@ -587,6 +588,7 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 		}
 		if (existing == NULL) {
 			intern->counter++;
+			judy_string_bytes_add(intern, klen);
 		}
 		break;
 
@@ -598,6 +600,7 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 		/* A MIXED slot holds a zval*, so NULL unambiguously means "new". */
 		if (JUDY_MVAL_READ(slot) == NULL) {
 			intern->counter++;
+			judy_string_bytes_add(intern, klen);
 		}
 		break;
 
@@ -631,6 +634,7 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 			   control deletes this exact line and requires the assertions to
 			   fire, so that the harness cannot rot into a no-op. */
 			intern->counter++; /* judy-mirror-negative-control */
+			judy_string_bytes_add(intern, klen);
 		}
 		break;
 
@@ -651,6 +655,7 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 				return FAILURE;
 			}
 			intern->counter++;
+			judy_string_bytes_add(intern, klen);
 		}
 		break;
 
@@ -673,6 +678,7 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 					return FAILURE;
 				}
 				intern->counter++;
+				judy_string_bytes_add(intern, klen);
 			}
 		} else {
 			JHSG(existing, intern->hs_array, (uint8_t *)key, klen);
@@ -687,6 +693,7 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 					return FAILURE;
 				}
 				intern->counter++;
+				judy_string_bytes_add(intern, klen);
 			}
 		}
 		break;
@@ -709,6 +716,7 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 					return FAILURE;
 				}
 				intern->counter++;
+				judy_string_bytes_add(intern, klen);
 			}
 		} else {
 			JHSI(slot, intern->hs_array, (uint8_t *)key, klen);
@@ -722,6 +730,7 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 					return FAILURE;
 				}
 				intern->counter++;
+				judy_string_bytes_add(intern, klen);
 			}
 		}
 		break;
@@ -1126,6 +1135,7 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 					JSLD(Rc_idx_del, intern->key_index, key);
 					if (Rc_idx_del == 1) {
 						intern->counter--;
+						judy_string_bytes_sub(intern, key_len);
 					}
 				}
 			}
@@ -1145,6 +1155,7 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 					JSLD(Rc_idx_del, intern->key_index, key);
 					if (Rc_idx_del == 1) {
 						intern->counter--;
+						judy_string_bytes_sub(intern, key_len);
 					}
 				}
 			}
@@ -1165,6 +1176,7 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 		}
 		if (Rc_int == 1) {
 			intern->counter--;
+			judy_string_bytes_sub(intern, (Word_t)Z_STRLEN_P(pstring_key));
 		}
 	} else if (intern->type == TYPE_STRING_TO_MIXED_HASH) {
 		Pvoid_t     *HValue;
@@ -1182,6 +1194,7 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 				JSLD(Rc_del, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
 				if (Rc_del == 1) {
 					intern->counter--;
+					judy_string_bytes_sub(intern, key_len);
 				}
 			}
 		}
@@ -1198,6 +1211,7 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 				JSLD(Rc_del, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
 				if (Rc_del == 1) {
 					intern->counter--;
+					judy_string_bytes_sub(intern, key_len);
 				}
 			}
 		}
@@ -1402,7 +1416,20 @@ PHP_METHOD(Judy, free)
 /* }}} */
 
 /* {{{ proto long Judy::memoryUsage()
-   Return the memory used by the Judy Array */
+   Return the memory used by the Judy Array.
+
+   Two different numbers wear this one name, and callers have to know which:
+
+     - Integer-keyed types (BITSET, INT_TO_*) return libJudy's EXACT total,
+       read in O(1) from the Judy1/JudyL root counter.
+     - String-keyed types return the extension's own APPROXIMATE payload total
+       (judy_string_entry_bytes()): key bytes plus value slots plus zval boxes,
+       excluding everything libJudy allocates for its trie and hash nodes. It is
+       a lower bound, not a measurement. JudySL/JudyHS expose no accounting to
+       do better; returning null instead — as this method did before — left the
+       only visible figure for the types most likely to hold a large working set
+       at nothing at all, since Judy memory is invisible to memory_get_usage()
+       and to Xdebug alike. */
 PHP_METHOD(Judy, memoryUsage)
 {
 	Word_t     Rc_word;
@@ -1420,6 +1447,14 @@ PHP_METHOD(Judy, memoryUsage)
 			case TYPE_INT_TO_PACKED:
 				JLMU(Rc_word, intern->array);
 				RETURN_LONG(Rc_word);
+				break;
+			case TYPE_STRING_TO_INT:
+			case TYPE_STRING_TO_MIXED:
+			case TYPE_STRING_TO_INT_HASH:
+			case TYPE_STRING_TO_MIXED_HASH:
+			case TYPE_STRING_TO_INT_ADAPTIVE:
+			case TYPE_STRING_TO_MIXED_ADAPTIVE:
+				RETURN_LONG(intern->approx_payload_bytes);
 				break;
 			default:
 				RETURN_NULL();
@@ -3178,6 +3213,7 @@ PHP_METHOD(Judy, slice)
 					JUDY_MVAL_WRITE(PNew, new_value);
 				}
 				result->counter++;
+				judy_string_bytes_add(result, (Word_t)strlen((char *)key));
 				JSLN(PValue, intern->array, key);
 			}
 		}
@@ -3229,6 +3265,7 @@ PHP_METHOD(Judy, slice)
 						goto alloc_error;
 					}
 					result->counter++;
+					judy_string_bytes_add(result, klen);
 				}
 				JSLN(KValue, intern->key_index, key);
 			}
@@ -3275,6 +3312,7 @@ PHP_METHOD(Judy, slice)
 						goto alloc_error;
 					}
 					result->counter++;
+					judy_string_bytes_add(result, klen);
 				}
 				JSLN(KValue, intern->key_index, key);
 			}
@@ -3363,6 +3401,7 @@ PHP_METHOD(Judy, slice)
 						goto alloc_error;
 					}
 					result->counter++;
+					judy_string_bytes_add(result, klen);
 				}
 				JSLN(KValue, intern->key_index, key);
 			}
@@ -3718,8 +3757,11 @@ static HashTable *judy_object_get_debug_info(zend_object *object, int *is_temp)
 	ZVAL_LONG(&tmp, intern->counter);
 	zend_hash_str_update(ht, "count", sizeof("count") - 1, &tmp);
 
-	/* Mirrors Judy::memoryUsage(): JudySL/JudyHS provide no accounting, so
-	 * string-keyed types report null here too. */
+	/* Mirrors Judy::memoryUsage(), including the fact that the number means two
+	 * different things: libJudy's exact total for the integer-keyed types, the
+	 * extension's approximate payload total for the string-keyed ones. The
+	 * string-keyed dumps carry an extra memoryUsageIsApproximate entry so that
+	 * nobody reading an IDE variable pane has to know that rule in advance. */
 	switch (intern->type) {
 		case TYPE_BITSET: {
 			Word_t Rc_word;
@@ -3736,9 +3778,19 @@ static HashTable *judy_object_get_debug_info(zend_object *object, int *is_temp)
 			break;
 		}
 		default:
-			ZVAL_NULL(&tmp);
+			if (intern->is_string_keyed) {
+				ZVAL_LONG(&tmp, intern->approx_payload_bytes);
+			} else {
+				ZVAL_NULL(&tmp);
+			}
 	}
 	zend_hash_str_update(ht, "memoryUsage", sizeof("memoryUsage") - 1, &tmp);
+
+	if (intern->is_string_keyed) {
+		ZVAL_TRUE(&tmp);
+		zend_hash_str_update(ht, "memoryUsageIsApproximate",
+			sizeof("memoryUsageIsApproximate") - 1, &tmp);
+	}
 
 	judy_debug_boundary_key(intern, &tmp, 0);
 	zend_hash_str_update(ht, "firstKey", sizeof("firstKey") - 1, &tmp);
@@ -4132,6 +4184,7 @@ PHP_METHOD(Judy, deleteRange)
 			if (Rc_idx_del) {
 				deleted++;
 				intern->counter--;
+				judy_string_bytes_sub(intern, klen);
 			}
 
 			if (value != NULL) {
@@ -4195,6 +4248,7 @@ PHP_METHOD(Judy, deleteRange)
 				if (Rc_idx_del) {
 					deleted++;
 					intern->counter--;
+					judy_string_bytes_sub(intern, klen);
 				}
 				if (value != NULL) {
 					zval_ptr_dtor(value);
@@ -4213,6 +4267,7 @@ PHP_METHOD(Judy, deleteRange)
 				if (Rc_str_del) {
 					deleted++;
 					intern->counter--;
+					judy_string_bytes_sub(intern, (Word_t)strlen((char *)key));
 				}
 				if (value != NULL) {
 					zval_ptr_dtor(value);

--- a/php_judy.c
+++ b/php_judy.c
@@ -41,6 +41,7 @@ zend_object_handlers judy_handlers;
 static void php_judy_init_globals(zend_judy_globals *judy_globals)
 {
 	judy_globals->max_length = 65536;
+	judy_globals->debug_preview_size = PHP_JUDY_DEFAULT_DEBUG_PREVIEW_SIZE;
 }
 /* }}} */
 
@@ -416,6 +417,7 @@ PHP_JUDY_API zend_class_entry *php_judy_ce(void)
 */
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("judy.string.maxlength", "65536", PHP_INI_ALL, OnUpdateLong, max_length, zend_judy_globals, judy_globals)
+	STD_PHP_INI_ENTRY("judy.debug_preview_size", PHP_JUDY_STR(PHP_JUDY_DEFAULT_DEBUG_PREVIEW_SIZE), PHP_INI_ALL, OnUpdateLong, debug_preview_size, zend_judy_globals, judy_globals)
 PHP_INI_END()
 /* }}} */
 
@@ -1208,6 +1210,8 @@ static inline int judy_object_write_dimension_helper_zv(judy_object *intern, zva
 	return judy_object_write_dimension_helper(&object_zv, offset, value);
 }
 
+static HashTable *judy_object_get_debug_info(zend_object *object, int *is_temp);
+
 /* {{{ PHP_MINIT_FUNCTION
 */
 PHP_MINIT_FUNCTION(judy)
@@ -1237,6 +1241,7 @@ PHP_MINIT_FUNCTION(judy)
 	judy_handlers.dtor_obj = zend_objects_destroy_object;
 	judy_handlers.free_obj = judy_object_free_storage;
 	judy_handlers.get_gc = judy_object_get_gc;
+	judy_handlers.get_debug_info = judy_object_get_debug_info;
 	judy_handlers.offset = offsetof(judy_object, std);
 
 	/* implements some interface to provide access to judy object as an array */
@@ -3221,15 +3226,34 @@ typedef enum {
 } judy_collect_mode;
 
 /* {{{ Helper to build a PHP array from a Judy array's contents.
-   Used by jsonSerialize(), __serialize(), toArray(), keys(), and values(). */
-static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mode mode)
+   Used by jsonSerialize(), __serialize(), toArray(), keys(), values(), and the
+   bounded preview built by get_debug_info().
+
+   `limit` < 0 collects everything; `limit` >= 0 stops after that many elements.
+   `cursor` overrides the shared intern->key_scratch walk buffer for string-keyed
+   types; pass a private buffer when the caller may run while a manual
+   rewind()/next() iteration holds the shared one (debug dumps do). */
+static void judy_populate_array_ex(judy_object *intern, zval *data, judy_collect_mode mode,
+		zend_long limit, uint8_t *cursor)
 {
+	zend_long emitted = 0;
+
+	if (limit == 0) {
+		return;
+	}
+	if (cursor == NULL) {
+		cursor = intern->key_scratch;
+	}
+
 	if (intern->type == TYPE_BITSET) {
 		Word_t index = 0;
 		int Rc_int;
 
 		J1F(Rc_int, intern->array, index);
 		while (Rc_int) {
+			if (limit >= 0 && emitted++ >= limit) {
+				break;
+			}
 			/* BITSET is a set of indices — the index IS the value.
 			   keys(), values(), and toArray() all return the same flat index list. */
 			add_next_index_long(data, (zend_long)index);
@@ -3242,6 +3266,9 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 
 		JLF(PValue, intern->array, index);
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
+			if (limit >= 0 && emitted++ >= limit) {
+				break;
+			}
 			if (mode == JUDY_COLLECT_KEYS) {
 				add_next_index_long(data, (zend_long)index);
 			} else if (intern->type == TYPE_INT_TO_INT) {
@@ -3289,12 +3316,15 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 		}
 
 	} else if (intern->is_adaptive) {
-		uint8_t *key = intern->key_scratch;
+		uint8_t *key = cursor;
 		Pvoid_t *PValue;
 		key[0] = '\0';
 		JSLF(PValue, intern->key_index, key);
 
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
+			if (limit >= 0 && emitted++ >= limit) {
+				break;
+			}
 			if (mode == JUDY_COLLECT_KEYS) {
 				add_next_index_string(data, (const char *)key);
 			} else {
@@ -3336,7 +3366,7 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 		}
 
 	} else { /* is_string_keyed */
-		uint8_t *key = intern->key_scratch;
+		uint8_t *key = cursor;
 		Pvoid_t *PValue;
 
 		key[0] = '\0';
@@ -3347,6 +3377,9 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 		}
 
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
+			if (limit >= 0 && emitted++ >= limit) {
+				break;
+			}
 			if (mode == JUDY_COLLECT_KEYS) {
 				add_next_index_string(data, (const char *)key);
 			} else {
@@ -3389,10 +3422,197 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 	}
 }
 
+static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mode mode)
+{
+	judy_populate_array_ex(intern, data, mode, -1, NULL);
+}
+
 static void judy_build_data_array(judy_object *intern, zval *data)
 {
 	judy_populate_array(intern, data, JUDY_COLLECT_ALL);
 }
+
+/* {{{ judy_type_name — human-readable name for a judy_type.
+   The debug output shows this rather than the raw integer constant. */
+static const char *judy_type_name(zend_long type)
+{
+	switch (type) {
+		case TYPE_BITSET:                   return "BITSET";
+		case TYPE_INT_TO_INT:               return "INT_TO_INT";
+		case TYPE_INT_TO_MIXED:             return "INT_TO_MIXED";
+		case TYPE_INT_TO_PACKED:            return "INT_TO_PACKED";
+		case TYPE_STRING_TO_INT:            return "STRING_TO_INT";
+		case TYPE_STRING_TO_MIXED:          return "STRING_TO_MIXED";
+		case TYPE_STRING_TO_INT_HASH:       return "STRING_TO_INT_HASH";
+		case TYPE_STRING_TO_MIXED_HASH:     return "STRING_TO_MIXED_HASH";
+		case TYPE_STRING_TO_INT_ADAPTIVE:   return "STRING_TO_INT_ADAPTIVE";
+		case TYPE_STRING_TO_MIXED_ADAPTIVE: return "STRING_TO_MIXED_ADAPTIVE";
+		default:                            return "UNINITIALIZED";
+	}
+}
+/* }}} */
+
+/* {{{ judy_debug_boundary_key — first (or last) key present, as a zval.
+   Ordered types only report a boundary; an empty array reports null. */
+static void judy_debug_boundary_key(judy_object *intern, zval *out, int want_last)
+{
+	ZVAL_NULL(out);
+
+	if (intern->type == TYPE_BITSET) {
+		Word_t index = want_last ? (Word_t)-1 : 0;
+		int Rc_int;
+
+		if (want_last) {
+			J1L(Rc_int, intern->array, index);
+		} else {
+			J1F(Rc_int, intern->array, index);
+		}
+		if (Rc_int == 1) {
+			ZVAL_LONG(out, (zend_long)index);
+		}
+	} else if (intern->is_integer_keyed) {
+		Word_t index = want_last ? (Word_t)-1 : 0;
+		PWord_t PValue;
+
+		if (want_last) {
+			JLL(PValue, intern->array, index);
+		} else {
+			JLF(PValue, intern->array, index);
+		}
+		if (PValue != NULL && PValue != PJERR) {
+			ZVAL_LONG(out, (zend_long)index);
+		}
+	} else if (intern->is_string_keyed) {
+		/* Private buffer: a debugger may inspect mid-iteration, and the shared
+		 * intern->key_scratch is live during a manual rewind()/next() walk. */
+		uint8_t *key = emalloc(PHP_JUDY_MAX_LENGTH);
+		Pvoid_t index_array = intern->is_hash_keyed ? intern->key_index : intern->array;
+		PWord_t PValue;
+
+		if (want_last) {
+			memset(key, 0xff, PHP_JUDY_MAX_LENGTH);
+			key[PHP_JUDY_MAX_LENGTH - 1] = '\0';
+			JSLL(PValue, index_array, key);
+		} else {
+			key[0] = '\0';
+			JSLF(PValue, index_array, key);
+		}
+		if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
+			ZVAL_STRING(out, (char *)key);
+		}
+		efree(key);
+	}
+}
+/* }}} */
+
+/* {{{ judy_object_get_debug_info — what var_dump()/print_r()/Xdebug/the IDE
+   variable panel (DBGp) show for a Judy object.
+
+   Without this handler the engine falls back to zend_std_get_debug_info, which
+   returns the (always empty) declared-properties table: a Judy holding millions
+   of elements renders as an opaque `object(Judy)#1 (0) {}`.
+
+   The element preview is deliberately BOUNDED by judy.debug_preview_size
+   (default PHP_JUDY_DEFAULT_DEBUG_PREVIEW_SIZE). Dumping every element of a
+   large Judy would hang the IDE session or overflow the debug transport, and a
+   debug dump must stay cheap enough to be safe at a breakpoint. Setting the INI
+   to 0 disables the element preview entirely, leaving only metadata. Whenever
+   fewer elements are shown than the array holds — including the 0 case — a
+   `previewTruncated` entry states the TRUE total, so the preview can never be
+   mistaken for the whole array. */
+static HashTable *judy_object_get_debug_info(zend_object *object, int *is_temp)
+{
+	judy_object *intern = php_judy_object(object);
+	HashTable *ht;
+	zval tmp;
+	zend_long limit;
+	zend_long shown;
+
+	*is_temp = 1;
+	ht = zend_new_array(8);
+
+	/* Keep any dynamic properties visible: they showed up in var_dump() before
+	 * this handler existed, and the synthetic entries below take precedence on
+	 * a name clash. */
+	if (object->properties && zend_hash_num_elements(object->properties) > 0) {
+		zend_string *pkey;
+		zval *pval;
+
+		ZEND_HASH_FOREACH_STR_KEY_VAL(object->properties, pkey, pval) {
+			if (pkey == NULL) {
+				continue;
+			}
+			if (Z_TYPE_P(pval) == IS_INDIRECT) {
+				pval = Z_INDIRECT_P(pval);
+			}
+			if (Z_TYPE_P(pval) == IS_UNDEF) {
+				continue;
+			}
+			Z_TRY_ADDREF_P(pval);
+			zend_hash_update(ht, pkey, pval);
+		} ZEND_HASH_FOREACH_END();
+	}
+
+	ZVAL_STRING(&tmp, judy_type_name(intern->type));
+	zend_hash_str_update(ht, "type", sizeof("type") - 1, &tmp);
+
+	ZVAL_LONG(&tmp, intern->counter);
+	zend_hash_str_update(ht, "count", sizeof("count") - 1, &tmp);
+
+	/* Mirrors Judy::memoryUsage(): JudySL/JudyHS provide no accounting, so
+	 * string-keyed types report null here too. */
+	switch (intern->type) {
+		case TYPE_BITSET: {
+			Word_t Rc_word;
+			J1MU(Rc_word, intern->array);
+			ZVAL_LONG(&tmp, (zend_long)Rc_word);
+			break;
+		}
+		case TYPE_INT_TO_INT:
+		case TYPE_INT_TO_MIXED:
+		case TYPE_INT_TO_PACKED: {
+			Word_t Rc_word;
+			JLMU(Rc_word, intern->array);
+			ZVAL_LONG(&tmp, (zend_long)Rc_word);
+			break;
+		}
+		default:
+			ZVAL_NULL(&tmp);
+	}
+	zend_hash_str_update(ht, "memoryUsage", sizeof("memoryUsage") - 1, &tmp);
+
+	judy_debug_boundary_key(intern, &tmp, 0);
+	zend_hash_str_update(ht, "firstKey", sizeof("firstKey") - 1, &tmp);
+	judy_debug_boundary_key(intern, &tmp, 1);
+	zend_hash_str_update(ht, "lastKey", sizeof("lastKey") - 1, &tmp);
+
+	limit = JUDY_G(debug_preview_size);
+	if (limit < 0) {
+		limit = 0;
+	}
+
+	array_init(&tmp);
+	if (intern->type != 0 && limit > 0) {
+		uint8_t *cursor = intern->is_string_keyed ? emalloc(PHP_JUDY_MAX_LENGTH) : NULL;
+		judy_populate_array_ex(intern, &tmp, JUDY_COLLECT_ALL, limit, cursor);
+		if (cursor) {
+			efree(cursor);
+		}
+	}
+	shown = (zend_long)zend_hash_num_elements(Z_ARRVAL(tmp));
+	zend_hash_str_update(ht, "preview", sizeof("preview") - 1, &tmp);
+
+	if (shown < intern->counter) {
+		zend_string *note = zend_strpprintf(0,
+			"showing " ZEND_LONG_FMT " of " ZEND_LONG_FMT " elements (judy.debug_preview_size=" ZEND_LONG_FMT ")",
+			shown, intern->counter, limit);
+		ZVAL_STR(&tmp, note);
+		zend_hash_str_update(ht, "previewTruncated", sizeof("previewTruncated") - 1, &tmp);
+	}
+
+	return ht;
+}
+/* }}} */
 
 /* {{{ proto array Judy::keys()
    Return the keys of the Judy array */

--- a/php_judy.h
+++ b/php_judy.h
@@ -196,6 +196,7 @@ typedef struct _judy_object {
 	Pvoid_t         key_index;           /* 8 */
 	Pvoid_t         hs_array;            /* 8 — for longer strings in ADAPTIVE type */
 	zend_long       counter;             /* 8 */
+	zend_long       approx_payload_bytes;/* 8 — string-keyed types only; see judy_string_entry_bytes() */
 	Word_t			next_empty;          /* 8 */
 	zend_long       type;                /* 8 */
 	/* Iterator state for Iterator interface methods */
@@ -236,6 +237,83 @@ static inline void judy_init_type_flags(judy_object *intern, zend_long jtype)
 	intern->is_hash_keyed = (jtype == TYPE_STRING_TO_MIXED_HASH || jtype == TYPE_STRING_TO_INT_HASH || jtype == TYPE_STRING_TO_MIXED_ADAPTIVE || jtype == TYPE_STRING_TO_INT_ADAPTIVE);
 	intern->is_adaptive = (jtype == TYPE_STRING_TO_MIXED_ADAPTIVE || jtype == TYPE_STRING_TO_INT_ADAPTIVE);
 }
+
+/* {{{ Approximate payload accounting for the string-keyed types.
+
+   libJudy exposes no accounting for JudySL/JudyHS — there is no JudySLMemUsed
+   twin of JudyLMemUsed — so Judy::memoryUsage() has nothing exact to report for
+   the six string-keyed types. Instead the extension keeps its own running total,
+   maintained wherever intern->counter is, of the bytes it can attribute to each
+   live entry:
+
+     - the key bytes as stored, counted once per structure that holds a copy.
+       The *_HASH types store every key twice (once in the JudyHS value store,
+       once in the JudySL key_index); ADAPTIVE packs keys shorter than 8 bytes
+       into the JudyL index word rather than copying them into JudyHS, so only
+       its long keys are counted twice.
+     - the Word_t value slot.
+     - for the _MIXED variants, the sizeof(zval) box the extension emallocs to
+       hold the value.
+
+   What the total EXCLUDES, and why it is only ever an approximation: every byte
+   libJudy allocates for its own trie branches, leaves and JudyHS hash
+   structures; allocator rounding; and the PHP heap reachable from a stored zval
+   (the string or array it points at, which memory_get_usage() does see). It is
+   a LOWER BOUND on the real footprint — for JudyHS-backed types the node
+   overhead is a large fraction of the total — and it must never be presented
+   with the authority of the exact JudyLMemUsed figure the integer-keyed types
+   return. It IS exact for what it claims: key bytes plus value slots plus zval
+   boxes, and so it is a sound basis for tracking growth and comparing
+   populations of the same type. */
+static inline zend_long judy_string_entry_bytes(const judy_object *intern, Word_t klen)
+{
+	zend_long bytes;
+
+	switch (intern->type) {
+	case TYPE_STRING_TO_INT:
+	case TYPE_STRING_TO_MIXED:
+		/* Plain JudySL: one NUL-terminated key copy, value in the same trie. */
+		bytes = (zend_long)klen + 1 + (zend_long)sizeof(Word_t);
+		break;
+	case TYPE_STRING_TO_INT_HASH:
+	case TYPE_STRING_TO_MIXED_HASH:
+		/* JudyHS key copy + JudySL key_index copy + value slot. */
+		bytes = (zend_long)klen + (zend_long)klen + 1 + (zend_long)sizeof(Word_t);
+		break;
+	case TYPE_STRING_TO_INT_ADAPTIVE:
+	case TYPE_STRING_TO_MIXED_ADAPTIVE:
+		/* key_index copy + value slot; long keys are copied into JudyHS too,
+		   short ones are packed into the JudyL index and cost nothing extra. */
+		bytes = (zend_long)klen + 1 + (zend_long)sizeof(Word_t);
+		if (klen >= 8) {
+			bytes += (zend_long)klen;
+		}
+		break;
+	default:
+		return 0;
+	}
+
+	if (intern->is_mixed_value) {
+		bytes += (zend_long)sizeof(zval);
+	}
+	return bytes;
+}
+
+static inline void judy_string_bytes_add(judy_object *intern, Word_t klen)
+{
+	intern->approx_payload_bytes += judy_string_entry_bytes(intern, klen);
+}
+
+static inline void judy_string_bytes_sub(judy_object *intern, Word_t klen)
+{
+	zend_long bytes = judy_string_entry_bytes(intern, klen);
+
+	/* Clamp rather than go negative: a partially-failed clone or a rolled-back
+	   insert must never make memoryUsage() report a nonsense value. */
+	intern->approx_payload_bytes =
+		(intern->approx_payload_bytes > bytes) ? intern->approx_payload_bytes - bytes : 0;
+}
+/* }}} */
 
 /* Max length, this must be a constant for it to work in
  * declarings as we cannot use runtime decided values at

--- a/php_judy.h
+++ b/php_judy.h
@@ -261,8 +261,19 @@ int judy_unpack_value(judy_packed_value *packed, zval *rv);
     zend_declare_class_constant_long(judy_ce, const_name, sizeof(const_name)-1, (zend_long) value);
 /* }}} */
 
+/* Default number of elements shown by var_dump()/print_r()/debugger panels
+ * (get_debug_info). Bounded so that dumping a multi-million-element Judy
+ * neither hangs the IDE nor blows the DBGp transport. */
+#define PHP_JUDY_DEFAULT_DEBUG_PREVIEW_SIZE 16
+
+/* Local stringifier: ZEND_TOSTR is not available across every supported PHP
+ * version, and the INI default has to be a string literal. */
+#define PHP_JUDY_STR_(x) #x
+#define PHP_JUDY_STR(x)  PHP_JUDY_STR_(x)
+
 ZEND_BEGIN_MODULE_GLOBALS(judy)
     unsigned long    max_length;
+    zend_long        debug_preview_size;
 ZEND_END_MODULE_GLOBALS(judy)
 
 ZEND_EXTERN_MODULE_GLOBALS(judy)

--- a/scripts/api-metadata.php
+++ b/scripts/api-metadata.php
@@ -149,12 +149,12 @@ PHP,
             'description' => 'Frees all memory used by the Judy array and resets the element count. Returns the number of bytes freed (or 0 for string-keyed types).',
         ],
         'memoryUsage' => [
-            'description' => 'Returns the number of bytes used by the internal Judy structure. Returns `null` for string-keyed types (JudySL and JudyHS do not provide memory accounting).',
+            'description' => "Returns the number of bytes used by the internal Judy structure. **The number means two different things depending on the key category, and callers must know which.** Integer-keyed types return libJudy's *exact* figure. String-keyed types return an *approximate* figure the extension maintains itself, because JudySL/JudyHS expose no accounting: it counts only the payload — stored key bytes (counted twice for the `_HASH` types, which hold each key in both the value store and the key index), one machine word per value slot, and the `zval` box allocated for each `_MIXED` value — and excludes everything libJudy allocates for its own trie and hash nodes. Treat it as a **lower bound**, good for tracking growth within one array, not for comparing against the exact figure. Both variants are O(1) and return `0` for a newly constructed or emptied array.",
             'table' => [
                 'headers' => ['Supported Types', 'Returns'],
                 'rows' => [
-                    ['BITSET, INT_TO_INT, INT_TO_MIXED, INT_TO_PACKED', '`int` (bytes)'],
-                    ['All string-keyed types', '`null`'],
+                    ['BITSET, INT_TO_INT, INT_TO_MIXED, INT_TO_PACKED', '`int` (bytes, exact — `Judy1MemUsed`/`JudyLMemUsed`)'],
+                    ['All string-keyed types', '`int` (bytes, **approximate** — payload only, excludes libJudy node overhead)'],
                 ],
             ],
         ],
@@ -364,8 +364,8 @@ PHP,
     'compatibility_matrix' => [
         '`memoryUsage()`' => [
             'BITSET' => 'int', 'INT_TO_INT' => 'int', 'INT_TO_MIXED' => 'int', 'INT_TO_PACKED' => 'int',
-            'STR_INT' => 'null', 'STR_MIXED' => 'null', 'STR_INT_HASH' => 'null', 'STR_MIX_HASH' => 'null',
-            'STR_INT_ADAPT' => 'null', 'STR_MIX_ADAPT' => 'null',
+            'STR_INT' => 'approx', 'STR_MIXED' => 'approx', 'STR_INT_HASH' => 'approx', 'STR_MIX_HASH' => 'approx',
+            'STR_INT_ADAPT' => 'approx', 'STR_MIX_ADAPT' => 'approx',
         ],
         '`union/intersect/diff/xor`' => [
             'BITSET' => 'yes', 'INT_TO_INT' => 'yes', 'INT_TO_MIXED' => '-', 'INT_TO_PACKED' => '-',
@@ -404,7 +404,7 @@ PHP,
         ],
     ],
 
-    'matrix_legend' => '**Legend**: `yes` = supported, `-` = throws exception, `null` = silently returns null, `int` = returns integer value.',
+    'matrix_legend' => '**Legend**: `yes` = supported, `-` = throws exception, `null` = silently returns null, `int` = returns an exact integer value, `approx` = returns an approximate integer value (see the method entry).',
     'matrix_footer' => 'All other methods (`slice`, `deleteRange`, `forEach`, `filter`, `map`, `keys`, `values`, `equals`, `mergeWith`, `toArray`, `fromArray`, `putAll`, `getAll`) work with all 10 types.',
 
     // ── Global functions ────────────────────────────────────────

--- a/tests/debug_info_dynamic_property_001.phpt
+++ b/tests/debug_info_dynamic_property_001.phpt
@@ -1,0 +1,32 @@
+--TEST--
+get_debug_info: dynamic properties stay visible and never shadow the synthetic entries
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--INI--
+judy.debug_preview_size=16
+error_reporting=E_ALL & ~E_DEPRECATED
+--FILE--
+<?php
+$j = new Judy(Judy::INT_TO_INT);
+$j[1] = 10;
+$j->label = "cache index";
+// A property named like a synthetic entry must not hide the real value.
+$j->type = "impostor";
+
+$info = print_r($j, true);
+echo preg_replace('/^\s+\[memoryUsage\].*\n/m', '', $info);
+?>
+--EXPECT--
+Judy Object
+(
+    [label] => cache index
+    [type] => INT_TO_INT
+    [count] => 1
+    [firstKey] => 1
+    [lastKey] => 1
+    [preview] => Array
+        (
+            [1] => 10
+        )
+
+)

--- a/tests/debug_info_empty_001.phpt
+++ b/tests/debug_info_empty_001.phpt
@@ -1,0 +1,135 @@
+--TEST--
+get_debug_info: empty and never-constructed Judy objects dump without boundary keys
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--INI--
+judy.debug_preview_size=16
+--FILE--
+<?php
+// Empty of every key category: bitset, integer-keyed, trie string-keyed,
+// hash string-keyed and adaptive string-keyed.
+foreach ([
+    Judy::BITSET,
+    Judy::INT_TO_INT,
+    Judy::STRING_TO_MIXED,
+    Judy::STRING_TO_INT_HASH,
+    Judy::STRING_TO_MIXED_ADAPTIVE,
+] as $type) {
+    var_dump(new Judy($type));
+}
+
+// Emptied after use: the boundary keys must go back to null.
+$j = new Judy(Judy::STRING_TO_MIXED);
+$j["a"] = 1;
+unset($j["a"]);
+var_dump($j);
+
+// Never constructed (no type argument): must not crash.
+var_dump(new Judy());
+?>
+--EXPECTF--
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(6) "BITSET"
+  ["count"]=>
+  int(0)
+  ["memoryUsage"]=>
+  int(%d)
+  ["firstKey"]=>
+  NULL
+  ["lastKey"]=>
+  NULL
+  ["preview"]=>
+  array(0) {
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(10) "INT_TO_INT"
+  ["count"]=>
+  int(0)
+  ["memoryUsage"]=>
+  int(%d)
+  ["firstKey"]=>
+  NULL
+  ["lastKey"]=>
+  NULL
+  ["preview"]=>
+  array(0) {
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(15) "STRING_TO_MIXED"
+  ["count"]=>
+  int(0)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  NULL
+  ["lastKey"]=>
+  NULL
+  ["preview"]=>
+  array(0) {
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(18) "STRING_TO_INT_HASH"
+  ["count"]=>
+  int(0)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  NULL
+  ["lastKey"]=>
+  NULL
+  ["preview"]=>
+  array(0) {
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(24) "STRING_TO_MIXED_ADAPTIVE"
+  ["count"]=>
+  int(0)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  NULL
+  ["lastKey"]=>
+  NULL
+  ["preview"]=>
+  array(0) {
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(15) "STRING_TO_MIXED"
+  ["count"]=>
+  int(0)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  NULL
+  ["lastKey"]=>
+  NULL
+  ["preview"]=>
+  array(0) {
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(13) "UNINITIALIZED"
+  ["count"]=>
+  int(0)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  NULL
+  ["lastKey"]=>
+  NULL
+  ["preview"]=>
+  array(0) {
+  }
+}

--- a/tests/debug_info_empty_001.phpt
+++ b/tests/debug_info_empty_001.phpt
@@ -58,13 +58,15 @@ object(Judy)#%d (6) {
   array(0) {
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(15) "STRING_TO_MIXED"
   ["count"]=>
   int(0)
   ["memoryUsage"]=>
-  NULL
+  int(0)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   NULL
   ["lastKey"]=>
@@ -73,13 +75,15 @@ object(Judy)#%d (6) {
   array(0) {
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(18) "STRING_TO_INT_HASH"
   ["count"]=>
   int(0)
   ["memoryUsage"]=>
-  NULL
+  int(0)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   NULL
   ["lastKey"]=>
@@ -88,13 +92,15 @@ object(Judy)#%d (6) {
   array(0) {
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(24) "STRING_TO_MIXED_ADAPTIVE"
   ["count"]=>
   int(0)
   ["memoryUsage"]=>
-  NULL
+  int(0)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   NULL
   ["lastKey"]=>
@@ -103,13 +109,15 @@ object(Judy)#%d (6) {
   array(0) {
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(15) "STRING_TO_MIXED"
   ["count"]=>
   int(0)
   ["memoryUsage"]=>
-  NULL
+  int(0)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   NULL
   ["lastKey"]=>

--- a/tests/debug_info_preview_size_ini_001.phpt
+++ b/tests/debug_info_preview_size_ini_001.phpt
@@ -1,0 +1,69 @@
+--TEST--
+judy.debug_preview_size: default, runtime ini_set, 0 disables the preview, negative clamps to 0
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// No --INI-- section here on purpose: this pins the compiled-in default.
+var_dump(ini_get("judy.debug_preview_size"));
+
+$j = new Judy(Judy::INT_TO_INT);
+for ($i = 0; $i < 40; $i++) {
+    $j[$i] = $i;
+}
+
+function preview_size(Judy $j): int {
+    $info = print_r($j, true);
+    preg_match('/\[preview\] => Array\s*\((.*?)\n\s*\)/s', $info, $m);
+    return preg_match_all('/=>/', $m[1] ?? '');
+}
+
+function truncation_note(Judy $j): string {
+    $info = print_r($j, true);
+    return preg_match('/\[previewTruncated\] => (.*)/', $info, $m) ? trim($m[1]) : "(none)";
+}
+
+// Default: 16 elements previewed out of 40.
+var_dump(preview_size($j));
+var_dump(truncation_note($j));
+
+// PHP_INI_ALL: changeable at runtime, so a debugger session can widen it.
+ini_set("judy.debug_preview_size", "3");
+var_dump(preview_size($j));
+var_dump(truncation_note($j));
+
+// Wider than the array: no truncation marker at all.
+ini_set("judy.debug_preview_size", "100");
+var_dump(preview_size($j));
+var_dump(truncation_note($j));
+
+// 0 means metadata only — the preview array stays empty and the marker still
+// reports the true total, so the dump cannot be misread as "empty array".
+ini_set("judy.debug_preview_size", "0");
+var_dump(preview_size($j));
+var_dump(truncation_note($j));
+
+// Negative values clamp to 0 rather than looping forever / dumping everything.
+ini_set("judy.debug_preview_size", "-5");
+var_dump(preview_size($j));
+var_dump(truncation_note($j));
+
+// The setting must not affect the real data accessors.
+ini_set("judy.debug_preview_size", "2");
+var_dump(count($j), count($j->toArray()), count($j->keys()));
+?>
+--EXPECT--
+string(2) "16"
+int(16)
+string(54) "showing 16 of 40 elements (judy.debug_preview_size=16)"
+int(3)
+string(52) "showing 3 of 40 elements (judy.debug_preview_size=3)"
+int(40)
+string(6) "(none)"
+int(0)
+string(52) "showing 0 of 40 elements (judy.debug_preview_size=0)"
+int(0)
+string(52) "showing 0 of 40 elements (judy.debug_preview_size=0)"
+int(40)
+int(40)
+int(40)

--- a/tests/debug_info_truncation_001.phpt
+++ b/tests/debug_info_truncation_001.phpt
@@ -1,0 +1,118 @@
+--TEST--
+get_debug_info: element preview is bounded at judy.debug_preview_size and states the true total
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--INI--
+judy.debug_preview_size=4
+--FILE--
+<?php
+// One under, exactly at, and one over the preview size — the boundary is the
+// point where the truncation marker must appear.
+function dump_int(int $n): void {
+    $j = new Judy(Judy::INT_TO_INT);
+    for ($i = 0; $i < $n; $i++) {
+        $j[$i] = $i * 10;
+    }
+    $info = print_r($j, true);
+    // memoryUsage is libJudy-dependent; drop it so the expectation is stable.
+    echo preg_replace('/^\s+\[memoryUsage\].*\n/m', '', $info), "\n";
+}
+
+function dump_string(int $n): void {
+    $j = new Judy(Judy::STRING_TO_INT);
+    for ($i = 0; $i < $n; $i++) {
+        $j["k" . $i] = $i;
+    }
+    $info = print_r($j, true);
+    // memoryUsage is null for string-keyed types; drop the line so the
+    // expectation carries no trailing whitespace.
+    echo preg_replace('/^\s+\[memoryUsage\].*\n/m', '', $info), "\n";
+}
+
+dump_int(3);
+dump_int(4);
+dump_int(5);
+dump_string(5);
+
+// A large array must stay cheap to dump: only the preview is materialised,
+// while count/lastKey still report the whole array.
+$big = new Judy(Judy::INT_TO_INT);
+for ($i = 0; $i < 100000; $i++) {
+    $big[$i] = $i;
+}
+$info = print_r($big, true);
+// 7 metadata rows (type, count, memoryUsage, firstKey, lastKey, preview,
+// previewTruncated) plus exactly 4 preview rows — never 100000.
+var_dump(substr_count($info, "=>") === 7 + 4);
+var_dump(strpos($info, "showing 4 of 100000 elements (judy.debug_preview_size=4)") !== false);
+var_dump(strlen($info) < 1024);
+?>
+--EXPECT--
+Judy Object
+(
+    [type] => INT_TO_INT
+    [count] => 3
+    [firstKey] => 0
+    [lastKey] => 2
+    [preview] => Array
+        (
+            [0] => 0
+            [1] => 10
+            [2] => 20
+        )
+
+)
+
+Judy Object
+(
+    [type] => INT_TO_INT
+    [count] => 4
+    [firstKey] => 0
+    [lastKey] => 3
+    [preview] => Array
+        (
+            [0] => 0
+            [1] => 10
+            [2] => 20
+            [3] => 30
+        )
+
+)
+
+Judy Object
+(
+    [type] => INT_TO_INT
+    [count] => 5
+    [firstKey] => 0
+    [lastKey] => 4
+    [preview] => Array
+        (
+            [0] => 0
+            [1] => 10
+            [2] => 20
+            [3] => 30
+        )
+
+    [previewTruncated] => showing 4 of 5 elements (judy.debug_preview_size=4)
+)
+
+Judy Object
+(
+    [type] => STRING_TO_INT
+    [count] => 5
+    [firstKey] => k0
+    [lastKey] => k4
+    [preview] => Array
+        (
+            [k0] => 0
+            [k1] => 1
+            [k2] => 2
+            [k3] => 3
+        )
+
+    [previewTruncated] => showing 4 of 5 elements (judy.debug_preview_size=4)
+)
+
+bool(true)
+bool(true)
+bool(true)

--- a/tests/debug_info_truncation_001.phpt
+++ b/tests/debug_info_truncation_001.phpt
@@ -24,9 +24,10 @@ function dump_string(int $n): void {
         $j["k" . $i] = $i;
     }
     $info = print_r($j, true);
-    // memoryUsage is null for string-keyed types; drop the line so the
-    // expectation carries no trailing whitespace.
-    echo preg_replace('/^\s+\[memoryUsage\].*\n/m', '', $info), "\n";
+    // memoryUsage is an approximation for string-keyed types (and carries the
+    // memoryUsageIsApproximate flag); drop both rows so the expectation stays
+    // about truncation only.
+    echo preg_replace('/^\s+\[memoryUsage(IsApproximate)?\].*\n/m', '', $info), "\n";
 }
 
 dump_int(3);

--- a/tests/debug_info_var_dump_001.phpt
+++ b/tests/debug_info_var_dump_001.phpt
@@ -1,0 +1,243 @@
+--TEST--
+get_debug_info: var_dump() shows type/count/memoryUsage/boundary keys/preview for every Judy type
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--INI--
+judy.debug_preview_size=16
+--FILE--
+<?php
+$types = [
+    Judy::BITSET,
+    Judy::INT_TO_INT,
+    Judy::INT_TO_PACKED,
+    Judy::INT_TO_MIXED,
+    Judy::STRING_TO_INT,
+    Judy::STRING_TO_MIXED,
+    Judy::STRING_TO_INT_HASH,
+    Judy::STRING_TO_MIXED_HASH,
+    Judy::STRING_TO_INT_ADAPTIVE,
+    Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+foreach ($types as $type) {
+    $j = new Judy($type);
+    switch ($type) {
+        case Judy::BITSET:
+            $j[3] = true;
+            $j[7] = true;
+            break;
+        case Judy::INT_TO_INT:
+            $j[3] = 30;
+            $j[7] = 70;
+            break;
+        case Judy::INT_TO_PACKED:
+        case Judy::INT_TO_MIXED:
+            $j[3] = "three";
+            $j[7] = "seven";
+            break;
+        case Judy::STRING_TO_INT:
+        case Judy::STRING_TO_INT_HASH:
+        case Judy::STRING_TO_INT_ADAPTIVE:
+            $j["alpha"] = 1;
+            $j["beta"] = 2;
+            break;
+        default:
+            $j["alpha"] = "one";
+            $j["beta"] = "two";
+            break;
+    }
+    var_dump($j);
+    unset($j);
+}
+?>
+--EXPECTF--
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(6) "BITSET"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  int(%d)
+  ["firstKey"]=>
+  int(3)
+  ["lastKey"]=>
+  int(7)
+  ["preview"]=>
+  array(2) {
+    [0]=>
+    int(3)
+    [1]=>
+    int(7)
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(10) "INT_TO_INT"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  int(%d)
+  ["firstKey"]=>
+  int(3)
+  ["lastKey"]=>
+  int(7)
+  ["preview"]=>
+  array(2) {
+    [3]=>
+    int(30)
+    [7]=>
+    int(70)
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(13) "INT_TO_PACKED"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  int(%d)
+  ["firstKey"]=>
+  int(3)
+  ["lastKey"]=>
+  int(7)
+  ["preview"]=>
+  array(2) {
+    [3]=>
+    string(5) "three"
+    [7]=>
+    string(5) "seven"
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(12) "INT_TO_MIXED"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  int(%d)
+  ["firstKey"]=>
+  int(3)
+  ["lastKey"]=>
+  int(7)
+  ["preview"]=>
+  array(2) {
+    [3]=>
+    string(5) "three"
+    [7]=>
+    string(5) "seven"
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(13) "STRING_TO_INT"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  string(5) "alpha"
+  ["lastKey"]=>
+  string(4) "beta"
+  ["preview"]=>
+  array(2) {
+    ["alpha"]=>
+    int(1)
+    ["beta"]=>
+    int(2)
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(15) "STRING_TO_MIXED"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  string(5) "alpha"
+  ["lastKey"]=>
+  string(4) "beta"
+  ["preview"]=>
+  array(2) {
+    ["alpha"]=>
+    string(3) "one"
+    ["beta"]=>
+    string(3) "two"
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(18) "STRING_TO_INT_HASH"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  string(5) "alpha"
+  ["lastKey"]=>
+  string(4) "beta"
+  ["preview"]=>
+  array(2) {
+    ["alpha"]=>
+    int(1)
+    ["beta"]=>
+    int(2)
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(20) "STRING_TO_MIXED_HASH"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  string(5) "alpha"
+  ["lastKey"]=>
+  string(4) "beta"
+  ["preview"]=>
+  array(2) {
+    ["alpha"]=>
+    string(3) "one"
+    ["beta"]=>
+    string(3) "two"
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(22) "STRING_TO_INT_ADAPTIVE"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  string(5) "alpha"
+  ["lastKey"]=>
+  string(4) "beta"
+  ["preview"]=>
+  array(2) {
+    ["alpha"]=>
+    int(1)
+    ["beta"]=>
+    int(2)
+  }
+}
+object(Judy)#%d (6) {
+  ["type"]=>
+  string(24) "STRING_TO_MIXED_ADAPTIVE"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  NULL
+  ["firstKey"]=>
+  string(5) "alpha"
+  ["lastKey"]=>
+  string(4) "beta"
+  ["preview"]=>
+  array(2) {
+    ["alpha"]=>
+    string(3) "one"
+    ["beta"]=>
+    string(3) "two"
+  }
+}

--- a/tests/debug_info_var_dump_001.phpt
+++ b/tests/debug_info_var_dump_001.phpt
@@ -127,13 +127,15 @@ object(Judy)#%d (6) {
     string(5) "seven"
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(13) "STRING_TO_INT"
   ["count"]=>
   int(2)
   ["memoryUsage"]=>
-  NULL
+  int(%d)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   string(5) "alpha"
   ["lastKey"]=>
@@ -146,13 +148,15 @@ object(Judy)#%d (6) {
     int(2)
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(15) "STRING_TO_MIXED"
   ["count"]=>
   int(2)
   ["memoryUsage"]=>
-  NULL
+  int(%d)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   string(5) "alpha"
   ["lastKey"]=>
@@ -165,13 +169,15 @@ object(Judy)#%d (6) {
     string(3) "two"
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(18) "STRING_TO_INT_HASH"
   ["count"]=>
   int(2)
   ["memoryUsage"]=>
-  NULL
+  int(%d)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   string(5) "alpha"
   ["lastKey"]=>
@@ -184,13 +190,15 @@ object(Judy)#%d (6) {
     int(2)
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(20) "STRING_TO_MIXED_HASH"
   ["count"]=>
   int(2)
   ["memoryUsage"]=>
-  NULL
+  int(%d)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   string(5) "alpha"
   ["lastKey"]=>
@@ -203,13 +211,15 @@ object(Judy)#%d (6) {
     string(3) "two"
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(22) "STRING_TO_INT_ADAPTIVE"
   ["count"]=>
   int(2)
   ["memoryUsage"]=>
-  NULL
+  int(%d)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   string(5) "alpha"
   ["lastKey"]=>
@@ -222,13 +232,15 @@ object(Judy)#%d (6) {
     int(2)
   }
 }
-object(Judy)#%d (6) {
+object(Judy)#%d (7) {
   ["type"]=>
   string(24) "STRING_TO_MIXED_ADAPTIVE"
   ["count"]=>
   int(2)
   ["memoryUsage"]=>
-  NULL
+  int(%d)
+  ["memoryUsageIsApproximate"]=>
+  bool(true)
   ["firstKey"]=>
   string(5) "alpha"
   ["lastKey"]=>

--- a/tests/foreach_with_vardump_int_to_int_001.phpt
+++ b/tests/foreach_with_vardump_int_to_int_001.phpt
@@ -2,6 +2,8 @@
 Test foreach() with var_dump() on INT_TO_INT Judy array
 --SKIPIF--
 <?php if (!extension_loaded("judy")) print "skip"; ?>
+--INI--
+judy.debug_preview_size=16
 --FILE--
 <?php
 /*
@@ -31,13 +33,30 @@ foreach ($judy as $k => $v) {
 
 unset($judy);
 ?>
---EXPECT--
+--EXPECTF--
 Instantiate object: $judy
 echo values
 17
 71
 var_dump($judy)
-object(Judy)#1 (0) {
+object(Judy)#1 (6) {
+  ["type"]=>
+  string(10) "INT_TO_INT"
+  ["count"]=>
+  int(2)
+  ["memoryUsage"]=>
+  int(%d)
+  ["firstKey"]=>
+  int(125)
+  ["lastKey"]=>
+  int(521)
+  ["preview"]=>
+  array(2) {
+    [125]=>
+    int(17)
+    [521]=>
+    int(71)
+  }
 }
 var_dump($judy[125])
 int(17)

--- a/tests/judy_memuse_004.phpt
+++ b/tests/judy_memuse_004.phpt
@@ -1,14 +1,26 @@
 --TEST--
-Judy memoryUsage() STRING_TO_INT returns null
+Judy memoryUsage() STRING_TO_INT returns approximate bytes
 --SKIPIF--
 <?php if (!extension_loaded("judy")) print "skip"; ?>
 --FILE--
 <?php
 $j = new Judy(Judy::STRING_TO_INT);
+echo "empty: ", var_export($j->memoryUsage(), true), "\n";
 for ($i = 0; $i < 100; $i++) { $j["key_$i"] = $i; }
 $mem = $j->memoryUsage();
-echo ($mem === null) ? "ok" : "fail";
-echo "\n";
+echo "populated is int: ", (is_int($mem) ? "yes" : "no"), "\n";
+echo "populated > 0: ", ($mem > 0 ? "yes" : "no"), "\n";
+/* The figure is approximate but not arbitrary: it counts at least the key
+   bytes it stores. */
+$key_bytes = 0;
+for ($i = 0; $i < 100; $i++) { $key_bytes += strlen("key_$i"); }
+echo "covers key bytes: ", ($mem > $key_bytes ? "yes" : "no"), "\n";
+$j->free();
+echo "after free: ", var_export($j->memoryUsage(), true), "\n";
 ?>
 --EXPECT--
-ok
+empty: 0
+populated is int: yes
+populated > 0: yes
+covers key bytes: yes
+after free: 0

--- a/tests/judy_memuse_005.phpt
+++ b/tests/judy_memuse_005.phpt
@@ -1,14 +1,29 @@
 --TEST--
-Judy memoryUsage() STRING_TO_MIXED returns null
+Judy memoryUsage() STRING_TO_MIXED returns approximate bytes
 --SKIPIF--
-<?php if (!extension_loaded("judy")) print "skip"; ?>
+<?php
+if (!extension_loaded("judy")) print "skip";
+try { new Judy(Judy::STRING_TO_MIXED); } catch (Exception $e) { print "skip MIXED types not supported"; }
+?>
 --FILE--
 <?php
 $j = new Judy(Judy::STRING_TO_MIXED);
+echo "empty: ", var_export($j->memoryUsage(), true), "\n";
 for ($i = 0; $i < 100; $i++) { $j["key_$i"] = "value_$i"; }
 $mem = $j->memoryUsage();
-echo ($mem === null) ? "ok" : "fail";
-echo "\n";
+echo "populated is int: ", (is_int($mem) ? "yes" : "no"), "\n";
+echo "populated > 0: ", ($mem > 0 ? "yes" : "no"), "\n";
+/* MIXED values carry a zval box each, so the same keys cost more here than in
+   the STRING_TO_INT twin. */
+$i2i = new Judy(Judy::STRING_TO_INT);
+for ($i = 0; $i < 100; $i++) { $i2i["key_$i"] = $i; }
+echo "costs more than STRING_TO_INT: ", ($mem > $i2i->memoryUsage() ? "yes" : "no"), "\n";
+$j->free();
+echo "after free: ", var_export($j->memoryUsage(), true), "\n";
 ?>
 --EXPECT--
-ok
+empty: 0
+populated is int: yes
+populated > 0: yes
+costs more than STRING_TO_INT: yes
+after free: 0

--- a/tests/judy_memuse_string_approx_001.phpt
+++ b/tests/judy_memuse_string_approx_001.phpt
@@ -1,0 +1,131 @@
+--TEST--
+Judy memoryUsage() reports approximate bytes for every string-keyed type
+--SKIPIF--
+<?php
+if (!extension_loaded("judy")) print "skip";
+try { new Judy(Judy::STRING_TO_MIXED); } catch (Exception $e) { print "skip MIXED types not supported"; }
+?>
+--FILE--
+<?php
+$types = [
+    'STRING_TO_INT'            => false,
+    'STRING_TO_MIXED'          => true,
+    'STRING_TO_INT_HASH'       => false,
+    'STRING_TO_MIXED_HASH'     => true,
+    'STRING_TO_INT_ADAPTIVE'   => false,
+    'STRING_TO_MIXED_ADAPTIVE' => true,
+];
+
+foreach ($types as $name => $mixed) {
+    $j = new Judy(constant("Judy::$name"));
+    $out = [];
+
+    $out[] = "new is int: " . (is_int($j->memoryUsage()) ? "yes" : "no");
+    $out[] = "new is zero: " . ($j->memoryUsage() === 0 ? "yes" : "no");
+
+    // Monotonic growth across inserts.
+    $growing = true;
+    $prev = $j->memoryUsage();
+    for ($i = 0; $i < 50; $i++) {
+        $j["key_with_padding_$i"] = $mixed ? "value_$i" : $i;
+        $now = $j->memoryUsage();
+        if ($now <= $prev) { $growing = false; }
+        $prev = $now;
+    }
+    $out[] = "grows on insert: " . ($growing ? "yes" : "no");
+
+    // An overwrite changes no key and allocates no extra slot.
+    $before = $j->memoryUsage();
+    $j["key_with_padding_0"] = $mixed ? "replacement" : 999;
+    $out[] = "flat on overwrite: " . ($j->memoryUsage() === $before ? "yes" : "no");
+
+    // A delete gives the bytes back; a no-op delete does not move it.
+    $before = $j->memoryUsage();
+    unset($j["key_with_padding_0"]);
+    $out[] = "shrinks on delete: " . ($j->memoryUsage() < $before ? "yes" : "no");
+    $after = $j->memoryUsage();
+    unset($j["never_inserted"]);
+    $out[] = "flat on absent delete: " . ($j->memoryUsage() === $after ? "yes" : "no");
+
+    // Longer keys must cost more than shorter ones.
+    $before = $j->memoryUsage();
+    $j["s"] = $mixed ? "x" : 1;
+    $short = $j->memoryUsage() - $before;
+    $before = $j->memoryUsage();
+    $j[str_repeat("l", 64)] = $mixed ? "x" : 1;
+    $long = $j->memoryUsage() - $before;
+    $out[] = "longer key costs more: " . ($long > $short ? "yes" : "no");
+
+    // Emptying by hand returns to exactly zero.
+    foreach ($j->keys() as $k) { unset($j[$k]); }
+    $out[] = "zero after unsetting all: " . ($j->memoryUsage() === 0 ? "yes" : "no");
+
+    // So does free().
+    $j["back_again"] = $mixed ? "v" : 1;
+    $j->free();
+    $out[] = "zero after free(): " . ($j->memoryUsage() === 0 ? "yes" : "no");
+
+    echo "== $name\n", implode("\n", $out), "\n";
+}
+?>
+--EXPECT--
+== STRING_TO_INT
+new is int: yes
+new is zero: yes
+grows on insert: yes
+flat on overwrite: yes
+shrinks on delete: yes
+flat on absent delete: yes
+longer key costs more: yes
+zero after unsetting all: yes
+zero after free(): yes
+== STRING_TO_MIXED
+new is int: yes
+new is zero: yes
+grows on insert: yes
+flat on overwrite: yes
+shrinks on delete: yes
+flat on absent delete: yes
+longer key costs more: yes
+zero after unsetting all: yes
+zero after free(): yes
+== STRING_TO_INT_HASH
+new is int: yes
+new is zero: yes
+grows on insert: yes
+flat on overwrite: yes
+shrinks on delete: yes
+flat on absent delete: yes
+longer key costs more: yes
+zero after unsetting all: yes
+zero after free(): yes
+== STRING_TO_MIXED_HASH
+new is int: yes
+new is zero: yes
+grows on insert: yes
+flat on overwrite: yes
+shrinks on delete: yes
+flat on absent delete: yes
+longer key costs more: yes
+zero after unsetting all: yes
+zero after free(): yes
+== STRING_TO_INT_ADAPTIVE
+new is int: yes
+new is zero: yes
+grows on insert: yes
+flat on overwrite: yes
+shrinks on delete: yes
+flat on absent delete: yes
+longer key costs more: yes
+zero after unsetting all: yes
+zero after free(): yes
+== STRING_TO_MIXED_ADAPTIVE
+new is int: yes
+new is zero: yes
+grows on insert: yes
+flat on overwrite: yes
+shrinks on delete: yes
+flat on absent delete: yes
+longer key costs more: yes
+zero after unsetting all: yes
+zero after free(): yes

--- a/tests/judy_memuse_string_approx_002.phpt
+++ b/tests/judy_memuse_string_approx_002.phpt
@@ -1,0 +1,174 @@
+--TEST--
+Judy memoryUsage() accounting survives clone, serialize, and every bulk mutation
+--SKIPIF--
+<?php
+if (!extension_loaded("judy")) print "skip";
+try { new Judy(Judy::STRING_TO_MIXED); } catch (Exception $e) { print "skip MIXED types not supported"; }
+?>
+--FILE--
+<?php
+/* The reported total must be a pure function of the live contents: an array
+   reached by any route has to agree with one built from scratch holding the
+   same keys and values. That is what pins the accounting to the operations
+   below, without hard-coding the per-entry model. */
+function rebuilt(Judy $j): int
+{
+    return Judy::fromArray($j->getType(), $j->toArray())->memoryUsage();
+}
+
+function check(string $what, Judy $j): void
+{
+    printf("%-22s %s\n", $what, $j->memoryUsage() === rebuilt($j) ? "agrees" : "DIFFERS");
+}
+
+$types = [
+    'STRING_TO_INT'            => false,
+    'STRING_TO_MIXED'          => true,
+    'STRING_TO_INT_HASH'       => false,
+    'STRING_TO_MIXED_HASH'     => true,
+    'STRING_TO_INT_ADAPTIVE'   => false,
+    'STRING_TO_MIXED_ADAPTIVE' => true,
+];
+
+foreach ($types as $name => $mixed) {
+    $type = constant("Judy::$name");
+    echo "== $name\n";
+
+    $j = new Judy($type);
+    /* Both key shapes: ADAPTIVE packs keys shorter than 8 bytes into the index
+       word and copies longer ones into JudyHS, so they are accounted apart. */
+    for ($i = 0; $i < 30; $i++) { $j[sprintf("s%03d", $i)] = $mixed ? "v$i" : $i; }
+    for ($i = 0; $i < 30; $i++) { $j["long_padded_key_$i"] = $mixed ? "v$i" : $i; }
+    check("populated", $j);
+
+    check("clone", clone $j);
+    check("unserialize", unserialize(serialize($j)));
+    check("slice", $j->slice("s000", "s015"));
+    check("filter", $j->filter(fn($v, $k) => true));
+    check("map", $j->map(fn($v, $k) => $v));
+
+    $d = clone $j;
+    $d->deleteRange("s005", "s020");
+    $d->deleteRange("long_padded_key_1", "long_padded_key_2");
+    check("deleteRange", $d);
+
+    $other = new Judy($type);
+    $other["s001"] = $mixed ? "overwritten" : 42;
+    $other["brand_new_long_key"] = $mixed ? "fresh" : 43;
+    $m = clone $j;
+    $m->mergeWith($other);
+    check("mergeWith", $m);
+
+    $p = Judy::fromArray($type, ["from_array_key" => $mixed ? "a" : 1]);
+    $p->putAll(["put_all_key" => $mixed ? "b" : 2, "from_array_key" => $mixed ? "c" : 3]);
+    check("fromArray+putAll", $p);
+
+    if (!$mixed) {
+        check("union", $j->union($other));
+        check("intersect", $j->intersect($other));
+        check("diff", $j->diff($other));
+        check("xor", $j->xor($other));
+
+        /* increment() covers STRING_TO_INT and STRING_TO_INT_HASH only. */
+        if ($name !== 'STRING_TO_INT_ADAPTIVE') {
+            $inc = clone $j;
+            $inc->increment("s001");
+            $inc->increment("newly_created_by_increment");
+            check("increment", $inc);
+        }
+    }
+
+    /* Serialize/clone must reproduce the number itself, not merely a consistent one. */
+    printf("%-22s %s\n", "clone equals source",
+        (clone $j)->memoryUsage() === $j->memoryUsage() ? "yes" : "no");
+    printf("%-22s %s\n", "unserialize equals",
+        unserialize(serialize($j))->memoryUsage() === $j->memoryUsage() ? "yes" : "no");
+}
+?>
+--EXPECT--
+== STRING_TO_INT
+populated              agrees
+clone                  agrees
+unserialize            agrees
+slice                  agrees
+filter                 agrees
+map                    agrees
+deleteRange            agrees
+mergeWith              agrees
+fromArray+putAll       agrees
+union                  agrees
+intersect              agrees
+diff                   agrees
+xor                    agrees
+increment              agrees
+clone equals source    yes
+unserialize equals     yes
+== STRING_TO_MIXED
+populated              agrees
+clone                  agrees
+unserialize            agrees
+slice                  agrees
+filter                 agrees
+map                    agrees
+deleteRange            agrees
+mergeWith              agrees
+fromArray+putAll       agrees
+clone equals source    yes
+unserialize equals     yes
+== STRING_TO_INT_HASH
+populated              agrees
+clone                  agrees
+unserialize            agrees
+slice                  agrees
+filter                 agrees
+map                    agrees
+deleteRange            agrees
+mergeWith              agrees
+fromArray+putAll       agrees
+union                  agrees
+intersect              agrees
+diff                   agrees
+xor                    agrees
+increment              agrees
+clone equals source    yes
+unserialize equals     yes
+== STRING_TO_MIXED_HASH
+populated              agrees
+clone                  agrees
+unserialize            agrees
+slice                  agrees
+filter                 agrees
+map                    agrees
+deleteRange            agrees
+mergeWith              agrees
+fromArray+putAll       agrees
+clone equals source    yes
+unserialize equals     yes
+== STRING_TO_INT_ADAPTIVE
+populated              agrees
+clone                  agrees
+unserialize            agrees
+slice                  agrees
+filter                 agrees
+map                    agrees
+deleteRange            agrees
+mergeWith              agrees
+fromArray+putAll       agrees
+union                  agrees
+intersect              agrees
+diff                   agrees
+xor                    agrees
+clone equals source    yes
+unserialize equals     yes
+== STRING_TO_MIXED_ADAPTIVE
+populated              agrees
+clone                  agrees
+unserialize            agrees
+slice                  agrees
+filter                 agrees
+map                    agrees
+deleteRange            agrees
+mergeWith              agrees
+fromArray+putAll       agrees
+clone equals source    yes
+unserialize equals     yes

--- a/tests/judy_memuse_string_to_mixed_hash.phpt
+++ b/tests/judy_memuse_string_to_mixed_hash.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Judy memoryUsage() STRING_TO_MIXED_HASH returns null
+Judy memoryUsage() STRING_TO_MIXED_HASH returns approximate bytes (keys held twice)
 --SKIPIF--
 <?php
 if (!extension_loaded("judy")) print "skip";
@@ -8,10 +8,23 @@ try { new Judy(Judy::INT_TO_MIXED); } catch (Exception $e) { print "skip MIXED t
 --FILE--
 <?php
 $j = new Judy(Judy::STRING_TO_MIXED_HASH);
+echo "empty: ", var_export($j->memoryUsage(), true), "\n";
 for ($i = 0; $i < 100; $i++) { $j["key_$i"] = "value_$i"; }
 $mem = $j->memoryUsage();
-echo ($mem === null) ? "ok" : "fail";
-echo "\n";
+echo "populated is int: ", (is_int($mem) ? "yes" : "no"), "\n";
+
+/* A _HASH type keeps every key twice — once in the JudyHS value store, once in
+   the JudySL key index that makes ordered iteration possible — so it accounts
+   for more than the single-copy trie type holding the same entries. */
+$trie = new Judy(Judy::STRING_TO_MIXED);
+for ($i = 0; $i < 100; $i++) { $trie["key_$i"] = "value_$i"; }
+echo "exceeds single-copy trie: ", ($mem > $trie->memoryUsage() ? "yes" : "no"), "\n";
+
+$j->free();
+echo "after free: ", var_export($j->memoryUsage(), true), "\n";
 ?>
 --EXPECT--
-ok
+empty: 0
+populated is int: yes
+exceeds single-copy trie: yes
+after free: 0


### PR DESCRIPTION
Makes Judy arrays observable to debuggers and profilers, and adds two examples covering dev-tooling use cases beyond caching.

## Extension changes

**`get_debug_info` handler.** The object handler table registered `clone_obj`, the four dimension handlers, `dtor_obj`, `free_obj` and `get_gc`, but not `get_debug_info`. `var_dump()`, `print_r()`, Xdebug's develop-mode `var_dump` and the DBGp variable panel all read that handler, so a Judy object rendered as `object(Judy)#1 (0) {}` — a developer stepping through code with a 2M-element array saw nothing.

Now reports `type` (name, not the raw constant), `count`, `memoryUsage`, first/last key, and a bounded element preview.

The preview is capped by a new `judy.debug_preview_size` INI (default 16). Dumping a 10M-element array into a DBGp payload would hang the IDE session, so the cap is the point. `0` means metadata-only rather than unlimited: the setting exists to bound a debug dump, and an unlimited value reachable by a typo reintroduces the hang it prevents. Negatives clamp to 0. When truncated, a `previewTruncated` entry carries the true total, so the preview cannot read as the whole array.

The preview walks a private cursor rather than the shared `intern->key_scratch`, so inspecting mid-iteration does not perturb a manual `rewind()`/`next()` walk. Covered by a test.

**`memoryUsage()` for string-keyed types.** Previously `null` for all six, because JudySL/JudyHS expose no equivalent of `JudyLMemUsed`. Judy memory is also invisible to `memory_get_usage()` and to Xdebug's memory profiler, so `memoryUsage()` was the only way to see this memory at all — and it returned nothing for exactly the types most likely to hold a large working set. With the handler above, that `null` also surfaced in every IDE debug pane.

Now an `int`, maintained as an O(1) per-object counter at the `judy_string_slot_acquire()` seam plus the delete, `slice()` and clone paths.

It is a lower bound and is labelled APPROXIMATE in the stub, `API.md`, `BENCHMARK.md`, `AGENTS.md`, and at runtime via `memoryUsageIsApproximate => true` in string-keyed debug dumps. It counts stored key bytes per structure holding a copy (`_HASH` stores each key twice; `_ADAPTIVE` packs sub-8-byte keys into the index word), one `Word_t` per value slot, and `sizeof(zval)` per `_MIXED` box. It omits libJudy's internal trie nodes, allocator rounding, and the PHP heap reachable from stored zvals. Measured against peak-RSS deltas the real footprint was ~1.0-1.5x the reported figure for shared-prefix keys and ~2.8-3.0x for random 16-byte keys.

## Documentation

Debugging section in `AGENTS.md` and `README.md`:

- Xdebug coexistence, verified in Docker (`php:8.4-cli`, Xdebug 3.5.3): both extensions load, `var_dump()` renders correctly under `xdebug.mode=develop`, and `extension` / `zend_extension` order is irrelevant. Judy registers object handlers and a class; it does not hook the executor.
- The memory blind spot, measured: filling `STRING_TO_INT` with 50K keys traces as a 65,696-byte delta — PHP-side overhead only, none of the ~1.24 MB of trie — while the equivalent PHP array traces its full 4,941,520 bytes.
- `$j[$key]` dispatches to the dimension handler and appears nowhere in a trace or cachegrind profile; the cost lands in the enclosing function. Only explicit `$j->offsetGet($key)` calls are counted. Documented because the natural assumption is the opposite.

Every doc asserting the old `memoryUsage()` null behaviour was corrected: stub, `scripts/api-metadata.php` -> `API.md`, `BENCHMARK.md`, `AGENTS.md`, and four benchmark examples.

## Examples

`examples/coverage-index.php` — coverage accumulation, worker merge, and test-impact selection.

The naive "one BITSET per line" shape does not work: one Judy object per `(file,line)` means millions of PHP objects and loses to a plain array. What works is one `Judy::BITSET` for the whole relation with the triple packed into a 62-bit key, `[file id (20) | line (20) | test id (22)]`, file-major, so every test id for a `file:line` is a contiguous block.

Selection handles the failure mode explicitly, with three outcomes: covered, line-unknown (widen to the whole file), and file-unknown (report `UNBOUNDED`; the runner must run everything). A stale index degrades toward running everything. The dangerous inversion — treating an unrecorded line as "no tests affected" — degrades toward running nothing, and no test failure ever reports it.

Both selection shapes are shown. Neither is labelled the answer: `first()`/`searchNext()` costs one PHP->C crossing per element, while `slice()` + `keys()` costs two traversals plus an allocation because `slice()` is a copy constructor, not a projection. The missing primitive is tracked in #96.

## Not included

No benchmark numbers. The host was under load average 20+ on 8 cores throughout, so no measurement taken would be attributable. The RSS harness in `examples/coverage-index.php` is runnable but its gate (>=2x lower peak RSS at 5000x500x10000, merge time at parity) has not been evaluated, and no measured claim entered `README.md`, `llms.txt` or `BENCHMARK.md`. `baselines/latest.json` and `PHP_JUDY_VERSION` are untouched.

## Verification

Full suite 199/199 (was 197 before this branch; +2 new tests, and the `--enable-judy-debug-mirror` build also passes). Zero compiler warnings. `php scripts/generate-api-docs.php --check` reports `API.md` up to date. Correctness across all five coverage-index shapes is asserted by digest.

## Coordination

`claude/php-judy-issue-83-c8d985` forked at #82 and is stale by roughly a dozen commits. It already conflicts with main on `.github/workflows/ci.yml`, `AGENTS.md`, `BENCHMARK.md` and `package.xml` independently of this branch; this branch adds only `examples/README.md` to that set, and touches no extension C source that branch touches. This branch merges into main with no conflicts.
