### PR TITLE
fix(iterator): release the string key at end of walk instead of blanking it

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -265,6 +265,7 @@
          <file name="tests/count_int_to_packed_overwrite_001.phpt" role="test" />
          <file name="tests/delete_range_001.phpt" role="test" />
          <file name="tests/regression_delete_range_destructor_reentrancy_001.phpt" role="test" />
+         <file name="tests/regression_iterator_key_leak_001.phpt" role="test" />
          <file name="tests/equals_001.phpt" role="test" />
          <file name="tests/foreach_string_key_stress_001.phpt" role="test" />
          <file name="tests/filter_snapshot_semantics_001.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -1897,6 +1897,19 @@ PHP_METHOD(Judy, searchNext)
 }
 /* }}} */
 
+/* Release the iterator's current key and mark the walk invalid.
+ *
+ * iterator_key holds a refcounted zend_string on the string-keyed types, so
+ * blanking it with a bare ZVAL_UNDEF leaks that string. Every end-of-walk and
+ * invalid-state path must go through here. zval_ptr_dtor is a no-op on the
+ * already-UNDEF and IS_LONG cases, so this is safe on the integer-keyed paths
+ * too and keeps the rule uniform. */
+static zend_always_inline void judy_iterator_key_clear(judy_object *intern)
+{
+	zval_ptr_dtor(&intern->iterator_key);
+	ZVAL_UNDEF(&intern->iterator_key);
+}
+
 /* {{{ Iterator interface next() method - Fixes GitHub issue #25
  *
  * This method was separated from the original Judy::next() search function
@@ -1932,7 +1945,7 @@ PHP_METHOD(Judy, next)
 			ZVAL_BOOL(&intern->iterator_data, 1);
 			intern->iterator_initialized = 1;
 		} else {
-			ZVAL_UNDEF(&intern->iterator_key);
+			judy_iterator_key_clear(intern);
 			intern->iterator_initialized = 0;
 		}
 
@@ -1959,7 +1972,7 @@ PHP_METHOD(Judy, next)
 			}
 			intern->iterator_initialized = 1;
 		} else {
-			ZVAL_UNDEF(&intern->iterator_key);
+			judy_iterator_key_clear(intern);
 			ZVAL_UNDEF(&intern->iterator_data);
 			intern->iterator_initialized = 0;
 		}
@@ -1980,7 +1993,7 @@ PHP_METHOD(Judy, next)
 			}
 		} else {
 			/* Invalid key type, mark iterator as invalid */
-			ZVAL_UNDEF(&intern->iterator_key);
+			judy_iterator_key_clear(intern);
 			intern->iterator_initialized = 0;
 			return;
 		}
@@ -1999,7 +2012,7 @@ PHP_METHOD(Judy, next)
 			}
 			intern->iterator_initialized = 1;
 		} else {
-			ZVAL_UNDEF(&intern->iterator_key);
+			judy_iterator_key_clear(intern);
 			intern->iterator_initialized = 0;
 		}
 	}
@@ -2027,7 +2040,7 @@ PHP_METHOD(Judy, rewind)
 			intern->iterator_initialized = 1;
 		} else {
 			/* Array is empty, mark iterator as invalid */
-			ZVAL_UNDEF(&intern->iterator_key);
+			judy_iterator_key_clear(intern);
 			ZVAL_UNDEF(&intern->iterator_data);
 			intern->iterator_initialized = 0;
 		}
@@ -2054,7 +2067,7 @@ PHP_METHOD(Judy, rewind)
 			}
 			intern->iterator_initialized = 1;
 		} else {
-			ZVAL_UNDEF(&intern->iterator_key);
+			judy_iterator_key_clear(intern);
 			ZVAL_UNDEF(&intern->iterator_data);
 			intern->iterator_initialized = 0;
 		}
@@ -2083,7 +2096,7 @@ PHP_METHOD(Judy, rewind)
 			}
 			intern->iterator_initialized = 1;
 		} else {
-			ZVAL_UNDEF(&intern->iterator_key);
+			judy_iterator_key_clear(intern);
 			ZVAL_UNDEF(&intern->iterator_data);
 			intern->iterator_initialized = 0;
 		}

--- a/tests/regression_iterator_key_leak_001.phpt
+++ b/tests/regression_iterator_key_leak_001.phpt
@@ -54,6 +54,38 @@ foreach ($types as $name => $type) {
     printf("%-24s walked=%d growth=%d\n", $name, walk($j), $growth);
 }
 
+/* Negative controls. The integer-keyed and BITSET walks hold a long in
+ * iterator_key and never leaked, but they run the same end-of-walk branches and
+ * were routed through the same helper. Pinning them keeps "only the string
+ * types were affected" under test rather than merely asserted. */
+$controls = [
+    'INT_TO_INT'   => Judy::INT_TO_INT,
+    'INT_TO_MIXED' => Judy::INT_TO_MIXED,
+    'BITSET'       => Judy::BITSET,
+];
+
+foreach ($controls as $name => $type) {
+    $j = new Judy($type);
+    foreach ([1, 2, 3] as $i => $k) {
+        $j[$k] = $type === Judy::BITSET
+            ? true
+            : ($type === Judy::INT_TO_INT ? $i : "v$i");
+    }
+
+    /* Settle allocator state before measuring. */
+    for ($i = 0; $i < 100; $i++) {
+        walk($j);
+    }
+
+    $before = memory_get_usage();
+    for ($i = 0; $i < 500; $i++) {
+        walk($j);
+    }
+    $growth = memory_get_usage() - $before;
+
+    printf("%-24s walked=%d growth=%d\n", $name, walk($j), $growth);
+}
+
 /* rewind() on an array emptied after a partial walk: the stale string key must
  * be released rather than blanked. */
 $j = new Judy(Judy::STRING_TO_MIXED);
@@ -77,6 +109,23 @@ for ($i = 0; $i < 500; $i++) {
     $j['beta'] = 2;
 }
 printf("rewind-on-emptied growth=%d\n", memory_get_usage() - $before);
+
+/* Every assertion above is satisfied by a walk that leaks nothing because it
+ * never yields anything, so pin what the walk actually produces and the state
+ * it lands in once exhausted. */
+$j = new Judy(Judy::STRING_TO_MIXED);
+$j['alpha'] = 'a';
+$j['beta']  = 'b';
+$j['gamma'] = 'c';
+$seen = [];
+for ($j->rewind(); $j->valid(); $j->next()) {
+    $seen[$j->key()] = $j->current();
+}
+printf("keys=%s values=%s\n", implode(',', array_keys($seen)), implode(',', $seen));
+printf("exhausted valid=%s key=%s current=%s\n",
+    var_export($j->valid(), true),
+    var_export($j->key(), true),
+    var_export($j->current(), true));
 ?>
 --EXPECT--
 STRING_TO_INT            walked=3 growth=0
@@ -85,4 +134,9 @@ STRING_TO_INT_HASH       walked=3 growth=0
 STRING_TO_MIXED_HASH     walked=3 growth=0
 STRING_TO_INT_ADAPTIVE   walked=3 growth=0
 STRING_TO_MIXED_ADAPTIVE walked=3 growth=0
+INT_TO_INT               walked=3 growth=0
+INT_TO_MIXED             walked=3 growth=0
+BITSET                   walked=3 growth=0
 rewind-on-emptied growth=0
+keys=alpha,beta,gamma values=a,b,c
+exhausted valid=false key=NULL current=NULL

--- a/tests/regression_iterator_key_leak_001.phpt
+++ b/tests/regression_iterator_key_leak_001.phpt
@@ -1,0 +1,88 @@
+--TEST--
+Judy regression: completed manual Iterator walks must not leak the string key
+--SKIPIF--
+<?php if (!extension_loaded('judy')) die('skip judy extension not available'); ?>
+--FILE--
+<?php
+/* next()/rewind() blanked iterator_key with a bare ZVAL_UNDEF on the
+ * end-of-walk and empty-array paths. On the string-keyed types that zval holds
+ * a refcounted zend_string, so each completed walk leaked one string (32 bytes
+ * measured). The leak is Zend-MM allocated, which is why memory_get_usage()
+ * can see it here. */
+
+$types = [
+    'STRING_TO_INT'            => Judy::STRING_TO_INT,
+    'STRING_TO_MIXED'          => Judy::STRING_TO_MIXED,
+    'STRING_TO_INT_HASH'       => Judy::STRING_TO_INT_HASH,
+    'STRING_TO_MIXED_HASH'     => Judy::STRING_TO_MIXED_HASH,
+    'STRING_TO_INT_ADAPTIVE'   => Judy::STRING_TO_INT_ADAPTIVE,
+    'STRING_TO_MIXED_ADAPTIVE' => Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+function walk(Judy $j): int
+{
+    $seen = 0;
+    $j->rewind();
+    while ($j->valid()) {
+        $j->key();
+        $j->current();
+        $j->next();
+        $seen++;
+    }
+    return $seen;
+}
+
+foreach ($types as $name => $type) {
+    $j = new Judy($type);
+    foreach (['alpha', 'beta', 'gamma'] as $i => $k) {
+        $j[$k] = ($type === Judy::STRING_TO_INT
+            || $type === Judy::STRING_TO_INT_HASH
+            || $type === Judy::STRING_TO_INT_ADAPTIVE) ? $i : "v$i";
+    }
+
+    /* Settle allocator state before measuring. */
+    for ($i = 0; $i < 100; $i++) {
+        walk($j);
+    }
+
+    $before = memory_get_usage();
+    for ($i = 0; $i < 500; $i++) {
+        walk($j);
+    }
+    $growth = memory_get_usage() - $before;
+
+    printf("%-24s walked=%d growth=%d\n", $name, walk($j), $growth);
+}
+
+/* rewind() on an array emptied after a partial walk: the stale string key must
+ * be released rather than blanked. */
+$j = new Judy(Judy::STRING_TO_MIXED);
+$j['alpha'] = 1;
+$j['beta'] = 2;
+for ($i = 0; $i < 100; $i++) {
+    $j->rewind();
+    $j->key();
+    unset($j['alpha'], $j['beta']);
+    $j->rewind();
+    $j['alpha'] = 1;
+    $j['beta'] = 2;
+}
+$before = memory_get_usage();
+for ($i = 0; $i < 500; $i++) {
+    $j->rewind();
+    $j->key();
+    unset($j['alpha'], $j['beta']);
+    $j->rewind();
+    $j['alpha'] = 1;
+    $j['beta'] = 2;
+}
+printf("rewind-on-emptied growth=%d\n", memory_get_usage() - $before);
+?>
+--EXPECT--
+STRING_TO_INT            walked=3 growth=0
+STRING_TO_MIXED          walked=3 growth=0
+STRING_TO_INT_HASH       walked=3 growth=0
+STRING_TO_MIXED_HASH     walked=3 growth=0
+STRING_TO_INT_ADAPTIVE   walked=3 growth=0
+STRING_TO_MIXED_ADAPTIVE walked=3 growth=0
+rewind-on-emptied growth=0


### PR DESCRIPTION
`Judy::next()` and `Judy::rewind()` blanked `intern->iterator_key` with a bare `ZVAL_UNDEF` on their end-of-walk, invalid-key and empty-array paths. On the six string-keyed types that zval holds a refcounted `zend_string`, so **every completed manual Iterator walk leaked one string**.

Pre-existing on `main`, unrelated to #85 — found while valgrinding the #85 canary suite, which walks often enough to make it visible.

## Measured on `origin/main`

Reproduced from a clean `git archive` export, Linux x86_64, `USE_ZEND_ALLOC=0 valgrind --leak-check=full`:

| walks | definitely lost |
| --- | --- |
| 1 | 32 bytes in **1** block |
| 10 | 320 bytes in **10** blocks |
| 50 | 1,600 bytes in **50** blocks |

Exactly one block per completed walk. Via `memory_get_usage()`: **32,000 bytes over 1,000 walks** on `main`, **0** with this fix.

The leak is Zend-MM allocated, which is what makes it observable from PHP — and therefore testable without valgrind in CI.

## Two distinct paths leaked

- **`next()` at end of walk** — the common one. Any `while ($j->valid())` loop that runs to completion.
- **`rewind()` on an array emptied after a partial walk** — the stale string key was blanked rather than released.

Long-running workers are where this bites: a Swoole/RoadRunner consumer iterating a string-keyed Judy once per request leaks 32 bytes per request, indefinitely.

## The fix

Adds `judy_iterator_key_clear()` and routes **all seven** walk-state sites through it, rather than patching only the two known-leaking ones — a future end-of-walk path cannot reintroduce this by writing the obvious-looking bare `ZVAL_UNDEF`.

`zval_ptr_dtor` is a no-op on the already-`UNDEF` and `IS_LONG` cases, so the integer-keyed sites are unaffected and the rule stays uniform rather than "remember which paths are string-keyed". The correct dtor+UNDEF pattern already existed elsewhere in the file; this makes it the only pattern.

Two bare `ZVAL_UNDEF`s remain and are correct: fresh object init (no prior value), and one already paired with a dtor.

## Test

`tests/regression_iterator_key_leak_001.phpt` asserts zero growth across 500 completed walks on all six string-keyed types, plus the rewind-on-emptied path, settling allocator state before measuring.

**Verified it fails on `origin/main` and passes here** — without that check it would be decoration rather than a regression test.

## Verification

- 203/203 pass on macOS/arm64 and Linux/x86_64.
- Zero compiler warnings.
- `USE_ZEND_ALLOC=0 valgrind`: **0 definitely-lost records** at 1 and 50 walks, against 1-per-walk on `main`.
- `package.xml` updated (203 on disk == 203 listed). `baselines/latest.json` untouched. No API change, so `API.md`/arginfo unaffected.
