### PR TITLE
docs(bench): publish the measured bounded-read figures

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1183,17 +1183,35 @@ type accepts the constructor argument and ignores it.
 ### Bounded reads
 
 2.5.0's ranged forms (`keys()`, `values()`, `toArray()`, `size()`) are covered by
-`api.range.*` in the suite as of this release, pinning the two claims the docs
-make: that `keys($lo, $hi)` beats `slice($lo, $hi)->keys()`, and that
-`size($lo, $hi)` beats `count(keys($lo, $hi))` on string keys. Those benchmarks
-were added alongside the 2.5.0 baseline, so their first CI-measured figures land
-with the next release comparison and are deliberately not quoted here yet — the
-numbers in this document come from Linux CI runs, never from a developer laptop.
+`api.range.*` in the suite, pinning the two claims the docs make: that
+`keys($lo, $hi)` beats `slice($lo, $hi)->keys()`, and that `size($lo, $hi)` beats
+`count(keys($lo, $hi))` on string keys.
+
+All figures `(measured)` on **php-judy 2.5.0**, PHP 8.4.24, Linux x86_64,
+500,000 elements, 7 iterations, median of runs. The window is the middle 10% of
+the key space. Run-wide median delta +0.13% against a PHP-array control of
++0.10% — clean, not contention-inflated.
+
+| Operation | Time | vs the alternative |
+| --- | ---: | ---: |
+| `keys($lo, $hi)` | 1.03 ms | — |
+| `slice($lo, $hi)->keys()` | 3.36 ms | **3.3x slower** |
+| PHP-array scan with a bounds test | 25.58 ms | 24.9x slower |
+| `size($lo, $hi)` on `STRING_TO_INT` | 4.86 ms | — |
+| `count($j->keys($lo, $hi))` | 6.02 ms | **1.24x slower** |
+
+Both documented claims hold. The `slice()` gap is the larger one and the easier
+mistake to make: `slice($lo, $hi)->keys()` copies the range into a whole new Judy
+array and then traverses that copy, so it pays for the sub-array twice. The
+`size()` gap is narrower because both sides walk the same range — the win is that
+`size()` allocates nothing, which the wall-clock number understates and which
+matters more as the range grows.
 
 Note that on integer keys `size($lo, $hi)` is O(1) — libJudy answers it from the
-population cache — so it is recorded as a 1000-call loop and is *not* compared
-against `count(keys(...))`. That comparison would be definitional rather than
-measured: an O(range) walk cannot beat an O(1) cache read at any size.
+population cache — so it is recorded as a 1000-call loop (0.73 ms per 1000 calls)
+and is *not* compared against `count(keys(...))`. That comparison would be
+definitional rather than measured: an O(range) walk cannot beat an O(1) cache
+read at any size.
 
 ---
 


### PR DESCRIPTION
## Summary

The `api.range.*` benchmarks added in #114 carried a placeholder: their figures would land "with the next release comparison" and were deliberately not quoted, because at that point they had only run on a laptop. They have since run on Linux CI, so this replaces the promissory note with the actual numbers.

| Operation | Time | vs the alternative |
| --- | ---: | ---: |
| `keys($lo, $hi)` | 1.03 ms | — |
| `slice($lo, $hi)->keys()` | 3.36 ms | **3.3x slower** |
| PHP-array scan with a bounds test | 25.58 ms | 24.9x slower |
| `size($lo, $hi)` on `STRING_TO_INT` | 4.86 ms | — |
| `count($j->keys($lo, $hi))` | 6.02 ms | **1.24x slower** |

Both documented claims hold.

## Provenance

`benchmark-linux-php8.4` from the CI run on `ci/baseline-2.5.0` — php-judy 2.5.0, PHP 8.4.24, Linux x86_64, 500k elements, 7 iterations. Same harness and parameters as every other figure in this document; no laptop numbers.

Contention control from the same run:

```
Interleaved comparison: 2.5.0 -> 2.5.0 | 5 groups x 5 rounds x 2 arms
Run-wide median delta: +0.13% (PHP-array control +0.10%) -> clean
Summary: 0 faster, 0 regressions, 99 unchanged, 1 unstable, 0 new, 0 removed
```

That run also self-compares 2.5.0 against 2.5.0 and reports 99 unchanged / 0 regressions, which independently confirms the pie pin bumped in #114 resolves correctly.

## Notes

- The `slice()` gap is the larger one and the easier mistake to make: that spelling copies the range into a whole new Judy array and then traverses the copy.
- The `size()` gap is narrower because both sides walk the same range. The win is that it allocates nothing, which a wall-clock median understates and which grows with the range.
- Integer `size($lo, $hi)` stays excluded from the comparison table — it is O(1) via the population cache, so pitting it against an O(range) walk would be definitional rather than measured. It is reported on its own as a 1000-call loop (0.73 ms).

## Test plan

- [x] Every figure and ratio in the table verified against `bench.json` programmatically, not transcribed
- [ ] CI green