### PR TITLE
perf(merge): reuse the iterator's value slot instead of re-descending

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -316,6 +316,9 @@
          <file name="tests/size_range_string_001.phpt" role="test" />
          <file name="tests/range_named_args_001.phpt" role="test" />
          <file name="tests/merge_with.phpt" role="test" />
+         <file name="tests/merge_with_slot_reuse_001.phpt" role="test" />
+         <file name="tests/merge_with_mixed_refcount_001.phpt" role="test" />
+         <file name="tests/merge_with_reentrancy_001.phpt" role="test" />
          <file name="tests/packed_complex_fallback_001.phpt" role="test" />
          <file name="tests/packed_scalar_fastpath_001.phpt" role="test" />
          <file name="tests/phase3_adaptive_001.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -526,6 +526,47 @@ static zend_always_inline int judy_reject_nul_key_zval(judy_object *intern, zval
 			_return_;						\
 	}
 
+/* {{{ judy_value_from_slot — materialise a live value slot into a zval.
+
+   The single place that knows how each type encodes its payload in the
+   Word_t slot libJudy hands back, so a caller already standing on that slot
+   never has to descend from the root a second time for a key it is holding.
+   judy_object_read_dimension_helper() below does the descend and then calls
+   this, which is what keeps the two conversions from drifting.
+
+   `PValue` must be a slot from the *value store* of `intern`. For the four
+   key_index-backed types (*_HASH / *_ADAPTIVE) an ordered cursor walks
+   `key_index`, whose slot is NOT the value — unless JUDY_MIRRORS_PAYLOAD()
+   holds for that key, which is exactly what the optimizeIteration mirror
+   makes true. Callers resolve that before calling here. BITSET has no value
+   slot and never reaches this function.
+
+   MIXED goes through ZVAL_COPY, so the result owns a reference and stays
+   valid even if the source entry is destroyed afterwards. That is what makes
+   it safe to materialise a value *before* an operation that may run
+   arbitrary user code. */
+static zend_always_inline void judy_value_from_slot(judy_object *intern, Pvoid_t *PValue, zval *rv)
+{
+	if (JUDY_IS_MIXED_VALUE(intern)) {
+		zval *value = JUDY_MVAL_READ(PValue);
+		if (JUDY_LIKELY(value != NULL)) {
+			ZVAL_COPY(rv, value);
+		} else {
+			ZVAL_NULL(rv);
+		}
+	} else if (JUDY_IS_PACKED_VALUE(intern)) {
+		judy_packed_value *packed = JUDY_PVAL_READ(PValue);
+		if (JUDY_LIKELY(packed != NULL)) {
+			judy_unpack_value(packed, rv);
+		} else {
+			ZVAL_NULL(rv);
+		}
+	} else {
+		ZVAL_LONG(rv, JUDY_LVAL_READ(PValue));
+	}
+}
+/* }}} */
+
 zval *judy_object_read_dimension_helper(zval *object, zval *offset, zval *rv) /* {{{ */
 {
 	zend_long index = 0;
@@ -580,20 +621,7 @@ zval *judy_object_read_dimension_helper(zval *object, zval *offset, zval *rv) /*
 	}
 
 	if (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-		if (intern->type == TYPE_INT_TO_INT || intern->type == TYPE_STRING_TO_INT
-				|| intern->type == TYPE_STRING_TO_INT_HASH || intern->type == TYPE_STRING_TO_INT_ADAPTIVE) {
-			ZVAL_LONG(rv, JUDY_LVAL_READ(PValue));
-		} else if (intern->type == TYPE_INT_TO_MIXED || intern->type == TYPE_STRING_TO_MIXED
-				|| intern->type == TYPE_STRING_TO_MIXED_HASH || intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE) {
-			ZVAL_COPY(rv, JUDY_MVAL_READ(PValue));
-		} else if (intern->type == TYPE_INT_TO_PACKED) {
-			judy_packed_value *packed = JUDY_PVAL_READ(PValue);
-			if (JUDY_LIKELY(packed != NULL)) {
-				judy_unpack_value(packed, rv);
-			} else {
-				ZVAL_NULL(rv);
-			}
-		}
+		judy_value_from_slot(intern, PValue, rv);
 		return rv;
 	}
 	return NULL;
@@ -5209,11 +5237,20 @@ static void judy_object_merge_with_helper(judy_object *intern, judy_object *othe
 			while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 				zval zidx, zval_val;
 				ZVAL_LONG(&zidx, (zend_long)index);
-				ZVAL_UNDEF(&zval_val);
-				judy_object_read_dimension_helper_zv(other, &zidx, &zval_val);
+				/* The cursor is already standing on the value slot for
+				 * `index`, so materialise it here instead of descending from
+				 * the root again. This must happen BEFORE the write: the
+				 * write can run a MIXED value's destructor, which can re-enter
+				 * and mutate `other`, and judy_value_from_slot() has taken a
+				 * reference by then (ZVAL_COPY for MIXED, a plain read for the
+				 * others), so `zval_val` survives it. */
+				judy_value_from_slot(other, PValue, &zval_val);
 				judy_object_write_dimension_helper_zv(intern, &zidx, &zval_val);
 				zval_ptr_dtor(&zval_val);
 				if (UNEXPECTED(EG(exception))) break;
+				/* PValue is NOT dereferenced across the write — JLN re-descends
+				 * from `index`, so a re-entrant mutation of `other` cannot
+				 * leave us reading a freed slot. */
 				JLN(PValue, other->array, index);
 			}
 		}
@@ -5231,14 +5268,39 @@ static void judy_object_merge_with_helper(judy_object *intern, judy_object *othe
 
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 			zval zkey, zval_val;
+			Pvoid_t *VValue;
+
 			ZVAL_STRING(&zkey, (const char *)key);
 			ZVAL_UNDEF(&zval_val);
-			judy_object_read_dimension_helper_zv(other, &zkey, &zval_val);
+
+			/* Which store the cursor is walking decides whether its slot is
+			 * the value. The two plain trie types keep the value in `array`,
+			 * which is what JSLF/JSLN walked, so PValue IS the value slot.
+			 * The four key_index-backed types walked `key_index` instead, and
+			 * there the value lives in the separate JudyHS (or, for short
+			 * ADAPTIVE keys, the packed JudyL) — so the second lookup stays,
+			 * except on an instance where optimizeIteration mirrored the
+			 * payload into the key_index slot we are holding. */
+			if (other->is_hash_keyed) {
+				Word_t klen = (Word_t)strlen((char *)key);
+				VValue = JUDY_MIRRORS_PAYLOAD(other, klen)
+					? PValue : judy_string_value_slot(other, key, klen);
+			} else {
+				VValue = PValue;
+			}
+			/* Materialise before the write, for the reason spelled out on the
+			 * private cursor above: the write can run user code. */
+			if (JUDY_LIKELY(VValue != NULL)) {
+				judy_value_from_slot(other, VValue, &zval_val);
+			}
+
 			judy_object_write_dimension_helper_zv(intern, &zkey, &zval_val);
 			zval_ptr_dtor(&zval_val);
 			zval_ptr_dtor(&zkey);
 			if (UNEXPECTED(EG(exception))) break;
 
+			/* Neither PValue nor VValue is dereferenced past the write; JSLN
+			 * re-descends from the key bytes in the private cursor. */
 			if (other->is_hash_keyed) {
 				JSLN(PValue, other->key_index, key);
 			} else {

--- a/tests/merge_with_mixed_refcount_001.phpt
+++ b/tests/merge_with_mixed_refcount_001.phpt
@@ -1,0 +1,126 @@
+--TEST--
+Judy mergeWith() - MIXED values are properly referenced, not aliased or leaked
+--DESCRIPTION--
+Issue #121: the merge loop now materialises a MIXED value straight out of the
+iterator's slot, which is a raw zval* — it has to take a reference (ZVAL_COPY
+semantics), or the destination ends up holding a dangling pointer once the
+source is freed, or holding one reference too many and never releasing it. This
+asserts both directions: the destination survives the source being dropped, and
+every tracked object is destroyed exactly once when both arrays go away.
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+class Tracked {
+    public static int $live = 0;
+    public function __construct(public string $tag) { self::$live++; }
+    public function __destruct() { self::$live--; }
+}
+
+$types = [
+    'INT_TO_MIXED'             => Judy::INT_TO_MIXED,
+    'STRING_TO_MIXED'          => Judy::STRING_TO_MIXED,
+    'STRING_TO_MIXED_HASH'     => Judy::STRING_TO_MIXED_HASH,
+    'STRING_TO_MIXED_ADAPTIVE' => Judy::STRING_TO_MIXED_ADAPTIVE,
+];
+
+foreach ($types as $name => $type) {
+    echo "=== $name ===\n";
+    $int = ($type === Judy::INT_TO_MIXED);
+    $k1 = $int ? 1 : 'k1';                 // short key: below the ADAPTIVE SSO boundary
+    $k2 = $int ? 2 : 'a_long_key_two';     // long key: above it
+
+    $src = new Judy($type);
+    $dst = new Judy($type);
+
+    $obj = new Tracked('obj');
+    $arr = ['deep' => ['nested' => 'value'], 'n' => 7];
+    $src[$k1] = $obj;
+    $src[$k2] = $arr;
+    $dst[$k1] = 'to be overwritten';
+
+    $dst->mergeWith($src);
+
+    // Drop every reference the source side held.
+    unset($src, $obj, $arr);
+
+    echo "live objects after dropping source: " . Tracked::$live . "\n";
+    echo "k1 class=" . get_class($dst[$k1]) . " tag=" . $dst[$k1]->tag . "\n";
+    echo "k2 deep=" . $dst[$k2]['deep']['nested'] . " n=" . $dst[$k2]['n'] . "\n";
+
+    // A read hands back a copy; mutating it must not reach into the store.
+    $tmp = $dst[$k2];
+    $tmp['n'] = 99;
+    echo "stored n after mutating the read copy: " . $dst[$k2]['n'] . "\n";
+
+    unset($dst, $tmp);
+    echo "live objects after dropping destination: " . Tracked::$live . "\n";
+}
+
+echo "=== repeated merges keep the object count exact ===\n";
+for ($round = 0; $round < 3; $round++) {
+    $src = new Judy(Judy::INT_TO_MIXED);
+    for ($i = 0; $i < 200; $i++) { $src[$i] = new Tracked("r$round-$i"); }
+    $dst = new Judy(Judy::INT_TO_MIXED);
+    $dst->mergeWith($src);
+    $dst->mergeWith($src);  // second pass overwrites every key with itself
+    unset($src);
+    echo "round $round live after source freed: " . Tracked::$live . "\n";
+    unset($dst);
+    echo "round $round live after destination freed: " . Tracked::$live . "\n";
+}
+
+echo "=== PHP heap does not grow across merge rounds ===\n";
+$baseline = null;
+$grown = false;
+for ($round = 0; $round < 12; $round++) {
+    $src = new Judy(Judy::STRING_TO_MIXED_HASH);
+    for ($i = 0; $i < 500; $i++) { $src["key_number_$i"] = ['payload' => str_repeat('x', 32), 'i' => $i]; }
+    $dst = new Judy(Judy::STRING_TO_MIXED_HASH);
+    $dst->mergeWith($src);
+    $dst->mergeWith($src);
+    unset($src, $dst);
+    gc_collect_cycles();
+    if ($round === 3) { $baseline = memory_get_usage(); }
+    if ($baseline !== null && memory_get_usage() > $baseline + 65536) { $grown = true; }
+}
+echo "heap grew past the settled baseline: " . var_export($grown, true) . "\n";
+echo "live objects at end: " . Tracked::$live . "\n";
+echo "Done.\n";
+?>
+--EXPECT--
+=== INT_TO_MIXED ===
+live objects after dropping source: 1
+k1 class=Tracked tag=obj
+k2 deep=value n=7
+stored n after mutating the read copy: 7
+live objects after dropping destination: 0
+=== STRING_TO_MIXED ===
+live objects after dropping source: 1
+k1 class=Tracked tag=obj
+k2 deep=value n=7
+stored n after mutating the read copy: 7
+live objects after dropping destination: 0
+=== STRING_TO_MIXED_HASH ===
+live objects after dropping source: 1
+k1 class=Tracked tag=obj
+k2 deep=value n=7
+stored n after mutating the read copy: 7
+live objects after dropping destination: 0
+=== STRING_TO_MIXED_ADAPTIVE ===
+live objects after dropping source: 1
+k1 class=Tracked tag=obj
+k2 deep=value n=7
+stored n after mutating the read copy: 7
+live objects after dropping destination: 0
+=== repeated merges keep the object count exact ===
+round 0 live after source freed: 200
+round 0 live after destination freed: 0
+round 1 live after source freed: 200
+round 1 live after destination freed: 0
+round 2 live after source freed: 200
+round 2 live after destination freed: 0
+=== PHP heap does not grow across merge rounds ===
+heap grew past the settled baseline: false
+live objects at end: 0
+Done.

--- a/tests/merge_with_reentrancy_001.phpt
+++ b/tests/merge_with_reentrancy_001.phpt
@@ -1,0 +1,123 @@
+--TEST--
+Judy mergeWith() - a MIXED destructor that re-enters mid-merge cannot leave a stale slot
+--DESCRIPTION--
+Issue #121: the merge loop now holds a live value-slot pointer from its own
+cursor. Writing into the destination releases whatever value that key held,
+which for a MIXED type runs a user destructor, which can mutate — or free
+outright — either array. The value is therefore materialised into a zval BEFORE
+the write, and neither the cursor slot nor the resolved value slot is
+dereferenced across it; JLN/JSLN re-descends from the key instead. These cases
+exercise both, on the integer and on all three string layouts.
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+class Harness { public static $src = null; public static $dst = null; public static array $log = []; }
+
+function report(string $label, Judy $j): void {
+    $out = [];
+    foreach ($j->keys() as $k) {
+        $v = $j[$k];
+        $out[] = (is_int($k) ? $k : "'$k'") . '=>' . (is_object($v) ? get_class($v) : var_export($v, true));
+    }
+    echo "$label count=" . count($j) . " {" . implode(', ', $out) . "}\n";
+}
+
+/* The destructor deletes a not-yet-visited source key, appends a source key
+   that sorts after the cursor, and writes into the destination. */
+class Mutator {
+    public function __construct(public string $tag, public $del, public $add) {}
+    public function __destruct() {
+        $s = Harness::$src; $d = Harness::$dst;
+        if ($s !== null) { unset($s[$this->del]); $s[$this->add] = 'added-by-dtor'; }
+        if ($d !== null) { $d[$this->add] = 'added-by-dtor'; }
+        Harness::$log[] = "dtor({$this->tag})";
+    }
+}
+
+foreach ([
+    ['INT_TO_MIXED', Judy::INT_TO_MIXED, [1, 2, 3, 4, 5], 3, 4, 99],
+    ['STRING_TO_MIXED', Judy::STRING_TO_MIXED, ['aa','bb','cc','dd','ee'], 'cc', 'dd', 'zzz'],
+    ['STRING_TO_MIXED_HASH', Judy::STRING_TO_MIXED_HASH, ['aa','bb','cc','dd','ee'], 'cc', 'dd', 'zzz'],
+    ['STRING_TO_MIXED_ADAPTIVE', Judy::STRING_TO_MIXED_ADAPTIVE, ['aa','bb','cc','dd_long_key','ee'], 'cc', 'dd_long_key', 'zzz_long_key'],
+] as [$name, $type, $keys, $hot, $del, $add]) {
+    echo "=== destructor mutates both arrays, $name ===\n";
+    Harness::$log = [];
+    $src = new Judy($type);
+    foreach ($keys as $k) { $src[$k] = "src-$k"; }
+    $dst = new Judy($type);
+    $dst[$hot] = new Mutator((string)$hot, $del, $add);
+    Harness::$src = $src; Harness::$dst = $dst;
+    $dst->mergeWith($src);
+    Harness::$src = null; Harness::$dst = null;
+    echo "log: " . implode(',', Harness::$log) . "\n";
+    report('src', $src);
+    report('dst', $dst);
+    unset($src, $dst);
+}
+
+/* The harshest case: the destructor frees the whole source store while the
+   merge loop is standing on it. The value for the key being written was
+   materialised before the destructor ran, so it must still land. */
+class Nuke {
+    public function __destruct() {
+        if (Harness::$src !== null) { Harness::$src->free(); Harness::$log[] = 'freed-source'; }
+    }
+}
+foreach ([
+    ['INT_TO_MIXED', Judy::INT_TO_MIXED, [1,2,3,4,5], 3],
+    ['STRING_TO_MIXED', Judy::STRING_TO_MIXED, ['aa','bb','cc','dd','ee'], 'cc'],
+    ['STRING_TO_MIXED_HASH', Judy::STRING_TO_MIXED_HASH, ['aa','bb','cc','dd','ee'], 'cc'],
+    ['STRING_TO_MIXED_ADAPTIVE', Judy::STRING_TO_MIXED_ADAPTIVE, ['aa','bb','cc_long_key','dd','ee'], 'cc_long_key'],
+] as [$name, $type, $keys, $hot]) {
+    echo "=== destructor frees the source mid-merge, $name ===\n";
+    Harness::$log = [];
+    $src = new Judy($type);
+    foreach ($keys as $k) { $src[$k] = "src-$k"; }
+    $dst = new Judy($type);
+    $dst[$hot] = new Nuke();
+    Harness::$src = $src; Harness::$dst = $dst;
+    $dst->mergeWith($src);
+    Harness::$src = null; Harness::$dst = null;
+    echo "log: " . implode(',', Harness::$log) . "\n";
+    report('src', $src);
+    report('dst', $dst);
+    unset($src, $dst);
+}
+
+echo "Done.\n";
+?>
+--EXPECT--
+=== destructor mutates both arrays, INT_TO_MIXED ===
+log: dtor(3)
+src count=5 {1=>'src-1', 2=>'src-2', 3=>'src-3', 5=>'src-5', 99=>'added-by-dtor'}
+dst count=5 {1=>'src-1', 2=>'src-2', 3=>'src-3', 5=>'src-5', 99=>'added-by-dtor'}
+=== destructor mutates both arrays, STRING_TO_MIXED ===
+log: dtor(cc)
+src count=5 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc'=>'src-cc', 'ee'=>'src-ee', 'zzz'=>'added-by-dtor'}
+dst count=5 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc'=>'src-cc', 'ee'=>'src-ee', 'zzz'=>'added-by-dtor'}
+=== destructor mutates both arrays, STRING_TO_MIXED_HASH ===
+log: dtor(cc)
+src count=5 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc'=>'src-cc', 'ee'=>'src-ee', 'zzz'=>'added-by-dtor'}
+dst count=5 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc'=>'src-cc', 'ee'=>'src-ee', 'zzz'=>'added-by-dtor'}
+=== destructor mutates both arrays, STRING_TO_MIXED_ADAPTIVE ===
+log: dtor(cc)
+src count=5 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc'=>'src-cc', 'ee'=>'src-ee', 'zzz_long_key'=>'added-by-dtor'}
+dst count=5 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc'=>'src-cc', 'ee'=>'src-ee', 'zzz_long_key'=>'added-by-dtor'}
+=== destructor frees the source mid-merge, INT_TO_MIXED ===
+log: freed-source
+src count=0 {}
+dst count=3 {1=>'src-1', 2=>'src-2', 3=>'src-3'}
+=== destructor frees the source mid-merge, STRING_TO_MIXED ===
+log: freed-source
+src count=0 {}
+dst count=3 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc'=>'src-cc'}
+=== destructor frees the source mid-merge, STRING_TO_MIXED_HASH ===
+log: freed-source
+src count=0 {}
+dst count=3 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc'=>'src-cc'}
+=== destructor frees the source mid-merge, STRING_TO_MIXED_ADAPTIVE ===
+log: freed-source
+src count=0 {}
+dst count=3 {'aa'=>'src-aa', 'bb'=>'src-bb', 'cc_long_key'=>'src-cc_long_key'}
+Done.

--- a/tests/merge_with_slot_reuse_001.phpt
+++ b/tests/merge_with_slot_reuse_001.phpt
@@ -1,0 +1,284 @@
+--TEST--
+Judy mergeWith() - contents are exact for every type, with and without optimizeIteration
+--DESCRIPTION--
+Regression guard for issue #121: mergeWith() materialises each value from the
+value slot its own cursor is already standing on instead of descending from the
+root a second time. The conversion differs per type (packed representation,
+refcounted zval*, plain word) and for the *_HASH / *_ADAPTIVE types the cursor
+walks key_index, whose slot is only the value when optimizeIteration mirrored
+the payload into it. This asserts the merged contents byte for byte on all ten
+types, both mirror settings, short and long ADAPTIVE keys, and high-byte keys.
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+function fmt($v) {
+    if (is_array($v)) return 'array' . json_encode($v);
+    if (is_object($v)) return get_class($v) . json_encode(get_object_vars($v));
+    // Keep the expectation block ASCII: high-byte payloads print as hex.
+    if (is_string($v) && preg_match('/[^\\x20-\\x7e]/', $v)) return 'hex:' . bin2hex($v);
+    return var_export($v, true);
+}
+function k($k) { return is_int($k) ? (string)$k : "'" . bin2hex($k) . "'"; }
+function show(string $label, Judy $j): void {
+    echo $label . " count=" . count($j) . " optimized=" . var_export($j->isIterationOptimized(), true) . "\n";
+    foreach ($j->keys() as $key) {
+        echo "  " . k($key) . " => " . fmt($j[$key]) . "\n";
+    }
+}
+
+echo "=== BITSET ===\n";
+$d = new Judy(Judy::BITSET); $d[1] = true; $d[2] = true;
+$s = new Judy(Judy::BITSET); $s[2] = true; $s[9] = true;
+$d->mergeWith($s); show("dst", $d); show("src", $s);
+
+echo "=== INT_TO_INT ===\n";
+$d = new Judy(Judy::INT_TO_INT); $d[1] = 10; $d[2] = 20;
+$s = new Judy(Judy::INT_TO_INT); $s[2] = 222; $s[-1] = 7;
+$d->mergeWith($s); show("dst", $d); show("src", $s);
+
+echo "=== INT_TO_PACKED ===\n";
+$d = new Judy(Judy::INT_TO_PACKED); $d[1] = 'keep'; $d[2] = 'gone';
+$s = new Judy(Judy::INT_TO_PACKED);
+$s[2] = 3.5; $s[3] = PHP_INT_MIN; $s[4] = true; $s[5] = false; $s[6] = null;
+$s[7] = 'a string'; $s[8] = [1, 'x' => 2];
+$d->mergeWith($s); show("dst", $d); show("src", $s);
+
+echo "=== INT_TO_MIXED ===\n";
+$d = new Judy(Judy::INT_TO_MIXED); $d[1] = 'keep'; $d[2] = 'gone';
+$s = new Judy(Judy::INT_TO_MIXED); $s[2] = ['a' => 1]; $s[3] = (object)['p' => 9]; $s[4] = null; $s[5] = 1.25;
+$d->mergeWith($s); show("dst", $d); show("src", $s);
+
+foreach ([
+    ['STRING_TO_INT', Judy::STRING_TO_INT, false],
+    ['STRING_TO_MIXED', Judy::STRING_TO_MIXED, false],
+    ['STRING_TO_INT_HASH', Judy::STRING_TO_INT_HASH, false],
+    ['STRING_TO_INT_HASH opt', Judy::STRING_TO_INT_HASH, true],
+    ['STRING_TO_MIXED_HASH', Judy::STRING_TO_MIXED_HASH, false],
+    ['STRING_TO_MIXED_HASH opt', Judy::STRING_TO_MIXED_HASH, true],
+    ['STRING_TO_INT_ADAPTIVE', Judy::STRING_TO_INT_ADAPTIVE, false],
+    ['STRING_TO_INT_ADAPTIVE opt', Judy::STRING_TO_INT_ADAPTIVE, true],
+    ['STRING_TO_MIXED_ADAPTIVE', Judy::STRING_TO_MIXED_ADAPTIVE, false],
+    ['STRING_TO_MIXED_ADAPTIVE opt', Judy::STRING_TO_MIXED_ADAPTIVE, true],
+] as [$name, $type, $opt]) {
+    echo "=== $name ===\n";
+    $mixed = str_contains($name, 'MIXED');
+    $d = new Judy($type, optimizeIteration: $opt);
+    $s = new Judy($type, optimizeIteration: $opt);
+    // 'ab' is below the ADAPTIVE SSO boundary, the others are at or above it.
+    $d['ab'] = $mixed ? 'keep-short' : 1;
+    $d['a_long_key_here'] = $mixed ? 'keep-long' : 2;
+    $d['zz'] = $mixed ? 'gone' : 3;
+    $s['zz'] = $mixed ? ['ov' => 1] : 33;
+    $s['a_much_longer_key'] = $mixed ? "\xff\xfe binary" : 44;
+    $s["\xffhi"] = $mixed ? 5.5 : 55;
+    $d->mergeWith($s);
+    show("dst", $d);
+    show("src", $s);
+}
+
+echo "=== empty source ===\n";
+$d = new Judy(Judy::INT_TO_MIXED); $d[1] = 'x';
+$d->mergeWith(new Judy(Judy::INT_TO_MIXED)); show("dst", $d);
+$d = new Judy(Judy::STRING_TO_MIXED_HASH); $d['k'] = 'x';
+$d->mergeWith(new Judy(Judy::STRING_TO_MIXED_HASH)); show("dst", $d);
+
+echo "=== empty destination ===\n";
+$s = new Judy(Judy::INT_TO_PACKED); $s[5] = 'v';
+$d = new Judy(Judy::INT_TO_PACKED); $d->mergeWith($s); show("dst", $d);
+$s = new Judy(Judy::STRING_TO_INT_ADAPTIVE, optimizeIteration: true); $s['aaaaaaaaaa'] = 1; $s['bb'] = 2;
+$d = new Judy(Judy::STRING_TO_INT_ADAPTIVE, optimizeIteration: true); $d->mergeWith($s); show("dst", $d);
+
+echo "=== self merge guard ===\n";
+$d = new Judy(Judy::STRING_TO_MIXED); $d['a'] = 1;
+$d->mergeWith($d); show("dst", $d);
+
+echo "=== cross-type merge (source drives conversion) ===\n";
+$d = new Judy(Judy::INT_TO_MIXED); $d[1] = 'x';
+$s = new Judy(Judy::INT_TO_INT); $s[1] = 9; $s[2] = 8;
+$d->mergeWith($s); show("dst", $d);
+$d = new Judy(Judy::INT_TO_INT); $d[1] = 1;
+$s = new Judy(Judy::BITSET); $s[3] = true;
+$d->mergeWith($s); show("dst", $d);
+
+echo "Done.\n";
+?>
+--EXPECT--
+=== BITSET ===
+dst count=3 optimized=false
+  1 => true
+  2 => true
+  9 => true
+src count=2 optimized=false
+  2 => true
+  9 => true
+=== INT_TO_INT ===
+dst count=3 optimized=false
+  1 => 10
+  2 => 222
+  -1 => 7
+src count=2 optimized=false
+  2 => 222
+  -1 => 7
+=== INT_TO_PACKED ===
+dst count=8 optimized=false
+  1 => 'keep'
+  2 => 3.5
+  3 => -9223372036854775807-1
+  4 => true
+  5 => false
+  6 => NULL
+  7 => 'a string'
+  8 => array{"0":1,"x":2}
+src count=7 optimized=false
+  2 => 3.5
+  3 => -9223372036854775807-1
+  4 => true
+  5 => false
+  6 => NULL
+  7 => 'a string'
+  8 => array{"0":1,"x":2}
+=== INT_TO_MIXED ===
+dst count=5 optimized=false
+  1 => 'keep'
+  2 => array{"a":1}
+  3 => stdClass{"p":9}
+  4 => NULL
+  5 => 1.25
+src count=4 optimized=false
+  2 => array{"a":1}
+  3 => stdClass{"p":9}
+  4 => NULL
+  5 => 1.25
+=== STRING_TO_INT ===
+dst count=5 optimized=false
+  '615f6c6f6e675f6b65795f68657265' => 2
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '6162' => 1
+  '7a7a' => 33
+  'ff6869' => 55
+src count=3 optimized=false
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '7a7a' => 33
+  'ff6869' => 55
+=== STRING_TO_MIXED ===
+dst count=5 optimized=false
+  '615f6c6f6e675f6b65795f68657265' => 'keep-long'
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '6162' => 'keep-short'
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+src count=3 optimized=false
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+=== STRING_TO_INT_HASH ===
+dst count=5 optimized=false
+  '615f6c6f6e675f6b65795f68657265' => 2
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '6162' => 1
+  '7a7a' => 33
+  'ff6869' => 55
+src count=3 optimized=false
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '7a7a' => 33
+  'ff6869' => 55
+=== STRING_TO_INT_HASH opt ===
+dst count=5 optimized=true
+  '615f6c6f6e675f6b65795f68657265' => 2
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '6162' => 1
+  '7a7a' => 33
+  'ff6869' => 55
+src count=3 optimized=true
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '7a7a' => 33
+  'ff6869' => 55
+=== STRING_TO_MIXED_HASH ===
+dst count=5 optimized=false
+  '615f6c6f6e675f6b65795f68657265' => 'keep-long'
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '6162' => 'keep-short'
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+src count=3 optimized=false
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+=== STRING_TO_MIXED_HASH opt ===
+dst count=5 optimized=false
+  '615f6c6f6e675f6b65795f68657265' => 'keep-long'
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '6162' => 'keep-short'
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+src count=3 optimized=false
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+=== STRING_TO_INT_ADAPTIVE ===
+dst count=5 optimized=false
+  '615f6c6f6e675f6b65795f68657265' => 2
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '6162' => 1
+  '7a7a' => 33
+  'ff6869' => 55
+src count=3 optimized=false
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '7a7a' => 33
+  'ff6869' => 55
+=== STRING_TO_INT_ADAPTIVE opt ===
+dst count=5 optimized=true
+  '615f6c6f6e675f6b65795f68657265' => 2
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '6162' => 1
+  '7a7a' => 33
+  'ff6869' => 55
+src count=3 optimized=true
+  '615f6d7563685f6c6f6e6765725f6b6579' => 44
+  '7a7a' => 33
+  'ff6869' => 55
+=== STRING_TO_MIXED_ADAPTIVE ===
+dst count=5 optimized=false
+  '615f6c6f6e675f6b65795f68657265' => 'keep-long'
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '6162' => 'keep-short'
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+src count=3 optimized=false
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+=== STRING_TO_MIXED_ADAPTIVE opt ===
+dst count=5 optimized=false
+  '615f6c6f6e675f6b65795f68657265' => 'keep-long'
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '6162' => 'keep-short'
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+src count=3 optimized=false
+  '615f6d7563685f6c6f6e6765725f6b6579' => hex:fffe2062696e617279
+  '7a7a' => array{"ov":1}
+  'ff6869' => 5.5
+=== empty source ===
+dst count=1 optimized=false
+  1 => 'x'
+dst count=1 optimized=false
+  '6b' => 'x'
+=== empty destination ===
+dst count=1 optimized=false
+  5 => 'v'
+dst count=2 optimized=true
+  '61616161616161616161' => 1
+  '6262' => 2
+=== self merge guard ===
+dst count=1 optimized=false
+  '61' => 1
+=== cross-type merge (source drives conversion) ===
+dst count=2 optimized=false
+  1 => 9
+  2 => 8
+dst count=2 optimized=false
+  1 => 1
+  3 => 1
+Done.


### PR DESCRIPTION
Fixes #121.

## What changed

`judy_object_merge_with_helper()` held a live pointer to the value slot from
its own `JLF`/`JLN` (or `JSLF`/`JSLN`) cursor, used it only as a loop
condition, and then called `judy_object_read_dimension_helper_zv()` — a
second, full, type-dispatched descend from the root for the key it was
already standing on. Three descends per merged element where two suffice.

The slot-to-`zval` conversion is factored out of
`judy_object_read_dimension_helper()` into `judy_value_from_slot()`, so the
descending path and the cursor path share one conversion and cannot drift.
The merge loop calls it directly.

## Which types reuse the cursor pointer, and which keep the fallback

| Type | Cursor walks | Reuse? |
| ---- | ------------ | ------ |
| `INT_TO_INT`, `INT_TO_PACKED`, `INT_TO_MIXED` | `array` (the value store) | yes |
| `STRING_TO_INT`, `STRING_TO_MIXED` | `array` (the trie holds the value) | yes |
| `*_HASH` / `*_ADAPTIVE`, `JUDY_MIRRORS_PAYLOAD()` holds | `key_index`, payload mirrored into it | yes |
| `*_HASH` / `*_ADAPTIVE`, no mirror | `key_index` | **no** — `judy_string_value_slot()` lookup kept |
| `BITSET` | — | unchanged, its branch reads no value |

The unmirrored `*_HASH` / `*_ADAPTIVE` fallback is deliberate: those cursors
walk `key_index`, whose slot is not the value, so there is nothing safe to
reuse. `JUDY_MIRRORS_PAYLOAD()` is only true on an `optimizeIteration`
instance of `STRING_TO_INT_HASH` or long-keyed `STRING_TO_INT_ADAPTIVE`
(the `_MIXED` variants never mirror), so the default-constructed and
`_MIXED` cases still pay the second lookup — this PR does not change that.

## Re-entrancy

Writing into the destination releases whatever the key held, which for a
`_MIXED` type runs a user destructor, which can mutate or `free()` the
source. So:

- the value is materialised into a `zval` **before** the write
  (`ZVAL_COPY` for `_MIXED`, so it owns a reference and survives the source
  being destroyed);
- neither the cursor slot nor the resolved value slot is dereferenced across
  the write — `JLN`/`JSLN` re-descends from the key;
- the string branch's private-cursor buffer is untouched and still
  load-bearing for the same reason.

## Performance

**Unmeasured, deliberately.** The redundant descend is removed; no number is
claimed. The work was done on a shared, loaded machine, so any local timing
would be contention noise. This needs a run on an idle host before anything
is said about the `mergeWith()` deficit recorded in `BENCHMARK.md`.
`BENCHMARK.md` and `baselines/latest.json` are untouched.

## Tests

Three new `.phpt` files, all added to `package.xml`. All three also pass
against the pre-change build — this has to be behaviour-preserving, and they
are written to fail if it is not.

- `tests/merge_with_slot_reuse_001.phpt` — exact merged contents on all ten
  types, both `optimizeIteration` settings, short and long `ADAPTIVE` keys,
  high-byte keys, negative integer keys, packed values of every tag, empty
  source, empty destination, self-merge guard, overwrite semantics,
  cross-type merges.
- `tests/merge_with_mixed_refcount_001.phpt` — `INT_TO_MIXED` /
  `STRING_TO_MIXED` / `STRING_TO_MIXED_HASH` / `STRING_TO_MIXED_ADAPTIVE`:
  the destination survives the source being dropped, tracked objects are
  destroyed exactly once, and the PHP heap stays flat across repeated merge
  rounds.
- `tests/merge_with_reentrancy_001.phpt` — a `_MIXED` destructor that deletes
  a not-yet-visited source key, appends one after the cursor and writes into
  the destination, plus one that `free()`s the source outright mid-merge, on
  `INT_TO_MIXED` and all three string `_MIXED` layouts.

## Verification

- 214/214 on the default build (macOS, PHP 8.5) and on
  `--enable-judy-debug-mirror`; zero compiler warnings on both.
- The new tests also pass on Linux / PHP 8.4 in the container below, so the
  expectations are not platform-specific.
- Valgrind (`USE_ZEND_ALLOC=0`, `--leak-check=full --show-leak-kinds=definite,indirect,possible --track-origins=yes`)
  over a stress script covering every type, both mirror settings and every
  re-entrancy case: **0 errors, 0 leaks, all heap blocks freed**
  (181,232 allocs / 181,232 frees).

## Not in scope

`intersect()` / `diff()` / `xor()` have the same shape — they hold a cursor
and then call the read helper. `union()` already benefits, since it routes
through this helper. The set-op loops are left for a follow-up rather than
widened here.
