### PR TITLE
chore: release v2.5.1

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1256,7 +1256,7 @@ php examples/benchmarks/run-benchmarks-robust.php
 
 Our methodology and insights are informed by the [Rusty Russell benchmark comparison](https://rusty.ozlabs.org/2010/11/08/hashtables-vs-judy-arrays-round-1.html) between hashtables and Judy arrays, which demonstrates Judy's strengths in ordered access patterns and memory efficiency.
 
-**Describes**: php-judy 2.5.0
+**Describes**: php-judy 2.5.1
 **Figures measured on**: 2.4.2, verified unchanged on 2.5.0 (0 regressions, run-wide
 median -0.04%; see Benchmarking Environment)
 **Last Updated**: August 2026

--- a/Judy_arginfo.h
+++ b/Judy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 81108e5fc59eb9a01659b6010a965acba8201911 */
+ * Stub hash: 955ab76c22ec9add9a817b2bcde3660aa2e00ab1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_judy_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/MIGRATION_2.5.0.md
+++ b/MIGRATION_2.5.0.md
@@ -1,4 +1,9 @@
-# Migrating to php-judy 2.5.0
+# Migrating to php-judy 2.5.x
+
+> **2.5.1** adds one further change, in §6: string keys containing an embedded
+> NUL byte are now rejected instead of silently truncated. If you store binary
+> keys — serialized payloads, packed tuples, raw hash digests — read that
+> section. Everything else below applies from 2.5.0.
 
 2.5.0 changes what a **negative integer offset** means on the write path, and
 makes an append that has run out of key space fail loudly. Both changes are
@@ -225,6 +230,75 @@ and ignores it. Call `isIterationOptimized()` to see what actually took effect.
 - `map()` and `filter()` now preserve negative keys. In 2.x they relocated
   them, so a key-preserving transform silently moved entries.
 
+## 6. Embedded NUL bytes in string keys now throw (2.5.1)
+
+Added in **2.5.1**. Like §1 and §3 this had no runtime signal — it silently
+destroyed data rather than reporting anything.
+
+### Before (2.5.0 and earlier)
+
+`STRING_TO_INT` and `STRING_TO_MIXED` truncated a key at its first NUL byte, so
+two distinct PHP strings collided and one value was lost:
+
+```php
+$j = new Judy(Judy::STRING_TO_INT);
+$j["ab\x00cd"] = 1;
+$j["ab"]       = 2;
+
+$j->count();        // 1   <-- two keys written, one survived
+$j->keys();         // ["ab"]
+$j["ab\x00cd"];     // 2   <-- reads back the value written under "ab"
+```
+
+The four `*_HASH` and `*_ADAPTIVE` types already rejected such a key **on
+write** — but only on write. Every ordered and range operation still truncated
+it, because all six types seek through the same JudySL key index:
+
+```php
+$h = new Judy(Judy::STRING_TO_INT_HASH);
+$h["ab"] = 1; $h["zz"] = 2;
+
+$h->first("ab\x00cd");             // "ab"      <-- wrong; "ab" < "ab\0cd"
+$h->slice("ab\x00cd", "zz")->keys(); // ["ab","zz"]  <-- includes "ab"
+$h->deleteRange("ab\x00cd", "zz"); // deletes "ab"
+```
+
+### After (2.5.1)
+
+All six types throw, on every path that takes a string key — `offsetSet`,
+`offsetGet`, `offsetExists`, `offsetUnset`, `increment()`, `fromArray()`,
+`putAll()`, `getAll()`, `slice()`, `deleteRange()`, `first()`/`last()`/
+`searchNext()`/`prev()`, and the bounds of `keys()`/`values()`/`toArray()`/
+`size()`.
+
+### Why rejecting, rather than supporting
+
+JudySL keys are NUL-terminated C strings by construction. That is precisely why
+`JudyHS` (length-prefixed) can hold arbitrary bytes and `JudySL` cannot, and it
+is not something the extension can work around. Rejecting loudly is the only
+correct option once truncation is off the table.
+
+### High bytes are unaffected
+
+Keys containing `0x80`-`0xFF` were always binary-safe and remain so: they store,
+round-trip, and sort in unsigned byte order. The `0xFF` prefix-successor carry
+arithmetic in `examples/symbol-table-prefix.php` is unchanged. **Only `0x00` is
+rejected.**
+
+### What to check
+
+If you build keys from `pack()`, `serialize()`, raw hash digests (`hash(...,
+true)`), or any binary payload, they can contain a NUL. Those keys were already
+being corrupted — silently — so the exception is surfacing existing data loss
+rather than creating a new failure:
+
+```
+grep -rn 'pack(\|hash([^)]*,\s*true\|serialize(' --include='*.php' .
+```
+
+Encode such keys before use — `bin2hex()`, `base64_encode()`, or any NUL-free
+encoding — or switch that array to an integer-keyed type.
+
 ## Migration steps
 
 1. **Find writes whose index can be negative.** Grep for array-subscript writes
@@ -263,7 +337,14 @@ and ignores it. Call `isIterationOptimized()` to see what actually took effect.
    grep -rn 'index_start:\|index_end:' --include='*.php' .
    ```
 
-7. **Find `size()` calls that pass string bounds** (§3). They were silently
+7. **Check for binary string keys** (§6, 2.5.1). Keys from `pack()`,
+   `serialize()` or raw digests may contain a NUL and were silently truncated:
+
+   ```
+   grep -rn 'pack(\|hash([^)]*,\s*true\|serialize(' --include='*.php' .
+   ```
+
+8. **Find `size()` calls that pass string bounds** (§3). They were silently
    returning the whole-array count and now return the range count:
 
    ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ API.md               Complete API reference
 BENCHMARK.md         Performance benchmarks and analysis
 BACKEND_EVALUATION.md  Judy vs ART/Masstree/HOT/Wormhole as the C backend
 MIGRATION_2.2.0.md   Migration guide for version 2.2.0
-MIGRATION_2.5.0.md   Migration guide for version 2.5.0
+MIGRATION_2.5.0.md   Migration guide for the 2.5.x line
 LICENSE              The PHP License used by this project
 
 tests/               Unit and regression tests (.phpt)
@@ -749,6 +749,6 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 - **API Reference**: [API.md](API.md) for complete method documentation
 - **Benchmarks**: [BENCHMARK.md](BENCHMARK.md) for performance analysis
-- **Migration Guide**: [MIGRATION_2.5.0.md](MIGRATION_2.5.0.md) for version 2.5.0 changes,
+- **Migration Guide**: [MIGRATION_2.5.0.md](MIGRATION_2.5.0.md) for the 2.5.x line (incl. 2.5.1),
   [MIGRATION_2.2.0.md](MIGRATION_2.2.0.md) for version 2.2.0 changes
 - **Examples**: Check the [examples/](examples/README.md) directory for runnable demos (dedup, range lookup, rate limiting, prefix invalidation, autocomplete, counters) — indexed by problem under [What people use it for](#what-people-use-it-for)

--- a/package.xml
+++ b/package.xml
@@ -16,11 +16,11 @@
       <email>nicolas@brousse.info</email>
       <active>yes</active>
    </lead>
-   <date>2026-08-17</date>
+   <date>2026-08-18</date>
    <time>00:00:00</time>
    <version>
-      <release>2.5.0</release>
-      <api>2.5.0</api>
+      <release>2.5.1</release>
+      <api>2.5.1</api>
    </version>
    <stability>
       <release>stable</release>
@@ -28,59 +28,17 @@
    </stability>
    <license uri="http://www.php.net/license">PHP</license>
    <notes>
-- BC BREAK: a negative integer offset now stores that key instead of appending.
-  Integer keys are unsigned machine words, so $j[-1] = $v addresses the maximum
-  index and reads back as -1. Previously every key in [PHP_INT_MIN, -1] was
-  discarded and the value appended at the next free index, so isset($j[-1]) was
-  false immediately after the write. See MIGRATION_2.5.0.md.
-- BC BREAK: $j[] = $v now throws when the maximum index is occupied, instead of
-  wrapping onto index 0 and overwriting it.
-- FIX: $j[] = $v no longer loses a value after a negative-offset write left the
-  append watermark stale
-- FIX: map()/filter() preserve negative keys instead of relocating them
-- SECURITY: fix use-after-free write on *_TO_MIXED overwrite/unset when a stored
-  value's destructor re-enters and mutates the same array (write-before-dtor /
-  delete-before-free)
-- SECURITY: fix type confusion (UB) in getAll()/next()/rewind() for adaptive
-  types, which queried a JudyHS operation against the JudyL (SSO) store
-- FIX: add get_gc handler so reference cycles through MIXED values are collectable
-  (previously leaked until request shutdown)
-- FIX: STRING_TO_*_ADAPTIVE counter no longer double-counts when the value 0 is
-  re-stored (size/count/equals/averageValues were affected)
-- FIX: $j[] = append after clone/fromArray/putAll no longer overwrites index 0
-- FIX: first()/last()/searchNext()/prev() now work on adaptive types
-- FIX: fromArray()/putAll() reject non-integer keys on integer-keyed types instead
-  of inserting at the string's hash
-- FIX: __unserialize() on a populated object frees prior contents (no leak)
-- FIX: forEach()/filter()/map() callbacks may re-enter without corrupting iteration
-- FIX: equals() on INT_TO_PACKED no longer risks an infinite loop
-- FIX: allocation failure (JERR) during write/unset is reported as failure, not success
-- FIX: bulk operations stop on the first thrown key instead of continuing with a
-  pending exception; clone/slice no longer leak zvals or diverge on OOM paths
-- FEATURE: keys(), values() and toArray() take an inclusive [$start, $end] key
-  range, where null leaves that side unbounded. All key types; string-keyed types
-  require string bounds and compare them lexicographically. A bounded read is one
-  traversal writing straight into the PHP array — prefer it to slice($lo,
-  $hi)->keys(), which copies a whole sub-array first.
-- FEATURE: size($start, $end) counts that same range, including on the six
-  string-keyed types, without materialising anything. Previously it accepted
-  string bounds, ignored them, and returned the whole-array count. Its parameters
-  were renamed $index_start/$index_end -> $start/$end to match the other range
-  methods, which breaks named-argument callers only; its defaults moved from
-  (0, -1) to (null, null). populationCount() is unchanged and stays
-  integer-keyed-only — it answers from libJudy's O(1) population cache, which the
-  string-keyed stores lack. See MIGRATION_2.5.0.md.
-- FEATURE: new Judy($type, optimizeIteration: true) mirrors payloads into the key
-  index for 24-47% faster ordered reads, at a write-path and memory cost. Opt-in,
-  per-instance, off by default, and honoured only by STRING_TO_INT_HASH and
-  STRING_TO_INT_ADAPTIVE; isIterationOptimized() reports what took effect.
-- FEATURE: Judy instances are now legible to debuggers — var_dump()/print_r()
-  show type, count, memory usage, first/last key and a bounded element preview
-  (judy.debug_preview_size). Ships lldb/gdb pretty-printers for the extension's
-  own structs under scripts/.
-- FEATURE: set operations (intersect/diff/xor) now supported for STRING_TO_INT_ADAPTIVE
-- BUILD: extension compiles warning-free; CI now fails on any new compiler warning
-- BUILD: minimum PHP raised to 8.1 (PHP 8.0 is no longer tested in CI)
+- FIX: string keys containing an embedded NUL byte are now rejected with an
+  exception on all six string-keyed types, instead of being silently truncated
+  at the NUL. Previously STRING_TO_INT and STRING_TO_MIXED truncated the key, so
+  "ab\0cd" and "ab" collided and one value was destroyed with no signal; the
+  four *_HASH/*_ADAPTIVE types already rejected such keys on write but still
+  truncated them on every ordered and range operation (first/last/searchNext/
+  prev/slice/deleteRange and the bounds of keys/values/toArray/size), because
+  all six seek through the same JudySL key index. JudySL keys are NUL-terminated
+  by construction, so rejecting is the only correct behaviour. High-byte keys
+  (0x80-0xFF) are unaffected and remain binary-safe, including 0xFF prefix-carry
+  arithmetic. See MIGRATION_2.5.0.md.
    </notes>
    <contents>
       <dir name="/">
@@ -380,6 +338,21 @@
       <configureoption default="autodetect" name="with-judy" prompt="Please provide the prefix of libJudy installation" />
    </extsrcrelease>
    <changelog>
+      <release>
+         <date>2026-08-17</date>
+         <version>
+            <release>2.5.0</release>
+            <api>2.5.0</api>
+         </version>
+         <stability>
+            <release>stable</release>
+            <api>stable</api>
+         </stability>
+         <notes>
+- Negative-key BC break, ranged keys()/values()/toArray()/size(),
+  optimizeIteration, debugger support; see the 2.5.0 release notes.
+         </notes>
+      </release>
       <release>
          <date>2026-08-14</date>
          <version>

--- a/php_judy.h
+++ b/php_judy.h
@@ -19,7 +19,7 @@
 #ifndef PHP_JUDY_H
 #define PHP_JUDY_H
 
-#define PHP_JUDY_VERSION "2.5.0"
+#define PHP_JUDY_VERSION "2.5.1"
 #define PHP_JUDY_EXTNAME "judy"
 
 /* Windows x64 (LLP64): Force 64-bit Word_t to match libjudy ABI.


### PR DESCRIPTION
## Summary

Ships the embedded-NUL key fix (#117, merged in #119) as a patch release. 2.5.0 is on PECL and `main` has behaved differently from it since #119 merged, so the version string needed to stop claiming to be the released 2.5.0.

Two commits: the release bump, and a one-line refresh of a stale generated-file hash.

## Release bump

| File | Change |
| --- | --- |
| `php_judy.h` | `PHP_JUDY_VERSION` → `2.5.1` |
| `package.xml` | `<release>`/`<api>` → 2.5.1, `<date>` → 2026-08-18; 2.5.0 notes moved into `<changelog>`; new `<notes>` for 2.5.1 |
| `MIGRATION_2.5.0.md` | Now the guide for the **2.5.x line**; new §6 for the NUL change + a binary-key grep step |
| `BENCHMARK.md` | Document stamp → 2.5.1 |
| `README.md` | Two MIGRATION references say "2.5.x line" |

The migration guide is retitled rather than split into a new file: someone upgrading from 2.4.x needs both halves, and the 2.5.1 delta is a single section.

## Framing — why a patch release is defensible here

This turns previously-*passing* calls into exceptions on the four `*_HASH`/`*_ADAPTIVE` types — `first()`/`last()`/`searchNext()`/`prev()`/`slice()`/`deleteRange()` and range bounds. That is only acceptable as a patch because **those calls were already returning wrong answers**: they truncated the key at the NUL and matched a different key. Nothing correct is being broken.

§6 of the migration guide states this plainly rather than presenting the change as purely additive.

## Second commit — stale stub hash

`Judy_arginfo.h`'s recorded stub hash went stale when #116 added the `toArray()` coercion docblock. **Zero declaration drift** — verified, the only differing line is the hash comment — but the generated file should match its source so the build tooling's staleness check stays meaningful.

## Deliberately NOT in this PR

- **`baselines/latest.json` untouched** and the CI perf baseline stays pinned at 2.4.2, per the convention that the baseline is bumped only after a release is on PECL, in its own PR.
- **#119 has never been benchmarked.** It added a `memchr` to the write path (twice — `increment`/`fromArray`/`putAll` reach the slot helper without the macro). It was not measured because the machine was at load average 13 on 8 cores, which makes any local timing uninterpretable under this repo's own benchmark-hygiene rule. The post-release baseline bump is the first honest look at that cost.

## Test plan

- [x] 211/211 tests pass
- [x] `judy_version()` reports `2.5.1` on a fresh build
- [x] NUL rejected on write **and** on ordered reads (`first()` on `STRING_TO_INT_HASH`)
- [x] High-byte keys (`0x80`, `0xFF`) still store and sort correctly — `61,80,ff`
- [x] Version lockstep `php_judy.h` == `package.xml` (CI-enforced)
- [x] `package.xml` well-formed, 211 tests in sync
- [x] `API.md` freshness gate passes
- [x] CI green