### PR TITLE
fix(keys): reject embedded NUL in string keys on all six string-keyed types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
 - **A string upper bound is a bound, not a prefix match.** `keys('bl', 'bl')`
   does not return `blackcurrant` — `blackcurrant` sorts *after* `bl`. For a
   prefix sweep, bound with the prefix and its successor: `keys('bl', 'bm')`.
-  Two details that bite on binary-safe keys, both worked through and asserted
+  Two details that bite on high-byte keys, both worked through and asserted
   in `examples/symbol-table-prefix.php`: the successor needs a **carry** when
   the prefix ends in `"\xff"` (and an all-`"\xff"` prefix has no successor at
   all — pass `null` for "to the end"), and because the upper bound is
@@ -183,9 +183,30 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
 - **Random access on small dense datasets is faster with native arrays.**
   Judy wins on memory at scale, ordered navigation, and sparse keysets —
   see BENCHMARK.md before claiming performance.
-- Keys are `int` (platform word) or binary-safe `string` depending on type;
-  mixing categories in set ops (`union` etc.) with a different key category
-  throws.
+- Keys are `int` (platform word) or `string` depending on type; mixing
+  categories in set ops (`union` etc.) with a different key category throws.
+- **String keys are binary-safe for every byte EXCEPT `0x00`.** `0x80`,
+  `0xFE`, `0xFF` and everything else store, compare and order as unsigned
+  bytes on all six string-keyed types, which is what the prefix-successor
+  arithmetic above relies on. A key containing an embedded NUL is **rejected
+  with an exception on all six types** — `Judy … keys must not contain
+  embedded null bytes` — on every method that takes a string key: `offsetSet`
+  /`offsetGet`/`offsetExists`/`offsetUnset`, `increment()`, `fromArray()`,
+  `putAll()`, `getAll()`, `slice()`, `deleteRange()`, `first()`/`last()`
+  /`searchNext()`/`prev()`, and the `$start`/`$end` bounds of `keys()`,
+  `values()`, `toArray()` and `size()`. The reason is structural, not a
+  policy choice: every string-keyed type orders its keys through a JudySL
+  trie (the two trie types store the value in it directly, the four
+  `_HASH`/`_ADAPTIVE` types keep a JudySL key index beside their
+  length-prefixed value store), and a JudySL index is a NUL-terminated C
+  string. There is nothing to fall back on, so the key is refused rather
+  than silently truncated at the NUL. **`pack()` output, raw digests,
+  serialized payloads and packed tuples therefore need encoding** (base64,
+  hex, or a NUL-free framing) before they can be used as keys. Values are
+  unaffected — a `_MIXED` value may contain any bytes at all.
+  (Before this landed, `STRING_TO_INT` and `STRING_TO_MIXED` truncated
+  instead, so `"ab\0cd"` and `"ab"` collided and one value was lost with no
+  signal; see [#117](https://github.com/orieg/php-judy/issues/117).)
 - **Integer keys sort in UNSIGNED order, so negative keys come last.** An
   integer key is the full unsigned machine word: a negative PHP int is
   reinterpreted as its bit pattern, so `-1` addresses the maximum index and

--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ $arr = $judy[2]; // Returns [1, 2, 3]
 
 Trie-based types use JudySL internally. Keys are stored in sorted lexicographic order, making iteration ordered and range queries efficient. Lookup is O(key-length).
 
+> **String keys are binary-safe for every byte except `0x00`.** High bytes (`0x80`, `0xFE`, `0xFF`) store, compare and sort as unsigned bytes on all six string-keyed types. A key containing an embedded NUL is rejected with an exception on all six, on every method that takes a string key — every type orders its keys through a JudySL trie, which indexes NUL-terminated C strings. Encode `pack()` output, raw digests and serialized payloads (base64, hex, or any NUL-free framing) before using them as keys. Values are unaffected.
+
 #### 5. Judy::STRING_TO_INT
 
 A Judy array with string keys and integer values.

--- a/examples/symbol-table-prefix.php
+++ b/examples/symbol-table-prefix.php
@@ -54,7 +54,8 @@ if (!extension_loaded('judy')) {
  * P itself is the correct inclusive $start.
  *
  * The upper bound is where prefix-to-range conversions go wrong. Two shortcuts
- * circulate, and both are subtly incorrect on binary-safe keys:
+ * circulate, and both are subtly incorrect on keys carrying high bytes (Judy
+ * string keys are binary-safe for every byte except 0x00, which is rejected):
  *
  *   P . "\xFF"   fails when a key actually has a 0xFF byte right after the
  *                prefix: that key sorts AFTER P."\xFF" (the bound is a proper
@@ -438,10 +439,13 @@ echo "  - a namespace prefix must include its trailing separator. \"App\\Domain\
 echo "    is a legitimate string prefix and it matches App\\DomainEvents\\* too;\n";
 echo "    only \"App\\Domain\\\" is the namespace. The bounds are correct either\n";
 echo "    way — the question changes, not the answer.\n";
-echo "  - Judy string keys are binary-safe, so a prefix-to-range helper has to\n";
-echo "    be as well. Appending \"\\xFF\" is not: it silently drops any key with a\n";
-echo "    0xFF byte immediately after the prefix. Increment-with-carry plus the\n";
-echo "    one-key trim has no such hole, and costs one array_pop.\n";
+echo "  - Judy string keys are binary-safe for every byte except 0x00, so a\n";
+echo "    prefix-to-range helper has to be as well. Appending \"\\xFF\" is not: it\n";
+echo "    silently drops any key with a 0xFF byte immediately after the prefix.\n";
+echo "    Increment-with-carry plus the one-key trim has no such hole, and costs\n";
+echo "    one array_pop. (An embedded NUL is rejected with an exception on all\n";
+echo "    six string-keyed types — JudySL indexes NUL-terminated C strings —\n";
+echo "    so encode pack() output or raw digests before using them as keys.)\n";
 echo "  - the trim is not paranoia about class names (no PHP identifier is\n";
 echo "    spelled \"App\\Domain]\"). It is what makes the helper reusable for keys\n";
 echo "    you did not choose — cache keys, file paths, serialised tuples.\n";

--- a/package.xml
+++ b/package.xml
@@ -207,6 +207,7 @@
          <file name="tests/boundary_long_string_001.phpt" role="test" />
          <file name="tests/boundary_empty_string_key_001.phpt" role="test" />
          <file name="tests/boundary_special_chars_001.phpt" role="test" />
+         <file name="tests/boundary_binary_keys_001.phpt" role="test" />
          <file name="tests/batch_empty_input_001.phpt" role="test" />
          <file name="tests/batch_large_001.phpt" role="test" />
          <file name="tests/increment_boundary_001.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -440,6 +440,63 @@ PHP_INI_BEGIN()
 PHP_INI_END()
 /* }}} */
 
+/* {{{ Embedded-NUL key precondition.
+
+   Every string-keyed type orders its keys through a JudySL trie: the two plain
+   trie types store the value in it directly, and the four *_HASH / *_ADAPTIVE
+   types keep a JudySL `key_index` alongside their length-prefixed value store.
+   A JudySL index is a NUL-terminated C string by construction, so a key
+   containing 0x00 is truncated at the first one. That is silent data loss on a
+   write ("ab\0cd" and "ab" become one key), a wrong answer on a plain-trie
+   read, and a wrong bound on every ordered/range operation of all six types.
+
+   Only 0x00 is affected. Every other byte value, 0x01 through 0xFF, is stored,
+   compared and ordered as an unsigned byte — high-byte keys are binary-safe and
+   examples/symbol-table-prefix.php relies on that.
+
+   There is no representation to fall back on: JudyHS accepts a NUL because it
+   is length-prefixed, JudySL cannot be made to. So a NUL byte is rejected at
+   every entry point that takes a caller-supplied string key, uniformly across
+   the six types, rather than accepted by some and truncated by others.
+   See GitHub issue #117. */
+static const char *judy_nul_key_error(judy_type type)
+{
+	switch (type) {
+		case TYPE_STRING_TO_INT:
+			return "Judy STRING_TO_INT keys must not contain embedded null bytes";
+		case TYPE_STRING_TO_MIXED:
+			return "Judy STRING_TO_MIXED keys must not contain embedded null bytes";
+		case TYPE_STRING_TO_INT_HASH:
+			return "Judy STRING_TO_INT_HASH keys must not contain embedded null bytes";
+		case TYPE_STRING_TO_MIXED_HASH:
+			return "Judy STRING_TO_MIXED_HASH keys must not contain embedded null bytes";
+		default:
+			return "Judy adaptive keys must not contain embedded null bytes";
+	}
+}
+
+/* Throws and returns 1 when the key contains a NUL; returns 0 otherwise.
+   Callers that already know the array is string-keyed use this directly. */
+static zend_always_inline int judy_reject_nul_key(judy_type type, const char *key, size_t klen)
+{
+	if (JUDY_UNLIKELY(memchr(key, '\0', klen) != NULL)) {
+		zend_throw_exception(NULL, judy_nul_key_error(type), 0);
+		return 1;
+	}
+	return 0;
+}
+
+/* Same check for a bound/key that arrives as a zval and may legitimately be a
+   non-string (integer-keyed arrays, optional null bounds). */
+static zend_always_inline int judy_reject_nul_key_zval(judy_object *intern, zval *z)
+{
+	if (z == NULL || Z_TYPE_P(z) != IS_STRING || !JUDY_IS_STRING_KEYED(intern)) {
+		return 0;
+	}
+	return judy_reject_nul_key(intern->type, Z_STRVAL_P(z), Z_STRLEN_P(z));
+}
+/* }}} */
+
 #define CHECK_ARRAY_AND_ARG_TYPE(_index_, _string_key_, _error_flag_, _return_)	\
 	switch (intern->type) {					\
 		case TYPE_BITSET:					\
@@ -456,6 +513,9 @@ PHP_INI_END()
 		case TYPE_STRING_TO_INT_ADAPTIVE:	\
 			if (UNEXPECTED(Z_TYPE_P(offset) != IS_STRING)) {	\
 				zend_throw_error(zend_ce_type_error, "Judy offset must be of type string for string-based arrays"); \
+				_error_flag_ = 1; \
+			} else if (UNEXPECTED(judy_reject_nul_key(intern->type,		\
+					Z_STRVAL_P(offset), Z_STRLEN_P(offset)))) {			\
 				_error_flag_ = 1; \
 			} else {								\
 				_string_key_ = offset;	\
@@ -605,12 +665,19 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 		*mirror_out = NULL;
 	}
 
+	/* One check for all six types rather than one per case: every one of them
+	   indexes through a JudySL (the trie itself, or the key_index), which
+	   cannot hold a key past its first NUL. See judy_nul_key_error(). */
+	if (JUDY_UNLIKELY(judy_reject_nul_key(intern->type, (const char *)key, (size_t)klen))) {
+		return FAILURE;
+	}
+
 	switch (intern->type) {
 
 	case TYPE_STRING_TO_INT:
 		/* Plain JudySL: the trie is itself the value store, so there is no
-		   mirror to keep and no NUL restriction. 0 is a legal stored value,
-		   hence the separate existence probe. */
+		   mirror to keep. 0 is a legal stored value, hence the separate
+		   existence probe. */
 		JSLG(existing, intern->array, (uint8_t *)key);
 		JSLI(slot, intern->array, (uint8_t *)key);
 		if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
@@ -640,11 +707,6 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 	   refactor is not allowed to spend. The repetition stays inside this one
 	   function, so nothing outside it learns about the key_index. */
 	case TYPE_STRING_TO_INT_HASH:
-		if (JUDY_UNLIKELY(memchr(key, '\0', (size_t)klen) != NULL)) {
-			zend_throw_exception(NULL,
-				"Judy STRING_TO_INT_HASH keys must not contain embedded null bytes", 0);
-			return FAILURE;
-		}
 		/* 0 is a legal stored value, so existence has to come from a probe
 		   either way — the only question is which structure answers it.
 
@@ -690,11 +752,6 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 		break;
 
 	case TYPE_STRING_TO_MIXED_HASH:
-		if (JUDY_UNLIKELY(memchr(key, '\0', (size_t)klen) != NULL)) {
-			zend_throw_exception(NULL,
-				"Judy STRING_TO_MIXED_HASH keys must not contain embedded null bytes", 0);
-			return FAILURE;
-		}
 		JHSI(slot, intern->array, (uint8_t *)key, klen);
 		if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
 			return FAILURE;
@@ -711,11 +768,6 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 		break;
 
 	case TYPE_STRING_TO_INT_ADAPTIVE:
-		if (JUDY_UNLIKELY(memchr(key, '\0', (size_t)klen) != NULL)) {
-			zend_throw_exception(NULL,
-				"Judy adaptive keys must not contain embedded null bytes", 0);
-			return FAILURE;
-		}
 		if (judy_pack_short_string_internal((const char *)key, (size_t)klen, &sso_idx)) {
 			/* Short keys keep the JudyL probe and are never mirrored, even on
 			   an opted-in instance: JLG costs 17.6 ns against 184.7 ns for a
@@ -765,11 +817,6 @@ static zend_always_inline int judy_string_slot_acquire(judy_object *intern, cons
 		break;
 
 	case TYPE_STRING_TO_MIXED_ADAPTIVE:
-		if (JUDY_UNLIKELY(memchr(key, '\0', (size_t)klen) != NULL)) {
-			zend_throw_exception(NULL,
-				"Judy adaptive keys must not contain embedded null bytes", 0);
-			return FAILURE;
-		}
 		if (judy_pack_short_string_internal((const char *)key, (size_t)klen, &sso_idx)) {
 			JLI(slot, intern->array, sso_idx);
 			if (JUDY_UNLIKELY(slot == NULL || slot == PJERR)) {
@@ -1886,6 +1933,12 @@ PHP_METHOD(Judy, first)
 			Z_PARAM_STRING(str, str_length)
 		ZEND_PARSE_PARAMETERS_END();
 
+		/* The bound is seeked as a NUL-terminated C string, so a NUL
+		   inside it would silently search from its truncation instead. */
+		if (judy_reject_nul_key(intern->type, str, str_length)) {
+			RETURN_THROWS();
+		}
+
 		/* JudySL require null terminated strings */
 		if (str_length == 0) {
 			key[0] = '\0';
@@ -1911,6 +1964,12 @@ PHP_METHOD(Judy, first)
 			Z_PARAM_OPTIONAL
 			Z_PARAM_STRING(str, str_length)
 		ZEND_PARSE_PARAMETERS_END();
+
+		/* The bound is seeked as a NUL-terminated C string, so a NUL
+		   inside it would silently search from its truncation instead. */
+		if (judy_reject_nul_key(intern->type, str, str_length)) {
+			RETURN_THROWS();
+		}
 
 		if (str_length == 0) {
 			key[0] = '\0';
@@ -1980,6 +2039,12 @@ PHP_METHOD(Judy, searchNext)
 			Z_PARAM_STRING(str, str_length)
 		ZEND_PARSE_PARAMETERS_END();
 
+		/* The bound is seeked as a NUL-terminated C string, so a NUL
+		   inside it would silently search from its truncation instead. */
+		if (judy_reject_nul_key(intern->type, str, str_length)) {
+			RETURN_THROWS();
+		}
+
 		/* JudySL require null terminated strings */
 		if (str_length == 0) {
 			key[0] = '\0';
@@ -2004,6 +2069,12 @@ PHP_METHOD(Judy, searchNext)
 		ZEND_PARSE_PARAMETERS_START(1, 1)
 			Z_PARAM_STRING(str, str_length)
 		ZEND_PARSE_PARAMETERS_END();
+
+		/* The bound is seeked as a NUL-terminated C string, so a NUL
+		   inside it would silently search from its truncation instead. */
+		if (judy_reject_nul_key(intern->type, str, str_length)) {
+			RETURN_THROWS();
+		}
 
 		if (str_length == 0) {
 			key[0] = '\0';
@@ -2325,6 +2396,12 @@ PHP_METHOD(Judy, last)
 			Z_PARAM_STRING(str, str_length)
 		ZEND_PARSE_PARAMETERS_END();
 
+		/* The bound is seeked as a NUL-terminated C string, so a NUL
+		   inside it would silently search from its truncation instead. */
+		if (judy_reject_nul_key(intern->type, str, str_length)) {
+			RETURN_THROWS();
+		}
+
 		/* JudySL require null terminated strings */
 		if (str_length == 0) {
 			memset(key, 0xff, PHP_JUDY_MAX_LENGTH);
@@ -2351,6 +2428,12 @@ PHP_METHOD(Judy, last)
 			Z_PARAM_OPTIONAL
 			Z_PARAM_STRING(str, str_length)
 		ZEND_PARSE_PARAMETERS_END();
+
+		/* The bound is seeked as a NUL-terminated C string, so a NUL
+		   inside it would silently search from its truncation instead. */
+		if (judy_reject_nul_key(intern->type, str, str_length)) {
+			RETURN_THROWS();
+		}
 
 		if (str_length == 0) {
 			memset(key, 0xff, PHP_JUDY_MAX_LENGTH);
@@ -2415,6 +2498,12 @@ PHP_METHOD(Judy, prev)
 			Z_PARAM_STRING(str, str_length)
 		ZEND_PARSE_PARAMETERS_END();
 
+		/* The bound is seeked as a NUL-terminated C string, so a NUL
+		   inside it would silently search from its truncation instead. */
+		if (judy_reject_nul_key(intern->type, str, str_length)) {
+			RETURN_THROWS();
+		}
+
 		/* JudySL require null terminated strings */
 		if (str_length == 0) {
 			key[0] = '\0';
@@ -2439,6 +2528,12 @@ PHP_METHOD(Judy, prev)
 		ZEND_PARSE_PARAMETERS_START(1, 1)
 			Z_PARAM_STRING(str, str_length)
 		ZEND_PARSE_PARAMETERS_END();
+
+		/* The bound is seeked as a NUL-terminated C string, so a NUL
+		   inside it would silently search from its truncation instead. */
+		if (judy_reject_nul_key(intern->type, str, str_length)) {
+			RETURN_THROWS();
+		}
 
 		if (str_length == 0) {
 			key[0] = '\0';
@@ -3237,6 +3332,13 @@ PHP_METHOD(Judy, slice)
 		Z_PARAM_ZVAL(zend_val)
 	ZEND_PARSE_PARAMETERS_END();
 
+	/* Checked before the result array exists so the failure leaves nothing
+	   half-built; both bounds seek through a JudySL and would truncate. */
+	if (judy_reject_nul_key_zval(intern, zstart)
+			|| judy_reject_nul_key_zval(intern, zend_val)) {
+		RETURN_THROWS();
+	}
+
 	result = judy_create_result(return_value, intern->type, intern->mirror_payload);
 
 	if (intern->type == TYPE_BITSET) {
@@ -3651,6 +3753,13 @@ static int judy_parse_collect_range(judy_object *intern, zval *zstart, zval *zen
 			|| (zend_val != NULL && Z_TYPE_P(zend_val) != IS_STRING)) {
 		zend_throw_error(zend_ce_type_error,
 			"Judy::%s() expects string arguments for string-keyed arrays", method);
+		return FAILURE;
+	}
+
+	/* Both bounds are compared and seeked as NUL-terminated C strings, so a
+	   NUL inside one silently widens the range instead of bounding it. */
+	if (judy_reject_nul_key_zval(intern, zstart)
+			|| judy_reject_nul_key_zval(intern, zend_val)) {
 		return FAILURE;
 	}
 
@@ -4496,6 +4605,11 @@ PHP_METHOD(Judy, deleteRange)
 			Z_PARAM_STRING(str_end, str_end_len)
 		ZEND_PARSE_PARAMETERS_END();
 
+		if (judy_reject_nul_key(intern->type, str_start, str_start_len)
+				|| judy_reject_nul_key(intern->type, str_end, str_end_len)) {
+			RETURN_THROWS();
+		}
+
 		if (strcmp(str_start, str_end) > 0) RETURN_LONG(0);
 
 		/* Private cursor rather than intern->key_scratch: a stored value's
@@ -4570,6 +4684,11 @@ PHP_METHOD(Judy, deleteRange)
 			Z_PARAM_STRING(str_start, str_start_len)
 			Z_PARAM_STRING(str_end, str_end_len)
 		ZEND_PARSE_PARAMETERS_END();
+
+		if (judy_reject_nul_key(intern->type, str_start, str_start_len)
+				|| judy_reject_nul_key(intern->type, str_end, str_end_len)) {
+			RETURN_THROWS();
+		}
 
 		if (strcmp(str_start, str_end) > 0) RETURN_LONG(0);
 
@@ -5451,6 +5570,24 @@ PHP_METHOD(Judy, getAll)
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_ARRAY(keys)
 	ZEND_PARSE_PARAMETERS_END();
+
+	/* Validate every key before building the result, so a rejected key leaves
+	   no half-populated array behind and getAll() stays all-or-nothing. */
+	if (JUDY_IS_STRING_KEYED(intern)) {
+		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(keys), key_entry) {
+			zend_string *skey = zval_get_string(key_entry);
+			int bad;
+			if (JUDY_UNLIKELY(EG(exception) != NULL)) {
+				zend_string_release(skey);
+				RETURN_THROWS();
+			}
+			bad = judy_reject_nul_key(intern->type, ZSTR_VAL(skey), ZSTR_LEN(skey));
+			zend_string_release(skey);
+			if (JUDY_UNLIKELY(bad)) {
+				RETURN_THROWS();
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
 
 	array_init(return_value);
 

--- a/tests/boundary_binary_keys_001.phpt
+++ b/tests/boundary_binary_keys_001.phpt
@@ -1,0 +1,188 @@
+--TEST--
+Judy boundary: high-byte string keys round-trip and sort by unsigned byte; embedded NUL is rejected on all six string-keyed types
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+$types = [
+    'STRING_TO_INT'            => Judy::STRING_TO_INT,
+    'STRING_TO_MIXED'          => Judy::STRING_TO_MIXED,
+    'STRING_TO_INT_HASH'       => Judy::STRING_TO_INT_HASH,
+    'STRING_TO_MIXED_HASH'     => Judy::STRING_TO_MIXED_HASH,
+    'STRING_TO_INT_ADAPTIVE'   => Judy::STRING_TO_INT_ADAPTIVE,
+    'STRING_TO_MIXED_ADAPTIVE' => Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+/* Part 1 — high bytes are legal key bytes and order as unsigned.
+   examples/symbol-table-prefix.php does 0xFF carry arithmetic on prefixes and
+   depends on this; the guard added for issue #117 must not touch it. */
+$keys = ["a", "a\xFF", "a\xFF\x7A", "b", "\x80", "\xFE", "\xFF", "m\x80n", "m\xFEn", "m\xFFn"];
+$expected = $keys;
+sort($expected, SORT_STRING); // PHP compares byte-wise unsigned, same as Judy
+
+echo "== high-byte keys ==\n";
+foreach ($types as $name => $type) {
+    $j = new Judy($type);
+    foreach ($keys as $i => $k) {
+        $j[$k] = $i;
+    }
+
+    $roundtrip = 'ok';
+    foreach ($keys as $i => $k) {
+        if (!isset($j[$k]) || $j[$k] !== $i) {
+            $roundtrip = 'FAILED at ' . bin2hex($k);
+            break;
+        }
+    }
+
+    $order = ($j->keys() === $expected)
+        ? 'ok'
+        : 'FAILED ' . implode(',', array_map('bin2hex', $j->keys()));
+
+    printf("%-24s count=%d roundtrip=%s order=%s first=%s last=%s\n",
+        $name, $j->count(), $roundtrip, $order,
+        bin2hex($j->first()), bin2hex($j->last()));
+}
+
+/* Part 2 — a key with an embedded NUL is rejected everywhere, on every type.
+   JudySL indexes NUL-terminated C strings, so such a key would be truncated:
+   "ab\0cd" and "ab" would collide and one value would be lost silently. */
+$nul = "ab\x00cd";
+
+$ops = [
+    'offsetSet'      => function (Judy $j) use ($nul) { $j[$nul] = 1; },
+    'offsetGet'      => function (Judy $j) use ($nul) { return $j[$nul]; },
+    'offsetExists'   => function (Judy $j) use ($nul) { return isset($j[$nul]); },
+    'offsetUnset'    => function (Judy $j) use ($nul) { unset($j[$nul]); },
+    'putAll'         => function (Judy $j) use ($nul) { $j->putAll([$nul => 1]); },
+    'getAll'         => function (Judy $j) use ($nul) { return $j->getAll([$nul]); },
+    'slice'          => function (Judy $j) use ($nul) { return $j->slice($nul, "zz"); },
+    'deleteRange'    => function (Judy $j) use ($nul) { return $j->deleteRange($nul, "zz"); },
+    'keys(range)'    => function (Judy $j) use ($nul) { return $j->keys($nul, "zz"); },
+    'values(range)'  => function (Judy $j) use ($nul) { return $j->values($nul, "zz"); },
+    'toArray(range)' => function (Judy $j) use ($nul) { return $j->toArray($nul, "zz"); },
+    'size(range)'    => function (Judy $j) use ($nul) { return $j->size($nul, "zz"); },
+    'first'          => function (Judy $j) use ($nul) { return $j->first($nul); },
+    'last'           => function (Judy $j) use ($nul) { return $j->last($nul); },
+    'searchNext'     => function (Judy $j) use ($nul) { return $j->searchNext($nul); },
+    'prev'           => function (Judy $j) use ($nul) { return $j->prev($nul); },
+];
+
+echo "\n== embedded NUL rejected ==\n";
+foreach ($types as $name => $type) {
+    $bad = [];
+    foreach ($ops as $op => $fn) {
+        $j = new Judy($type);
+        $j["ab"] = 2;
+        try {
+            $fn($j);
+            $bad[] = $op;
+        } catch (Exception $e) {
+            if (strpos($e->getMessage(), 'must not contain embedded null bytes') === false) {
+                $bad[] = $op . '(wrong message: ' . $e->getMessage() . ')';
+            }
+        }
+        // The rejected operation must not have disturbed the array.
+        if ($j->count() !== 1 || $j["ab"] !== 2) {
+            $bad[] = $op . '(mutated)';
+        }
+    }
+    printf("%-24s %s\n", $name, $bad === [] ? 'all rejected' : 'NOT REJECTED: ' . implode(', ', $bad));
+}
+
+// fromArray() is static, so it gets its own pass.
+echo "\n== embedded NUL rejected by fromArray() ==\n";
+foreach ($types as $name => $type) {
+    try {
+        Judy::fromArray($type, [$nul => 1]);
+        printf("%-24s NOT REJECTED\n", $name);
+    } catch (Exception $e) {
+        printf("%-24s %s\n", $name,
+            strpos($e->getMessage(), 'must not contain embedded null bytes') !== false
+                ? 'rejected' : 'wrong message: ' . $e->getMessage());
+    }
+}
+
+// increment() is only defined for the two INT trie/hash types.
+echo "\n== embedded NUL rejected by increment() ==\n";
+foreach (['STRING_TO_INT' => Judy::STRING_TO_INT, 'STRING_TO_INT_HASH' => Judy::STRING_TO_INT_HASH] as $name => $type) {
+    $j = new Judy($type);
+    try {
+        $j->increment($nul, 1);
+        printf("%-24s NOT REJECTED\n", $name);
+    } catch (Exception $e) {
+        printf("%-24s %s\n", $name,
+            strpos($e->getMessage(), 'must not contain embedded null bytes') !== false
+                ? 'rejected' : 'wrong message: ' . $e->getMessage());
+    }
+    printf("%-24s count after rejection: %d\n", $name, $j->count());
+}
+
+/* Part 3 — the exact collision from issue #117 can no longer happen silently. */
+echo "\n== issue #117 collision ==\n";
+foreach ($types as $name => $type) {
+    $j = new Judy($type);
+    $threw = 'no';
+    try {
+        $j["ab\x00cd"] = 1;
+    } catch (Exception $e) {
+        $threw = 'yes';
+    }
+    $j["ab"] = 2;
+    $reread = 'threw';
+    try {
+        $reread = var_export($j["ab\x00cd"], true);
+    } catch (Exception $e) {
+        // expected: the truncating read is refused rather than answered wrongly
+    }
+    printf("%-24s write threw=%s count=%d keys=%s reread=%s\n", $name, $threw, $j->count(),
+        implode(',', array_map('bin2hex', $j->keys())), $reread);
+}
+
+// A NUL is only rejected as a KEY. Values are unaffected.
+echo "\n== NUL in a value is still fine ==\n";
+$j = new Judy(Judy::STRING_TO_MIXED);
+$j["packed"] = "a\x00b";
+var_dump(bin2hex($j["packed"]));
+?>
+--EXPECT--
+== high-byte keys ==
+STRING_TO_INT            count=10 roundtrip=ok order=ok first=61 last=ff
+STRING_TO_MIXED          count=10 roundtrip=ok order=ok first=61 last=ff
+STRING_TO_INT_HASH       count=10 roundtrip=ok order=ok first=61 last=ff
+STRING_TO_MIXED_HASH     count=10 roundtrip=ok order=ok first=61 last=ff
+STRING_TO_INT_ADAPTIVE   count=10 roundtrip=ok order=ok first=61 last=ff
+STRING_TO_MIXED_ADAPTIVE count=10 roundtrip=ok order=ok first=61 last=ff
+
+== embedded NUL rejected ==
+STRING_TO_INT            all rejected
+STRING_TO_MIXED          all rejected
+STRING_TO_INT_HASH       all rejected
+STRING_TO_MIXED_HASH     all rejected
+STRING_TO_INT_ADAPTIVE   all rejected
+STRING_TO_MIXED_ADAPTIVE all rejected
+
+== embedded NUL rejected by fromArray() ==
+STRING_TO_INT            rejected
+STRING_TO_MIXED          rejected
+STRING_TO_INT_HASH       rejected
+STRING_TO_MIXED_HASH     rejected
+STRING_TO_INT_ADAPTIVE   rejected
+STRING_TO_MIXED_ADAPTIVE rejected
+
+== embedded NUL rejected by increment() ==
+STRING_TO_INT            rejected
+STRING_TO_INT            count after rejection: 0
+STRING_TO_INT_HASH       rejected
+STRING_TO_INT_HASH       count after rejection: 0
+
+== issue #117 collision ==
+STRING_TO_INT            write threw=yes count=1 keys=6162 reread=threw
+STRING_TO_MIXED          write threw=yes count=1 keys=6162 reread=threw
+STRING_TO_INT_HASH       write threw=yes count=1 keys=6162 reread=threw
+STRING_TO_MIXED_HASH     write threw=yes count=1 keys=6162 reread=threw
+STRING_TO_INT_ADAPTIVE   write threw=yes count=1 keys=6162 reread=threw
+STRING_TO_MIXED_ADAPTIVE write threw=yes count=1 keys=6162 reread=threw
+
+== NUL in a value is still fine ==
+string(6) "610062"


### PR DESCRIPTION
Closes #117.

## What was wrong

`STRING_TO_INT` and `STRING_TO_MIXED` truncated a string key at its first NUL byte, so two distinct PHP strings collided and one value was destroyed with no signal.

Auditing the other five paths turned up more than the issue reported. The guard the four `*_HASH`/`*_ADAPTIVE` types already carry lives only in `judy_string_slot_acquire()`, i.e. on the **write** path. Their **ordered and range** operations seek through the same JudySL `key_index` and truncated identically. Measured on `main` before the fix, all six types:

```php
$j->first("ab\x00cd");          // "ab"  — wrong: "ab" < "ab\0cd"
$j->slice("ab\x00cd", "zz");    // includes "ab" — same reason
$j->keys("ab\x00cd", "zz");     // same
$j->deleteRange("ab\x00cd","zz"); // deletes "ab"
```

So extending the guard to the four already-guarded types is a bug fix, not only a consistency change. Full pre-fix matrix (20 ops × 6 types) is in the negative-control table below.

## The fix

A NUL byte in a string key is rejected on **all six** string-keyed types, at **every entry point that takes a caller-supplied string key**:

`offsetSet` / `offsetGet` / `offsetExists` / `offsetUnset`, `increment()`, `fromArray()`, `putAll()`, `getAll()`, `slice()`, `deleteRange()`, `first()` / `last()` / `searchNext()` / `prev()`, and the `$start`/`$end` bounds of `keys()` / `values()` / `toArray()` / `size()`.

Supporting embedded NUL is not available: every string-keyed type orders its keys through a JudySL trie (the trie types store the value in it directly; the four others keep a JudySL `key_index` beside their length-prefixed value store), and a JudySL index is a NUL-terminated C string by construction. JudyHS accepts a NUL because it is length-prefixed; JudySL cannot be made to.

Implementation is three choke points plus four method-local ones:

| Site | Covers |
| --- | --- |
| `CHECK_ARRAY_AND_ARG_TYPE` | `offsetSet`/`offsetGet`/`offsetExists`/`offsetUnset` |
| `judy_string_slot_acquire()` (hoisted; replaces 4 per-case checks) | `offsetSet`, `increment()`, `fromArray()`, `putAll()`, `__unserialize()` |
| `judy_parse_collect_range()` | `keys()`/`values()`/`toArray()`/`size()` bounds |
| `Judy::slice`, `Judy::deleteRange`, `Judy::getAll`, `first`/`last`/`searchNext`/`prev` | their own arguments |

**Exception messages are unchanged** for the four types that already threw (`increment_string_to_int_hash_001.phpt` still passes unmodified). The two trie types gained messages in the same shape: `Judy STRING_TO_INT keys must not contain embedded null bytes`.

## High bytes are untouched — proven, not assumed

Only `0x00` is rejected. `0x80`, `0xFE`, `0xFF` and a `0xFF` mid-string all store, round-trip and sort in unsigned byte order on all six types. `examples/symbol-table-prefix.php`'s prefix-successor carry arithmetic depends on this. Part 1 of the new test asserts it, and its output is **byte-identical on the unfixed and fixed builds** — it appears nowhere in the negative-control diff.

## Negative control (required, and it discriminates)

`tests/boundary_binary_keys_001.phpt` run against two builds of the same tree — `origin/main`'s `php_judy.c` and this branch's — on PHP 8.5.8, macOS/arm64:

| Build | Result | Mismatched output lines |
| --- | --- | --- |
| unfixed (`origin/main`) | **FAIL** | **16** |
| fixed (this branch) | **PASS** | **0** |

What the 16 lines say:

```
== embedded NUL rejected ==
- STRING_TO_INT            all rejected
+ STRING_TO_INT            NOT REJECTED: offsetSet, offsetSet(mutated), offsetGet, offsetExists,
+   offsetUnset, offsetUnset(mutated), putAll, putAll(mutated), getAll, slice, deleteRange,
+   deleteRange(mutated), keys(range), values(range), toArray(range), size(range),
+   first, last, searchNext, prev                                        (20/20 unguarded)
+ STRING_TO_MIXED          NOT REJECTED: … same 20
+ STRING_TO_INT_HASH       NOT REJECTED: offsetGet, offsetExists, offsetUnset, getAll, slice,
+   deleteRange, deleteRange(mutated), keys/values/toArray/size(range),
+   first, last, searchNext, prev                                        (15/20 unguarded)
+ STRING_TO_MIXED_HASH     NOT REJECTED: … same 15
+ STRING_TO_INT_ADAPTIVE   NOT REJECTED: … same 15
+ STRING_TO_MIXED_ADAPTIVE NOT REJECTED: … same 15

== embedded NUL rejected by fromArray() ==
- STRING_TO_INT / STRING_TO_MIXED   rejected
+ STRING_TO_INT / STRING_TO_MIXED   NOT REJECTED

== embedded NUL rejected by increment() ==
- STRING_TO_INT   rejected / count after rejection: 0
+ STRING_TO_INT   NOT REJECTED / count after rejection: 1

== issue #117 collision ==
- STRING_TO_INT   write threw=yes count=1 keys=6162 reread=threw
+ STRING_TO_INT   write threw=no  count=1 keys=6162 reread=2      <-- the reported bug
```

The `(mutated)` markers are a second assertion: each rejected op must leave `count()` and the existing `"ab"` entry untouched.

## Verification

- `make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1` — **211/211 pass**, 0 failed, 0 warned (210 before, +1 new).
- Compiler warnings: `-Wall -Wextra -fsyntax-only` reports the **same 4 pre-existing warnings** on this branch as on `HEAD` — no new ones. Normal `make` is clean apart from the pre-existing macOS linker/`dsymutil` notes.
- New test also runs clean under `USE_ZEND_ALLOC=0` and with `MallocScribble`/`MallocPreScribble`.
- All 9 `examples/*.php` run to completion.
- `package.xml` test list diffs clean against `tests/*.phpt` (the check `validate-pecl` performs).
- `scripts/generate-api-docs.php` produces no diff — `Judy.stub.php` is untouched, so no arginfo/`API.md` regeneration is needed.
- `baselines/latest.json` untouched.

## BC impact

Two categories.

1. **`STRING_TO_INT` / `STRING_TO_MIXED`, any op with a NUL key** — previously truncated, now throws. Such code is silently losing data today, so failing loudly is strictly better.
2. **`*_HASH` / `*_ADAPTIVE`, read and range ops with a NUL key** — previously returned `null`/`false` (point reads) or a wrongly-widened range (ordered/range ops), now throws. The point-read change is the only one that turns a currently *correct* answer into an exception; it is included so that "a NUL is not a valid Judy string key" is one rule with one enforcement surface rather than six type-specific behaviours. Happy to split it out if you would rather land only the range half.

Affected key shapes are exactly the non-obvious ones: `pack()` output, raw digests, serialized payloads, packed binary tuples. Those need encoding (base64/hex/any NUL-free framing) before use as keys. **Values are unaffected** — a `_MIXED` value may contain any bytes; the test asserts that too.

## Docs

- `AGENTS.md` — new pitfall entry: binary-safe for every byte except `0x00`, full method list, the structural reason, the encode-your-digests advice. Also corrected the adjacent "binary-safe keys" phrasing to "high-byte keys".
- `README.md` — callout under *String-Keyed Types (Trie-Based)*.
- `examples/symbol-table-prefix.php` — its unqualified *"Judy string keys are binary-safe"* claim is now *"binary-safe for every byte except 0x00"*, in both the header comment and the printed notes.
- **No `MIGRATION_*.md` written** — that file is per-version and the version is yours to pick (below). Draft text is ready; say the word and I will add it to the right file.

## Two things I did not decide

1. **Version.** Not bumped — 2.5.0 is released and on PECL. **My recommendation: 2.6.0, not 2.5.1.** Reasoning: this changes observable behaviour on all six string-keyed types, including turning `isset()`/`offsetGet` on the four hash/adaptive types from `false`/`null` into an exception. `MIGRATION_2.5.0.md`'s own framing — "a behaviour change with no runtime signal deserves more attention than a minor version number usually implies" — applies here with more force, and 2.5.0 set the precedent of shipping exactly this kind of silent-semantics correction as a minor. A patch release should not be able to make previously-passing `isset()` calls throw. If you prefer 2.5.1, dropping BC category 2 above (guard only the paths that produce wrong answers) would make that defensible.
2. **Not merged**, per instruction.

## One note for the maintainer

The write path now runs `memchr` twice on the key — once in `CHECK_ARRAY_AND_ARG_TYPE`, once in `judy_string_slot_acquire()` (which cannot drop it, since `increment()`/`fromArray()`/`putAll()` reach it without passing the macro). Expected to be far below the JudySL descend it precedes, but **I did not benchmark it**: this machine's load average was 13.0 on 8 cores while I worked, which per the repo's own benchmark-hygiene rule makes any local timing uninterpretable. Worth a look at the CI benchmark delta on this PR.

Also worth a follow-up in the ecosystem repos: `judy-polyfill`'s parity suite and `judy-cache` will want matching semantics, and the polyfill will need the two new `STRING_TO_INT` / `STRING_TO_MIXED` message strings.
