### PR TITLE
docs(release): correct the 2.5.0 API record before tagging

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -42,7 +42,9 @@ Modern data structures like Swiss tables (used in abseil and Folly) and Robin Ho
 
 - **Hardware**: Tests run on modern x86_64 systems with sufficient RAM to avoid memory pressure
 - **Operating System**: Linux (Docker containers for consistency)
-- **PHP Version**: 8.x with Judy extension 2.4.2
+- **PHP Version**: 8.x with Judy extension 2.4.2 — the release these figures were
+  measured on. They have not been re-measured on 2.5.0; the ranged reads and the
+  opt-in `optimizeIteration` mirror that 2.5.0 adds are not represented here.
 - **Test Methodology**: Multiple iterations with statistical analysis (min/max/median/percentiles)
 - **Memory Measurement**: Using `memory_get_usage(true)` and `Judy::memoryUsage()`
 
@@ -1174,5 +1176,6 @@ php examples/benchmarks/run-benchmarks-robust.php
 
 Our methodology and insights are informed by the [Rusty Russell benchmark comparison](https://rusty.ozlabs.org/2010/11/08/hashtables-vs-judy-arrays-round-1.html) between hashtables and Judy arrays, which demonstrates Judy's strengths in ordered access patterns and memory efficiency.
 
-**Judy Extension Version**: 2.4.2
+**Describes**: php-judy 2.5.0
+**Figures measured on**: 2.4.2 (see Benchmarking Environment — not yet re-run on 2.5.0)
 **Last Updated**: August 2026

--- a/MIGRATION_2.5.0.md
+++ b/MIGRATION_2.5.0.md
@@ -7,11 +7,15 @@ warn today and does not warn after, it just puts your data somewhere else. Read
 the detection recipe below even if you are sure you never use negative keys —
 the affected range is much wider than `-1`.
 
-Nothing else in the API changed. There are no renamed methods, no signature
-changes, and no new required arguments — which is why this ships in a minor
-release. But a behaviour change with no runtime signal deserves more attention
-than a minor version number usually implies, so treat the detection recipe as
-the actual upgrade step rather than optional reading.
+There are **no renamed methods and no new required arguments** — every new
+parameter is optional and every existing call keeps working positionally, which
+is why this ships in a minor release. But five signatures did gain or change
+optional parameters (§4), one of them renaming its parameters in a way that
+matters if you call it with named arguments, and `size()` changed what it
+*answers* on string-keyed arrays (§3). A behaviour change with no runtime signal
+deserves more attention than a minor version number usually implies, so treat
+the detection recipes below as the actual upgrade step rather than optional
+reading.
 
 ## 1. A negative integer offset now stores that key
 
@@ -129,7 +133,91 @@ $j->keys();   // [PHP_INT_MAX, PHP_INT_MIN]
 `$j[-1] =` with append on the same array, write explicit keys instead of
 appending.
 
-## 3. Related fixes
+## 3. `size($start, $end)` now counts a string key range
+
+This is the second change with no runtime signal, and it turns a wrong answer
+into a right one rather than the reverse.
+
+### Before (2.4.x)
+
+On a string-keyed array, `size()` accepted string bounds, **ignored them**, and
+returned the whole-array count:
+
+```php
+$j = new Judy(Judy::STRING_TO_MIXED);
+foreach (["App\\Domain\\A", "App\\Domain\\B", "App\\Http\\C", "Zzz\\D"] as $k) {
+    $j[$k] = 1;
+}
+
+$j->size("App\\Domain\\", "App\\Domain]");   // 4  <-- bounds ignored
+count($j->keys("App\\Domain\\", "App\\Domain]"));  // 2  <-- the correct count
+```
+
+### After (2.5.0)
+
+```php
+$j->size("App\\Domain\\", "App\\Domain]");   // 2
+```
+
+`size($lo, $hi)` now counts the same inclusive range `keys()`/`values()`/
+`toArray()` read, sharing their bound parsing and traversal — so counting and
+reading agree by construction. It costs the range, not the array, and unlike
+`count($j->keys($lo, $hi))` it materialises nothing.
+
+**What to check:** any call that passed string bounds to `size()` was getting
+the whole-array count. If you compensated for that — by not passing bounds, or
+by using `count(keys(...))` instead — the compensation is now unnecessary, and
+if you *relied* on the whole-array count coming back you must now call `size()`
+with no arguments to get it.
+
+`populationCount()` is deliberately unchanged: it answers from libJudy's O(1)
+population cache, which the JudySL/JudyHS string stores do not have, so it stays
+integer-keyed-only and still throws on string-keyed arrays. Ranged counting on
+string keys is `size()`; `populationCount()` is the integer-only cache read.
+
+Integer-keyed behaviour is unchanged. `size(0, -1)` still means "everything",
+because bounds are unsigned machine words and `-1` is the maximum key — the same
+ordering rule as §1.
+
+## 4. New and changed signatures
+
+All additive: no new required arguments, and every existing positional call
+still compiles and means what it did.
+
+| Method | 2.4.x | 2.5.0 |
+| --- | --- | --- |
+| `__construct` | `(int $type)` | `(int $type, bool $optimizeIteration = false)` |
+| `keys` | `()` | `(mixed $start = null, mixed $end = null)` |
+| `values` | `()` | `(mixed $start = null, mixed $end = null)` |
+| `toArray` | `()` | `(mixed $start = null, mixed $end = null)` |
+| `size` | `(mixed $index_start = 0, mixed $index_end = -1)` | `(mixed $start = null, mixed $end = null)` |
+
+**The one real break is `size()` with named arguments.** Its parameters were
+renamed from `$index_start`/`$index_end` to `$start`/`$end` so that all seven
+range methods spell their bounds the same way. Positional calls are unaffected;
+named ones are not:
+
+```php
+$j->size(index_start: 0, index_end: 10);   // 2.4.x — Error in 2.5.0
+$j->size(start: 0, end: 10);               // 2.5.0
+```
+
+Grep for it directly — this is the only mechanical break in the release:
+
+```
+grep -rn 'index_start:\|index_end:' --include='*.php' .
+```
+
+`size()`'s defaults also moved from `(0, -1)` to `(null, null)`, so that
+"unbounded" is expressible on string-keyed types, which have no sentinel key
+meaning "the maximum". For integer-keyed arrays the two spellings are
+equivalent — `null` and `-1` both mean "to the end of the key space".
+
+`optimizeIteration` is opt-in, off by default, and honoured only by
+`STRING_TO_INT_HASH` and `STRING_TO_INT_ADAPTIVE`; every other type accepts it
+and ignores it. Call `isIterationOptimized()` to see what actually took effect.
+
+## 5. Related fixes
 
 - `$j[] =` no longer loses a value when a negative-offset write left the append
   watermark stale. In 2.x, `$j[] = 10; $j[-1] = 20; $j[] = 30;` produced
@@ -168,6 +256,24 @@ appending.
    ones. `serialize()`/`fromArray()` payloads are unaffected — those paths
    always stored the intended key.
 
+6. **Grep for `size()` called with named arguments** (§4). This is the only
+   mechanical break in the release:
+
+   ```
+   grep -rn 'index_start:\|index_end:' --include='*.php' .
+   ```
+
+7. **Find `size()` calls that pass string bounds** (§3). They were silently
+   returning the whole-array count and now return the range count:
+
+   ```
+   grep -rn '->size(' --include='*.php' .
+   ```
+
+   Any that compensated with `count($j->keys($lo, $hi))` can now call
+   `$j->size($lo, $hi)` directly, which counts the same range without building
+   the array.
+
 ## Verifying the upgrade
 
 ```php
@@ -176,4 +282,10 @@ $j[-1] = 20;
 var_dump(isset($j[-1]), $j[-1], $j->keys());
 // 2.5.0: bool(true) int(20) [-1]
 // 2.x:   bool(false) null   [0]
+
+$s = new Judy(Judy::STRING_TO_INT);
+$s['a'] = 1; $s['b'] = 2; $s['c'] = 3;
+var_dump($s->size('a', 'b'));
+// 2.5.0: int(2)   <-- counts the range
+// 2.x:   int(3)   <-- bounds ignored, whole-array count
 ```

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ while ($judy->valid()) {
 
 - **Memory Efficiency**: Judy arrays use 2-4x less memory than PHP arrays
 - **Sequential Access**: Excellent performance for ordered iteration
-- **Range Queries**: Native support via `slice()`, `deleteRange()`, and `populationCount()`
+- **Range Queries**: Native support via `slice()`, `deleteRange()`, and the bounded forms of `keys()`, `values()`, `toArray()` and `size()`
 - **Random Access**: Trie types are slower than PHP arrays (O(log n) vs O(1)); Hash types offer O(1) average-case lookups for string keys
 - **String Lookups**: Use `STRING_TO_*_HASH` or `STRING_TO_*_ADAPTIVE` types for faster string key access when sorted traversal is not the primary use case
 
@@ -499,11 +499,15 @@ $judy->putAll([20 => 400, 30 => 500]);
 // Retrieve multiple values at once (missing keys return null)
 $values = $judy->getAll([0, 5, 99]); // [0 => 100, 5 => 200, 99 => null]
 
-// Read only part of the key space: keys(), values() and toArray() all take an
-// inclusive range, with null leaving that side unbounded
+// Read only part of the key space: keys(), values(), toArray() and size() all
+// take an inclusive range, with null leaving that side unbounded
 $judy->keys(5, 20);      // [5, 10, 20]
 $judy->toArray(5, 10);   // [5 => 200, 10 => 300]
 $judy->values(null, 5);  // [100, 200]
+
+// To count a range rather than read it, size() runs the same traversal and
+// materialises nothing — prefer it to count($judy->keys($lo, $hi))
+$judy->size(5, 20);      // 3
 ```
 
 A bounded read is one traversal writing straight into the returned PHP array,
@@ -546,8 +550,9 @@ Beyond basic array access, Judy provides a rich API including:
 
 - **Set operations**: `union()`, `intersect()`, `diff()`, `xor()`, `mergeWith()`
 - **Functional iteration**: `forEach()`, `filter()`, `map()` (C-level, bypasses Iterator overhead)
-- **Range operations**: `slice()`, `deleteRange()`, `populationCount()`, and the
-  bounded forms of `keys()`, `values()`, `toArray()`
+- **Range operations**: `slice()`, `deleteRange()`, and the bounded forms of
+  `keys()`, `values()`, `toArray()` and `size()` — with `populationCount()` as
+  the integer-only O(1) counter
 - **Aggregation**: `sumValues()`, `averageValues()`
 - **Batch operations**: `putAll()`, `getAll()`, `keys()`, `values()`, `toArray()`, `fromArray()`
 - **Serialization**: `serialize()`/`unserialize()`, `json_encode()`

--- a/package.xml
+++ b/package.xml
@@ -57,6 +57,27 @@
 - FIX: allocation failure (JERR) during write/unset is reported as failure, not success
 - FIX: bulk operations stop on the first thrown key instead of continuing with a
   pending exception; clone/slice no longer leak zvals or diverge on OOM paths
+- FEATURE: keys(), values() and toArray() take an inclusive [$start, $end] key
+  range, where null leaves that side unbounded. All key types; string-keyed types
+  require string bounds and compare them lexicographically. A bounded read is one
+  traversal writing straight into the PHP array — prefer it to slice($lo,
+  $hi)->keys(), which copies a whole sub-array first.
+- FEATURE: size($start, $end) counts that same range, including on the six
+  string-keyed types, without materialising anything. Previously it accepted
+  string bounds, ignored them, and returned the whole-array count. Its parameters
+  were renamed $index_start/$index_end -> $start/$end to match the other range
+  methods, which breaks named-argument callers only; its defaults moved from
+  (0, -1) to (null, null). populationCount() is unchanged and stays
+  integer-keyed-only — it answers from libJudy's O(1) population cache, which the
+  string-keyed stores lack. See MIGRATION_2.5.0.md.
+- FEATURE: new Judy($type, optimizeIteration: true) mirrors payloads into the key
+  index for 24-47% faster ordered reads, at a write-path and memory cost. Opt-in,
+  per-instance, off by default, and honoured only by STRING_TO_INT_HASH and
+  STRING_TO_INT_ADAPTIVE; isIterationOptimized() reports what took effect.
+- FEATURE: Judy instances are now legible to debuggers — var_dump()/print_r()
+  show type, count, memory usage, first/last key and a bounded element preview
+  (judy.debug_preview_size). Ships lldb/gdb pretty-printers for the extension's
+  own structs under scripts/.
 - FEATURE: set operations (intersect/diff/xor) now supported for STRING_TO_INT_ADAPTIVE
 - BUILD: extension compiles warning-free; CI now fails on any new compiler warning
 - BUILD: minimum PHP raised to 8.1 (PHP 8.0 is no longer tested in CI)


### PR DESCRIPTION
## Summary

The 2.5.0 docs were written against the negative-key work and never caught up with the ~25 PRs that followed, so the release surface understated what shipped. Found while auditing readiness to tag 2.5.0.

### `MIGRATION_2.5.0.md` was factually wrong

It claimed *"There are no renamed methods, no signature changes, and no new required arguments."* Five signatures changed since v2.4.2:

| Method | 2.4.2 | 2.5.0 |
| --- | --- | --- |
| `__construct` | `(int $type)` | `+ bool $optimizeIteration = false` |
| `keys` / `values` / `toArray` | `()` | `+ (mixed $start = null, mixed $end = null)` |
| `size` | `(mixed $index_start = 0, mixed $index_end = -1)` | `(mixed $start = null, mixed $end = null)` |

"No new *required* arguments" is still true — which is why minor stays defensible — but `size()`'s parameters were **renamed**, a real break for named-argument callers:

```
$j->size(index_start: 0);   // Error: Unknown named parameter $index_start
```

The guide also never documented that `size()` changed what it *answers* on string-keyed arrays (previously accepted string bounds, ignored them, returned the whole-array count) — the same silent, no-runtime-signal class of change the doc says deserves attention.

Adds §3 (string-bound behaviour change), §4 (signature table + named-arg grep), two migration steps, and a string-keyed case in the verification snippet.

### `package.xml` `<notes>`

Listed one FEATURE and none of today's: ranged `keys()`/`values()`/`toArray()`, ranged `size()`, `optimizeIteration`, debugger observability.

### `README.md`

Two range lists omitted `size()` and pointed at `populationCount()` as the ranged counter — that is the integer-only population-cache read, which throws on string-keyed arrays.

### `BENCHMARK.md` — deliberately not following the checklist literally

The release checklist says "refresh BENCHMARK.md version/date stamps." Applied naively that would relabel **2.4.2 measurements as 2.5.0**, including a block explicitly tagged `(measured)` with a contention log. Only the document-level stamp is bumped; the measurement stamps stay at 2.4.2, now stated explicitly as not re-run.

## Test plan

- [x] 209/209 tests pass
- [x] 0 compiler warnings
- [x] `API.md` freshness gate passes
- [x] `package.xml` well-formed; 209/209 tests in sync; examples + scripts complete
- [x] All `examples/*.php` exit 0
- [x] Version lockstep at 2.5.0; `ci.yml` baseline correctly at 2.4.2 (previous release)
- [x] **Every code sample added here was executed against a 2.5.0 build**, including the named-argument break and `size(0, -1) === count()`

## Still blocking the 2.5.0 tag (not in this PR)

1. **BENCHMARK.md figures are 2.4.2 measurements.** 2.5.0 ships perf changes (#86, #100) not represented, and there is no benchmark coverage of the ranged forms. Making the numbers describe 2.5.0 needs a CI re-run on Linux x86_64.
2. **`baselines/latest.json` is pinned at 2.4.2/2026-08-14** and needs its own dedicated PR — per CLAUDE.md that bump never rides inside another PR, so it is deliberately not here.