### PR TITLE
feat(bulk): add range-limited keys(), values() and toArray()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,19 @@ Bulk (run in C, prefer over PHP loops): `toArray()`, `Judy::fromArray($type,
 $arr)`, `putAll($arr)`, `getAll($keys)`, `keys()`, `values()`, `forEach($cb)`,
 `filter($cb)`, `map($cb)`.
 
+`keys`, `values` and `toArray` also take an inclusive range —
+`keys($start = null, $end = null)` — where `null` leaves that side unbounded.
+All key types are supported; string-keyed types require string bounds and
+compare them lexicographically. **This is the primitive to reach for on a
+bounded read**: it is one traversal writing straight into the PHP array, so
+prefer it over `slice($lo, $hi)->keys()`, which copies a whole sub-Judy first
+and then traverses that copy.
+
 Set ops (return new Judy): `union`, `intersect`, `diff`, `xor`; in-place:
 `mergeWith`. Range: `slice($start, $end)` (inclusive), `deleteRange`,
-`populationCount`. Aggregation: `sumValues()`, `averageValues()`. Atomic:
-`increment($key, $amount = 1)` — creates the key if absent.
+`populationCount`, `keys`/`values`/`toArray` with bounds. Aggregation:
+`sumValues()`, `averageValues()`. Atomic: `increment($key, $amount = 1)` —
+creates the key if absent.
 
 Functions: `judy_version(): string`, `judy_type(mixed): int`.
 
@@ -84,6 +93,10 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   not change what that element contributes to the result.
 - **`count()` takes no arguments** (Countable); ranged counting is
   `size($start, $end)` or `populationCount($start, $end)`.
+- **A string upper bound is a bound, not a prefix match.** `keys('bl', 'bl')`
+  does not return `blackcurrant` — `blackcurrant` sorts *after* `bl`. For a
+  prefix sweep, bound with the prefix and its successor (`keys('bl', 'bm')`)
+  or append `"\xff"`. Same rule for `slice()` and `deleteRange()`.
 - **Random access on small dense datasets is faster with native arrays.**
   Judy wins on memory at scale, ordered navigation, and sparse keysets —
   see BENCHMARK.md before claiming performance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,18 @@ and then traverses that copy.
 
 Set ops (return new Judy): `union`, `intersect`, `diff`, `xor`; in-place:
 `mergeWith`. Range: `slice($start, $end)` (inclusive), `deleteRange`,
-`populationCount`, `keys`/`values`/`toArray` with bounds. Aggregation:
+`populationCount`, `size`, `keys`/`values`/`toArray` with bounds. Aggregation:
 `sumValues()`, `averageValues()`. Atomic: `increment($key, $amount = 1)` —
 creates the key if absent.
+
+**Every range here is a pair of inclusive keys, never an offset and a length.**
+Read `slice(5, 10)` as `range(5, 10)`, not as `array_slice($a, 5, 10)` — it is
+"keys 5 through 10", and it returns nothing if no key in that span is set. Both
+operations exist and they are different: `byCount($n)` is the positional one
+("the Nth element present"); everything above is key-space. Key-space is where
+Judy is fast — a bound is a seek plus a walk, so a narrow range out of a huge
+array costs the range, not the array. All range methods use `$start`/`$end`
+parameter names, so named arguments are uniform across them.
 
 Functions: `judy_version(): string`, `judy_type(mixed): int`.
 

--- a/API.md
+++ b/API.md
@@ -112,10 +112,18 @@ Returns the number of bytes used by the internal Judy structure. **The number me
 ### size()
 
 ```php
-public function size(mixed $index_start = 0, mixed $index_end = -1): int
+public function size(mixed $start = 0, mixed $end = -1): int
 ```
 
-Returns the number of elements. When called with arguments, returns the population count within the given range (integer-keyed types only).
+Returns the number of elements. When called with arguments, returns the population count of keys in the inclusive `[$start, $end]` range (integer-keyed types only). The bounds are keys, not offsets — see [Range Operations](#range-operations).
+
+```php
+$judy = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 1000 => 100]);
+
+$judy->size();          // 3
+$judy->size(0, 100);    // 2  — keys 1 and 5; key 1000 is outside the range
+$judy->size(0, -1);     // 3  — -1 is the maximum bound, so this is "everything"
+```
 
 ### count()
 
@@ -300,6 +308,33 @@ $a->mergeWith($b);
 ---
 
 ## Range Operations
+
+**Every range in this API is a pair of inclusive *keys*, never an offset and a length.**
+
+Think `range($start, $end)`, not `array_slice($a, $offset, $length)`. PHP splits
+the convention by data shape: offset/length suits *sequences* (`array_slice`,
+`substr`), where positions are dense and meaningful; start/end suits *ordered
+value domains* (`range()`, `DatePeriod`). A Judy array is the second kind — a
+sparse ordered map — so `slice(5, 10)` means "keys 5 through 10 inclusive", and
+returns nothing at all if no key in that span is set.
+
+The distinction is not cosmetic, because both operations exist here and they are
+different:
+
+| Question | Method | How it works |
+| --- | --- | --- |
+| "the element at position N" | `byCount($nth_index)` | positional; counts elements |
+| "elements with keys in [lo, hi]" | `slice`, `deleteRange`, `populationCount`, `size`, and the bounded forms of `keys`/`values`/`toArray` | key-space; seeks directly |
+
+Key-space is where Judy is fast: bounding by key is a seek to the first key at or
+above `$start` and then a walk, so reading a narrow range out of a huge array
+costs the range, not the array. An offset-based equivalent would have to count
+from the beginning to find where to start — which is exactly the work `byCount()`
+does, and exactly the work the key-bounded methods exist to avoid.
+
+Bounds are inclusive on both ends, an inverted range (`$start > $end`) yields
+nothing rather than erroring, and string-keyed types compare bounds
+lexicographically with `strcmp()`.
 
 ### slice()
 

--- a/API.md
+++ b/API.md
@@ -358,10 +358,21 @@ $judy = Judy::fromArray(Judy::INT_TO_INT, [0 => 100, 5 => 200, 10 => 300]);
 ### toArray()
 
 ```php
-public function toArray(): array
+public function toArray(mixed $start = null, mixed $end = null): array
 ```
 
-Converts the Judy array to a PHP array. Uses native C iteration internally, 2-3x faster than manual `foreach`.
+Converts the Judy array to a PHP array. Uses native C iteration internally, 2-3x faster than manual `foreach`. With `$start` and/or `$end`, only the inclusive `[$start, $end]` key range is returned; `null` leaves that side unbounded.
+
+**Supported types**: All types. String-keyed types require string bounds and compare them lexicographically.
+
+```php
+$judy = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 10 => 100]);
+
+$judy->toArray();          // [1 => 10, 5 => 50, 10 => 100]
+$judy->toArray(5, 10);     // [5 => 50, 10 => 100]
+$judy->toArray(5);         // [5 => 50, 10 => 100]  (unbounded end)
+$judy->toArray(null, 5);   // [1 => 10, 5 => 50]    (unbounded start)
+```
 
 ### putAll()
 
@@ -388,18 +399,40 @@ $values = $judy->getAll([0, 2, 99]);
 ### keys()
 
 ```php
-public function keys(): array
+public function keys(mixed $start = null, mixed $end = null): array
 ```
 
-Returns all keys as a PHP array.
+Returns all keys as a PHP array. With `$start` and/or `$end`, only the inclusive `[$start, $end]` key range is returned; `null` leaves that side unbounded.
+
+A bounded read is a single traversal writing straight into the returned array, so prefer it to `slice($lo, $hi)->keys()`, which allocates and populates a whole intermediate Judy array and then traverses that copy.
+
+**Supported types**: All types. String-keyed types require string bounds and compare them lexicographically.
+
+```php
+$judy = new Judy(Judy::BITSET);
+foreach ([1, 5, 10, 15] as $i) $judy[$i] = true;
+
+$judy->keys(5, 10);        // [5, 10]
+$judy->keys(5);            // [5, 10, 15]  (unbounded end)
+$judy->keys(null, 5);      // [1, 5]       (unbounded start)
+$judy->keys(10, 5);        // []           (inverted range)
+
+// An upper bound is a bound, not a prefix filter: "blackcurrant" sorts after
+// "bl", so bound a prefix sweep with the prefix's successor.
+$fruit = Judy::fromArray(Judy::STRING_TO_INT, ['blackcurrant' => 1, 'cherry' => 2]);
+$fruit->keys('bl', 'bl');  // []
+$fruit->keys('bl', 'bm');  // ['blackcurrant']
+```
 
 ### values()
 
 ```php
-public function values(): array
+public function values(mixed $start = null, mixed $end = null): array
 ```
 
-Returns all values as a PHP array.
+Returns all values as a PHP array. With `$start` and/or `$end`, only the values of keys in the inclusive `[$start, $end]` range are returned; `null` leaves that side unbounded.
+
+**Supported types**: All types. String-keyed types require string bounds and compare them lexicographically.
 
 ### increment()
 

--- a/Judy.stub.php
+++ b/Judy.stub.php
@@ -80,10 +80,11 @@ class Judy implements ArrayAccess, Countable, Iterator, JsonSerializable
     /**
      * Return the number of elements, optionally within a key range.
      *
-     * When called with arguments, returns the count within
-     * [$index_start, $index_end] (integer-keyed types only).
+     * When called with arguments, returns the count of keys in the inclusive
+     * [$start, $end] range (integer-keyed types only). The bounds are keys,
+     * not offsets — see the note on Judy::slice().
      */
-    public function size(mixed $index_start = 0, mixed $index_end = -1): int {}
+    public function size(mixed $start = 0, mixed $end = -1): int {}
 
     /** Return the number of elements. Implements Countable. */
     public function count(): int {}

--- a/Judy.stub.php
+++ b/Judy.stub.php
@@ -187,8 +187,12 @@ class Judy implements ArrayAccess, Countable, Iterator, JsonSerializable
      * Convert the Judy array to a native PHP array.
      *
      * Uses native C iteration internally, faster than manual foreach.
+     *
+     * With $start and/or $end, only the inclusive [$start, $end] key range is
+     * returned; null leaves that side unbounded. String-keyed types compare
+     * bounds lexicographically and require string bounds.
      */
-    public function toArray(): array {}
+    public function toArray(mixed $start = null, mixed $end = null): array {}
 
     /**
      * Create a new Judy array from a PHP array.
@@ -236,11 +240,24 @@ class Judy implements ArrayAccess, Countable, Iterator, JsonSerializable
 
     /* ── Expanded API ─────────────────────────────────────────── */
 
-    /** Return all keys as a PHP array. */
-    public function keys(): array {}
+    /**
+     * Return all keys as a PHP array.
+     *
+     * With $start and/or $end, only the inclusive [$start, $end] key range is
+     * returned; null leaves that side unbounded. String-keyed types compare
+     * bounds lexicographically and require string bounds.
+     */
+    public function keys(mixed $start = null, mixed $end = null): array {}
 
-    /** Return all values as a PHP array. */
-    public function values(): array {}
+    /**
+     * Return all values as a PHP array.
+     *
+     * With $start and/or $end, only the values of keys in the inclusive
+     * [$start, $end] range are returned; null leaves that side unbounded.
+     * String-keyed types compare bounds lexicographically and require string
+     * bounds.
+     */
+    public function values(mixed $start = null, mixed $end = null): array {}
 
     /**
      * Call a callback for each element, iterating in C.

--- a/Judy_arginfo.h
+++ b/Judy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2c3d6e08ad8d66c9985ad460a5b801aecb4e3398 */
+ * Stub hash: 8c261dc26ae7be1d021f8e17fda503786d7455b3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_judy_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -100,7 +100,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy___unserialize, 0, 1, 
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Judy_toArray arginfo_class_Judy___serialize
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_toArray, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_MIXED, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_MIXED, 0, "null")
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Judy_fromArray, 0, 2, Judy, 0)
 	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
@@ -130,9 +133,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Judy_next arginfo_class_Judy_rewind
 
-#define arginfo_class_Judy_keys arginfo_class_Judy___serialize
+#define arginfo_class_Judy_keys arginfo_class_Judy_toArray
 
-#define arginfo_class_Judy_values arginfo_class_Judy___serialize
+#define arginfo_class_Judy_values arginfo_class_Judy_toArray
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_forEach, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)

--- a/Judy_arginfo.h
+++ b/Judy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e0cba2d9a949592b101da4eff41c901a7448662c */
+ * Stub hash: 5e3d1f5cee0d80d5d6729e766fd821c016f8f6c8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_judy_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -24,8 +24,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_memoryUsage, 0, 0, IS
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_size, 0, 0, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, index_start, IS_MIXED, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, index_end, IS_MIXED, 0, "-1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_MIXED, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_MIXED, 0, "-1")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Judy_count arginfo_class_Judy_getType

--- a/README.md
+++ b/README.md
@@ -454,6 +454,15 @@ A bounded read is one traversal writing straight into the returned PHP array,
 so prefer it to `slice($lo, $hi)->keys()`, which first copies the range into a
 new Judy array and then traverses that copy.
 
+> **Ranges are keys, not offsets.** Every range argument in this API —
+> `slice()`, `deleteRange()`, `populationCount()`, `size()`, and the bounded
+> forms above — is a pair of **inclusive keys**. Read `keys(5, 10)` as
+> `range(5, 10)`, not as `array_slice($a, 5, 10)`: it returns the keys *between*
+> 5 and 10, and nothing at all if none are set. If you want the element at a
+> *position*, that is `byCount($n)`. Bounding by key is a seek plus a walk, so a
+> narrow range out of a huge array costs the range rather than the array — which
+> is the reason the distinction is worth keeping.
+
 ### Atomic Increment
 
 For `INT_TO_INT`, `STRING_TO_INT`, and `STRING_TO_INT_HASH` types, `increment()` performs an efficient counter update:

--- a/README.md
+++ b/README.md
@@ -441,7 +441,17 @@ $judy->putAll([20 => 400, 30 => 500]);
 
 // Retrieve multiple values at once (missing keys return null)
 $values = $judy->getAll([0, 5, 99]); // [0 => 100, 5 => 200, 99 => null]
+
+// Read only part of the key space: keys(), values() and toArray() all take an
+// inclusive range, with null leaving that side unbounded
+$judy->keys(5, 20);      // [5, 10, 20]
+$judy->toArray(5, 10);   // [5 => 200, 10 => 300]
+$judy->values(null, 5);  // [100, 200]
 ```
+
+A bounded read is one traversal writing straight into the returned PHP array,
+so prefer it to `slice($lo, $hi)->keys()`, which first copies the range into a
+new Judy array and then traverses that copy.
 
 ### Atomic Increment
 
@@ -465,7 +475,8 @@ Beyond basic array access, Judy provides a rich API including:
 
 - **Set operations**: `union()`, `intersect()`, `diff()`, `xor()`, `mergeWith()`
 - **Functional iteration**: `forEach()`, `filter()`, `map()` (C-level, bypasses Iterator overhead)
-- **Range operations**: `slice()`, `deleteRange()`, `populationCount()`
+- **Range operations**: `slice()`, `deleteRange()`, `populationCount()`, and the
+  bounded forms of `keys()`, `values()`, `toArray()`
 - **Aggregation**: `sumValues()`, `averageValues()`
 - **Batch operations**: `putAll()`, `getAll()`, `keys()`, `values()`, `toArray()`, `fromArray()`
 - **Serialization**: `serialize()`/`unserialize()`, `json_encode()`

--- a/package.xml
+++ b/package.xml
@@ -272,6 +272,7 @@
          <file name="tests/keys_values_001.phpt" role="test" />
          <file name="tests/keys_range_int_001.phpt" role="test" />
          <file name="tests/keys_range_string_001.phpt" role="test" />
+         <file name="tests/range_named_args_001.phpt" role="test" />
          <file name="tests/merge_with.phpt" role="test" />
          <file name="tests/packed_complex_fallback_001.phpt" role="test" />
          <file name="tests/packed_scalar_fastpath_001.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -262,6 +262,8 @@
          <file name="tests/filter_snapshot_semantics_001.phpt" role="test" />
          <file name="tests/adaptive_clone_isset_unset_empty_slice.phpt" role="test" />
          <file name="tests/keys_values_001.phpt" role="test" />
+         <file name="tests/keys_range_int_001.phpt" role="test" />
+         <file name="tests/keys_range_string_001.phpt" role="test" />
          <file name="tests/merge_with.phpt" role="test" />
          <file name="tests/packed_complex_fallback_001.phpt" role="test" />
          <file name="tests/packed_scalar_fastpath_001.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -3379,16 +3379,113 @@ typedef enum {
 	JUDY_COLLECT_VALUES
 } judy_collect_mode;
 
-/* {{{ Helper to build a PHP array from a Judy array's contents.
-   Used by jsonSerialize(), __serialize(), toArray(), keys(), and values(). */
-static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mode mode)
+/* An inclusive key range for the bulk collectors. A NULL range means "the
+   whole array"; a bounded range narrows the same single traversal, so a range
+   read costs no more than a full one — unlike slice()->keys(), which copies a
+   sub-array first and then traverses it again. Either side may be unbounded:
+   for integer keys that is 0 / Word_t maximum, for string keys a NULL bound. */
+typedef struct {
+	Word_t       start;          /* integer-keyed: inclusive lower bound */
+	Word_t       end;            /* integer-keyed: inclusive upper bound */
+	const char  *str_start;      /* string-keyed: lower bound, NULL = first key */
+	const char  *str_end;        /* string-keyed: upper bound, NULL = last key */
+	size_t       str_start_len;
+	zend_bool    is_empty;       /* $start > $end — nothing can match */
+} judy_collect_range;
+
+/* Seed a JudySL traversal key with the range's lower bound. Over-long bounds
+   are truncated like every other string-key entry point, which only widens
+   the range (JSLF seeks to the first key at or after the bound). */
+static void judy_range_seed_key(uint8_t *key, const judy_collect_range *range)
 {
+	size_t key_len;
+
+	if (range == NULL || range->str_start == NULL || range->str_start_len == 0) {
+		key[0] = '\0';
+		return;
+	}
+
+	key_len = range->str_start_len >= PHP_JUDY_MAX_LENGTH
+		? PHP_JUDY_MAX_LENGTH - 1 : range->str_start_len;
+	memcpy(key, range->str_start, key_len);
+	key[key_len] = '\0';
+}
+
+/* Is this traversal key still at or below the range's upper bound? */
+static zend_always_inline int judy_range_key_in_bounds(const uint8_t *key, const char *str_end)
+{
+	return str_end == NULL || strcmp((const char *)key, str_end) <= 0;
+}
+
+/* Parse the optional ($start, $end) pair the bulk collectors accept. A missing
+   or null argument leaves that side unbounded. Returns FAILURE with an
+   exception pending when a string-keyed array is handed a non-string bound. */
+static int judy_parse_collect_range(judy_object *intern, zval *zstart, zval *zend_val,
+		judy_collect_range *range, const char *method)
+{
+	memset(range, 0, sizeof(*range));
+
+	if (zstart != NULL && Z_TYPE_P(zstart) == IS_NULL) {
+		zstart = NULL;
+	}
+	if (zend_val != NULL && Z_TYPE_P(zend_val) == IS_NULL) {
+		zend_val = NULL;
+	}
+
+	if (intern->is_integer_keyed) {
+		range->start = zstart != NULL ? (Word_t) zval_get_long(zstart) : (Word_t) 0;
+		range->end = zend_val != NULL ? (Word_t) zval_get_long(zend_val) : (Word_t) -1;
+		if (EG(exception)) {
+			return FAILURE;
+		}
+		range->is_empty = range->start > range->end;
+		return SUCCESS;
+	}
+
+	if ((zstart != NULL && Z_TYPE_P(zstart) != IS_STRING)
+			|| (zend_val != NULL && Z_TYPE_P(zend_val) != IS_STRING)) {
+		zend_throw_error(zend_ce_type_error,
+			"Judy::%s() expects string arguments for string-keyed arrays", method);
+		return FAILURE;
+	}
+
+	if (zstart != NULL) {
+		range->str_start = Z_STRVAL_P(zstart);
+		range->str_start_len = Z_STRLEN_P(zstart);
+	}
+	if (zend_val != NULL) {
+		range->str_end = Z_STRVAL_P(zend_val);
+	}
+	if (range->str_start != NULL && range->str_end != NULL
+			&& strcmp(range->str_start, range->str_end) > 0) {
+		range->is_empty = 1;
+	}
+
+	return SUCCESS;
+}
+
+/* {{{ Helper to build a PHP array from a Judy array's contents, optionally
+   restricted to an inclusive key range.
+   Used by jsonSerialize(), __serialize(), toArray(), keys(), and values(). */
+static void judy_populate_array_range(judy_object *intern, zval *data, judy_collect_mode mode,
+		const judy_collect_range *range)
+{
+	/* An absent range is exactly an unbounded one: 0..Word_t maximum for
+	   integer keys, NULL bounds for string keys. */
+	Word_t range_start = range != NULL ? range->start : (Word_t) 0;
+	Word_t range_end = range != NULL ? range->end : (Word_t) -1;
+	const char *range_str_end = range != NULL ? range->str_end : NULL;
+
+	if (range != NULL && range->is_empty) {
+		return;
+	}
+
 	if (intern->type == TYPE_BITSET) {
-		Word_t index = 0;
+		Word_t index = range_start;
 		int Rc_int;
 
 		J1F(Rc_int, intern->array, index);
-		while (Rc_int) {
+		while (Rc_int && index <= range_end) {
 			/* BITSET is a set of indices — the index IS the value.
 			   keys(), values(), and toArray() all return the same flat index list. */
 			add_next_index_long(data, (zend_long)index);
@@ -3396,11 +3493,11 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 		}
 
 	} else if (intern->is_integer_keyed) {
-		Word_t index = 0;
+		Word_t index = range_start;
 		Pvoid_t *PValue;
 
 		JLF(PValue, intern->array, index);
-		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
+		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR) && index <= range_end) {
 			if (mode == JUDY_COLLECT_KEYS) {
 				add_next_index_long(data, (zend_long)index);
 			} else if (intern->type == TYPE_INT_TO_INT) {
@@ -3450,10 +3547,11 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 	} else if (intern->is_adaptive) {
 		uint8_t *key = intern->key_scratch;
 		Pvoid_t *PValue;
-		key[0] = '\0';
+		judy_range_seed_key(key, range);
 		JSLF(PValue, intern->key_index, key);
 
-		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
+		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)
+				&& judy_range_key_in_bounds(key, range_str_end)) {
 			if (mode == JUDY_COLLECT_KEYS) {
 				add_next_index_string(data, (const char *)key);
 			} else {
@@ -3498,14 +3596,15 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 		uint8_t *key = intern->key_scratch;
 		Pvoid_t *PValue;
 
-		key[0] = '\0';
+		judy_range_seed_key(key, range);
 		if (intern->is_hash_keyed) {
 			JSLF(PValue, intern->key_index, key);
 		} else {
 			JSLF(PValue, intern->array, key);
 		}
 
-		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
+		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)
+				&& judy_range_key_in_bounds(key, range_str_end)) {
 			if (mode == JUDY_COLLECT_KEYS) {
 				add_next_index_string(data, (const char *)key);
 			} else {
@@ -3548,30 +3647,53 @@ static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mo
 	}
 }
 
+static void judy_populate_array(judy_object *intern, zval *data, judy_collect_mode mode)
+{
+	judy_populate_array_range(intern, data, mode, NULL);
+}
+
 static void judy_build_data_array(judy_object *intern, zval *data)
 {
 	judy_populate_array(intern, data, JUDY_COLLECT_ALL);
 }
 
-/* {{{ proto array Judy::keys()
-   Return the keys of the Judy array */
+/* Shared body of keys()/values()/toArray(): parse the optional range pair and
+   run one bounded traversal straight into the returned PHP array. */
+static void judy_collect_method(INTERNAL_FUNCTION_PARAMETERS, judy_collect_mode mode,
+		const char *method)
+{
+	zval *zstart = NULL, *zend_val = NULL;
+	judy_collect_range range;
+
+	JUDY_METHOD_GET_OBJECT
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(zstart)
+		Z_PARAM_ZVAL(zend_val)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (judy_parse_collect_range(intern, zstart, zend_val, &range, method) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	array_init(return_value);
+	judy_populate_array_range(intern, return_value, mode, &range);
+}
+
+/* {{{ proto array Judy::keys(mixed $start = null, mixed $end = null)
+   Return the keys of the Judy array, optionally limited to [$start, $end] */
 PHP_METHOD(Judy, keys)
 {
-	JUDY_METHOD_GET_OBJECT
-	ZEND_PARSE_PARAMETERS_NONE();
-	array_init(return_value);
-	judy_populate_array(intern, return_value, JUDY_COLLECT_KEYS);
+	judy_collect_method(INTERNAL_FUNCTION_PARAM_PASSTHRU, JUDY_COLLECT_KEYS, "keys");
 }
 /* }}} */
 
-/* {{{ proto array Judy::values()
-   Return the values of the Judy array */
+/* {{{ proto array Judy::values(mixed $start = null, mixed $end = null)
+   Return the values of the Judy array, optionally limited to [$start, $end] */
 PHP_METHOD(Judy, values)
 {
-	JUDY_METHOD_GET_OBJECT
-	ZEND_PARSE_PARAMETERS_NONE();
-	array_init(return_value);
-	judy_populate_array(intern, return_value, JUDY_COLLECT_VALUES);
+	judy_collect_method(INTERNAL_FUNCTION_PARAM_PASSTHRU, JUDY_COLLECT_VALUES, "values");
 }
 /* }}} */
 
@@ -4589,16 +4711,11 @@ PHP_METHOD(Judy, __unserialize)
 }
 /* }}} */
 
-/* {{{ proto array Judy::toArray()
-   Convert the Judy array to a native PHP array */
+/* {{{ proto array Judy::toArray(mixed $start = null, mixed $end = null)
+   Convert the Judy array to a native PHP array, optionally limited to [$start, $end] */
 PHP_METHOD(Judy, toArray)
 {
-	JUDY_METHOD_GET_OBJECT
-
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	array_init(return_value);
-	judy_build_data_array(intern, return_value);
+	judy_collect_method(INTERNAL_FUNCTION_PARAM_PASSTHRU, JUDY_COLLECT_ALL, "toArray");
 }
 /* }}} */
 

--- a/scripts/api-metadata.php
+++ b/scripts/api-metadata.php
@@ -91,6 +91,34 @@ PHP,
         ],
         'Range Operations' => [
             'methods' => ['slice', 'deleteRange', 'populationCount'],
+            'description' => <<<'MD'
+**Every range in this API is a pair of inclusive *keys*, never an offset and a length.**
+
+Think `range($start, $end)`, not `array_slice($a, $offset, $length)`. PHP splits
+the convention by data shape: offset/length suits *sequences* (`array_slice`,
+`substr`), where positions are dense and meaningful; start/end suits *ordered
+value domains* (`range()`, `DatePeriod`). A Judy array is the second kind — a
+sparse ordered map — so `slice(5, 10)` means "keys 5 through 10 inclusive", and
+returns nothing at all if no key in that span is set.
+
+The distinction is not cosmetic, because both operations exist here and they are
+different:
+
+| Question | Method | How it works |
+| --- | --- | --- |
+| "the element at position N" | `byCount($nth_index)` | positional; counts elements |
+| "elements with keys in [lo, hi]" | `slice`, `deleteRange`, `populationCount`, `size`, and the bounded forms of `keys`/`values`/`toArray` | key-space; seeks directly |
+
+Key-space is where Judy is fast: bounding by key is a seek to the first key at or
+above `$start` and then a walk, so reading a narrow range out of a huge array
+costs the range, not the array. An offset-based equivalent would have to count
+from the beginning to find where to start — which is exactly the work `byCount()`
+does, and exactly the work the key-bounded methods exist to avoid.
+
+Bounds are inclusive on both ends, an inverted range (`$start > $end`) yields
+nothing rather than erroring, and string-keyed types compare bounds
+lexicographically with `strcmp()`.
+MD,
         ],
         'Batch Operations' => [
             'methods' => ['fromArray', 'toArray', 'putAll', 'getAll', 'keys', 'values', 'increment'],
@@ -159,7 +187,14 @@ PHP,
             ],
         ],
         'size' => [
-            'description' => 'Returns the number of elements. When called with arguments, returns the population count within the given range (integer-keyed types only).',
+            'description' => 'Returns the number of elements. When called with arguments, returns the population count of keys in the inclusive `[$start, $end]` range (integer-keyed types only). The bounds are keys, not offsets — see [Range Operations](#range-operations).',
+            'example' => <<<'PHP'
+$judy = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 1000 => 100]);
+
+$judy->size();          // 3
+$judy->size(0, 100);    // 2  — keys 1 and 5; key 1000 is outside the range
+$judy->size(0, -1);     // 3  — -1 is the maximum bound, so this is "everything"
+PHP,
         ],
         'count' => [
             'description' => "Returns the number of elements. Implements PHP's `Countable` interface.",

--- a/scripts/api-metadata.php
+++ b/scripts/api-metadata.php
@@ -242,7 +242,16 @@ PHP,
             'example' => '$judy = Judy::fromArray(Judy::INT_TO_INT, [0 => 100, 5 => 200, 10 => 300]);',
         ],
         'toArray' => [
-            'description' => 'Converts the Judy array to a PHP array. Uses native C iteration internally, 2-3x faster than manual `foreach`.',
+            'description' => 'Converts the Judy array to a PHP array. Uses native C iteration internally, 2-3x faster than manual `foreach`. With `$start` and/or `$end`, only the inclusive `[$start, $end]` key range is returned; `null` leaves that side unbounded.',
+            'supported_types' => 'All types. String-keyed types require string bounds and compare them lexicographically.',
+            'example' => <<<'PHP'
+$judy = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 10 => 100]);
+
+$judy->toArray();          // [1 => 10, 5 => 50, 10 => 100]
+$judy->toArray(5, 10);     // [5 => 50, 10 => 100]
+$judy->toArray(5);         // [5 => 50, 10 => 100]  (unbounded end)
+$judy->toArray(null, 5);   // [1 => 10, 5 => 50]    (unbounded start)
+PHP,
         ],
         'putAll' => [
             'description' => 'Bulk-inserts all key-value pairs from the given PHP array.',
@@ -256,10 +265,27 @@ $values = $judy->getAll([0, 2, 99]);
 PHP,
         ],
         'keys' => [
-            'description' => 'Returns all keys as a PHP array.',
+            'description' => "Returns all keys as a PHP array. With `\$start` and/or `\$end`, only the inclusive `[\$start, \$end]` key range is returned; `null` leaves that side unbounded.\n\nA bounded read is a single traversal writing straight into the returned array, so prefer it to `slice(\$lo, \$hi)->keys()`, which allocates and populates a whole intermediate Judy array and then traverses that copy.",
+            'supported_types' => 'All types. String-keyed types require string bounds and compare them lexicographically.',
+            'example' => <<<'PHP'
+$judy = new Judy(Judy::BITSET);
+foreach ([1, 5, 10, 15] as $i) $judy[$i] = true;
+
+$judy->keys(5, 10);        // [5, 10]
+$judy->keys(5);            // [5, 10, 15]  (unbounded end)
+$judy->keys(null, 5);      // [1, 5]       (unbounded start)
+$judy->keys(10, 5);        // []           (inverted range)
+
+// An upper bound is a bound, not a prefix filter: "blackcurrant" sorts after
+// "bl", so bound a prefix sweep with the prefix's successor.
+$fruit = Judy::fromArray(Judy::STRING_TO_INT, ['blackcurrant' => 1, 'cherry' => 2]);
+$fruit->keys('bl', 'bl');  // []
+$fruit->keys('bl', 'bm');  // ['blackcurrant']
+PHP,
         ],
         'values' => [
-            'description' => 'Returns all values as a PHP array.',
+            'description' => 'Returns all values as a PHP array. With `$start` and/or `$end`, only the values of keys in the inclusive `[$start, $end]` range are returned; `null` leaves that side unbounded.',
+            'supported_types' => 'All types. String-keyed types require string bounds and compare them lexicographically.',
         ],
         'increment' => [
             'description' => 'Atomically increments the value at `$key` by `$amount`. If the key does not exist, it is created with the value `$amount`. Returns the new value.',

--- a/tests/keys_range_int_001.phpt
+++ b/tests/keys_range_int_001.phpt
@@ -1,0 +1,140 @@
+--TEST--
+Judy keys()/values()/toArray() range arguments for integer-keyed types
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+function show(string $label, array $a): void
+{
+    echo $label, ": ", json_encode($a), "\n";
+}
+
+/* ── BITSET: the index is both key and value ──────────────────────── */
+
+$b = new Judy(Judy::BITSET);
+foreach ([1, 5, 10, 15, 20, 100] as $k) {
+    $b[$k] = true;
+}
+show("bitset keys(5,15)",     $b->keys(5, 15));
+show("bitset values(5,15)",   $b->values(5, 15));
+show("bitset toArray(5,15)",  $b->toArray(5, 15));
+show("bitset keys(5,5)",      $b->keys(5, 5));
+show("bitset keys(6,9)",      $b->keys(6, 9));      // range inside a gap
+show("bitset keys(200,300)",  $b->keys(200, 300));  // past the last key
+show("bitset keys(15,5)",     $b->keys(15, 5));     // inverted
+show("bitset keys(5)",        $b->keys(5));         // unbounded end
+show("bitset keys(null,10)",  $b->keys(null, 10));  // unbounded start
+show("bitset keys()",         $b->keys());
+show("bitset keys(null,null)", $b->keys(null, null));
+
+/* ── INT_TO_INT ───────────────────────────────────────────────────── */
+
+$i = new Judy(Judy::INT_TO_INT);
+foreach ([1 => 10, 5 => 50, 10 => 100, 15 => 150] as $k => $v) {
+    $i[$k] = $v;
+}
+show("int keys(5,10)",     $i->keys(5, 10));
+show("int values(5,10)",   $i->values(5, 10));
+show("int toArray(5,10)",  $i->toArray(5, 10));
+show("int toArray(10,5)",  $i->toArray(10, 5));
+show("int values(6)",      $i->values(6));
+
+/* ── INT_TO_MIXED ─────────────────────────────────────────────────── */
+
+$m = new Judy(Judy::INT_TO_MIXED);
+$m[1] = "one";
+$m[5] = [1, 2];
+$m[10] = null;
+$m[15] = 3.5;
+show("mixed keys(5,10)",    $m->keys(5, 10));
+show("mixed values(5,10)",  $m->values(5, 10));
+show("mixed toArray(5,10)", $m->toArray(5, 10));
+show("mixed toArray(2,4)",  $m->toArray(2, 4));
+
+/* ── INT_TO_PACKED ────────────────────────────────────────────────── */
+
+$p = new Judy(Judy::INT_TO_PACKED);
+$p[1] = "one";
+$p[5] = 50;
+$p[10] = true;
+$p[15] = 3.5;
+show("packed keys(5,10)",    $p->keys(5, 10));
+show("packed values(5,10)",  $p->values(5, 10));
+show("packed toArray(5,10)", $p->toArray(5, 10));
+show("packed toArray(11,14)", $p->toArray(11, 14));
+
+/* ── Empty source ─────────────────────────────────────────────────── */
+
+foreach ([Judy::BITSET, Judy::INT_TO_INT, Judy::INT_TO_MIXED, Judy::INT_TO_PACKED] as $type) {
+    $e = new Judy($type);
+    printf(
+        "empty type %d: %s %s %s\n",
+        $type,
+        json_encode($e->keys(0, 100)),
+        json_encode($e->values(0, 100)),
+        json_encode($e->toArray(0, 100))
+    );
+}
+
+/* ── A bounded read agrees with slice() over the same range ───────── */
+
+foreach ([[5, 15], [0, 0], [6, 9], [15, 5], [-1, -1]] as [$lo, $hi]) {
+    $same = $b->keys($lo, $hi) === $b->slice($lo, $hi)->keys()
+        && $i->toArray($lo, $hi) === $i->slice($lo, $hi)->toArray()
+        && $m->toArray($lo, $hi) === $m->slice($lo, $hi)->toArray()
+        && $p->toArray($lo, $hi) === $p->slice($lo, $hi)->toArray();
+    printf("slice agreement [%d,%d]: %s\n", $lo, $hi, $same ? "yes" : "no");
+}
+
+/* ── Bounds are Word_t, so -1 is the maximum bound, as in size() ──── */
+
+$w = new Judy(Judy::INT_TO_INT);
+$w[1] = 10;
+$w[PHP_INT_MAX] = 20;
+show("word keys(0,-1)",   $w->keys(0, -1));    // 0 .. Word_t max: everything
+show("word keys(0,100)",  $w->keys(0, 100));
+show("word keys(2,-1)",   $w->keys(2, -1));
+printf("word size(0,-1) agrees: %s\n", count($w->keys(0, -1)) === $w->size(0, -1) ? "yes" : "no");
+
+/* Integer-keyed bounds are coerced like slice()'s, so numeric strings work. */
+show("coerced keys('5','10')", $i->keys("5", "10"));
+?>
+--EXPECT--
+bitset keys(5,15): [5,10,15]
+bitset values(5,15): [5,10,15]
+bitset toArray(5,15): [5,10,15]
+bitset keys(5,5): [5]
+bitset keys(6,9): []
+bitset keys(200,300): []
+bitset keys(15,5): []
+bitset keys(5): [5,10,15,20,100]
+bitset keys(null,10): [1,5,10]
+bitset keys(): [1,5,10,15,20,100]
+bitset keys(null,null): [1,5,10,15,20,100]
+int keys(5,10): [5,10]
+int values(5,10): [50,100]
+int toArray(5,10): {"5":50,"10":100}
+int toArray(10,5): []
+int values(6): [100,150]
+mixed keys(5,10): [5,10]
+mixed values(5,10): [[1,2],null]
+mixed toArray(5,10): {"5":[1,2],"10":null}
+mixed toArray(2,4): []
+packed keys(5,10): [5,10]
+packed values(5,10): [50,true]
+packed toArray(5,10): {"5":50,"10":true}
+packed toArray(11,14): []
+empty type 1: [] [] []
+empty type 2: [] [] []
+empty type 3: [] [] []
+empty type 6: [] [] []
+slice agreement [5,15]: yes
+slice agreement [0,0]: yes
+slice agreement [6,9]: yes
+slice agreement [15,5]: yes
+slice agreement [-1,-1]: yes
+word keys(0,-1): [1,9223372036854775807]
+word keys(0,100): [1]
+word keys(2,-1): [9223372036854775807]
+word size(0,-1) agrees: yes
+coerced keys('5','10'): [5,10]

--- a/tests/keys_range_string_001.phpt
+++ b/tests/keys_range_string_001.phpt
@@ -1,0 +1,191 @@
+--TEST--
+Judy keys()/values()/toArray() range arguments for string-keyed types
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+/*
+ * String-keyed types are in scope for the range arguments: every one of them
+ * iterates its JudySL key index in lexicographic order, so the same bounded
+ * single traversal applies. Bounds must be strings and are compared with
+ * strcmp(), exactly as slice() compares them.
+ */
+
+$int_types = [
+    'STRING_TO_INT'          => Judy::STRING_TO_INT,
+    'STRING_TO_INT_HASH'     => Judy::STRING_TO_INT_HASH,
+    'STRING_TO_INT_ADAPTIVE' => Judy::STRING_TO_INT_ADAPTIVE,
+];
+$mixed_types = [
+    'STRING_TO_MIXED'          => Judy::STRING_TO_MIXED,
+    'STRING_TO_MIXED_HASH'     => Judy::STRING_TO_MIXED_HASH,
+    'STRING_TO_MIXED_ADAPTIVE' => Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+/* Deliberately mixes keys at or below the 7-byte SSO threshold with longer
+   ones, so the adaptive types exercise both their JudyL and JudyHS stores. */
+$fruit = ["apple", "apricot", "banana", "blackcurrant", "cherry", "date"];
+
+foreach ($int_types + $mixed_types as $name => $type) {
+    $j = new Judy($type);
+    foreach ($fruit as $i => $key) {
+        $j[$key] = isset($int_types[$name]) ? $i : "v$i";
+    }
+
+    echo "== $name\n";
+    echo "  keys(b,c):        ", json_encode($j->keys("b", "c")), "\n";
+    echo "  keys(apricot,cherry): ", json_encode($j->keys("apricot", "cherry")), "\n";
+    echo "  keys(b):          ", json_encode($j->keys("b")), "\n";
+    echo "  keys(null,b):     ", json_encode($j->keys(null, "b")), "\n";
+    echo "  keys():           ", json_encode($j->keys()), "\n";
+    /* An upper bound is a bound, not a prefix filter: "blackcurrant" sorts
+       after "bl", so bounding at "bl" excludes it and "bm" includes it. */
+    echo "  keys(bb,bl):      ", json_encode($j->keys("bb", "bl")), "\n";
+    echo "  keys(bb,bm):      ", json_encode($j->keys("bb", "bm")), "\n";
+    echo "  keys(zz,zzz):     ", json_encode($j->keys("zz", "zzz")), "\n";
+    echo "  keys(c,b):        ", json_encode($j->keys("c", "b")), "\n";
+    echo "  values(b,c):      ", json_encode($j->values("b", "c")), "\n";
+    echo "  toArray(b,c):     ", json_encode($j->toArray("b", "c")), "\n";
+    echo "  toArray(c,b):     ", json_encode($j->toArray("c", "b")), "\n";
+
+    /* A bounded read must equal the same range copied then read whole. */
+    $agree = true;
+    foreach ([["b", "c"], ["apple", "apple"], ["bb", "bl"], ["c", "b"], ["", "zzz"]] as [$lo, $hi]) {
+        $agree = $agree
+            && $j->keys($lo, $hi) === $j->slice($lo, $hi)->keys()
+            && $j->toArray($lo, $hi) === $j->slice($lo, $hi)->toArray();
+    }
+    echo "  agrees with slice: ", $agree ? "yes" : "no", "\n";
+
+    /* Non-string bounds are a TypeError, as they are for slice(). */
+    foreach ([[1, 2], ["a", 2], [1.5, "z"], [true, "z"]] as [$lo, $hi]) {
+        try {
+            $j->keys($lo, $hi);
+            echo "  no throw\n";
+        } catch (TypeError $e) {
+            echo "  TypeError: ", $e->getMessage(), "\n";
+        }
+    }
+
+    $empty = new Judy($type);
+    echo "  empty source:     ",
+        json_encode($empty->keys("a", "z")), " ",
+        json_encode($empty->values("a", "z")), " ",
+        json_encode($empty->toArray("a", "z")), "\n";
+}
+?>
+--EXPECTF--
+== STRING_TO_INT
+  keys(b,c):        ["banana","blackcurrant"]
+  keys(apricot,cherry): ["apricot","banana","blackcurrant","cherry"]
+  keys(b):          ["banana","blackcurrant","cherry","date"]
+  keys(null,b):     ["apple","apricot"]
+  keys():           ["apple","apricot","banana","blackcurrant","cherry","date"]
+  keys(bb,bl):      []
+  keys(bb,bm):      ["blackcurrant"]
+  keys(zz,zzz):     []
+  keys(c,b):        []
+  values(b,c):      [2,3]
+  toArray(b,c):     {"banana":2,"blackcurrant":3}
+  toArray(c,b):     []
+  agrees with slice: yes
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  empty source:     [] [] []
+== STRING_TO_INT_HASH
+  keys(b,c):        ["banana","blackcurrant"]
+  keys(apricot,cherry): ["apricot","banana","blackcurrant","cherry"]
+  keys(b):          ["banana","blackcurrant","cherry","date"]
+  keys(null,b):     ["apple","apricot"]
+  keys():           ["apple","apricot","banana","blackcurrant","cherry","date"]
+  keys(bb,bl):      []
+  keys(bb,bm):      ["blackcurrant"]
+  keys(zz,zzz):     []
+  keys(c,b):        []
+  values(b,c):      [2,3]
+  toArray(b,c):     {"banana":2,"blackcurrant":3}
+  toArray(c,b):     []
+  agrees with slice: yes
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  empty source:     [] [] []
+== STRING_TO_INT_ADAPTIVE
+  keys(b,c):        ["banana","blackcurrant"]
+  keys(apricot,cherry): ["apricot","banana","blackcurrant","cherry"]
+  keys(b):          ["banana","blackcurrant","cherry","date"]
+  keys(null,b):     ["apple","apricot"]
+  keys():           ["apple","apricot","banana","blackcurrant","cherry","date"]
+  keys(bb,bl):      []
+  keys(bb,bm):      ["blackcurrant"]
+  keys(zz,zzz):     []
+  keys(c,b):        []
+  values(b,c):      [2,3]
+  toArray(b,c):     {"banana":2,"blackcurrant":3}
+  toArray(c,b):     []
+  agrees with slice: yes
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  empty source:     [] [] []
+== STRING_TO_MIXED
+  keys(b,c):        ["banana","blackcurrant"]
+  keys(apricot,cherry): ["apricot","banana","blackcurrant","cherry"]
+  keys(b):          ["banana","blackcurrant","cherry","date"]
+  keys(null,b):     ["apple","apricot"]
+  keys():           ["apple","apricot","banana","blackcurrant","cherry","date"]
+  keys(bb,bl):      []
+  keys(bb,bm):      ["blackcurrant"]
+  keys(zz,zzz):     []
+  keys(c,b):        []
+  values(b,c):      ["v2","v3"]
+  toArray(b,c):     {"banana":"v2","blackcurrant":"v3"}
+  toArray(c,b):     []
+  agrees with slice: yes
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  empty source:     [] [] []
+== STRING_TO_MIXED_HASH
+  keys(b,c):        ["banana","blackcurrant"]
+  keys(apricot,cherry): ["apricot","banana","blackcurrant","cherry"]
+  keys(b):          ["banana","blackcurrant","cherry","date"]
+  keys(null,b):     ["apple","apricot"]
+  keys():           ["apple","apricot","banana","blackcurrant","cherry","date"]
+  keys(bb,bl):      []
+  keys(bb,bm):      ["blackcurrant"]
+  keys(zz,zzz):     []
+  keys(c,b):        []
+  values(b,c):      ["v2","v3"]
+  toArray(b,c):     {"banana":"v2","blackcurrant":"v3"}
+  toArray(c,b):     []
+  agrees with slice: yes
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  empty source:     [] [] []
+== STRING_TO_MIXED_ADAPTIVE
+  keys(b,c):        ["banana","blackcurrant"]
+  keys(apricot,cherry): ["apricot","banana","blackcurrant","cherry"]
+  keys(b):          ["banana","blackcurrant","cherry","date"]
+  keys(null,b):     ["apple","apricot"]
+  keys():           ["apple","apricot","banana","blackcurrant","cherry","date"]
+  keys(bb,bl):      []
+  keys(bb,bm):      ["blackcurrant"]
+  keys(zz,zzz):     []
+  keys(c,b):        []
+  values(b,c):      ["v2","v3"]
+  toArray(b,c):     {"banana":"v2","blackcurrant":"v3"}
+  toArray(c,b):     []
+  agrees with slice: yes
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  TypeError: Judy::keys() expects string arguments for string-keyed arrays
+  empty source:     [] [] []

--- a/tests/range_named_args_001.phpt
+++ b/tests/range_named_args_001.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Judy range methods accept uniform $start/$end named arguments
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+/*
+ * Every range in this API is a pair of inclusive KEYS, never an offset and a
+ * length, and every range method spells its bounds $start/$end. This test is
+ * the guard on that second half: named arguments only stay uniform if nobody
+ * reintroduces a differently-named parameter later.
+ */
+
+$j = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 10 => 100, 1000 => 1000]);
+
+echo "size:            ", $j->size(start: 0, end: 100), "\n";
+echo "populationCount: ", $j->populationCount(start: 0, end: 100), "\n";
+echo "slice:           ", json_encode($j->slice(start: 0, end: 100)->keys()), "\n";
+echo "keys:            ", json_encode($j->keys(start: 0, end: 100)), "\n";
+echo "values:          ", json_encode($j->values(start: 0, end: 100)), "\n";
+echo "toArray:         ", json_encode($j->toArray(start: 0, end: 100)), "\n";
+
+/* Skipping the first bound by name is the payoff of a uniform spelling. */
+echo "keys(end:):      ", json_encode($j->keys(end: 10)), "\n";
+echo "toArray(start:): ", json_encode($j->toArray(start: 10)), "\n";
+
+$d = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 10 => 100]);
+echo "deleteRange:     ", $d->deleteRange(start: 0, end: 5), " deleted, left ",
+    json_encode($d->keys()), "\n";
+
+/* The bounds are keys, not offsets: this range spans positions 0..2 of the
+   array but only keys 0..2 of the key space, where a single element lives. */
+echo "keys(0,2):       ", json_encode($j->keys(0, 2)), "\n";
+echo "byCount(2):      ", $j->byCount(2), "  <- the positional accessor\n";
+
+/* Reflection: the parameter names are the documented contract. */
+foreach (['size', 'populationCount', 'slice', 'deleteRange', 'keys', 'values', 'toArray'] as $m) {
+    $names = array_map(
+        static fn(ReflectionParameter $p): string => $p->getName(),
+        (new ReflectionMethod('Judy', $m))->getParameters()
+    );
+    printf("%-16s %s\n", $m . ':', implode(', ', $names));
+}
+?>
+--EXPECT--
+size:            3
+populationCount: 3
+slice:           [1,5,10]
+keys:            [1,5,10]
+values:          [10,50,100]
+toArray:         {"1":10,"5":50,"10":100}
+keys(end:):      [1,5,10]
+toArray(start:): {"10":100,"1000":1000}
+deleteRange:     2 deleted, left [10]
+keys(0,2):       [1]
+byCount(2):      5  <- the positional accessor
+size:            start, end
+populationCount: start, end
+slice:           start, end
+deleteRange:     start, end
+keys:            start, end
+values:          start, end
+toArray:         start, end


### PR DESCRIPTION
## The gap

`keys()` and `toArray()` are fast because they make **one** traversal writing straight into the destination PHP array — but they had no range-limited form. Range arguments existed only on `size()`, `populationCount()`, `deleteRange()` and `slice()`.

So the only bulk way to read a bounded key range was `slice($lo, $hi)->keys()`. `Judy::slice` is a copy constructor, not a projection: it runs a J1F/J1N traversal and inserts every key into a freshly allocated Judy, which `keys()` then traverses a **second** time. Two traversals, an insert per key and an allocation, to avoid one PHP method dispatch per key.

The consequence was that the repo's own "prefer bulk operations, they run in C" guidance (AGENTS.md; BENCHMARK.md Tables 5 and 6) did not hold for range reads, because the primitive it needs did not exist.

## The change

`keys()`, `values()` and `toArray()` take an optional inclusive range:

```php
public function keys(mixed $start = null, mixed $end = null): array
public function values(mixed $start = null, mixed $end = null): array
public function toArray(mixed $start = null, mixed $end = null): array
```

`null` on either side leaves it unbounded, so `keys(100)` reads from 100 onward and `keys(null, 100)` up to 100. Extending the three existing methods rather than adding `keysInRange()` matches how `size()` and `populationCount()` already carry bounds, and is fully backward compatible.

The range is threaded into `judy_populate_array()` as a descriptor, so a bounded read is the same single traversal with a start seek and an end test — no intermediate Judy, no second traversal, no insert per key. A NULL range is exactly an unbounded one (0..`Word_t` maximum, or NULL string bounds), so the existing callers (`jsonSerialize()`, `__serialize()`) are untouched. `keys`/`values`/`toArray` now share one `judy_collect_method()` body.

## String-keyed types are in scope

Every string-keyed type iterates a JudySL key index in lexicographic order, so the same bounded traversal applies, and excluding them would have been an odd asymmetry with `slice()`, which already supports them. They require string bounds — a non-string bound is a `TypeError` with the same wording `slice()` uses — and compare with `strcmp()`.

Integer bounds are `Word_t`, so `-1` is the maximum bound, consistent with `size()` and `populationCount()`.

One trap worth knowing, documented in AGENTS.md, API.md and the tests: **an upper bound is a bound, not a prefix filter.** `keys('bl', 'bl')` does not return `blackcurrant` — it sorts after `bl`. Bound a prefix sweep with the prefix's successor (`keys('bl', 'bm')`).

## Measured

Interleaved A/B/C rounds, medians, one block inside a 400k-key array:

| block keys | walk | slice+keys | keys(lo,hi) | vs walk | vs slice |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 108 ns | 180 | 78 | 1.37x | 2.29x |
| 64 | 4,806 | 6,435 | 2,909 | 1.65x | 2.21x |
| 1,024 | 75,944 | 115,817 | 45,664 | 1.66x | 2.54x |
| 65,536 | 4,824,597 | 6,982,347 | 2,897,583 | 1.67x | 2.41x |

On the `coverage-index` test-impact selection that motivated this (26-pair diff, 185,700 triples, all four shapes verified digest-identical):

| shape | median | vs walk |
| --- | ---: | ---: |
| walk `first()`/`searchNext()` | 0.034 ms | 1.00x |
| bulk `slice()+keys()` | 0.048 ms | 0.72x |
| `populationCount()` + `keys($lo,$hi)` | 0.033 ms | 1.02x |
| `keys($lo,$hi)` alone | 0.022 ms | **1.55x** |

The finding there is not just "swap `slice()` for `keys()`" — it is "one crossing per changed line instead of three". With mostly small blocks, `populationCount()`'s extra crossing eats the entire gain; the returned array's emptiness answers the same question for free.

**Honest disclosure on these numbers:** taken on an M1 (8 cores) at load average 4.7-10.2, above the N/2 threshold this repo's benchmark hygiene calls contaminated, with Spotlight indexing at ~97% CPU. They were run interleaved and reported as ratios precisely so contention hits all shapes equally, and both benchmarks reproduced to two significant figures across runs at different loads. Nothing in this PR depends on them: no baseline bump, no BENCHMARK.md claim. A clean idle-machine run is owed before any of this is written into BENCHMARK.md.

## Tests

- `tests/keys_range_int_001.phpt` — BITSET, INT_TO_INT, INT_TO_MIXED, INT_TO_PACKED across `keys`/`values`/`toArray`: bounded, single-key, inside-a-gap, past-the-end, **empty** and **inverted** (`$start > $end`) ranges, unbounded sides, empty source, `-1`-as-maximum-bound agreeing with `size(0, -1)`, and numeric-string bound coercion.
- `tests/keys_range_string_001.phpt` — all six string-keyed types across the same shapes, the prefix-bound trap, `TypeError` on int/float/bool bounds, empty source.

Both assert that a bounded read equals `slice($lo, $hi)` read whole, for every range shape tested. Full suite 194/194; the new tests also pass under `USE_ZEND_ALLOC=0`.

## Checklist

- [x] `Judy.stub.php` updated as the canonical API definition; arginfo regenerated
- [x] `php scripts/generate-api-docs.php` run; `--check` clean
- [x] AGENTS.md kept in sync (bulk section, range section, new pitfall); README.md updated
- [x] `package.xml` lists both new test files
- [x] Zero compiler warnings
- [x] `baselines/latest.json` untouched

## Follow-up, not in this PR

`examples/coverage-index.php` lives on `a2/test-impact-analysis`, not on `main`, so this PR cannot touch it. Its `selectJudyBulk()` docblock and closing notes now assert something this change refutes ("There is no range-limited equivalent — no `keys($lo, $hi)`"). That needs a separate commit on that branch once this lands.



---

## Update: parameter-name alignment and the reasoning, now documented

Two follow-ups landed on this branch after review discussion.

**`size()` aligned on `$start`/`$end`.** It was the last range method spelling its bounds differently (`$index_start`/`$index_end`), which PHP 8 named arguments made user-visible — `size(index_start: 5)` sitting next to `slice(start: 5)`. All seven range methods now agree, and `tests/range_named_args_001.phpt` pins that via Reflection so the next range method added cannot quietly drift. BC note: this affects only callers passing `size()`'s bounds as *named* arguments; positional calls are unaffected.

**The key-vs-offset reasoning is now written down**, in API.md (a new Range Operations preamble), AGENTS.md and README.md, because the API had been leaving it implicit and `slice()` invites the wrong reading:

> Every range in this API is a pair of inclusive **keys**, never an offset and a length. Reach for `range($start, $end)`, not `array_slice($a, $offset, $length)`.

PHP splits that convention by data shape — offset/length for *sequences* where positions are dense (`array_slice`, `substr`), start/end for *ordered value domains* (`range()`, `DatePeriod`). A Judy array is the second kind. Both operations exist in this API and they are genuinely different: `byCount($n)` is the positional accessor; everything else is key-space. Key-space is also where the performance lives — a key bound is a seek plus a walk, so a narrow range out of a huge array costs the range rather than the array, whereas an offset-based equivalent would have to count from the beginning (which is what `byCount()` does, and what these methods exist to avoid).

## Backward compatibility

Deliberately accepted, having checked the ecosystem rather than assumed:

- **Subclasses overriding `keys()`/`values()`/`toArray()`** with the old zero-arg signature now fatal at class-declaration time. Nothing in the ecosystem subclasses `Judy` — judy-cache composes it, the polyfill is an independent class — so this is unknown third-party code only. The break is loud and immediate, and the error message prints the required signature.
- **`size()` named arguments**, as above.
- Both together mean this should ship as **2.5.0, not a patch release**.

## Downstream, tracked and deliberately deferred

Not in this PR; queued until the extension side settles:

- **`orieg/judy-polyfill`** — `keys()`/`values()`/`toArray()` still take no arguments and `size()` still uses the old parameter names. Its `bootstrap.php` aliases the class to the global `Judy`, so code written against the new signatures fatals under the polyfill until it is updated. The parity suite is what should catch this.
- **`orieg/phpstorm-stubs`** — the Judy stub needs the same signatures, then an upstream PR to JetBrains.
