### PR TITLE
docs(api): warn that toArray() coerces integer-looking string keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,17 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
   JudySL/JudyHS do not have, and throws on a string-keyed array. `size()` on a
   string-keyed range walks the key index instead: the cost of the range, not
   of the array.
+- **`toArray()` coerces integer-looking string keys; `keys()` does not.** The
+  result is a PHP array, which cannot hold the string key `"42"`, so a canonical
+  decimal integer in `PHP_INT` range comes back as an `int` (`"42"`, `"-7"`),
+  while `"07"`, `"-0"`, `" 42"`, `"4.0"` and out-of-range values stay strings.
+  Round-tripping bites: `foreach ($j->toArray() as $k => $v) { unset($j[$k]); }`
+  throws `TypeError` on a string-keyed array the moment one key is numeric,
+  because the offset arrives as an `int`. Use `keys()` (always strings) when the
+  key has to go back into the Judy, or cast with `(string)`. This is a PHP array
+  limitation, not something the extension can fix — but it is silent until a
+  numeric key shows up, so code that only ever saw `"user.3"`-shaped keys will
+  pass its tests and fail in production.
 - **A string upper bound is a bound, not a prefix match.** `keys('bl', 'bl')`
   does not return `blackcurrant` — `blackcurrant` sorts *after* `bl`. For a
   prefix sweep, bound with the prefix and its successor: `keys('bl', 'bm')`.

--- a/Judy.stub.php
+++ b/Judy.stub.php
@@ -246,6 +246,20 @@ class Judy implements ArrayAccess, Countable, Iterator, JsonSerializable
      * With $start and/or $end, only the inclusive [$start, $end] key range is
      * returned; null leaves that side unbounded. String-keyed types compare
      * bounds lexicographically and require string bounds.
+     *
+     * **On string-keyed types, a key that looks like an integer comes back as
+     * one.** The result is a PHP array, and PHP array keys cannot hold the
+     * string "42" — a canonical decimal integer within PHP_INT range is
+     * coerced, so "42" and "-7" return as int, while "07", "-0", " 42", "4.0"
+     * and out-of-range values stay strings. Feeding such a key straight back
+     * into the array throws, because a string-keyed Judy rejects an integer
+     * offset:
+     *
+     *     foreach ($j->toArray() as $k => $v) { unset($j[$k]); }  // TypeError
+     *
+     * keys() does not coerce — it returns every key as a string. Use it when
+     * you need keys to round-trip, or cast with (string) when iterating
+     * toArray().
      */
     public function toArray(mixed $start = null, mixed $end = null): array {}
 

--- a/package.xml
+++ b/package.xml
@@ -162,6 +162,7 @@
          <file name="tests/to_array_string_to_int_001.phpt" role="test" />
          <file name="tests/to_array_string_to_mixed_001.phpt" role="test" />
          <file name="tests/to_array_empty_001.phpt" role="test" />
+         <file name="tests/to_array_numeric_key_coercion_001.phpt" role="test" />
          <file name="tests/from_array_roundtrip_001.phpt" role="test" />
          <file name="tests/from_array_error_001.phpt" role="test" />
          <file name="tests/put_all_001.phpt" role="test" />

--- a/tests/to_array_numeric_key_coercion_001.phpt
+++ b/tests/to_array_numeric_key_coercion_001.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Judy toArray() coerces integer-looking string keys; keys() does not
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+/*
+ * toArray() returns a PHP array, and a PHP array cannot hold the string key
+ * "42" — the engine coerces a canonical decimal integer in PHP_INT range to an
+ * int. keys() has no such constraint and returns every key as a string.
+ *
+ * The asymmetry is silent until a numeric key appears, and then it bites on
+ * round-trip: a key taken from toArray() and fed back as an offset arrives as
+ * an int, which a string-keyed Judy rejects. This test pins both halves so the
+ * documented contract cannot drift.
+ */
+
+$cases = [
+    /* coerced to int */
+    '42', '-7', '0', '9223372036854775807',
+    /* left as string */
+    '07', '-0', ' 42', '42 ', '4.0', '', '0x1A', '9223372036854775808',
+    'user.3',
+];
+
+foreach ([Judy::STRING_TO_INT, Judy::STRING_TO_MIXED] as $type) {
+    $j = new Judy($type);
+    foreach ($cases as $i => $k) {
+        $j[$k] = $i;
+    }
+
+    echo "== type $type\n";
+
+    $arr = $j->toArray();
+    $ints = [];
+    foreach ($arr as $k => $_) {
+        if (is_int($k)) {
+            $ints[] = $k;
+        }
+    }
+    sort($ints);
+    echo "  toArray() int keys: ", implode(', ', $ints), "\n";
+
+    /* keys() never coerces */
+    $allString = true;
+    foreach ($j->keys() as $k) {
+        $allString = $allString && is_string($k);
+    }
+    echo "  keys() all string:  ", $allString ? 'yes' : 'no', "\n";
+
+    /* Same set either way, once spelling is normalised. */
+    $viaToArray = array_map('strval', array_keys($arr));
+    $viaKeys = $j->keys();
+    sort($viaToArray);
+    sort($viaKeys);
+    echo "  same key set:       ", $viaToArray === $viaKeys ? 'yes' : 'no', "\n";
+
+    /* The round-trip trap: a coerced key fed back as an offset throws. */
+    try {
+        unset($j[42]);
+        echo "  unset(int) threw:   no\n";
+    } catch (TypeError $e) {
+        echo "  unset(int) threw:   yes\n";
+    }
+
+    /* Casting back to string is the documented fix. */
+    $before = $j->count();
+    foreach ($arr as $k => $_) {
+        unset($j[(string)$k]);
+    }
+    printf("  (string) cast unset: %d -> %d\n", $before, $j->count());
+}
+?>
+--EXPECT--
+== type 4
+  toArray() int keys: -7, 0, 42, 9223372036854775807
+  keys() all string:  yes
+  same key set:       yes
+  unset(int) threw:   yes
+  (string) cast unset: 13 -> 0
+== type 5
+  toArray() int keys: -7, 0, 42, 9223372036854775807
+  keys() all string:  yes
+  same key set:       yes
+  unset(int) threw:   yes
+  (string) cast unset: 13 -> 0


### PR DESCRIPTION
## Summary

Found via a **live bug in judy-cache**, not by reading source. Its `prune()` iterates `toArray()` and unsets each key:

```php
foreach ($this->expiries->toArray() as $key => $expiry) {
    unset($this->values[$key], $this->expiries[$key]);   // TypeError
}
```

That throws the moment a cache key is spelled `"42"` — a perfectly legal PSR-16 key. Nothing in `API.md`, `AGENTS.md` or `Judy.stub.php` said this could happen.

## The behaviour

`toArray()` returns a PHP array, and a PHP array cannot hold the *string* key `"42"` — the engine coerces a canonical decimal integer in `PHP_INT` range. Verified against a 2.5.0 build:

| Stored key | `toArray()` | `keys()` |
| --- | --- | --- |
| `"42"`, `"-7"`, `"0"`, `"9223372036854775807"` | **int** | string |
| `"07"`, `"-0"`, `" 42"`, `"42 "`, `"4.0"`, `"0x1A"`, `""`, `"9223372036854775808"` | string | string |

`keys()` has no such constraint and returns every key as a string.

**The asymmetry is the trap.** A string-keyed Judy rejects an integer offset, so a key taken from `toArray()` and fed back throws. Code that only ever sees `"user.3"`-shaped keys passes its tests and fails in production the first time a numeric one appears — which is exactly how this survived in judy-cache, whose fuzz pool had no bare numeric keys.

This is a PHP array limitation the extension cannot fix, so it is **documented and pinned rather than changed**. No behaviour change in this PR.

## Changes

- `Judy.stub.php` — `toArray()` docblock gains the coercion rule, the failing round-trip, and the two fixes (`keys()`, or `(string)` cast). `API.md` regenerated.
- `AGENTS.md` — new pitfall entry, next to the existing "a string upper bound is a bound" one.
- `tests/to_array_numeric_key_coercion_001.phpt` — pins both halves across `STRING_TO_INT` and `STRING_TO_MIXED`: which spellings coerce, that `keys()` never does, that both agree on the key set once normalised, that the int round-trip throws, and that the documented `(string)` cast works.

## Test plan

- [x] 210/210 tests pass (209 + the new one)
- [x] `package.xml` well-formed and in sync with `tests/`
- [x] `API.md` freshness gate passes after regeneration
- [x] Coercion table above verified against a real 2.5.0 build, case by case
- [ ] CI green