### PR TITLE
feat(examples): symbol-table prefix demo, and correct the prefix-bound recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,8 +153,16 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   `size($start, $end)` or `populationCount($start, $end)`.
 - **A string upper bound is a bound, not a prefix match.** `keys('bl', 'bl')`
   does not return `blackcurrant` — `blackcurrant` sorts *after* `bl`. For a
-  prefix sweep, bound with the prefix and its successor (`keys('bl', 'bm')`)
-  or append `"\xff"`. Same rule for `slice()` and `deleteRange()`.
+  prefix sweep, bound with the prefix and its successor: `keys('bl', 'bm')`.
+  Two details that bite on binary-safe keys, both worked through and asserted
+  in `examples/symbol-table-prefix.php`: the successor needs a **carry** when
+  the prefix ends in `"\xff"` (and an all-`"\xff"` prefix has no successor at
+  all — pass `null` for "to the end"), and because the upper bound is
+  **inclusive** the range over-reaches by at most one key, the one spelled
+  exactly like the bound (`'bm'` itself), which a read should drop. Appending
+  `"\xff"` to the prefix instead is *not* equivalent — it silently omits any
+  key carrying a `0xff` byte right after the prefix. Same rule for `slice()`
+  and `deleteRange()`, except a delete cannot drop the over-reach afterwards.
 - **Random access on small dense datasets is faster with native arrays.**
   Judy wins on memory at scale, ordered navigation, and sparse keysets —
   see BENCHMARK.md before claiming performance.
@@ -244,5 +252,10 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   `BITSET` over packed keys, merged with `union()`/`mergeWith()`, then queried
   for test-impact selection — the contiguous-block walk, and why an uncovered
   changed line must widen rather than select nothing),
-  `autocomplete-trie.php` (prefix search), `worker-counters.php` (atomic
+  `symbol-table-prefix.php` (FQCN symbol table queried by namespace —
+  deriving inclusive key bounds from a prefix binary-safely, then reading the
+  slice with one `keys`/`values`/`toArray($lo, $hi)` call; counts keys visited
+  and PHP→C crossings against a hash scan and against the per-element walk),
+  `autocomplete-trie.php` (prefix search, and when the walk still beats a
+  bounded read), `worker-counters.php` (atomic
   `increment()`), `quickstart.php` (API tour).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Each pattern below is a runnable script in [examples/](examples/README.md):
 | Which CIDR/tariff/shard does this value fall in? | `last()` resolves the greatest key ≤ N in one call; hash tables must scan | [ip-range-lookup.php](examples/ip-range-lookup.php) |
 | Rate limiting and rolling metrics over a time window | `deleteRange()` expires aged-out buckets without touching the retained set | [sliding-window-rate-limit.php](examples/sliding-window-rate-limit.php) |
 | Invalidate every cache key under `user:123:*` | Ordered keys make a namespace one contiguous slice — cost follows the slice, not the cache size | [prefix-invalidation.php](examples/prefix-invalidation.php) |
-| Autocomplete / typeahead over a string keyset | `first()` + `searchNext()` walk a prefix in sorted order | [autocomplete-trie.php](examples/autocomplete-trie.php) |
+| List every class under `App\Domain\` — LSP completion, namespace-scoped analysis rules, PHPUnit `--filter` | A namespace prefix is one contiguous key range; `keys($lo, $hi)` reads exactly that slice in a single traversal | [symbol-table-prefix.php](examples/symbol-table-prefix.php) |
+| Autocomplete / typeahead over a string keyset | `first()` + `searchNext()` walk a prefix in sorted order and stop once the dropdown is full | [autocomplete-trie.php](examples/autocomplete-trie.php) |
 | Per-metric counters in a long-running worker | Atomic `increment()` skips the read-modify-write round trip | [worker-counters.php](examples/worker-counters.php) |
 
 New to the extension? Start with [quickstart.php](examples/quickstart.php).

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,8 @@ php examples/quickstart.php
 | ------ | ------- | -------------- |
 | [quickstart.php](quickstart.php) | The essentials in one file: array access, iteration, navigation, bulk ops | `INT_TO_INT`, `STRING_TO_MIXED` |
 | [dedup-large-stream.php](dedup-large-stream.php) | Membership "seen set" over millions of keys, with honest peak-RSS comparison of array vs exact-key Judy vs hashed-fingerprint BITSET | `STRING_TO_INT_HASH`, `BITSET` |
-| [autocomplete-trie.php](autocomplete-trie.php) | Prefix search / autocomplete via ordered keys — `first()` + `searchNext()` | `STRING_TO_MIXED` |
+| [autocomplete-trie.php](autocomplete-trie.php) | Prefix search / autocomplete via ordered keys — the `first()` + `searchNext()` walk, which is the right shape when a `$limit` lets it stop early | `STRING_TO_MIXED` |
+| [symbol-table-prefix.php](symbol-table-prefix.php) | Symbol table keyed by fully-qualified class name, queried by namespace (`App\Domain\*`) for LSP completion, namespace-scoped analysis rules and PHPUnit `--filter`: deriving inclusive key bounds from a prefix binary-safely (carry, unbounded and over-reach cases, all asserted), then reading the slice with one `keys`/`values`/`toArray($lo, $hi)` call, with keys-visited and PHP→C-crossing counts against a hash-table scan and against the per-element walk | `STRING_TO_MIXED`, `STRING_TO_MIXED_HASH` |
 | [worker-counters.php](worker-counters.php) | Metrics accumulators in long-running workers with atomic `increment()` | `STRING_TO_INT_HASH`, `INT_TO_INT` |
 | [ip-range-lookup.php](ip-range-lookup.php) | Floor lookup (`last()`) over range tables — IPs, tariffs, time buckets | `INT_TO_MIXED` |
 | [sliding-window-rate-limit.php](sliding-window-rate-limit.php) | Sliding-window rate limiting / rolling metrics — `deleteRange()` expiry that visits only aged-out buckets | `INT_TO_INT` |

--- a/examples/autocomplete-trie.php
+++ b/examples/autocomplete-trie.php
@@ -3,8 +3,25 @@
  * Prefix search / autocomplete with a sorted string-keyed Judy array.
  *
  * STRING_TO_MIXED is trie-based and keeps keys in lexicographic order,
- * so "all keys starting with $prefix" is a first() + searchNext() walk —
- * no full scan, no separate index structure.
+ * so "all keys starting with $prefix" is one contiguous slice of the key
+ * space — no full scan, no separate index structure.
+ *
+ * This file walks that slice with first() + searchNext() because completion
+ * is the case where a walk beats a bounded bulk read: an editor dropdown
+ * wants the first few matches and stops, and only a walk can stop. A bounded
+ * read cannot — it materialises the whole slice, however large "ma" turns out
+ * to be in a real dictionary.
+ *
+ * When you do want the whole slice, do NOT copy this shape. Reach for the
+ * range-limited bulk extractors, which make one C traversal writing straight
+ * into the PHP array instead of crossing back per element:
+ *
+ *     $judy->keys($lo, $hi);      $judy->values($lo, $hi);
+ *     $judy->toArray($lo, $hi);
+ *
+ * The bounds are a pair of inclusive KEYS, and deriving them from a prefix
+ * correctly (binary-safe, with the carry and over-reach cases) is the subject
+ * of examples/symbol-table-prefix.php, which also counts what each shape costs.
  *
  * Run: php examples/autocomplete-trie.php [prefix]
  */
@@ -29,7 +46,11 @@ foreach (
 }
 
 /**
- * Return every [key => value] whose key starts with $prefix.
+ * Return at most $limit [key => value] pairs whose key starts with $prefix.
+ *
+ * The $limit is what justifies the walk: the loop stops as soon as the
+ * dropdown is full, so a prefix matching ten thousand words still costs ten
+ * steps. Drop the limit and this should become one keys($lo, $hi) call.
  */
 function prefixSearch(Judy $sorted, string $prefix, int $limit = 10): array
 {

--- a/examples/prefix-invalidation.php
+++ b/examples/prefix-invalidation.php
@@ -24,6 +24,10 @@ if (!extension_loaded('judy')) {
 /**
  * Delete every key starting with $prefix. Returns [deleted, keysVisited].
  *
+ * The walk is written out longhand so that keys visited stays countable — that
+ * count is what this example exists to show. In production the same deletion is
+ * one call, deleteRange($start, $end), over the same inclusive key bounds.
+ *
  * @return array{0:int,1:int}
  */
 function deletePrefix(Judy $store, string $prefix): array
@@ -94,13 +98,14 @@ printf(
 echo "That ratio is the whole point: Judy's cost follows the slice being\n";
 echo "dropped, the hash table's follows the cache size.\n";
 
-// Range reads work the same way — list a namespace without scanning.
-$listed = [];
-for (
-    $key = $judy->first('user:7:');
-    $key !== null && str_starts_with($key, 'user:7:');
-    $key = $judy->searchNext($key)
-) {
-    $listed[] = $key;
-}
+// Range reads work the same way — list a namespace without scanning. Here the
+// consumer wants the whole slice rather than the first few, so this is one
+// bounded bulk read instead of the per-element walk above: keys($start, $end)
+// makes a single C traversal writing straight into the PHP array.
+//
+// The bounds are inclusive KEYS, so the upper one is the prefix's successor
+// ('user:7;' — ':' is 0x3A, ';' is 0x3B), not the prefix itself. That bound can
+// over-reach by exactly one key, the one spelled like the bound. Deriving it
+// safely for arbitrary binary keys is examples/symbol-table-prefix.php.
+$listed = $judy->keys('user:7:', 'user:7;');
 printf("\nkeys under user:7: -> %s\n", implode(', ', $listed));

--- a/examples/symbol-table-prefix.php
+++ b/examples/symbol-table-prefix.php
@@ -1,0 +1,433 @@
+<?php
+/**
+ * Symbol table keyed by fully-qualified class name, queried by namespace.
+ *
+ * The structure every PHP tool eventually builds: FQCN -> metadata (declaring
+ * file, kind, line). Point lookup by name is the obvious query. The other one,
+ * which a plain hash table cannot answer without scanning, is
+ *
+ *     "every symbol under App\Domain\"
+ *
+ * IDE and LSP completion, namespace-scoped static-analysis rules, and PHPUnit's
+ * --filter picking Tests\Unit\Foo\* out of a large suite are all that query.
+ *
+ * STRING_TO_MIXED is trie-based and orders keys lexicographically, so every
+ * symbol sharing a namespace prefix is one contiguous slice of the key space.
+ * A namespace query is then a bounded read of that slice and nothing else.
+ *
+ * The point of this file is the conversion that makes such a read correct:
+ *
+ *   1. a prefix is not a bound (section 1) — turning one into a pair of
+ *      inclusive bounds has a carry case, an unbounded case, and exactly one
+ *      possible false positive, all of which this file derives and asserts;
+ *   2. once you have bounds, the read is ONE call — keys($lo, $hi) /
+ *      values($lo, $hi) / toArray($lo, $hi) — not a per-element walk
+ *      (sections 2 and 4).
+ *
+ * Contrast with examples/autocomplete-trie.php, which walks the same kind of
+ * slice with first() + searchNext(). That is not an older way of doing this:
+ * it is the other half of the same trade, and section 5 says when each wins.
+ *
+ * Run: php examples/symbol-table-prefix.php [namespace-prefix]
+ *
+ * Everything this script prints is a COUNT — keys visited, PHP->C crossings,
+ * symbols selected. Counts do not move with machine load, which is why they
+ * are the evidence here and no wall-clock number is. For measured timings see
+ * BENCHMARK.md, and only trust them from an idle machine.
+ */
+
+if (!extension_loaded('judy')) {
+    fwrite(STDERR, "The judy extension is not loaded.\n");
+    exit(1);
+}
+
+/* ── 1. Prefix -> inclusive key range ────────────────────────────────── */
+
+/*
+ * Judy's range API takes a pair of INCLUSIVE keys, and a string upper bound is
+ * a bound, not a prefix test: keys('App\Domain\', 'App\Domain\') returns
+ * nothing but an exact 'App\Domain\' key, because every symbol under that
+ * namespace sorts strictly after it.
+ *
+ * The lower bound is easy. For any key K whose prefix is P, either K === P or
+ * P is a proper prefix of K and therefore sorts before it, so K >= P always.
+ * P itself is the correct inclusive $start.
+ *
+ * The upper bound is where prefix-to-range conversions go wrong. Two shortcuts
+ * circulate, and both are subtly incorrect on binary-safe keys:
+ *
+ *   P . "\xFF"   fails when a key actually has a 0xFF byte right after the
+ *                prefix: that key sorts AFTER P."\xFF" (the bound is a proper
+ *                prefix of it) and is silently dropped. Appending more 0xFF
+ *                bytes only moves the cliff; it never removes it.
+ *
+ *   succ(P) as   right idea, wrong end. succ('bl') is 'bm', and everything
+ *   a bound      under 'bl' does sort below 'bm' — but Judy's upper bound is
+ *                inclusive, so a key spelled exactly 'bm' comes back too.
+ *
+ * The correct construction takes the second shortcut and closes its one hole.
+ * Let P end with byte b. Write Q for P minus that last byte, and
+ * succ(P) = Q . chr(b + 1). For any key K with P <= K <= succ(P):
+ *
+ *   - K must start with Q (differing earlier and lower would put K below P);
+ *   - K[|Q|] is therefore >= b (from K >= P) and <= b + 1 (from K <= succ(P));
+ *   - if that byte is b, K starts with Q.b = P — a genuine match;
+ *   - if it is b + 1, K starts with succ(P), and K <= succ(P) forces
+ *     K === succ(P).
+ *
+ * So the inclusive range [P, succ(P)] returns exactly the P-prefixed keys plus
+ * AT MOST ONE extra key, the one spelled succ(P) itself. Drop that single key
+ * and the answer is exact — for any byte string, no assumption about the key
+ * alphabet.
+ *
+ * Two edge cases fall out of the same derivation:
+ *
+ *   carry        P ending in 0xFF has no in-place successor. Strip the trailing
+ *                0xFF run and increment the last byte before it: succ("a\xFF")
+ *                is "b", and every key under "a\xFF" does sort below "b".
+ *   no successor P consisting only of 0xFF bytes (and the empty prefix, which
+ *                matches everything) has no successor at all. The slice runs to
+ *                the end of the array, which is what a null $end means.
+ */
+
+/**
+ * Inclusive [$start, $end] bounds covering every key beginning with $prefix.
+ *
+ * $end is null when the slice runs to the end of the key space. When $end is a
+ * string it may over-reach by exactly one key — the one equal to $end — which
+ * prefixRead() below trims.
+ *
+ * @return array{0:string,1:?string}
+ */
+function prefixBounds(string $prefix): array
+{
+    $i = strlen($prefix) - 1;
+    while ($i >= 0 && $prefix[$i] === "\xFF") {   // carry past a trailing 0xFF run
+        $i--;
+    }
+    if ($i < 0) {
+        return [$prefix, null];                   // empty or all-0xFF: no successor
+    }
+    return [$prefix, substr($prefix, 0, $i) . chr(ord($prefix[$i]) + 1)];
+}
+
+/**
+ * Every [key => value] whose key begins with $prefix, in ONE bounded read.
+ *
+ * toArray($start, $end) is a single C traversal writing straight into the
+ * returned PHP array. It visits the slice plus the one key that ends it, and
+ * crosses from PHP into C exactly once regardless of how many symbols match.
+ */
+function prefixRead(Judy $symbols, string $prefix): array
+{
+    [$lo, $hi] = prefixBounds($prefix);
+    $out = $symbols->toArray($lo, $hi);
+    if ($hi !== null) {
+        unset($out[$hi]);                         // the single possible false positive
+    }
+    return $out;
+}
+
+/** Just the names — same traversal, no values materialised. */
+function prefixKeys(Judy $symbols, string $prefix): array
+{
+    [$lo, $hi] = prefixBounds($prefix);
+    $keys = $symbols->keys($lo, $hi);
+    if ($hi !== null && $keys !== [] && end($keys) === $hi) {
+        array_pop($keys);                         // keys() is ordered: it can only be last
+    }
+    return $keys;
+}
+
+/*
+ * Checks, so the derivation above is executable rather than a story. Written
+ * as explicit comparisons rather than assert(), which zend.assertions=-1
+ * compiles away — a correctness claim that can silently not run is not a
+ * correctness claim.
+ */
+
+$checks = [];
+$check  = static function (string $what, bool $ok) use (&$checks): void {
+    $checks[$what] = $ok;
+};
+
+$edge = new Judy(Judy::STRING_TO_MIXED);
+foreach (
+    [
+        'App\Domain\Order',                       // in
+        'App\Domain\Pricing\TaxRate',             // in (nested namespace)
+        'App\Domain]',                            // == succ('App\Domain\'): the false positive
+        'App\DomainEvents\OrderPlaced',           // sibling namespace, NOT under App\Domain\
+        "bin\xFFtail",                            // 0xFF right after a "bin\xFF" prefix
+        "bin\xFF\xFF",
+        'zzz',
+    ] as $fqcn
+) {
+    $edge[$fqcn] = true;
+}
+
+$check('successor of a separator-terminated namespace', prefixBounds('App\Domain\\') === ['App\Domain\\', 'App\Domain]']);
+$check('carry past a trailing 0xFF run', prefixBounds("a\xFF\xFF") === ["a\xFF\xFF", 'b']);
+$check('all-0xFF prefix has no successor', prefixBounds("\xFF\xFF") === ["\xFF\xFF", null]);
+$check('empty prefix is unbounded above', prefixBounds('') === ['', null]);
+
+// The whole namespace, and nothing else: no sibling, no false positive.
+$check(
+    'namespace read excludes the sibling and the successor key',
+    prefixKeys($edge, 'App\Domain\\') === ['App\Domain\Order', 'App\Domain\Pricing\TaxRate'],
+);
+// Dropping the trailing separator changes the question, and 'App\DomainEvents'
+// answers it. A namespace prefix must carry its separator.
+$check(
+    'prefix without the separator does match the sibling namespace',
+    in_array('App\DomainEvents\OrderPlaced', prefixKeys($edge, 'App\Domain'), true),
+);
+// Binary-safe: the naive P."\xFF" bound would drop both of these.
+$check('keys with a 0xFF byte after the prefix survive', count(prefixKeys($edge, "bin\xFF")) === 2);
+$check('empty prefix reads the whole table', prefixKeys($edge, '') === array_keys($edge->toArray()));
+
+echo "1. Prefix -> inclusive key range\n\n";
+foreach (['App\Domain\\', 'App\Domain', "a\xFF\xFF", "\xFF\xFF", ''] as $p) {
+    [$lo, $hi] = prefixBounds($p);
+    printf(
+        "   %-22s -> [ %-22s , %-22s ]\n",
+        '"' . addcslashes($p, "\0..\37\177..\377") . '"',
+        '"' . addcslashes($lo, "\0..\37\177..\377") . '"',
+        $hi === null ? 'null (end of array)' : '"' . addcslashes($hi, "\0..\37\177..\377") . '"',
+    );
+}
+echo "\n   The upper bound is inclusive, so it can over-reach by exactly one key:\n";
+echo "   the one spelled like the bound itself. Trim it and the slice is exact.\n\n";
+
+foreach ($checks as $what => $ok) {
+    printf("   [%s] %s\n", $ok ? ' ok ' : 'FAIL', $what);
+}
+if (array_keys($checks, false, true) !== []) {
+    fwrite(STDERR, "prefixBounds() is wrong on this build; the rest of this demo is meaningless.\n");
+    exit(1);
+}
+echo "\n";
+
+/* ── The symbol table ─────────────────────────────────────────────────── */
+
+/**
+ * A synthetic PSR-4 tree, plus enough vendor code to make "scan everything"
+ * look like what it is.
+ *
+ * @return array<string,array{kind:string,file:string}>
+ */
+function symbolFixture(int $vendorPackages, int $classesPerPackage): array
+{
+    $tree = [
+        'App\Domain\\'                   => ['Order', 'Cart', 'Customer', 'Money', 'Sku'],
+        'App\Domain\Pricing\\'           => ['Discount', 'PriceList', 'TaxRate'],
+        'App\DomainEvents\\'             => ['CartEmptied', 'OrderPlaced'],
+        'App\Http\Controller\\'          => ['CartController', 'OrderController'],
+        'App\Infrastructure\Doctrine\\'  => ['OrderRepository'],
+        'Tests\Unit\Domain\\'            => ['MoneyTest', 'OrderTest', 'SkuTest'],
+        'Tests\Unit\Http\\'              => ['OrderControllerTest'],
+        'Tests\Feature\Checkout\\'       => ['GuestCheckoutTest', 'PayLaterTest'],
+    ];
+
+    $symbols = [];
+    foreach ($tree as $ns => $names) {
+        foreach ($names as $name) {
+            $symbols[$ns . $name] = [
+                'kind' => str_ends_with($name, 'Test') ? 'test' : 'class',
+                'file' => '/app/' . str_replace('\\', '/', $ns . $name) . '.php',
+            ];
+        }
+    }
+    for ($p = 0; $p < $vendorPackages; $p++) {
+        for ($c = 0; $c < $classesPerPackage; $c++) {
+            $fqcn = sprintf('Vendor\Package%03d\Class%03d', $p, $c);
+            $symbols[$fqcn] = [
+                'kind' => 'class',
+                'file' => '/vendor/' . str_replace('\\', '/', $fqcn) . '.php',
+            ];
+        }
+    }
+    return $symbols;
+}
+
+const VENDOR_PACKAGES = 400;
+const VENDOR_CLASSES  = 15;
+
+$fixture = symbolFixture(VENDOR_PACKAGES, VENDOR_CLASSES);
+
+$symbols = Judy::fromArray(Judy::STRING_TO_MIXED, $fixture);
+$hashed  = Judy::fromArray(Judy::STRING_TO_MIXED_HASH, $fixture);
+$plain   = $fixture;                              // the hash-table shape, for scanning
+
+$prefix = $argv[1] ?? 'App\Domain\\';
+
+/* ── 2. Querying a namespace ─────────────────────────────────────────── */
+
+echo "2. Querying a namespace\n\n";
+printf("   symbol table holds %s symbols\n", number_format(count($symbols)));
+printf("   point lookup App\\Domain\\Order -> %s\n\n", $symbols['App\Domain\Order']['file']);
+
+$members = prefixRead($symbols, $prefix);
+printf("   symbols under \"%s\" (%d):\n", $prefix, count($members));
+foreach ($members as $fqcn => $meta) {
+    printf("     %-34s %-5s %s\n", $fqcn, $meta['kind'], $meta['file']);
+}
+
+// keys(), values() and toArray() all take the same bounds. Reach for the one
+// whose output you actually want rather than materialising more and discarding.
+[$lo, $hi] = prefixBounds($prefix);
+printf("\n   keys(\$lo, \$hi)    -> %d names, no values materialised\n", count(prefixKeys($symbols, $prefix)));
+printf("   values(\$lo, \$hi)  -> %d metadata records, no names\n", count($symbols->values($lo, $hi)));
+printf("   toArray(\$lo, \$hi) -> %d pairs\n\n", count($members));
+
+// Completion usually wants direct children, not the whole subtree. That is the
+// same bounded read plus a filter at VM speed — still one crossing.
+$direct = [];
+foreach (prefixKeys($symbols, $prefix) as $fqcn) {
+    $tail = substr($fqcn, strlen($prefix));
+    $direct[strstr($tail, '\\', true) ?: $tail] = str_contains($tail, '\\');
+}
+$rendered = [];
+foreach ($direct as $name => $isNamespace) {
+    $rendered[] = $isNamespace ? $name . '\\' : $name;
+}
+printf("   direct children of \"%s\": %s\n\n", $prefix, implode(', ', $rendered));
+
+/* ── 3. Keys visited: ordered slice vs hash-table scan ───────────────── */
+
+/** The prefix walk, instrumented. Returns [names, keysVisited, crossings]. */
+function prefixWalk(Judy $symbols, string $prefix): array
+{
+    $names     = [];
+    $visited   = 0;
+    $crossings = 0;
+
+    $key = $symbols->first($prefix);              // seek straight to the slice
+    $crossings++;
+    while ($key !== null && str_starts_with($key, $prefix)) {
+        $visited++;
+        $names[] = $key;
+        $key = $symbols->searchNext($key);        // one crossing per step, including
+        $crossings++;                             // the one that ends the walk
+    }
+
+    return [$names, $visited + 1, $crossings];    // +1 for the key that ended the walk
+}
+
+/** The same question of a hash table: every key must be tested. */
+function prefixScan(array $symbols, string $prefix): array
+{
+    $names   = [];
+    $visited = 0;
+    foreach ($symbols as $fqcn => $_) {
+        $visited++;
+        if (str_starts_with($fqcn, $prefix)) {
+            $names[] = $fqcn;
+        }
+    }
+    sort($names);
+    return [$names, $visited];
+}
+
+[$walkNames, $walkVisited, $walkCrossings] = prefixWalk($symbols, $prefix);
+[$scanNames, $scanVisited]                 = prefixScan($plain, $prefix);
+$bulkNames                                 = prefixKeys($symbols, $prefix);
+
+echo "3. Keys visited\n\n";
+printf("   query: every symbol under \"%s\" of %s in the table\n\n", $prefix, number_format(count($symbols)));
+printf("   ordered trie (bounded read)   matched=%-4d keys visited=%d\n", count($bulkNames), $walkVisited);
+printf("   hash table   (full scan)      matched=%-4d keys visited=%d\n", count($scanNames), $scanVisited);
+printf(
+    "\n   The trie touched %.2f%% of the table; the hash table touched 100%%.\n",
+    $walkVisited / count($symbols) * 100,
+);
+echo "   That ratio is the point: the trie's cost follows the slice being read,\n";
+echo "   the hash table's follows the size of the table. Add a symbol in an\n";
+echo "   unrelated namespace and only the second number moves.\n\n";
+
+// Judy's own *_HASH types are NOT the scanning shape above: they keep a sorted
+// key index, so the identical bounded read works and returns the same answer.
+// What differs is cost, not capability — prefix work over the hash types scales
+// with the whole store rather than with the slice. BENCHMARK.md measures that
+// gap as a complexity-class difference across a 100x sweep; this script does
+// not time anything, so read it there.
+$hashedNames = prefixKeys($hashed, $prefix);
+printf(
+    "   STRING_TO_MIXED_HASH answers the same bounded read identically: %s\n",
+    $hashedNames === $bulkNames ? 'yes' : 'NO - the types disagree',
+);
+echo "   (capability is not the difference between the trie and hash types —\n";
+echo "    cost is. See BENCHMARK.md before choosing on performance grounds.)\n\n";
+
+/* ── 4. Crossings: walk vs bounded bulk read ─────────────────────────── */
+
+echo "4. PHP->C crossings for the same slice\n\n";
+printf("   first() + searchNext() walk   crossings=%d  (1 + one per matched symbol)\n", $walkCrossings);
+echo   "   keys(\$lo, \$hi)                crossings=1  (one bounded traversal)\n\n";
+echo "   Both make the same number of KEY visits inside libJudy — the walk and\n";
+echo "   the bounded read traverse the same slice. What the bulk form removes is\n";
+echo "   the per-element method dispatch: keys()/values()/toArray() write straight\n";
+echo "   into the destination PHP array in one pass. Prefer them over\n";
+echo "   slice(\$lo, \$hi)->keys() too, which copies the range into a freshly\n";
+echo "   allocated Judy and then traverses that copy a second time.\n\n";
+echo "   The walk counted above collects names only. Wanting the metadata too\n";
+echo "   adds a \$symbols[\$key] fetch per element and doubles its crossings,\n";
+echo "   while toArray(\$lo, \$hi) still costs one.\n\n";
+
+$agree = $bulkNames === $walkNames && $bulkNames === $scanNames && $bulkNames === $hashedNames;
+printf(
+    "   bounded read, walk, hash scan and STRING_TO_MIXED_HASH all select the\n"
+    . "   identical symbol set: %s\n\n",
+    $agree ? 'yes' : 'NO - the shapes disagree',
+);
+
+/* ── 5. When the walk is still the right tool ────────────────────────── */
+
+echo "5. When to walk instead\n\n";
+echo "   A bounded read materialises the whole slice. That is what you want for\n";
+echo "   a static-analysis rule scoped to a namespace, or for PHPUnit --filter\n";
+echo "   selecting Tests\\Unit\\Foo\\* — the consumer needs every match anyway.\n\n";
+echo "   Completion does not. An editor showing ten rows wants the first ten\n";
+echo "   matches and should stop there, and a walk can stop; a bounded read\n";
+echo "   cannot. examples/autocomplete-trie.php is that shape, and it is not an\n";
+echo "   older way of writing this one:\n\n";
+echo "     whole slice, count unbounded   ->  keys/values/toArray(\$lo, \$hi)\n";
+echo "     first N matches, N small       ->  first() + searchNext(), break early\n";
+echo "     just \"how many\" / \"any at all\" ->  bounded read and count it; the\n";
+echo "                                        empty array IS the \"none\" answer\n\n";
+
+$top = [];
+foreach (prefixWalk($symbols, 'Vendor\Package00')[0] as $fqcn) {
+    $top[] = $fqcn;
+    if (count($top) === 3) {
+        break;                                    // an LSP dropdown, not a full read
+    }
+}
+printf("   first 3 completions under Vendor\\Package00: %s\n\n", implode(', ', $top));
+
+echo "Notes:\n";
+echo "  - a namespace prefix must include its trailing separator. \"App\\Domain\"\n";
+echo "    is a legitimate string prefix and it matches App\\DomainEvents\\* too;\n";
+echo "    only \"App\\Domain\\\" is the namespace. The bounds are correct either\n";
+echo "    way — the question changes, not the answer.\n";
+echo "  - Judy string keys are binary-safe, so a prefix-to-range helper has to\n";
+echo "    be as well. Appending \"\\xFF\" is not: it silently drops any key with a\n";
+echo "    0xFF byte immediately after the prefix. Increment-with-carry plus the\n";
+echo "    one-key trim has no such hole, and costs one array_pop.\n";
+echo "  - the trim is not paranoia about class names (no PHP identifier is\n";
+echo "    spelled \"App\\Domain]\"). It is what makes the helper reusable for keys\n";
+echo "    you did not choose — cache keys, file paths, serialised tuples.\n";
+echo "  - size(\$start, \$end) does NOT bound on string-keyed types: it ignores\n";
+echo "    string bounds and returns the whole count. Use count(keys(\$lo, \$hi))\n";
+echo "    for a namespace population; populationCount() throws on these types\n";
+echo "    rather than answering wrongly.\n";
+echo "  - deleting a namespace is the same range, one call: deleteRange(\$lo,\n";
+echo "    \$hi) — but the bound is inclusive there too, so it removes the one\n";
+echo "    key spelled like \$hi as well. A read can trim that key afterwards; a\n";
+echo "    delete cannot, so delete the exact-successor key's range separately\n";
+echo "    (or re-insert it) when the keyspace can contain it.\n";
+echo "    examples/prefix-invalidation.php writes the equivalent walk out\n";
+echo "    longhand so that keys-visited stays countable.\n";
+echo "  - every number printed above is a count, not a timing, so a loaded\n";
+echo "    machine cannot change it. Nothing here is a performance claim; for\n";
+echo "    measured cost see BENCHMARK.md and re-run it when idle.\n";

--- a/llms.txt
+++ b/llms.txt
@@ -48,8 +48,15 @@ Runnable, self-contained scripts — one per pattern Judy is chosen for.
 - [prefix-invalidation.php](https://github.com/orieg/php-judy/blob/main/examples/prefix-invalidation.php):
   namespace invalidation (`user:123:*`) walking only the matching key slice,
   with a keys-visited comparison against a hash table
+- [symbol-table-prefix.php](https://github.com/orieg/php-judy/blob/main/examples/symbol-table-prefix.php):
+  symbol table keyed by fully-qualified class name, queried by namespace
+  (`App\Domain\*`) for LSP completion, namespace-scoped analysis rules and
+  PHPUnit `--filter`: deriving inclusive key bounds from a prefix
+  binary-safely, then reading the slice with one `keys`/`values`/`toArray($lo,
+  $hi)` call, with keys-visited and crossing counts against a hash scan
 - [autocomplete-trie.php](https://github.com/orieg/php-judy/blob/main/examples/autocomplete-trie.php):
-  prefix search / typeahead via `first()` + `searchNext()`
+  prefix search / typeahead via `first()` + `searchNext()`, and when that walk
+  still beats a bounded bulk read
 - [worker-counters.php](https://github.com/orieg/php-judy/blob/main/examples/worker-counters.php):
   metrics accumulators in long-running workers with atomic `increment()`
 

--- a/package.xml
+++ b/package.xml
@@ -61,6 +61,7 @@
          <file name="examples/ip-range-lookup.php" role="doc" />
          <file name="examples/sliding-window-rate-limit.php" role="doc" />
          <file name="examples/prefix-invalidation.php" role="doc" />
+         <file name="examples/symbol-table-prefix.php" role="doc" />
         <file name="examples/coverage-index.php" role="doc" />
          <file name="examples/benchmarks/benchmark_ordered_data.php" role="doc" />
          <file name="examples/benchmarks/benchmark_ordered_data_demo.php" role="doc" />


### PR DESCRIPTION
Adds `examples/symbol-table-prefix.php` — a symbol table keyed by FQCN, answering "everything under `App\Domain\`" as one bounded read. Applies to IDE/LSP completion, namespace-scoped analysis rules, and `--filter Tests\Unit\Foo\*` over a large suite.

Also corrects a wrong recipe in AGENTS.md and reconciles two older examples with the range-read guidance from #96/#98.

## Why a new file rather than a section in autocomplete-trie.php

Because the two teach opposite halves of the same trade, and merging them would blur it:

- `autocomplete-trie.php` is bounded by a `$limit`. A `first()`/`searchNext()` walk **wins** there — an editor dropdown wants ten rows and stops, and a bounded read cannot stop early. That walk is not stale; the reason it is right was simply unstated.
- This example wants the *whole* slice with the count unknown ahead of time. That is the bounded-bulk-read case, and it is what `keys($lo, $hi)` exists for.

The new file also owns content neither existing example nor the docs covered: prefix-to-range conversion. That is what earns it a file, not the keys-visited comparison, which `prefix-invalidation.php` already does for deletes.

## AGENTS.md was wrong about prefix bounds

It offered `keys('bl', 'bm')` and "append `\xff`" as interchangeable recipes. They are not:

- **Appending `"\xff"` silently drops keys.** Any key with a `0xFF` byte immediately after the prefix sorts *after* that bound and is missed.
- **The successor form over-reaches by exactly one key**, which went unmentioned.

Corrected, with the derivation carried in the example: the lower bound is the prefix `P`; the upper bound is `succ(P)` — strip the trailing `0xFF` run, increment the last remaining byte. Inclusive `[P, succ(P)]` returns exactly the P-prefixed keys plus at most one extra, the key spelled exactly `succ(P)`, because any key in range must start with `P` minus its last byte and its next byte is either `b` (genuine match) or `b+1` (which forces the key to *be* `succ(P)`). Trim that one and the read is exact for arbitrary binary-safe byte strings. Carry (`"a\xFF\xFF"` → `"b"`) and no-successor (all-`0xFF`, or an empty prefix meaning "to the end") fall out of the same rule.

Also verified and noted: a `deleteRange()` cannot trim the over-reach after the fact — `deleteRange('App\Domain\', 'App\Domain]')` deletes 3, including the successor key.

## Evidence is counts, not timings

Both figures are machine-load-independent, so they are valid regardless of what else is running:

- **keys visited**: 9 (slice + 1) vs 6,019 for a full hash scan — 0.15% of the table.
- **PHP→C crossings**: 9 for the walk vs 1 for `keys($lo, $hi)`. Wanting values as well doubles the walk's crossings, while `toArray()` still costs one.

No timings, no performance verdict. `STRING_TO_MIXED_HASH` is shown answering the identical bounded read — it does — with the AGENTS.md framing that capability is not the difference, cost is.

The eight correctness checks ship as explicit comparisons with a printed pass/fail table and a non-zero exit, deliberately **not** `assert()`: `zend.assertions=-1` would compile a correctness claim away silently.

## Reconciling the older walks

- `autocomplete-trie.php` — code unchanged because it is correct as written; the docblock now says *why* the walk wins for a limited read and points at the bulk shape for whole-slice reads. `prefixSearch()` notes that dropping the limit should make it one `keys($lo, $hi)` call.
- `prefix-invalidation.php` — its trailing "list a namespace" section was a whole-slice read written as a walk, directly contradicting the new guidance. Now one `keys('user:7:', 'user:7;')` call with the bound explained. Its `deletePrefix()` walk stays longhand so keys-visited remains countable, with a note that `deleteRange()` is the one-call production form.

## Known trap documented, and filed

`size($start, $end)` silently ignores string bounds and returns the whole-array count, while `populationCount()` throws a clear exception for the same call — so "how many classes under this namespace?" yields a plausible-looking wrong number. Filed as #105; documented in this example's notes pending the fix.

## Verification

Full suite 205/205, zero build warnings. `API.md` regenerates to no diff (stub untouched). `php -l` clean on all three touched PHP files; all three examples run clean. Registered in `examples/README.md`, the AGENTS.md runnable-demos list, README.md's pattern table, `llms.txt`, and `package.xml`. `baselines/latest.json` untouched.
