### PR TITLE
feat(size): count a key range on string-keyed types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,13 +45,15 @@ Bulk (run in C, prefer over PHP loops): `toArray()`, `Judy::fromArray($type,
 $arr)`, `putAll($arr)`, `getAll($keys)`, `keys()`, `values()`, `forEach($cb)`,
 `filter($cb)`, `map($cb)`.
 
-`keys`, `values` and `toArray` also take an inclusive range —
+`keys`, `values`, `toArray` and `size` also take an inclusive range —
 `keys($start = null, $end = null)` — where `null` leaves that side unbounded.
 All key types are supported; string-keyed types require string bounds and
 compare them lexicographically. **This is the primitive to reach for on a
 bounded read**: it is one traversal writing straight into the PHP array, so
 prefer it over `slice($lo, $hi)->keys()`, which copies a whole sub-Judy first
-and then traverses that copy.
+and then traverses that copy. To *count* a range rather than read it, use
+`size($lo, $hi)`, which runs the same traversal without building anything —
+never `count($j->keys($lo, $hi))`.
 
 Set ops (return new Judy): `union`, `intersect`, `diff`, `xor`; in-place:
 `mergeWith`. Range: `slice($start, $end)` (inclusive), `deleteRange`,
@@ -150,7 +152,11 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   the predicate received; a predicate that writes or unsets `$this[$key]` does
   not change what that element contributes to the result.
 - **`count()` takes no arguments** (Countable); ranged counting is
-  `size($start, $end)` or `populationCount($start, $end)`.
+  `size($start, $end)` for every type, or `populationCount($start, $end)` for
+  integer-keyed types only — it reads libJudy's population cache, which
+  JudySL/JudyHS do not have, and throws on a string-keyed array. `size()` on a
+  string-keyed range walks the key index instead: the cost of the range, not
+  of the array.
 - **A string upper bound is a bound, not a prefix match.** `keys('bl', 'bl')`
   does not return `blackcurrant` — `blackcurrant` sorts *after* `bl`. For a
   prefix sweep, bound with the prefix and its successor: `keys('bl', 'bm')`.

--- a/API.md
+++ b/API.md
@@ -136,10 +136,12 @@ Returns the number of bytes used by the internal Judy structure. **The number me
 ### size()
 
 ```php
-public function size(mixed $start = 0, mixed $end = -1): int
+public function size(mixed $start = null, mixed $end = null): int
 ```
 
-Returns the number of elements. When called with arguments, returns the population count of keys in the inclusive `[$start, $end]` range (integer-keyed types only). The bounds are keys, not offsets — see [Range Operations](#range-operations).
+Returns the number of elements. When called with arguments, returns the count of keys in the inclusive `[$start, $end]` range, where `null` leaves that side unbounded. The bounds are keys, not offsets — see [Range Operations](#range-operations). Unbounded, this is O(1) for every type; so is a bounded count on an integer-keyed type, which libJudy answers from its population cache. A bounded count on a string-keyed type walks the key index between the bounds — the cost of the range, not of the array, and cheaper than `count($judy->keys($start, $end))`, which builds the array first.
+
+**Supported types**: All types. String-keyed types require string bounds and compare them lexicographically.
 
 ```php
 $judy = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 1000 => 100]);
@@ -147,6 +149,15 @@ $judy = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 1000 => 100]);
 $judy->size();          // 3
 $judy->size(0, 100);    // 2  — keys 1 and 5; key 1000 is outside the range
 $judy->size(0, -1);     // 3  — -1 is the maximum bound, so this is "everything"
+
+$sym = new Judy(Judy::STRING_TO_MIXED);
+$sym['App\Domain\Order'] = true;
+$sym['App\Domain\Cart']  = true;
+$sym['App\Http\Y']       = true;
+
+// "How many classes are under this namespace?" — bound with the prefix and
+// its successor, since an upper bound is a bound and not a prefix match.
+$sym->size('App\Domain\\', 'App\Domain]');  // 2
 ```
 
 ### count()
@@ -394,7 +405,7 @@ Deletes all elements with keys in the range `[$start, $end]` (inclusive). Return
 public function populationCount(mixed $start = 0, mixed $end = -1): int
 ```
 
-Returns the number of elements with keys in the range `[$start, $end]`. Uses Judy's internal population cache for O(1) counting.
+Returns the number of elements with keys in the range `[$start, $end]`. Uses Judy's internal population cache for O(1) counting, which is why it is integer-keyed only: JudySL and JudyHS keep no population count. For a ranged count on a string-keyed type, use [`size()`](#size), which walks the key index between the bounds.
 
 **Supported types**: Integer-keyed types only (BITSET, INT_TO_INT, INT_TO_MIXED, INT_TO_PACKED). Throws exception for string-keyed types.
 
@@ -683,4 +694,4 @@ Summary of which methods are available for each type. Methods not listed here wo
 
 **Legend**: `yes` = supported, `-` = throws exception, `null` = silently returns null, `int` = returns an exact integer value, `approx` = returns an approximate integer value (see the method entry).
 
-All other methods (`slice`, `deleteRange`, `forEach`, `filter`, `map`, `keys`, `values`, `equals`, `mergeWith`, `toArray`, `fromArray`, `putAll`, `getAll`) work with all 10 types.
+All other methods (`size`, `slice`, `deleteRange`, `forEach`, `filter`, `map`, `keys`, `values`, `equals`, `mergeWith`, `toArray`, `fromArray`, `putAll`, `getAll`) work with all 10 types, ranged forms included.

--- a/Judy.stub.php
+++ b/Judy.stub.php
@@ -107,10 +107,18 @@ class Judy implements ArrayAccess, Countable, Iterator, JsonSerializable
      * Return the number of elements, optionally within a key range.
      *
      * When called with arguments, returns the count of keys in the inclusive
-     * [$start, $end] range (integer-keyed types only). The bounds are keys,
-     * not offsets — see the note on Judy::slice().
+     * [$start, $end] range, where null leaves that side unbounded. All key
+     * types are supported: string-keyed types require string bounds and
+     * compare them lexicographically, exactly as keys()/values()/toArray()
+     * do. The bounds are keys, not offsets — see the note on Judy::slice().
+     *
+     * Unbounded, this is O(1) for every type; so is a bounded count on an
+     * integer-keyed type, which libJudy answers from its population cache.
+     * A bounded count on a string-keyed type walks the key index between the
+     * bounds — the cost of the range, not of the array, and cheaper than
+     * count(keys($start, $end)), which builds the array first.
      */
-    public function size(mixed $start = 0, mixed $end = -1): int {}
+    public function size(mixed $start = null, mixed $end = null): int {}
 
     /** Return the number of elements. Implements Countable. */
     public function count(): int {}

--- a/Judy_arginfo.h
+++ b/Judy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b282c2b7e9533a09c14092837dc3f755561b296f */
+ * Stub hash: 81108e5fc59eb9a01659b6010a965acba8201911 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_judy_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -28,8 +28,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_memoryUsage, 0, 0, IS
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_size, 0, 0, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_MIXED, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_MIXED, 0, "-1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_MIXED, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Judy_count arginfo_class_Judy_getType
@@ -159,7 +159,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_averageValues, 0, 0, IS_DOUBLE, 1)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Judy_populationCount arginfo_class_Judy_size
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_populationCount, 0, 0, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_MIXED, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_MIXED, 0, "-1")
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Judy_deleteRange, 0, 2, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, start, IS_MIXED, 0)

--- a/examples/symbol-table-prefix.php
+++ b/examples/symbol-table-prefix.php
@@ -139,6 +139,24 @@ function prefixKeys(Judy $symbols, string $prefix): array
     return $keys;
 }
 
+/**
+ * Just how many — same traversal again, nothing materialised at all.
+ *
+ * size($start, $end) counts the range over the same bounded walk keys() reads,
+ * so this answers "how big is this namespace?" without building an array only
+ * to call count() on it and throw it away. The one-key trim is the same
+ * correction prefixKeys() makes, done with an isset() instead of an array_pop().
+ */
+function prefixCount(Judy $symbols, string $prefix): int
+{
+    [$lo, $hi] = prefixBounds($prefix);
+    $n = $symbols->size($lo, $hi);
+    if ($hi !== null && isset($symbols[$hi])) {
+        $n--;                                     // the single possible false positive
+    }
+    return $n;
+}
+
 /*
  * Checks, so the derivation above is executable rather than a story. Written
  * as explicit comparisons rather than assert(), which zend.assertions=-1
@@ -185,6 +203,15 @@ $check(
 // Binary-safe: the naive P."\xFF" bound would drop both of these.
 $check('keys with a 0xFF byte after the prefix survive', count(prefixKeys($edge, "bin\xFF")) === 2);
 $check('empty prefix reads the whole table', prefixKeys($edge, '') === array_keys($edge->toArray()));
+// Counting the range and reading it must agree — including on the edge case
+// this whole file is about, where the successor bound is itself a stored key.
+$check(
+    'counting a namespace agrees with reading it',
+    prefixCount($edge, 'App\Domain\\') === 2
+        && prefixCount($edge, 'App\Domain') === count(prefixKeys($edge, 'App\Domain'))
+        && prefixCount($edge, "bin\xFF") === 2
+        && prefixCount($edge, '') === count($edge),
+);
 
 echo "1. Prefix -> inclusive key range\n\n";
 foreach (['App\Domain\\', 'App\Domain', "a\xFF\xFF", "\xFF\xFF", ''] as $p) {
@@ -278,7 +305,8 @@ foreach ($members as $fqcn => $meta) {
 [$lo, $hi] = prefixBounds($prefix);
 printf("\n   keys(\$lo, \$hi)    -> %d names, no values materialised\n", count(prefixKeys($symbols, $prefix)));
 printf("   values(\$lo, \$hi)  -> %d metadata records, no names\n", count($symbols->values($lo, $hi)));
-printf("   toArray(\$lo, \$hi) -> %d pairs\n\n", count($members));
+printf("   toArray(\$lo, \$hi) -> %d pairs\n", count($members));
+printf("   size(\$lo, \$hi)    -> %d, and nothing materialised at all\n\n", prefixCount($symbols, $prefix));
 
 // Completion usually wants direct children, not the whole subtree. That is the
 // same bounded read plus a filter at VM speed — still one crossing.
@@ -417,10 +445,13 @@ echo "    one-key trim has no such hole, and costs one array_pop.\n";
 echo "  - the trim is not paranoia about class names (no PHP identifier is\n";
 echo "    spelled \"App\\Domain]\"). It is what makes the helper reusable for keys\n";
 echo "    you did not choose — cache keys, file paths, serialised tuples.\n";
-echo "  - size(\$start, \$end) does NOT bound on string-keyed types: it ignores\n";
-echo "    string bounds and returns the whole count. Use count(keys(\$lo, \$hi))\n";
-echo "    for a namespace population; populationCount() throws on these types\n";
-echo "    rather than answering wrongly.\n";
+echo "  - size(\$lo, \$hi) counts the range on string-keyed types too, over the\n";
+echo "    same bounded walk keys() reads — so a namespace population costs the\n";
+echo "    range and materialises nothing. Prefer it to count(keys(\$lo, \$hi)),\n";
+echo "    which builds an array only to measure it. The one-key trim applies\n";
+echo "    here as well, as an isset() rather than an array_pop().\n";
+echo "    populationCount() still throws on these types: it answers from\n";
+echo "    libJudy's population cache, which the string-keyed stores lack.\n";
 echo "  - deleting a namespace is the same range, one call: deleteRange(\$lo,\n";
 echo "    \$hi) — but the bound is inclusive there too, so it removes the one\n";
 echo "    key spelled like \$hi as well. A read can trim that key afterwards; a\n";

--- a/package.xml
+++ b/package.xml
@@ -290,6 +290,7 @@
          <file name="tests/keys_values_001.phpt" role="test" />
          <file name="tests/keys_range_int_001.phpt" role="test" />
          <file name="tests/keys_range_string_001.phpt" role="test" />
+         <file name="tests/size_range_string_001.phpt" role="test" />
          <file name="tests/range_named_args_001.phpt" role="test" />
          <file name="tests/merge_with.phpt" role="test" />
          <file name="tests/packed_complex_fallback_001.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -1570,39 +1570,24 @@ PHP_METHOD(Judy, memoryUsage)
 }
 /* }}} */
 
-/* {{{ proto long Judy::size()
-   Return the current size of the array. */
+/* Defined with the bulk collectors below, next to the range parsing it shares
+   with keys()/values()/toArray(): counting a range and reading one must agree
+   on what the bounds mean, so they parse them in the same place. */
+static void judy_range_count_method(INTERNAL_FUNCTION_PARAMETERS, const char *method);
+
+/* {{{ proto long Judy::size(mixed $start = null, mixed $end = null)
+   Return the current size of the array, or of an inclusive key range. */
 PHP_METHOD(Judy, size)
 {
 	JUDY_METHOD_GET_OBJECT
 
-		if (intern->type == TYPE_BITSET || intern->type == TYPE_INT_TO_INT
-				|| intern->type == TYPE_INT_TO_MIXED || intern->type == TYPE_INT_TO_PACKED) {
-			zend_long   zl_idx1 = 0;
-			zend_long   zl_idx2 = -1;
-			Word_t   idx1, idx2;
-			Word_t   Rc_word;
+	/* A Judy whose type was never initialised has no key space to count in.
+	   Report null, as this method always has for that state. */
+	if (!intern->is_integer_keyed && !intern->is_string_keyed) {
+		RETURN_NULL();
+	}
 
-			ZEND_PARSE_PARAMETERS_START(0, 2)
-				Z_PARAM_OPTIONAL
-				Z_PARAM_LONG(zl_idx1)
-				Z_PARAM_LONG(zl_idx2)
-			ZEND_PARSE_PARAMETERS_END();
-			idx1 = (Word_t)zl_idx1;
-			idx2 = (Word_t)zl_idx2;
-
-			if (intern->type == TYPE_BITSET) {
-				J1C(Rc_word, intern->array, idx1, idx2);
-			} else {
-				JLC(Rc_word, intern->array, idx1, idx2);
-			}
-
-			RETURN_LONG(Rc_word);
-		} else if (intern->type == TYPE_STRING_TO_INT || intern->type == TYPE_STRING_TO_MIXED
-				|| intern->type == TYPE_STRING_TO_MIXED_HASH || intern->type == TYPE_STRING_TO_INT_HASH
-				|| intern->type == TYPE_STRING_TO_INT_ADAPTIVE || intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE) {
-			RETURN_LONG(intern->counter);
-		}
+	judy_range_count_method(INTERNAL_FUNCTION_PARAM_PASSTHRU, "size");
 }
 
 /* {{{ proto long Judy::count()
@@ -4128,6 +4113,80 @@ static void judy_collect_method(INTERNAL_FUNCTION_PARAMETERS, judy_collect_mode 
 
 	array_init(return_value);
 	judy_populate_array_ex(intern, return_value, mode, -1, NULL, &range);
+}
+
+/* How many keys fall inside `range`? Answers without materialising them, so a
+   count never costs an allocation per element the way count(keys($lo, $hi))
+   does.
+
+   Integer-keyed types read libJudy's population cache (J1C/JLC), which is O(1)
+   whatever the range spans. String-keyed types have no such cache — JudySL and
+   JudyHS keep no population count — so a bounded count walks the JudySL key
+   index between the bounds. That is the same seek-then-walk keys($lo, $hi)
+   performs, minus the array building: it costs the range, not the array. The
+   unbounded case still short-circuits to the maintained element counter. */
+static zend_long judy_count_range(judy_object *intern, const judy_collect_range *range)
+{
+	Pvoid_t   index_array;
+	uint8_t  *key;
+	Pvoid_t  *PValue;
+	zend_long counted = 0;
+
+	if (range->is_empty) {
+		return 0;
+	}
+
+	if (intern->is_integer_keyed) {
+		Word_t Rc_word;
+
+		if (intern->type == TYPE_BITSET) {
+			J1C(Rc_word, intern->array, range->start, range->end);
+		} else {
+			JLC(Rc_word, intern->array, range->start, range->end);
+		}
+		return (zend_long)Rc_word;
+	}
+
+	/* Unbounded on both sides is the whole array, which the counter already
+	   knows exactly — no walk. */
+	if (range->str_start == NULL && range->str_end == NULL) {
+		return (zend_long)intern->counter;
+	}
+
+	index_array = intern->is_hash_keyed ? intern->key_index : intern->array;
+	key = intern->key_scratch;
+
+	judy_range_seed_key(key, range);
+	JSLF(PValue, index_array, key);
+	while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)
+			&& judy_range_key_in_bounds(key, range->str_end)) {
+		counted++;
+		JSLN(PValue, index_array, key);
+	}
+
+	return counted;
+}
+
+/* Shared body of the ranged counters: parse the optional ($start, $end) pair
+   exactly as the collectors do, then count what falls inside it. */
+static void judy_range_count_method(INTERNAL_FUNCTION_PARAMETERS, const char *method)
+{
+	zval *zstart = NULL, *zend_val = NULL;
+	judy_collect_range range;
+
+	JUDY_METHOD_GET_OBJECT
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(zstart)
+		Z_PARAM_ZVAL(zend_val)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (judy_parse_collect_range(intern, zstart, zend_val, &range, method) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	RETURN_LONG(judy_count_range(intern, &range));
 }
 
 /* {{{ proto array Judy::keys(mixed $start = null, mixed $end = null)

--- a/scripts/api-metadata.php
+++ b/scripts/api-metadata.php
@@ -215,13 +215,23 @@ PHP,
             ],
         ],
         'size' => [
-            'description' => 'Returns the number of elements. When called with arguments, returns the population count of keys in the inclusive `[$start, $end]` range (integer-keyed types only). The bounds are keys, not offsets — see [Range Operations](#range-operations).',
+            'description' => 'Returns the number of elements. When called with arguments, returns the count of keys in the inclusive `[$start, $end]` range, where `null` leaves that side unbounded. The bounds are keys, not offsets — see [Range Operations](#range-operations). Unbounded, this is O(1) for every type; so is a bounded count on an integer-keyed type, which libJudy answers from its population cache. A bounded count on a string-keyed type walks the key index between the bounds — the cost of the range, not of the array, and cheaper than `count($judy->keys($start, $end))`, which builds the array first.',
+            'supported_types' => 'All types. String-keyed types require string bounds and compare them lexicographically.',
             'example' => <<<'PHP'
 $judy = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 1000 => 100]);
 
 $judy->size();          // 3
 $judy->size(0, 100);    // 2  — keys 1 and 5; key 1000 is outside the range
 $judy->size(0, -1);     // 3  — -1 is the maximum bound, so this is "everything"
+
+$sym = new Judy(Judy::STRING_TO_MIXED);
+$sym['App\Domain\Order'] = true;
+$sym['App\Domain\Cart']  = true;
+$sym['App\Http\Y']       = true;
+
+// "How many classes are under this namespace?" — bound with the prefix and
+// its successor, since an upper bound is a bound and not a prefix match.
+$sym->size('App\Domain\\', 'App\Domain]');  // 2
 PHP,
         ],
         'count' => [
@@ -297,7 +307,7 @@ PHP,
             'supported_types' => 'All types.',
         ],
         'populationCount' => [
-            'description' => "Returns the number of elements with keys in the range `[\$start, \$end]`. Uses Judy's internal population cache for O(1) counting.",
+            'description' => "Returns the number of elements with keys in the range `[\$start, \$end]`. Uses Judy's internal population cache for O(1) counting, which is why it is integer-keyed only: JudySL and JudyHS keep no population count. For a ranged count on a string-keyed type, use [`size()`](#size), which walks the key index between the bounds.",
             'supported_types' => 'Integer-keyed types only (BITSET, INT_TO_INT, INT_TO_MIXED, INT_TO_PACKED). Throws exception for string-keyed types.',
         ],
         'fromArray' => [
@@ -494,7 +504,7 @@ PHP,
     ],
 
     'matrix_legend' => '**Legend**: `yes` = supported, `-` = throws exception, `null` = silently returns null, `int` = returns an exact integer value, `approx` = returns an approximate integer value (see the method entry).',
-    'matrix_footer' => 'All other methods (`slice`, `deleteRange`, `forEach`, `filter`, `map`, `keys`, `values`, `equals`, `mergeWith`, `toArray`, `fromArray`, `putAll`, `getAll`) work with all 10 types.',
+    'matrix_footer' => 'All other methods (`size`, `slice`, `deleteRange`, `forEach`, `filter`, `map`, `keys`, `values`, `equals`, `mergeWith`, `toArray`, `fromArray`, `putAll`, `getAll`) work with all 10 types, ranged forms included.',
 
     // ── Global functions ────────────────────────────────────────
     'global_functions' => ['judy_version', 'judy_type'],

--- a/tests/size_range_string_001.phpt
+++ b/tests/size_range_string_001.phpt
@@ -120,6 +120,26 @@ echo "== BITSET\n";
 echo "  size():           ", $b->size(), "\n";
 echo "  size(0,49):       ", $b->size(0, 49), "\n";
 echo "  size(50,99):      ", $b->size(50, 99), "\n";
+
+/* The bounds are unsigned machine words, and that is load-bearing rather than
+   incidental: -1 has to keep reading as the maximum bound (which is what makes
+   the no-argument default and the explicit size(0, -1) the same query), and
+   negative keys sort above PHP_INT_MAX, so a range over them must not be
+   treated as inverted. A signed comparison here would break both. */
+$n = new Judy(Judy::INT_TO_INT);
+$n[1] = 1;
+$n[5] = 5;
+$n[-2] = -2;
+$n[-1] = -1;
+echo "== negative keys\n";
+echo "  count:            ", count($n), "\n";
+echo "  size(0,-1):       ", $n->size(0, -1), "\n";
+echo "  == count():       ", $n->size(0, -1) === count($n) ? "yes" : "no", "\n";
+echo "  == size():        ", $n->size(0, -1) === $n->size() ? "yes" : "no", "\n";
+echo "  size(-2,-1):      ", $n->size(-2, -1), "\n";
+echo "  size(0,PHP_INT_MAX): ", $n->size(0, PHP_INT_MAX), "\n";
+echo "  size(PHP_INT_MIN,-1):", $n->size(PHP_INT_MIN, -1), "\n";
+echo "  == popCount:      ", $n->size(-2, -1) === $n->populationCount(-2, -1) ? "yes" : "no", "\n";
 ?>
 --EXPECT--
 == STRING_TO_INT
@@ -247,3 +267,12 @@ echo "  size(50,99):      ", $b->size(50, 99), "\n";
   size():           5
   size(0,49):       3
   size(50,99):      2
+== negative keys
+  count:            4
+  size(0,-1):       4
+  == count():       yes
+  == size():        yes
+  size(-2,-1):      2
+  size(0,PHP_INT_MAX): 2
+  size(PHP_INT_MIN,-1):2
+  == popCount:      yes

--- a/tests/size_range_string_001.phpt
+++ b/tests/size_range_string_001.phpt
@@ -1,0 +1,249 @@
+--TEST--
+Judy size() counts a key range on string-keyed types
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+/*
+ * size($start, $end) used to accept string bounds on a string-keyed array,
+ * ignore them, and return the whole-array count — a plausible-looking wrong
+ * answer. It now counts the same inclusive [$start, $end] range that
+ * keys()/values()/toArray() read, so `size($lo, $hi)` and
+ * `count($j->keys($lo, $hi))` agree by construction; the point of the former
+ * is that it never builds the array.
+ */
+
+$int_types = [
+    'STRING_TO_INT'          => Judy::STRING_TO_INT,
+    'STRING_TO_INT_HASH'     => Judy::STRING_TO_INT_HASH,
+    'STRING_TO_INT_ADAPTIVE' => Judy::STRING_TO_INT_ADAPTIVE,
+];
+$mixed_types = [
+    'STRING_TO_MIXED'          => Judy::STRING_TO_MIXED,
+    'STRING_TO_MIXED_HASH'     => Judy::STRING_TO_MIXED_HASH,
+    'STRING_TO_MIXED_ADAPTIVE' => Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+/* Mixes keys at or below the 7-byte SSO threshold with longer ones, so the
+   adaptive types count across both their JudyL and JudyHS stores. */
+$fruit = ["apple", "apricot", "banana", "blackcurrant", "cherry", "date"];
+
+foreach ($int_types + $mixed_types as $name => $type) {
+    $j = new Judy($type);
+    foreach ($fruit as $i => $key) {
+        $j[$key] = isset($int_types[$name]) ? $i : "v$i";
+    }
+
+    echo "== $name\n";
+    echo "  size():           ", $j->size(), "\n";
+    echo "  size(b,c):        ", $j->size("b", "c"), "\n";
+    echo "  size(apricot,cherry): ", $j->size("apricot", "cherry"), "\n";
+    echo "  size(b):          ", $j->size("b"), "\n";
+    echo "  size(null,b):     ", $j->size(null, "b"), "\n";
+    echo "  size(apple,apple):", $j->size("apple", "apple"), "\n";
+    /* An upper bound is a bound, not a prefix filter: "blackcurrant" sorts
+       after "bl", so bounding at "bl" excludes it and "bm" includes it. */
+    echo "  size(bb,bl):      ", $j->size("bb", "bl"), "\n";
+    echo "  size(bb,bm):      ", $j->size("bb", "bm"), "\n";
+    echo "  size(zz,zzz):     ", $j->size("zz", "zzz"), "\n";
+    /* An inverted range yields nothing rather than erroring. */
+    echo "  size(c,b):        ", $j->size("c", "b"), "\n";
+
+    /* The contract that matters: counting a range agrees with reading it. */
+    $agree = true;
+    foreach ([["b", "c"], ["apple", "apple"], ["bb", "bl"], ["c", "b"], ["", "zzz"],
+              [null, "b"], ["b", null], [null, null]] as [$lo, $hi]) {
+        $agree = $agree && $j->size($lo, $hi) === count($j->keys($lo, $hi));
+    }
+    echo "  agrees with keys: ", $agree ? "yes" : "no", "\n";
+
+    /* Non-string bounds are a TypeError, as they are for keys() and slice(). */
+    foreach ([[1, 2], ["a", 2], [1.5, "z"], [true, "z"]] as [$lo, $hi]) {
+        try {
+            $j->size($lo, $hi);
+            echo "  no throw\n";
+        } catch (TypeError $e) {
+            echo "  TypeError: ", $e->getMessage(), "\n";
+        }
+    }
+
+    $empty = new Judy($type);
+    echo "  empty source:     ", $empty->size(), " ", $empty->size("a", "z"), "\n";
+
+    /* Counting inside a foreach must not disturb the walk: the iterator holds
+       its own key buffer. */
+    $seen = 0;
+    foreach ($j as $key => $_) {
+        $seen += $j->size($key, $key);
+    }
+    echo "  counted in loop:  ", $seen, "\n";
+}
+
+/* The reported use case: "how many classes live under this namespace?", with
+   no way to answer it before except by materialising the keys. */
+$sym = new Judy(Judy::STRING_TO_MIXED);
+foreach (["App\\Domain\\Order", "App\\Domain\\Cart", "App\\DomainEvents\\X", "App\\Http\\Y"] as $class) {
+    $sym[$class] = true;
+}
+echo "== namespace prefix\n";
+echo "  total:            ", count($sym), "\n";
+echo "  App\\Domain\\:      ", $sym->size("App\\Domain\\", "App\\Domain]"), "\n";
+echo "  matches keys:     ", count($sym->keys("App\\Domain\\", "App\\Domain]")), "\n";
+
+/* Integer-keyed control: the bounds still mean what they did, and the two
+   unbounded spellings (no arguments, explicit nulls, explicit 0/-1) still
+   agree. */
+$i = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 10 => 100, 1000 => 1000]);
+echo "== INT_TO_INT\n";
+echo "  size():           ", $i->size(), "\n";
+echo "  size(null,null):  ", $i->size(null, null), "\n";
+echo "  size(0,-1):       ", $i->size(0, -1), "\n";
+echo "  size(0,100):      ", $i->size(0, 100), "\n";
+echo "  size(null,100):   ", $i->size(null, 100), "\n";
+echo "  size(100,0):      ", $i->size(100, 0), "\n";
+echo "  matches popCount: ", $i->size(0, 100) === $i->populationCount(0, 100) ? "yes" : "no", "\n";
+
+/* size() and keys() now parse their bounds in the same place, so they agree on
+   integer-keyed arrays too — whatever the coercion rules are, one method can
+   no longer read a bound differently from the other. */
+$agree = true;
+foreach ([[0, 100], ["5", 100], [null, 100], [0, null], [100, 0], [0, -1]] as [$lo, $hi]) {
+    $agree = $agree && $i->size($lo, $hi) === count($i->keys($lo, $hi));
+}
+echo "  agrees with keys: ", $agree ? "yes" : "no", "\n";
+
+$b = new Judy(Judy::BITSET);
+foreach ([0, 1, 2, 50, 99] as $bit) {
+    $b[$bit] = 1;
+}
+echo "== BITSET\n";
+echo "  size():           ", $b->size(), "\n";
+echo "  size(0,49):       ", $b->size(0, 49), "\n";
+echo "  size(50,99):      ", $b->size(50, 99), "\n";
+?>
+--EXPECT--
+== STRING_TO_INT
+  size():           6
+  size(b,c):        2
+  size(apricot,cherry): 4
+  size(b):          4
+  size(null,b):     2
+  size(apple,apple):1
+  size(bb,bl):      0
+  size(bb,bm):      1
+  size(zz,zzz):     0
+  size(c,b):        0
+  agrees with keys: yes
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  empty source:     0 0
+  counted in loop:  6
+== STRING_TO_INT_HASH
+  size():           6
+  size(b,c):        2
+  size(apricot,cherry): 4
+  size(b):          4
+  size(null,b):     2
+  size(apple,apple):1
+  size(bb,bl):      0
+  size(bb,bm):      1
+  size(zz,zzz):     0
+  size(c,b):        0
+  agrees with keys: yes
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  empty source:     0 0
+  counted in loop:  6
+== STRING_TO_INT_ADAPTIVE
+  size():           6
+  size(b,c):        2
+  size(apricot,cherry): 4
+  size(b):          4
+  size(null,b):     2
+  size(apple,apple):1
+  size(bb,bl):      0
+  size(bb,bm):      1
+  size(zz,zzz):     0
+  size(c,b):        0
+  agrees with keys: yes
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  empty source:     0 0
+  counted in loop:  6
+== STRING_TO_MIXED
+  size():           6
+  size(b,c):        2
+  size(apricot,cherry): 4
+  size(b):          4
+  size(null,b):     2
+  size(apple,apple):1
+  size(bb,bl):      0
+  size(bb,bm):      1
+  size(zz,zzz):     0
+  size(c,b):        0
+  agrees with keys: yes
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  empty source:     0 0
+  counted in loop:  6
+== STRING_TO_MIXED_HASH
+  size():           6
+  size(b,c):        2
+  size(apricot,cherry): 4
+  size(b):          4
+  size(null,b):     2
+  size(apple,apple):1
+  size(bb,bl):      0
+  size(bb,bm):      1
+  size(zz,zzz):     0
+  size(c,b):        0
+  agrees with keys: yes
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  empty source:     0 0
+  counted in loop:  6
+== STRING_TO_MIXED_ADAPTIVE
+  size():           6
+  size(b,c):        2
+  size(apricot,cherry): 4
+  size(b):          4
+  size(null,b):     2
+  size(apple,apple):1
+  size(bb,bl):      0
+  size(bb,bm):      1
+  size(zz,zzz):     0
+  size(c,b):        0
+  agrees with keys: yes
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  TypeError: Judy::size() expects string arguments for string-keyed arrays
+  empty source:     0 0
+  counted in loop:  6
+== namespace prefix
+  total:            4
+  App\Domain\:      2
+  matches keys:     2
+== INT_TO_INT
+  size():           4
+  size(null,null):  4
+  size(0,-1):       4
+  size(0,100):      3
+  size(null,100):   3
+  size(100,0):      0
+  matches popCount: yes
+  agrees with keys: yes
+== BITSET
+  size():           5
+  size(0,49):       3
+  size(50,99):      2


### PR DESCRIPTION
Closes #105.

`size($start, $end)` accepted string bounds on a string-keyed array, ignored them, and
returned the whole-array count — a plausible-looking wrong answer for "how many classes
are under this namespace?" — while `populationCount()` threw on the same bounds. The stub
already documented the ranged form as integer-keyed only; the implementation never
enforced it.

This takes option (b) from the issue: widen the contract rather than enforce the narrower
one. `size()` now counts over the same inclusive `[$start, $end]` range that
`keys()`/`values()`/`toArray()` read, so string-keyed types get the cheap ranged
population count they lacked — previously only reachable as `count($j->keys($lo, $hi))`,
which materialises the array first.

## What changed

- `size()` delegates to the shared `judy_parse_collect_range()`, so a count and a read
  can no longer disagree about what the bounds mean.
- Integer-keyed types keep the O(1) `J1C`/`JLC` population-cache path. String-keyed types
  walk the JudySL key index between the bounds — the same seek-then-walk `keys($lo, $hi)`
  performs, minus the array building, so it costs the range and not the array. Fully
  unbounded still short-circuits to `intern->counter`. All six string types are covered,
  including the `_HASH`/`_ADAPTIVE` layouts, which share the one key index.
- Signature moves from `(mixed $start = 0, mixed $end = -1)` to
  `(mixed $start = null, mixed $end = null)`, matching `keys()`. The old defaults were
  unusable on string-keyed types, where passing `0, -1` explicitly is a `TypeError`.
  Integer behaviour is unchanged: `size()`, `size(null, null)` and `size(0, -1)` all still
  mean "everything", and `size()` matches `populationCount()` across inverted, wrapped and
  full ranges.

## Deliberate non-change: populationCount() stays integer-keyed only

Its contract is O(1) via libJudy's population cache, which JudySL and JudyHS do not have;
extending it would quietly turn it into an O(range) walk. It keeps its `0`/`-1` defaults
and gained its own arginfo block, since it no longer matches `size()`'s. AGENTS.md and
API.md state the split and point string-keyed callers at `size()`.

Cross-repo confirmation: judy-polyfill implemented the same option and its type guard runs
before its shared range helper, so its `populationCount()` throws on string-keyed arrays
bounded or unbounded — matching this split, and now pinned there as a parity scenario.

## One narrow side effect

Sharing the parse path means `size()` coerces integer-keyed bounds exactly as `keys()`
already did, instead of rejecting them via `Z_PARAM_LONG` — so `size("abc", 100)` is no
longer a `TypeError`. The test pins the *agreement* between the two rather than any
specific coercion result, leaving a later tightening of the shared parser (which would
affect all four range methods) open.

## Evidence

- 209/209 tests pass; extension sources compile warning-free, including under
  `-Wall -Wextra`; `scripts/generate-api-docs.php --check` passes.
- This closes a real cross-repo divergence, not a theoretical one: on the issue's repro
  shape, judy-polyfill measured **ext 4 / polyfill 2** for `size()` with string bounds,
  both 2 for `count(keys(...))`. The polyfill was documenting the gap as a known
  divergence pending this fix.
- `tests/size_range_string_001.phpt` asserts `size($lo, $hi) === count($j->keys($lo, $hi))`
  across all six string types and a spread of bounds, and pins the unsigned bound
  semantics on integer keys — `size(0, -1) === count() === size()`, a negative-only range,
  both halves of the keyspace either side of `PHP_INT_MAX`, and agreement with
  `populationCount()` over a negative range. That last part matters now that 2.5.0 makes
  negative keys addressable: the `Word_t` comparison is load-bearing in a way it wasn't
  when the code was written, and nothing pinned it.
- `examples/symbol-table-prefix.php` gains `prefixCount()` beside `prefixKeys()` and a
  self-check that counting a namespace agrees with reading it. **The check discriminates**:
  on a pre-fix build it fails (exit 1) while the other eight checks stay green; on this
  build it passes. Verified on an actual pre-fix build in a separate worktree by another
  session, not in the branch's own tree.

## Follow-up (not in this PR)

judy-polyfill's `size(mixed $start = 0, mixed $end = -1)` will fail its new
Reflection-based signature-parity check the moment this merges. That is the drift detector
working as intended; they are deliberately not pre-matching until this lands.
