### PR TITLE
feat(debug): lldb/gdb pretty-printers for the extension's own structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,9 @@ judy-*/
 test-package/
 temp_update/
 
+# Byte-compiled debugger printers (lldb/gdb import scripts/*.py)
+__pycache__/
+*.pyc
+
 # Claude Code session files
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,18 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   `API.md` is stale.
 - **Version lockstep**: `php_judy.h` (`PHP_JUDY_VERSION`) and `package.xml`
   must match; see the Releasing section in README.md.
+- **Debugging the C side**: `scripts/judy_lldb.py` (lldb) and
+  `scripts/judy_gdb.py` (gdb, composes with the valgrind recipe above) decode a
+  raw `judy_object` — type NAME rather than the enum integer, element counter,
+  every packed flag bitfield, which libJudy structure each `Pvoid_t` root is
+  for that type (including the key_index/value-store split on
+  `*_HASH`/`*_ADAPTIVE`), and iterator/cursor state. **The default build is not
+  debuggable** — PHP's own CFLAGS carry `-O3 -flto`, which leaves the debugger
+  with no types and no locals; rebuild with `make clean && make
+  EXTRA_CFLAGS="-g -O0 -fno-lto"` first. They deliberately do NOT walk the Judy
+  tree (libJudy's node layout is internal and version-dependent). Load
+  instructions and the full rationale: CONTRIBUTING.md "Debugging the extension
+  itself".
 - **Measured claims have re-runnable harnesses**: `research/` (see
   `research/README.md`) holds standalone C benches backing doc and issue
   claims — `shm-arena/` for #83, `iteration-cost/` for #85. Nothing there

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,117 @@ and the payload comparison are driven from `key_index` outwards. A value-store
 entry that `key_index` does not list is reachable only through the population
 counter or as a valgrind leak.
 
+## Debugging the extension itself (lldb)
+
+This is the C-side story — a crash, a core dump, or a stop inside `php_judy.c`
+where you are looking at a raw `judy_object`. (What a *PHP user* sees in
+`var_dump()`, Xdebug or an IDE variable pane is a different thing entirely: the
+`get_debug_info` handler, described in AGENTS.md.)
+
+**The default build is not debuggable.** `phpize && ./configure && make`
+inherits PHP's own `CFLAGS`, which on a typical distro or Homebrew PHP include
+`-O3 -DNDEBUG -flto`. Under `-flto` clang emits a single debug-map entry
+pointing at a temporary `/tmp/lto.o` that is gone by the time you debug, so
+lldb has **no type information and no locals at all** for the extension — a
+breakpoint hits and `frame variable intern` finds nothing. Rebuild first:
+
+```sh
+make clean && make EXTRA_CFLAGS="-g -O0 -fno-lto"
+```
+
+`EXTRA_CFLAGS` lands after `CFLAGS` on the compile line, so it wins. Confirm
+with `nm -pa modules/judy.so | grep OSO`: you want one entry per object file
+under `.libs/`, not a single `/tmp/lto.o`.
+
+Then load the printers:
+
+```
+(lldb) command script import scripts/judy_lldb.py
+```
+
+They give `judy_object`, `judy_iterator` and `judy_packed_value` one-line
+summaries, so plain `frame variable` is readable:
+
+```
+(judy_object *) intern = 0x104405320 Judy STRING_TO_INT_HASH count=3 \
+    [string_keyed hash_keyed mirror_payload next_empty_is_valid iterator_initialized]
+```
+
+and a `judy` command for the full breakdown — the type as its name, the element
+counter, every packed flag bitfield decoded, the storage roots labelled with
+which libJudy flavour each one is *for this type*, and the iterator/cursor
+state:
+
+```
+(lldb) judy intern
+judy_object @ 0x104405320
+  type              8 = STRING_TO_INT_HASH   [names from debug info (enum judy_type)]
+  counter           3 element(s)
+  ...
+  storage roots (Pvoid_t; contents opaque — see the header note)
+    array      0x788c0d000    JudyHS VALUE STORE — key -> zend_long, O(1) point lookup, unordered
+    key_index  0x7890fd1d0    JudySL key index — sorted keys; payload slot MIRRORED (optimizeIteration on)
+    hs_array   NULL           unused
+  iterator / cursor state (Iterator methods; foreach uses judy_iterator)
+    iterator_key     STRING(len=12) "session:beef"
+    iterator_data    LONG 22
+    next_empty       0   cached, usable
+    key_scratch      0x1044bb000   -> "session:beef"   (live cursor key)
+```
+
+`judy` takes any variable path — `judy intern`, `judy object` (a `zend_object*`
+is rebased through `offsetof(judy_object, std)` the way `php_judy_object()`
+does), `judy it->intern.data` — and defaults to `intern` in the current frame.
+It also cross-checks the six type-derived flags against `->type` and shouts if
+they disagree, which is what a corrupted or half-constructed object looks like.
+
+Two things to know:
+
+- **The type names come from the `judy_type` enum in the debug info**, not from
+  a table in the script, so they cannot drift from `judy_type_name()` in
+  `php_judy.c`. There is a literal fallback for builds whose debug info lacks
+  the enum.
+- **It does not walk the Judy tree, deliberately.** libJudy's node layout is
+  internal and version-dependent; a printer that decoded it by guesswork would
+  be confidently wrong against the next libJudy, and a wrong element listing is
+  worse than none when you are already chasing a corruption. Storage roots are
+  printed as pointers with their role; population comes from `intern->counter`,
+  which the extension maintains itself. To see elements, use the PHP side.
+
+Nothing is evaluated in the inferior — every field is a direct memory read — so
+the printers also work on a core dump and at a breakpoint in a crash handler.
+
+Two gotchas that are not the printers' fault:
+
+- A breakpoint set by *function name* stops at the function's first line,
+  before its locals are assigned, so `intern` there is uninitialised garbage.
+  Set the breakpoint a line or two later (`breakpoint set -f php_judy.c -l
+  <line>`) or `next` once first.
+- Once a summary is installed, `p intern` shows the summary instead of the
+  struct. `frame variable --raw intern` (lldb) or `print /r intern` (gdb) gets
+  the unfiltered fields back.
+
+### The same thing under gdb (Linux, valgrind)
+
+`scripts/judy_gdb.py` is the gdb twin — same command, same output. Everything
+php-judy-specific lives in `scripts/judy_debug_common.py`, which both
+front-ends import, so the two cannot drift; the front-ends only know how to
+read fields out of their own debugger's values.
+
+```sh
+gdb -ex 'source scripts/judy_gdb.py' --args php -n -d extension=modules/judy.so t.php
+```
+
+It composes with the valgrind recipe above, which is the main reason it exists:
+
+```sh
+valgrind --vgdb=yes --vgdb-error=0 php -n -d extension=modules/judy.so t.php
+gdb -ex 'source scripts/judy_gdb.py' -ex 'target remote | vgdb' $(which php)
+```
+
+Because nothing is evaluated in the inferior, `judy intern` works unchanged
+over the vgdb remote and on a core dump (`gdb php core`).
+
 ## Code conventions
 
 - **Zero compiler warnings.** CI fails on any warning in the extension source

--- a/package.xml
+++ b/package.xml
@@ -332,6 +332,9 @@
          <file name="scripts/api-metadata.php" role="doc" />
          <file name="scripts/bench-compare.php" role="doc" />
          <file name="scripts/generate-api-docs.php" role="doc" />
+         <file name="scripts/judy_debug_common.py" role="doc" />
+         <file name="scripts/judy_gdb.py" role="doc" />
+         <file name="scripts/judy_lldb.py" role="doc" />
          <file md5sum="513b0c0813de66e8cba534d4fa1b0eb2" name="MIGRATION_2.2.0.md" role="doc" />
          <file md5sum="23186208fc931049aac9169f60dfc9be" name="MIGRATION_2.5.0.md" role="doc" />
          <file md5sum="366b0129d18f1e9b38f1712590805903" name="Dockerfile" role="doc" />

--- a/scripts/judy_debug_common.py
+++ b/scripts/judy_debug_common.py
@@ -1,0 +1,276 @@
+# php-judy debugger printers — the debugger-independent half.
+#
+# Everything php-judy-specific lives here: the judy_type table, the flag block,
+# which storage root plays which role for each type, and the report layout. The
+# two front-ends — scripts/judy_lldb.py and scripts/judy_gdb.py — only know how
+# to read fields out of their own debugger's value objects; they hand the values
+# to summary_line() / report_lines() below and print what comes back.
+#
+# The split exists so the two cannot drift. If you add a flag, a type or a
+# storage root, change it HERE and both debuggers pick it up.
+#
+# See scripts/judy_lldb.py for the load instructions, the build flags the
+# printers need, and why the Judy tree itself is not walked.
+#
+# Pure Python: no lldb, no gdb, no PHP. Importable on its own, which is what
+# makes the tables testable.
+
+# judy_type values, mirroring php_judy.h. Both front-ends prefer the enum in
+# the debug info (so the names cannot drift from judy_type_name() in
+# php_judy.c) and fall back to this only when the enum is not there.
+TYPE_FALLBACK = {
+    1: "BITSET",
+    2: "INT_TO_INT",
+    3: "INT_TO_MIXED",
+    4: "STRING_TO_INT",
+    5: "STRING_TO_MIXED",
+    6: "INT_TO_PACKED",
+    7: "STRING_TO_MIXED_HASH",
+    8: "STRING_TO_INT_HASH",
+    9: "STRING_TO_MIXED_ADAPTIVE",
+    10: "STRING_TO_INT_ADAPTIVE",
+}
+
+# The six caches judy_init_type_flags() derives from ->type.
+INTEGER_KEYED = {"BITSET", "INT_TO_INT", "INT_TO_MIXED", "INT_TO_PACKED"}
+STRING_KEYED = {
+    "STRING_TO_INT", "STRING_TO_MIXED", "STRING_TO_INT_HASH",
+    "STRING_TO_MIXED_HASH", "STRING_TO_INT_ADAPTIVE", "STRING_TO_MIXED_ADAPTIVE",
+}
+MIXED_VALUE = {
+    "INT_TO_MIXED", "STRING_TO_MIXED", "STRING_TO_MIXED_HASH",
+    "STRING_TO_MIXED_ADAPTIVE",
+}
+PACKED_VALUE = {"INT_TO_PACKED"}
+HASH_KEYED = {
+    "STRING_TO_INT_HASH", "STRING_TO_MIXED_HASH",
+    "STRING_TO_INT_ADAPTIVE", "STRING_TO_MIXED_ADAPTIVE",
+}
+ADAPTIVE = {"STRING_TO_INT_ADAPTIVE", "STRING_TO_MIXED_ADAPTIVE"}
+
+# judy_type_can_mirror(): the only two types optimizeIteration can reach.
+CAN_MIRROR = {"STRING_TO_INT_HASH", "STRING_TO_INT_ADAPTIVE"}
+
+DERIVED_FLAGS = ("is_integer_keyed", "is_string_keyed", "is_mixed_value",
+                 "is_packed_value", "is_hash_keyed", "is_adaptive")
+ALL_FLAGS = DERIVED_FLAGS + ("mirror_payload", "next_empty_is_valid",
+                             "iterator_initialized")
+
+ROOT_FIELDS = ("array", "key_index", "hs_array")
+
+# zval type tags, Zend/zend_types.h. Used by both front-ends' zval renderers.
+ZVAL_TYPES = {
+    0: "UNDEF", 1: "NULL", 2: "FALSE", 3: "TRUE", 4: "LONG", 5: "DOUBLE",
+    6: "STRING", 7: "ARRAY", 8: "OBJECT", 9: "RESOURCE", 10: "REFERENCE",
+}
+
+# judy_packed_tag, php_judy.h.
+PACKED_TAGS = {0: "LONG", 1: "DOUBLE", 2: "TRUE", 3: "FALSE", 4: "NULL",
+               5: "STRING", 255: "SERIALIZED"}
+
+NO_DEBUG_INFO_HINT = (
+    "The target has no 'judy_object' type, so judy.so was almost certainly "
+    "built with PHP's default CFLAGS (-O3 -flto), under which the compiler "
+    "leaves behind a debug map pointing at a temporary object file that no "
+    "longer exists and the debugger ends up with no types and no locals. "
+    'Rebuild:\n    make clean && make EXTRA_CFLAGS="-g -O0 -fno-lto"')
+
+
+def type_name(table, raw_type):
+    if raw_type is None:
+        return "UNKNOWN(?)"
+    return table.get(raw_type, "UNKNOWN(%s)" % raw_type)
+
+
+def expected_flags(tname):
+    """What judy_init_type_flags() would have set for this type."""
+    return {
+        "is_integer_keyed": 1 if tname in INTEGER_KEYED else 0,
+        "is_string_keyed": 1 if tname in STRING_KEYED else 0,
+        "is_mixed_value": 1 if tname in MIXED_VALUE else 0,
+        "is_packed_value": 1 if tname in PACKED_VALUE else 0,
+        "is_hash_keyed": 1 if tname in HASH_KEYED else 0,
+        "is_adaptive": 1 if tname in ADAPTIVE else 0,
+    }
+
+
+def store_roles(tname, mirrored):
+    """[(field, role)] — what each Pvoid_t root holds for this type.
+
+    Mirrors judy_string_value_slot()'s dispatch in php_judy.c and the per-type
+    free path in judy_object_dtor()."""
+    if tname == "BITSET":
+        return [("array", "Judy1 — bitmap of set indexes, no value store"),
+                ("key_index", "unused"),
+                ("hs_array", "unused")]
+    if tname in ("INT_TO_INT", "INT_TO_MIXED", "INT_TO_PACKED"):
+        payload = {"INT_TO_INT": "zend_long in the slot",
+                   "INT_TO_MIXED": "zval* in the slot",
+                   "INT_TO_PACKED": "judy_packed_value* in the slot"}[tname]
+        return [("array", "JudyL, int key -> " + payload),
+                ("key_index", "unused"),
+                ("hs_array", "unused")]
+    if tname in ("STRING_TO_INT", "STRING_TO_MIXED"):
+        payload = "zend_long" if tname == "STRING_TO_INT" else "zval*"
+        return [("array", "JudySL — keys AND values in one trie, %s in the slot" % payload),
+                ("key_index", "unused (the trie is already ordered)"),
+                ("hs_array", "unused")]
+    if tname in ("STRING_TO_INT_HASH", "STRING_TO_MIXED_HASH"):
+        payload = "zend_long" if tname.endswith("INT_HASH") else "zval*"
+        idx = "JudySL key index — sorted keys; payload slot %s" % (
+            "MIRRORED (optimizeIteration on)" if mirrored
+            else "allocated but unwritten, traversal re-looks-up the value")
+        return [("array", "JudyHS VALUE STORE — key -> %s, O(1) point lookup, unordered" % payload),
+                ("key_index", idx),
+                ("hs_array", "unused")]
+    if tname in ("STRING_TO_INT_ADAPTIVE", "STRING_TO_MIXED_ADAPTIVE"):
+        payload = "zend_long" if tname.endswith("INT_ADAPTIVE") else "zval*"
+        idx = "JudySL key index — sorted keys, ALL lengths; payload slot %s" % (
+            "MIRRORED for keys >= 8 bytes (optimizeIteration on)" if mirrored
+            else "allocated but unwritten")
+        return [("array", "JudyL SHORT-KEY value store — keys < 8 bytes packed "
+                          "into the index word -> %s" % payload),
+                ("key_index", idx),
+                ("hs_array", "JudyHS LONG-KEY value store — keys >= 8 bytes -> %s" % payload)]
+    return [(f, "? (unrecognised type)") for f in ROOT_FIELDS]
+
+
+SPLIT_NOTE = [
+    "^ this is the key_index / value-store split: which keys exist and in what",
+    "  ORDER is answered by the JudySL key_index; what the value IS comes from",
+    "  the separate store. Nothing at the type level ties the two together —",
+    "  see judy_debug_check_mirror() and the --enable-judy-debug-mirror build",
+    "  in CONTRIBUTING.md.",
+]
+
+
+def quote_bytes(raw, truncated=False):
+    """Binary-safe rendering. Judy string keys may hold any byte."""
+    out = []
+    for b in raw:
+        c = b if isinstance(b, int) else ord(b)
+        if 0x20 <= c < 0x7F and c not in (0x22, 0x5C):
+            out.append(chr(c))
+        else:
+            out.append("\\x%02x" % c)
+    return '"' + "".join(out) + '"' + ("..." if truncated else "")
+
+
+def ptr(value):
+    return "NULL" if not value else "0x%x" % value
+
+
+def summary_line(f):
+    """One-liner for `frame variable` / `print`."""
+    tname = type_name(f["type_table"], f["raw_type"])
+    on = [n for n in ALL_FLAGS if f["flags"].get(n)]
+    return "Judy %s count=%s [%s]" % (
+        tname,
+        "?" if f["counter"] is None else f["counter"],
+        " ".join(n[3:] if n.startswith("is_") else n for n in on) or "-",
+    )
+
+
+def report_lines(f):
+    """The full `judy` breakdown, as a list of lines.
+
+    `f` is a plain dict the front-end filled in by reading memory:
+      addr, note, raw_type, type_table, type_source, counter,
+      approx_payload, flags{}, roots{}, iterator_key, iterator_data,
+      next_empty, key_scratch, key_scratch_text
+    Any value may be None; the report says so rather than guessing."""
+    tname = type_name(f["type_table"], f["raw_type"])
+    flags = f["flags"]
+    mirrored = bool(flags.get("mirror_payload"))
+    out = []
+    add = out.append
+
+    add("judy_object @ %s" % ptr(f.get("addr")))
+    if f.get("note"):
+        add("  note              %s" % f["note"])
+    add("  type              %s = %s   [names from %s]"
+        % (f["raw_type"], tname, f["type_source"]))
+    add("  counter           %s element(s)" % f["counter"])
+
+    if tname in STRING_KEYED:
+        add("  approx_payload    %s bytes  (string-keyed lower bound: key bytes "
+            "+ value slots + zval boxes, excludes libJudy nodes)" % f["approx_payload"])
+    else:
+        add("  approx_payload    %s  (unused — integer-keyed types report exact "
+            "JudyLMemUsed/Judy1MemUsed instead)" % f["approx_payload"])
+
+    add("  flags (packed bitfield)")
+    expected = expected_flags(tname)
+    disagree = []
+    for name in DERIVED_FLAGS:
+        got = flags.get(name)
+        mark = ""
+        if got is None:
+            mark = "   <not in debug info>"
+        elif got != expected[name]:
+            mark = "   <<< MISMATCH: type %s implies %d" % (tname, expected[name])
+            disagree.append(name)
+        add("    %-22s %s%s" % (name, "?" if got is None else got, mark))
+
+    mp = flags.get("mirror_payload")
+    if mp is None:
+        mp_note = "<not in debug info>"
+    elif mp and tname not in CAN_MIRROR:
+        mp_note = "<<< MISMATCH: %s cannot mirror (judy_type_can_mirror)" % tname
+        disagree.append("mirror_payload")
+    elif mp:
+        mp_note = ("optimizeIteration ON — key_index slots carry the payload"
+                   + (" for keys >= 8 bytes" if tname in ADAPTIVE else ""))
+    else:
+        mp_note = ("off" if tname in CAN_MIRROR
+                   else "off (this type can never honour optimizeIteration)")
+    add("    %-22s %s   %s" % ("mirror_payload", "?" if mp is None else mp, mp_note))
+
+    for name, hint in (("next_empty_is_valid", "guards the cached next_empty below"),
+                       ("iterator_initialized", "a manual rewind()/next() cursor is live")):
+        val = flags.get(name)
+        add("    %-22s %s   (kept a whole byte, mutated during iteration; %s)"
+            % (name, "?" if val is None else val, hint))
+
+    if disagree:
+        add("  !! the flag cache disagrees with ->type: %s" % ", ".join(disagree))
+        add("     judy_init_type_flags() derives all six from ->type, so a mismatch")
+        add("     means the object was built without it, or memory is corrupt.")
+
+    add("  storage roots (Pvoid_t; contents opaque — the tree is NOT walked, see")
+    add("  the header note in scripts/judy_lldb.py)")
+    for field, role in store_roles(tname, mirrored):
+        add("    %-10s %-16s %s" % (field, ptr(f["roots"].get(field)), role))
+    if tname in HASH_KEYED:
+        for line in SPLIT_NOTE:
+            add("    " + line)
+
+    add("  iterator / cursor state (Iterator methods; foreach uses judy_iterator)")
+    add("    iterator_key     %s" % f["iterator_key"])
+    add("    iterator_data    %s" % f["iterator_data"])
+    add("    next_empty       %s   %s" % (
+        "?" if f["next_empty"] is None else f["next_empty"],
+        "cached, usable" if flags.get("next_empty_is_valid")
+        else "STALE — a write invalidated it; recompute before trusting it"))
+    ks = f.get("key_scratch")
+    line = "    key_scratch      %s" % ptr(ks)
+    if ks:
+        if f.get("key_scratch_text"):
+            line += "   -> %s" % f["key_scratch_text"]
+        line += ("   (live cursor key)" if flags.get("iterator_initialized")
+                 else "   (no walk in progress; contents are leftovers)")
+    add(line)
+    return out
+
+
+HELP = """judy [<expression>] — decode a php-judy judy_object.
+
+With no argument, looks for `intern`, then `object`, then `obj` in the current
+frame. The argument may be a judy_object, a judy_object*, a zend_object* (which
+gets rebased through offsetof(judy_object, std), the way php_judy_object()
+does), or a zval holding a Judy instance. Any variable path works, e.g.
+`judy it->intern.data`.
+
+Reads memory only — nothing runs in the inferior — so this is safe on a core
+dump and at a breakpoint in a crash handler. It does NOT walk the Judy tree;
+see the header note in scripts/judy_lldb.py for why."""

--- a/scripts/judy_gdb.py
+++ b/scripts/judy_gdb.py
@@ -1,0 +1,453 @@
+# php-judy gdb pretty-printers — the Linux/valgrind twin of scripts/judy_lldb.py.
+#
+# Same audience, same output, same deliberate limits: this decodes the raw
+# `judy_object` struct for someone debugging the EXTENSION, not the PHP-visible
+# view that the `get_debug_info` handler produces for var_dump()/Xdebug/IDEs.
+#
+# Read the header of scripts/judy_lldb.py first — it is the primary document
+# and covers what is rendered, and why the Judy tree itself is not walked.
+# Everything php-judy-specific is shared between the two front-ends in
+# scripts/judy_debug_common.py, so they cannot drift.
+#
+#   LOADING
+#
+#       (gdb) source scripts/judy_gdb.py
+#
+#   or permanently, in ~/.gdbinit (absolute path required):
+#
+#       source /path/to/php-judy/scripts/judy_gdb.py
+#
+#   BUILD REQUIREMENT — as on macOS, the default build is not debuggable:
+#   `./configure && make` inherits PHP's own CFLAGS (typically -O2/-O3
+#   -DNDEBUG, often -flto), which at best inlines the locals away and at worst
+#   leaves gdb with no usable types. Rebuild with:
+#
+#       make clean && make EXTRA_CFLAGS="-g -O0 -fno-lto"
+#
+#   USE WITH VALGRIND (the reason this file exists — see the valgrind recipe in
+#   AGENTS.md and CONTRIBUTING.md):
+#
+#       valgrind --vgdb=yes --vgdb-error=0 php -n -d extension=modules/judy.so t.php
+#       gdb -ex 'source scripts/judy_gdb.py' -ex 'target remote | vgdb' $(which php)
+#
+#   Then `judy intern` at the stop. Everything here is a plain memory read, so
+#   it works over the vgdb remote and on a core dump (`gdb php core`).
+#
+#   WHAT YOU GET
+#
+#       judy_object / judy_iterator / judy_packed_value    one-line summaries
+#       (gdb) judy [<expression>]                          full breakdown
+#
+#   `judy` defaults to `intern` in the current frame and accepts a judy_object,
+#   a judy_object*, a zend_object* (rebased through offsetof(judy_object, std)
+#   like php_judy_object() does), or a zval holding a Judy instance.
+#
+#   ONE GDB GOTCHA, not the printers' fault: a breakpoint set by function name
+#   stops after the prologue but a local may still be unassigned on the first
+#   source line, so `intern` there can be garbage. Break a line or two later
+#   (`break php_judy.c:<line>`) or `next` once first.
+
+import os
+import sys
+
+import gdb
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import judy_debug_common as jc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# judy_type -> name, from the debug info where possible.
+# ---------------------------------------------------------------------------
+
+_type_table_cache = {}
+
+
+def _type_table():
+    key = gdb.current_progspace().filename or "<no-exe>"
+    cached = _type_table_cache.get(key)
+    if cached is not None:
+        return cached
+
+    table, source = None, None
+    for name in ("judy_type", "enum _judy_type"):
+        try:
+            t = gdb.lookup_type(name)
+        except gdb.error:
+            continue
+        entries = {}
+        for f in t.fields():
+            fname = f.name or ""
+            if fname.startswith("TYPE_"):
+                fname = fname[len("TYPE_"):]
+            entries[int(f.enumval)] = fname
+        if entries:
+            table, source = entries, "debug info (enum judy_type)"
+            break
+
+    if table is None:
+        table, source = dict(jc.TYPE_FALLBACK), "built-in fallback table"
+
+    _type_table_cache[key] = (table, source)
+    return table, source
+
+
+# ---------------------------------------------------------------------------
+# Value helpers. Pure memory reads; nothing runs in the inferior.
+# ---------------------------------------------------------------------------
+
+def _member(v, *path):
+    try:
+        for name in path:
+            if v is None:
+                return None
+            v = v[name]
+        return v
+    except (gdb.error, KeyError, RuntimeError):
+        return None
+
+
+def _u(v, *path):
+    m = _member(v, *path)
+    if m is None:
+        return None
+    try:
+        return int(m) & 0xFFFFFFFFFFFFFFFF
+    except (gdb.error, ValueError):
+        return None
+
+
+def _s(v, *path):
+    m = _member(v, *path)
+    if m is None:
+        return None
+    try:
+        return int(m)
+    except (gdb.error, ValueError):
+        return None
+
+
+def _addr_of(v):
+    try:
+        a = v.address
+        return None if a is None else int(a)
+    except (gdb.error, AttributeError):
+        return None
+
+
+def _read(addr, size):
+    if not addr or size <= 0:
+        return None
+    try:
+        return bytes(gdb.selected_inferior().read_memory(addr, size))
+    except (gdb.MemoryError, gdb.error, OverflowError):
+        return None
+
+
+def _read_cstr(addr, limit=96):
+    data = _read(addr, limit)
+    if data is None:
+        data = _read(addr, 16)
+        if data is None:
+            return None
+    nul = data.find(b"\x00")
+    truncated = nul < 0
+    if not truncated:
+        data = data[:nul]
+    return jc.quote_bytes(data, truncated)
+
+
+def _zval_str(z):
+    if z is None:
+        return "<unreadable>"
+    tag = _u(z, "u1", "v", "type")
+    if tag is None:
+        return "<no zval type info>"
+    if tag == 4:
+        return "LONG %d" % (_s(z, "value", "lval") or 0)
+    if tag == 5:
+        d = _member(z, "value", "dval")
+        return "DOUBLE %s" % ("?" if d is None else float(d))
+    if tag == 6:
+        sp = _member(z, "value", "str")
+        if sp is None or int(sp) == 0:
+            return "STRING <null zend_string*>"
+        zs = sp.dereference()
+        ln = _u(zs, "len")
+        val = _member(zs, "val")
+        if ln is None or val is None:
+            return "STRING @0x%x <no zend_string type info>" % int(sp)
+        show = min(ln, 96)
+        raw = _read(_addr_of(val), show) if show else b""
+        if raw is None:
+            return "STRING(len=%d) <unreadable>" % ln
+        return "STRING(len=%d) %s" % (ln, jc.quote_bytes(raw, ln > show))
+    return jc.ZVAL_TYPES.get(tag, "type#%d" % tag)
+
+
+# ---------------------------------------------------------------------------
+# Getting to a judy_object from whatever the user has in hand.
+# ---------------------------------------------------------------------------
+
+def _typename(v):
+    try:
+        return str(v.type.strip_typedefs()).replace("const ", "").strip()
+    except gdb.error:
+        return ""
+
+
+def _as_judy_object(v):
+    """Returns (gdb.Value of judy_object, note) or (None, reason)."""
+    if v is None:
+        return None, "not a valid value"
+
+    t = _typename(v)
+    if t in ("judy_object *", "struct _judy_object *"):
+        if int(v) == 0:
+            return None, "judy_object* is NULL"
+        return v.dereference(), None
+    if t in ("judy_object", "struct _judy_object"):
+        return v, None
+    if t in ("zend_object *", "struct _zend_object *"):
+        if int(v) == 0:
+            return None, "zend_object* is NULL"
+        return _rebase_zend_object(int(v))
+    if t in ("zend_object", "struct _zend_object"):
+        return _rebase_zend_object(_addr_of(v))
+    if t in ("zval", "struct _zval_struct", "zval *", "struct _zval_struct *"):
+        z = v.dereference() if t.endswith("*") else v
+        obj = _member(z, "value", "obj")
+        if obj is not None and int(obj) != 0:
+            return _rebase_zend_object(int(obj))
+        return None, "zval does not hold an object"
+
+    return None, "don't know how to read a judy_object out of type '%s'" % t
+
+
+def _judy_object_type():
+    for name in ("judy_object", "struct _judy_object"):
+        try:
+            return gdb.lookup_type(name)
+        except gdb.error:
+            continue
+    return None
+
+
+def _rebase_zend_object(addr):
+    """php_judy_object(): back up from the embedded ->std to the container."""
+    if not addr:
+        return None, "zend_object address unavailable"
+    jo = _judy_object_type()
+    if jo is None:
+        return None, "no 'judy_object' type in the debug info.\n" + jc.NO_DEBUG_INFO_HINT
+    offset = None
+    for f in jo.fields():
+        if f.name == "std":
+            offset = f.bitpos // 8
+            break
+    if offset is None:
+        return None, "judy_object has no 'std' field?"
+    base = addr - offset
+    try:
+        val = gdb.Value(base).cast(jo.pointer()).dereference()
+    except gdb.error as exc:
+        return None, "could not materialise judy_object at 0x%x: %s" % (base, exc)
+    return val, ("rebased from zend_object 0x%x (offsetof(judy_object, std) = %d)"
+                 % (addr, offset))
+
+
+def _collect(jo, note=None):
+    table, source = _type_table()
+    ks = _u(jo, "key_scratch")
+    return {
+        "addr": _addr_of(jo),
+        "note": note,
+        "raw_type": _s(jo, "type"),
+        "type_table": table,
+        "type_source": source,
+        "counter": _s(jo, "counter"),
+        "approx_payload": _s(jo, "approx_payload_bytes"),
+        "flags": dict((n, _u(jo, n)) for n in jc.ALL_FLAGS),
+        "roots": dict((n, _u(jo, n)) for n in jc.ROOT_FIELDS),
+        "iterator_key": _zval_str(_member(jo, "iterator_key")),
+        "iterator_data": _zval_str(_member(jo, "iterator_data")),
+        "next_empty": _u(jo, "next_empty"),
+        "key_scratch": ks,
+        "key_scratch_text": _read_cstr(ks) if ks else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pretty printers.
+# ---------------------------------------------------------------------------
+
+def _deref(val):
+    """(value, address-prefix). gdb replaces the whole `(T *) 0x...` line with
+    the printer output, so a pointer's address has to come back in the string
+    or it is lost."""
+    try:
+        if val.type.strip_typedefs().code == gdb.TYPE_CODE_PTR:
+            if int(val) == 0:
+                return None, ""
+            return val.dereference(), "0x%x " % int(val)
+    except gdb.error:
+        return None, ""
+    return val, ""
+
+
+class _JudyObjectPrinter(object):
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        jo, err = _as_judy_object(self.val)
+        if jo is None:
+            return "<%s>" % err.splitlines()[0]
+        addr = _addr_of(jo)
+        prefix = ("0x%x " % addr) if addr else ""
+        return prefix + jc.summary_line(_collect(jo))
+
+
+class _JudyIteratorPrinter(object):
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        v, prefix = _deref(self.val)
+        if v is None:
+            return "judy_iterator NULL"
+        valid = _u(v, "valid")
+        return prefix + "judy_iterator valid=%s key=%s data=%s" % (
+            "?" if valid is None else valid,
+            _zval_str(_member(v, "key")), _zval_str(_member(v, "data")))
+
+
+class _JudyPackedPrinter(object):
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        v, prefix = _deref(self.val)
+        if v is None:
+            return "judy_packed_value NULL"
+        tag = _u(v, "tag")
+        if tag is None:
+            return prefix + "<unreadable judy_packed_value>"
+        name = jc.PACKED_TAGS.get(tag, "UNKNOWN(%d)" % tag)
+        if tag == 0:
+            return prefix + "packed LONG %d" % (_s(v, "v", "lval") or 0)
+        if tag == 1:
+            d = _member(v, "v", "dval")
+            return prefix + "packed DOUBLE %s" % ("?" if d is None else float(d))
+        if tag in (5, 255):
+            ln = _u(v, "v", "str", "len")
+            blob = _member(v, "v", "str", "data")
+            text = ""
+            if blob is not None and ln:
+                show = min(ln, 64)
+                raw = _read(_addr_of(blob), show)
+                if raw is not None:
+                    text = " " + jc.quote_bytes(raw, ln > show)
+            return prefix + "packed %s(len=%s)%s" % (name, ln, text)
+        return prefix + "packed %s" % name
+
+
+_PRINTERS = {
+    "judy_object": _JudyObjectPrinter,
+    "_judy_object": _JudyObjectPrinter,
+    "judy_iterator": _JudyIteratorPrinter,
+    "judy_packed_value": _JudyPackedPrinter,
+    "_judy_packed_value": _JudyPackedPrinter,
+}
+
+
+def _names(t):
+    """Every name a type answers to. judy_iterator is a typedef of an ANONYMOUS
+    struct, so strip_typedefs() leaves it with neither name nor tag — the
+    typedef name is the only handle on it, and looking only at the stripped
+    type silently skips that printer."""
+    out = set()
+    for candidate in (t, t.strip_typedefs()):
+        for name in (candidate.name, candidate.tag):
+            if name:
+                out.add(name)
+    return out
+
+
+def _lookup(val):
+    try:
+        t = val.type
+    except gdb.error:
+        return None
+    if t.strip_typedefs().code == gdb.TYPE_CODE_PTR:
+        t = t.strip_typedefs().target()
+    if t.strip_typedefs().code not in (gdb.TYPE_CODE_STRUCT, gdb.TYPE_CODE_UNION):
+        return None
+    for name in _names(t):
+        cls = _PRINTERS.get(name)
+        if cls:
+            return cls(val)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# `judy` command.
+# ---------------------------------------------------------------------------
+
+def _debug_info_hint():
+    return "" if _judy_object_type() is not None else "\n\n" + jc.NO_DEBUG_INFO_HINT
+
+
+class JudyCommand(gdb.Command):
+    """Decode a php-judy judy_object. `judy --help` for details."""
+
+    def __init__(self):
+        super(JudyCommand, self).__init__("judy", gdb.COMMAND_DATA)
+
+    def invoke(self, arg, from_tty):
+        expr = (arg or "").strip()
+        if expr in ("-h", "--help", "help"):
+            gdb.write(jc.HELP + "\n")
+            return
+
+        note = None
+        if expr:
+            try:
+                v = gdb.parse_and_eval(expr)
+            except gdb.error as exc:
+                raise gdb.GdbError("cannot resolve '%s': %s%s"
+                                   % (expr, exc, _debug_info_hint()))
+        else:
+            v = None
+            for name in ("intern", "object", "obj", "result"):
+                try:
+                    v = gdb.parse_and_eval(name)
+                except gdb.error:
+                    continue
+                note = "(no argument given; using `%s` from this frame)" % name
+                break
+            if v is None:
+                raise gdb.GdbError(
+                    "no argument given and no `intern`/`object`/`obj` in this "
+                    "frame — pass an expression, e.g. `judy intern`"
+                    + _debug_info_hint())
+
+        jo, err = _as_judy_object(v)
+        if jo is None:
+            raise gdb.GdbError(err)
+        if err:
+            note = ((note + " ") if note else "") + err
+
+        gdb.write("\n".join(jc.report_lines(_collect(jo, note))) + "\n")
+
+
+def _register():
+    if _lookup not in gdb.pretty_printers:
+        gdb.pretty_printers.append(_lookup)
+    JudyCommand()
+    gdb.write("php-judy: printers for judy_object / judy_iterator / "
+              "judy_packed_value installed; `judy` command available "
+              "(`judy --help`).\n")
+
+
+_register()

--- a/scripts/judy_lldb.py
+++ b/scripts/judy_lldb.py
@@ -1,0 +1,403 @@
+# php-judy lldb pretty-printers — for contributors debugging the EXTENSION.
+#
+# This is the C-side companion to the `get_debug_info` handler. That handler is
+# what a PHP user sees (var_dump(), Xdebug, the IDE variable pane): type name,
+# count, memoryUsage, first/last key, a bounded preview. This file is for the
+# other audience — someone in lldb on a crash, a core dump or a valgrind run,
+# looking at the raw `judy_object` struct, where the type is a bare integer, the
+# storage roots are opaque `Pvoid_t`, and the flag block is a row of bitfields.
+#
+#   LOADING
+#
+#       (lldb) command script import scripts/judy_lldb.py
+#
+#   or permanently, in ~/.lldbinit (absolute path required):
+#
+#       command script import /path/to/php-judy/scripts/judy_lldb.py
+#
+#   It imports scripts/judy_debug_common.py from the same directory, which
+#   holds everything php-judy-specific and is shared with scripts/judy_gdb.py.
+#
+#   BUILD REQUIREMENT — the default build is NOT debuggable.
+#
+#   `phpize && ./configure && make` inherits PHP's own CFLAGS, which on a
+#   typical distro or Homebrew PHP include `-O3 -DNDEBUG -flto`. Under `-flto`
+#   clang emits a single debug-map entry pointing at a temporary `/tmp/lto.o`
+#   that is gone by the time you debug, so lldb has NO type information and NO
+#   locals for the extension: a breakpoint hits and `frame variable intern`
+#   finds nothing. Rebuild with:
+#
+#       make clean && make EXTRA_CFLAGS="-g -O0 -fno-lto"
+#
+#   (EXTRA_CFLAGS lands after CFLAGS on the compile line, so it wins.) Confirm
+#   with `nm -pa modules/judy.so | grep OSO` — you want one entry per .o under
+#   .libs/, not a single /tmp/lto.o.
+#
+#   WHAT YOU GET
+#
+#   Automatic summaries, so plain `frame variable` / `p` are readable:
+#
+#       judy_object, judy_object *   one-line digest: type name, count, flags
+#       judy_iterator                foreach-iterator cursor state
+#       judy_packed_value            INT_TO_PACKED tagged union, decoded
+#
+#   And one command for the full breakdown:
+#
+#       (lldb) judy                  # defaults to `intern` in the current frame
+#       (lldb) judy intern
+#       (lldb) judy object           # a zend_object* is accepted and rebased
+#       (lldb) judy it->intern.data  # any variable path
+#
+#   The type NAMES come from the `judy_type` enum in the debug info rather than
+#   from a table here, so they cannot drift from judy_type_name() in php_judy.c.
+#   judy_debug_common.TYPE_FALLBACK is only used when that enum is missing.
+#
+#   WHAT IT DELIBERATELY DOES NOT DO — walk the Judy tree.
+#
+#   libJudy's node layout is internal, undocumented and version-dependent: the
+#   root word is a tagged pointer whose meaning depends on the population and
+#   on compile-time constants of the libJudy you linked against. A printer that
+#   decoded it by guesswork would be confidently wrong on the next libJudy, and
+#   a wrong element listing is worse than none when you are already debugging a
+#   corruption. So the storage roots are printed as pointers, annotated with
+#   which libJudy flavour (Judy1/JudyL/JudySL/JudyHS) each one is for this type,
+#   and the population is read from `intern->counter`, which the extension
+#   maintains itself. To see elements, use the PHP side: break somewhere you can
+#   run code and call `var_dump()`, or drive the array from a .phpt.
+#
+#   No expression evaluation is used for any of the rendering — every field is a
+#   direct memory read through the SB API — so the printers work in a core dump
+#   and at a breakpoint in a signal handler, where running code in the inferior
+#   would fail or lie.
+#
+#   ONE LLDB GOTCHA, not the printers' fault: a breakpoint set by function name
+#   stops at the function's first line, BEFORE its locals are assigned, so
+#   `intern` there is uninitialised garbage. Set the breakpoint a line or two
+#   later (`breakpoint set -f php_judy.c -l <line>`), or `next` once first.
+#
+#   The Python files here are named with underscores, not the dashes used by the
+#   PHP scripts beside them, because the debugger imports them as Python modules
+#   and a module name has to be a valid identifier.
+
+import os
+import sys
+
+import lldb
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import judy_debug_common as jc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# judy_type -> name, from the debug info where possible.
+# ---------------------------------------------------------------------------
+
+_type_table_cache = {}
+
+
+def _type_table(target):
+    exe = target.GetExecutable()
+    key = (exe.fullpath if exe and exe.IsValid() else None) or "<no-exe>"
+    cached = _type_table_cache.get(key)
+    if cached is not None:
+        return cached
+
+    table, source = None, None
+    for type_name in ("judy_type", "enum _judy_type", "_judy_type"):
+        t = target.FindFirstType(type_name)
+        if not t or not t.IsValid():
+            continue
+        members = t.GetEnumMembers()
+        if not members or members.GetSize() == 0:
+            continue
+        table = {}
+        for i in range(members.GetSize()):
+            m = members.GetTypeEnumMemberAtIndex(i)
+            name = m.GetName() or ""
+            if name.startswith("TYPE_"):
+                name = name[len("TYPE_"):]
+            table[m.GetValueAsSigned()] = name
+        source = "debug info (enum judy_type)"
+        break
+
+    if table is None:
+        table, source = dict(jc.TYPE_FALLBACK), "built-in fallback table"
+
+    _type_table_cache[key] = (table, source)
+    return table, source
+
+
+# ---------------------------------------------------------------------------
+# SB helpers. Everything is a memory read; nothing runs in the inferior, so it
+# all works on a core dump.
+# ---------------------------------------------------------------------------
+
+def _member(v, *path):
+    for name in path:
+        if not v or not v.IsValid():
+            return None
+        v = v.GetChildMemberWithName(name)
+    return v if (v and v.IsValid()) else None
+
+
+def _u(v, *path):
+    m = _member(v, *path)
+    return None if m is None else m.GetValueAsUnsigned()
+
+
+def _s(v, *path):
+    m = _member(v, *path)
+    return None if m is None else m.GetValueAsSigned()
+
+
+def _read(value, addr, size):
+    if not addr or addr == lldb.LLDB_INVALID_ADDRESS or size <= 0:
+        return None
+    process = value.GetProcess()
+    if not process or not process.IsValid():
+        return None
+    err = lldb.SBError()
+    data = process.ReadMemory(addr, size, err)
+    return data if err.Success() else None
+
+
+def _read_cstr(value, addr, limit=96):
+    """NUL-terminated bytes at addr, quoted. None if unreadable."""
+    data = _read(value, addr, limit)
+    if data is None:
+        # A short read near the end of a mapping is normal; retry smaller.
+        data = _read(value, addr, 16)
+        if data is None:
+            return None
+    nul = data.find(b"\x00")
+    truncated = nul < 0
+    if not truncated:
+        data = data[:nul]
+    return jc.quote_bytes(data, truncated)
+
+
+def _zval_str(z):
+    """Render a zval by hand — the engine's own printers are not loaded here."""
+    if z is None or not z.IsValid():
+        return "<unreadable>"
+    tag = _u(z, "u1", "v", "type")
+    if tag is None:
+        return "<no zval type info>"
+    if tag == 4:
+        return "LONG %d" % (_s(z, "value", "lval") or 0)
+    if tag == 5:
+        d = _member(z, "value", "dval")
+        return "DOUBLE %s" % (d.GetValue() if d else "?")
+    if tag == 6:
+        sp = _member(z, "value", "str")
+        if sp is None or sp.GetValueAsUnsigned() == 0:
+            return "STRING <null zend_string*>"
+        zs = sp.Dereference()
+        ln = _u(zs, "len")
+        val = _member(zs, "val")
+        if ln is None or val is None:
+            return "STRING @0x%x <no zend_string type info>" % sp.GetValueAsUnsigned()
+        show = min(ln, 96)
+        raw = _read(z, val.GetLoadAddress(), show) if show else b""
+        if raw is None:
+            return "STRING(len=%d) <unreadable>" % ln
+        return "STRING(len=%d) %s" % (ln, jc.quote_bytes(raw, ln > show))
+    return jc.ZVAL_TYPES.get(tag, "type#%d" % tag)
+
+
+# ---------------------------------------------------------------------------
+# Getting to a judy_object from whatever the user has in hand.
+# ---------------------------------------------------------------------------
+
+def _as_judy_object(v):
+    """Returns (SBValue of judy_object, note) or (None, reason)."""
+    if v is None or not v.IsValid():
+        return None, "not a valid value"
+
+    t = v.GetType()
+    if t.IsReferenceType():
+        v = v.Dereference()
+        t = v.GetType()
+
+    name = (t.GetName() or "").replace("const ", "").strip()
+
+    if name in ("judy_object *", "struct _judy_object *"):
+        if v.GetValueAsUnsigned() == 0:
+            return None, "judy_object* is NULL"
+        return v.Dereference(), None
+    if name in ("judy_object", "struct _judy_object"):
+        return v, None
+
+    if name in ("zend_object *", "struct _zend_object *"):
+        if v.GetValueAsUnsigned() == 0:
+            return None, "zend_object* is NULL"
+        return _rebase_zend_object(v, v.GetValueAsUnsigned())
+    if name in ("zend_object", "struct _zend_object"):
+        return _rebase_zend_object(v, v.GetLoadAddress())
+
+    if name in ("zval", "struct _zval_struct", "zval *", "struct _zval_struct *"):
+        z = v.Dereference() if name.endswith("*") else v
+        obj = _member(z, "value", "obj")
+        if obj is not None and obj.GetValueAsUnsigned():
+            return _rebase_zend_object(obj, obj.GetValueAsUnsigned())
+        return None, "zval does not hold an object"
+
+    return None, "don't know how to read a judy_object out of type '%s'" % name
+
+
+def _rebase_zend_object(v, addr):
+    """php_judy_object(): back up from the embedded ->std to the container."""
+    if addr in (0, lldb.LLDB_INVALID_ADDRESS):
+        return None, "zend_object address unavailable"
+    target = v.GetTarget()
+    jo = target.FindFirstType("judy_object")
+    if not jo or not jo.IsValid():
+        return None, "no 'judy_object' type in the debug info.\n" + jc.NO_DEBUG_INFO_HINT
+    offset = None
+    for i in range(jo.GetNumberOfFields()):
+        f = jo.GetFieldAtIndex(i)
+        if f.GetName() == "std":
+            offset = f.GetOffsetInBytes()
+            break
+    if offset is None:
+        return None, "judy_object has no 'std' field?"
+    base = addr - offset
+    out = target.CreateValueFromAddress("judy", lldb.SBAddress(base, target), jo)
+    if not out or not out.IsValid():
+        return None, "could not materialise judy_object at 0x%x" % base
+    return out, ("rebased from zend_object 0x%x (offsetof(judy_object, std) = %d)"
+                 % (addr, offset))
+
+
+def _collect(jo, note=None):
+    """Read every field the report needs into the plain dict jc expects."""
+    table, source = _type_table(jo.GetTarget())
+    addr = jo.GetLoadAddress()
+    ks = _u(jo, "key_scratch")
+    return {
+        "addr": None if addr == lldb.LLDB_INVALID_ADDRESS else addr,
+        "note": note,
+        "raw_type": _s(jo, "type"),
+        "type_table": table,
+        "type_source": source,
+        "counter": _s(jo, "counter"),
+        "approx_payload": _s(jo, "approx_payload_bytes"),
+        "flags": dict((n, _u(jo, n)) for n in jc.ALL_FLAGS),
+        "roots": dict((n, _u(jo, n)) for n in jc.ROOT_FIELDS),
+        "iterator_key": _zval_str(_member(jo, "iterator_key")),
+        "iterator_data": _zval_str(_member(jo, "iterator_data")),
+        "next_empty": _u(jo, "next_empty"),
+        "key_scratch": ks,
+        "key_scratch_text": _read_cstr(jo, ks) if ks else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Summaries.
+# ---------------------------------------------------------------------------
+
+def judy_object_summary(valobj, internal_dict, options=None):
+    jo, err = _as_judy_object(valobj)
+    if jo is None:
+        return "<%s>" % err.splitlines()[0]
+    return jc.summary_line(_collect(jo))
+
+
+def judy_iterator_summary(valobj, internal_dict, options=None):
+    v = valobj.Dereference() if valobj.GetType().IsPointerType() else valobj
+    valid = _u(v, "valid")
+    return "judy_iterator valid=%s key=%s data=%s" % (
+        "?" if valid is None else valid,
+        _zval_str(_member(v, "key")), _zval_str(_member(v, "data")))
+
+
+def judy_packed_value_summary(valobj, internal_dict, options=None):
+    v = valobj.Dereference() if valobj.GetType().IsPointerType() else valobj
+    tag = _u(v, "tag")
+    if tag is None:
+        return "<unreadable judy_packed_value>"
+    name = jc.PACKED_TAGS.get(tag, "UNKNOWN(%d)" % tag)
+    if tag == 0:
+        return "packed LONG %d" % (_s(v, "v", "lval") or 0)
+    if tag == 1:
+        d = _member(v, "v", "dval")
+        return "packed DOUBLE %s" % (d.GetValue() if d else "?")
+    if tag in (5, 255):
+        ln = _u(v, "v", "str", "len")
+        blob = _member(v, "v", "str", "data")
+        text = ""
+        if blob is not None and ln:
+            show = min(ln, 64)
+            raw = _read(v, blob.GetLoadAddress(), show)
+            if raw is not None:
+                text = " " + jc.quote_bytes(raw, ln > show)
+        return "packed %s(len=%s)%s" % (name, ln, text)
+    return "packed %s" % name
+
+
+# ---------------------------------------------------------------------------
+# `judy` command.
+# ---------------------------------------------------------------------------
+
+def _debug_info_hint(frame):
+    target = frame.GetThread().GetProcess().GetTarget()
+    t = target.FindFirstType("judy_object")
+    return "" if (t and t.IsValid()) else "\n\n" + jc.NO_DEBUG_INFO_HINT
+
+
+def _resolve(frame, expr):
+    if expr:
+        v = frame.GetValueForVariablePath(expr)
+        if v and v.IsValid():
+            return v, None
+        v = frame.EvaluateExpression(expr)
+        if v and v.IsValid() and v.GetError().Success():
+            return v, None
+        return None, ("cannot resolve '%s' in this frame" % expr) + _debug_info_hint(frame)
+    for name in ("intern", "object", "obj", "result"):
+        v = frame.FindVariable(name)
+        if v and v.IsValid():
+            return v, "(no argument given; using `%s` from this frame)" % name
+    return None, ("no argument given and no `intern`/`object`/`obj` in this frame "
+                  "— pass an expression, e.g. `judy intern`" + _debug_info_hint(frame))
+
+
+def cmd_judy(debugger, command, exe_ctx, result, internal_dict):
+    expr = command.strip()
+    if expr in ("-h", "--help", "help"):
+        result.AppendMessage(jc.HELP)
+        return
+
+    frame = exe_ctx.GetFrame()
+    if not frame or not frame.IsValid():
+        result.SetError("no frame — select one first (`thread select`, `frame select`)")
+        return
+
+    v, note = _resolve(frame, expr)
+    if v is None:
+        result.SetError(note)
+        return
+
+    jo, err = _as_judy_object(v)
+    if jo is None:
+        result.SetError(err)
+        return
+    if err:  # a note, not a failure
+        note = ((note + " ") if note else "") + err
+
+    result.AppendMessage("\n".join(jc.report_lines(_collect(jo, note))))
+
+
+def __lldb_init_module(debugger, internal_dict):
+    mod = __name__
+    for func, specs in (
+        ("judy_object_summary", ("judy_object", "judy_object *")),
+        ("judy_iterator_summary", ("judy_iterator", "judy_iterator *")),
+        ("judy_packed_value_summary", ("judy_packed_value", "judy_packed_value *")),
+    ):
+        for spec in specs:
+            debugger.HandleCommand(
+                'type summary add -F %s.%s "%s"' % (mod, func, spec))
+    debugger.HandleCommand('command script add -o -f %s.cmd_judy judy' % mod)
+    print("php-judy: summaries for judy_object / judy_iterator / "
+          "judy_packed_value installed; `judy` command available (`judy --help`).")


### PR DESCRIPTION
Contributor-facing debugging aid: lldb/gdb pretty-printers for the extension's own C structs. Nothing here ships in the extension or affects runtime — three Python files under `scripts/`, listed `role="doc"`.

This does **not** overlap the end-user debugging story. `get_debug_info` (#97) already covers `var_dump()` and IDE panes. This is for someone in an lldb session on a crash, a core dump, or a valgrind run, staring at raw `judy_object` fields.

## The build trap, which may be the more useful half

**The default build is not debuggable.** `phpize` inherits PHP's own CFLAGS — `-O3 -DNDEBUG -flto` on Homebrew PHP 8.5. Under `-flto` clang emits a single debug-map entry pointing at a temporary `/tmp/lto.o` that is gone by debug time, so lldb has no types and no locals for the extension and a breakpoint simply finds nothing.

    make clean && make EXTRA_CFLAGS="-g -O0 -fno-lto"

`EXTRA_CFLAGS` lands after `CFLAGS` on the compile line, so it wins. Verify with `nm -pa modules/judy.so | grep OSO` — you want per-object entries under `.libs/`, not one `/tmp/lto.o`. Both scripts detect the condition and print that instruction rather than silently rendering nothing.

This reproduces outside the debugger too: a normal `make` on this branch's base emits `warning: (arm64) /tmp/lto.o unable to open object file`, which is the same fact surfacing as a link-time warning nobody reads.

## What the printers do

- `judy_lldb.py` — summaries for `judy_object` / `judy_iterator` / `judy_packed_value`, plus a `judy [<expr>]` command.
- `judy_gdb.py` — the gdb twin for the Linux/valgrind path (`target remote | vgdb`).
- `judy_debug_common.py` — all php-judy-specific knowledge (type table, flag semantics, storage-root roles, report layout). Both front-ends import it so they cannot drift; each only knows how to read fields out of its own debugger's values.

Design points:

- **Type names come from the `judy_type` enum in the debug info**, not a table in the script, so they cannot disagree with `judy_type_name()` in php_judy.c. The literal fallback applies only to builds missing the enum.
- **The six type-derived flags are cross-checked against `->type`.** `judy_init_type_flags()` derives them all, so disagreement means a corrupt or half-constructed object — the report says so rather than printing bits and leaving you to compare.
- **No expression evaluation.** Every field is a direct memory read, so both work on a core dump and at a breakpoint inside a crash handler.
- `judy` accepts a `judy_object`, `judy_object*`, `zend_object*` (rebased through `offsetof(judy_object, std)` exactly as `php_judy_object()` does), or a `zval` holding a Judy.

Captured on a real `STRING_TO_INT_HASH` with `optimizeIteration: true` — the key_index/value-store split, the least obvious part of the layout:

    (judy_object *) intern = 0x104405320 Judy STRING_TO_INT_HASH count=3 [string_keyed hash_keyed mirror_payload next_empty_is_valid iterator_initialized]

      storage roots (Pvoid_t; contents opaque — the tree is NOT walked)
        array      0xb2cc05000      JudyHS VALUE STORE — key -> zend_long, O(1) point lookup, unordered
        key_index  0xb2d4b1200      JudySL key index — sorted keys; payload slot MIRRORED (optimizeIteration on)
        hs_array   NULL             unused
      iterator / cursor state
        next_empty       0   STALE — a write invalidated it; recompute before trusting it

Verified against `INT_TO_INT`, `STRING_TO_MIXED`, `STRING_TO_INT_HASH`, `STRING_TO_MIXED_ADAPTIVE` (all three roots live), `INT_TO_PACKED`, `BITSET`, the packed-value summary, and `judy_iterator` mid-foreach. gdb produced byte-identical reports on linux/arm64 in a container.

## What is deliberately not rendered

**The Judy tree is not walked.** libJudy's root word is a tagged pointer whose meaning depends on population and on that build's compile-time constants. A printer decoding it by guesswork would be confidently wrong against the next libJudy, and a wrong element listing is worse than none mid-corruption. Roots print as annotated pointers; population comes from `intern->counter`.

`TYPE_FALLBACK` has no automated guard — it only matters on a build whose debug info lacks the enum, where the printers barely work anyway. Cross-checked by hand against the ten `Judy::` constants; a `.phpt` cannot reach Python.

## Scope question for review

The one-line summaries are the part expected to earn their keep daily: `frame variable intern` going from a bare pointer to a typed, flag-decoded summary is a real improvement, and the flag-vs-`->type` cross-check turns a nine-bit read into a stated verdict.

The full `judy` report is more *annotation* than *decoding* — for `INT_TO_INT` it tells you little that `p *intern` does not, and its real payload is the per-type store roles and mirror semantics, knowledge currently spread across php_judy.h comments and `judy_string_value_slot()`.

Whether that justifies ~1130 lines of shipped Python is a fair question. `judy_gdb.py` (453 lines) is the most trimmable piece if the Linux/valgrind path is not worth the second front-end — say so on review and it can be dropped without touching the rest, since all shared knowledge already lives in `judy_debug_common.py`. The CONTRIBUTING.md build-flag section stands on its own either way.

## Also

- `CONTRIBUTING.md` — new "Debugging the extension itself (lldb)" section beside the valgrind and debug-mirror recipes, plus a gdb/valgrind subsection.
- `AGENTS.md` — bullet in "Modifying the extension", alongside the valgrind recipe and stale-build trap.
- `.gitignore` — `__pycache__/` / `*.pyc`, which debuggers create when importing the shared module.
- Load instructions and rationale live in each script's header, so they are self-describing when opened cold.

No C changed. Suite 207/207 on the `-O0` debug build. No benchmarks run, `baselines/latest.json` untouched.
