### PR TITLE
fix(research): make probebench honour keylen, unblocking the SSO probe

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -31,7 +31,47 @@ gcc -O2 -Wall -Wextra -o iterbench research/iteration-cost/iterbench.c -lJudy
 gcc -O2 -Wall -Wextra -o probebench research/write-probe-cost/probebench.c -lJudy
 ./probebench 1000000 16 5       # n, key length, reps; keylen < 8 adds the
                                 # ADAPTIVE short-string (SSO) probe
+./probebench 200000 6 5         # the SSO probe itself
 
 # shm-arena
 cd research/shm-arena && make && make run
 ```
+
+## probebench key shapes
+
+`probebench` emits two different key shapes, split at `keylen = 16`:
+
+- **`keylen >= 16`** — `user:00001234:f5` padded with `x`, the same shape as
+  `iteration-cost/iterbench.c`, so those figures sit next to the ones in
+  [#85](https://github.com/orieg/php-judy/issues/85). Ten keys share each
+  `user:` prefix.
+- **`keylen < 16`** — a fixed-width base-36 counter filling exactly `keylen`
+  bytes. The long format is 16 characters at minimum and cannot be squeezed
+  shorter while staying unique, so a second shape is required to reach the
+  short-key regime at all.
+
+The boundary matters when reading results: a `keylen = 6` run and a
+`keylen = 16` run differ in key *shape* as well as key *length*, so trie depth
+and fan-out are not directly comparable across it. Within a regime they are.
+
+Before [#118](https://github.com/orieg/php-judy/issues/118) the short shape did
+not exist: `make_key()` only padded up, never truncated, so every `keylen`
+below 16 silently produced a 16-byte key, and the SSO branch then copied 16
+bytes into an 8-byte `Word_t` and aborted. **The `JLG hit (SSO packed)` row had
+therefore never been produced**; any pre-#118 note claiming a number for it is
+wrong.
+
+## Reading probebench's absolute numbers
+
+The ns/op figures include real harness overhead and should not be quoted as
+pure Judy cost. On a 1,000,000 x 16-byte run, `__strlen_avx2` and
+`__strcpy_avx2` over the key array account for ~31% of the run's DRAM misses,
+and `snprintf` in `make_key` for ~7% of instructions.
+
+*Relative* comparisons are unaffected — the harness is identical across the
+configurations being compared, which is what the flag-matrix study on
+[#113](https://github.com/orieg/php-judy/issues/113) relies on.
+
+As with every benchmark in this repo, check machine load before believing a
+number: a load average above cores/2, or any non-target process over ~50% CPU,
+makes the run uninterpretable.

--- a/research/write-probe-cost/probebench.c
+++ b/research/write-probe-cost/probebench.c
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <time.h>
 #include <Judy.h>
 
@@ -56,19 +57,57 @@ static double med(double *v, int k) { qsort(v, k, sizeof(double), cmpd); return 
 #define MAXK 128
 #define MAXREPS 64
 
-/* Same key shape as research/iteration-cost/iterbench.c, so the numbers here
- * sit next to the ones already in issue #85: "user:00001234:f5" padded with
- * 'x' to keylen. 10 keys share each user: prefix. */
+/* The long format is at minimum 16 characters ("user:" + 8 digits + ":f" +
+ * 1 digit), so it cannot express a shorter key at all. Keys below that width
+ * therefore use a different shape: a fixed-width base-36 counter, which fills
+ * exactly keylen bytes and stays unique. Two regimes, one boundary. */
+#define LONGKEY_MIN 16
+#define KEY_RADIX 36
+static const char key_alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/* Absent keys are drawn from an index range disjoint from the populated one.
+ * The long regime has room to spare; the short regime does not, so it offsets
+ * by n and main() checks the space is big enough. */
+#define ABSENT_OFFSET_LONG 500000000UL
+
+/* keylen >= LONGKEY_MIN keeps the exact shape of
+ * research/iteration-cost/iterbench.c, so those numbers still sit next to the
+ * ones in issue #85: "user:00001234:f5" padded with 'x'. 10 keys share each
+ * user: prefix.
+ *
+ * keylen < LONGKEY_MIN emits base-36 of i, zero-padded to exactly keylen. This
+ * is what makes the ADAPTIVE/SSO probe (keylen < 8) reachable: before, the
+ * format's 16 characters were emitted regardless of keylen, so every keylen
+ * below 16 silently produced a 16-byte key and the SSO branch then memcpy'd
+ * 16 bytes into an 8-byte Word_t. See issue #118. */
 static void make_key(char *buf, unsigned long i, int keylen) {
-    int m = snprintf(buf, MAXK, "user:%08lu:f%lu", i / 10, i % 10);
-    while (m < keylen) buf[m++] = 'x';
-    buf[m] = '\0';
+    if (keylen >= LONGKEY_MIN) {
+        int m = snprintf(buf, MAXK, "user:%08lu:f%lu", i / 10, i % 10);
+        while (m < keylen) buf[m++] = 'x';
+        buf[m] = '\0';
+        return;
+    }
+    for (int p = keylen - 1; p >= 0; p--) {
+        buf[p] = key_alphabet[i % KEY_RADIX];
+        i /= KEY_RADIX;
+    }
+    buf[keylen] = '\0';
 }
 
-/* Absent keys with the same shape and the same trie depth, drawn from an
- * index range disjoint from the populated one. */
-static void make_absent_key(char *buf, unsigned long i, int keylen) {
-    make_key(buf, i + 500000000UL, keylen);
+static void make_absent_key(char *buf, unsigned long i, int keylen, unsigned long n) {
+    make_key(buf, i + (keylen >= LONGKEY_MIN ? ABSENT_OFFSET_LONG : n), keylen);
+}
+
+/* How many distinct keys the short regime can express, saturating rather than
+ * overflowing. Used to reject a (n, keylen) pair that cannot hold n present
+ * plus n absent keys without collisions. */
+static unsigned long short_key_space(int keylen) {
+    unsigned long cap = 1;
+    for (int p = 0; p < keylen; p++) {
+        if (cap > ULONG_MAX / KEY_RADIX) return ULONG_MAX;
+        cap *= KEY_RADIX;
+    }
+    return cap;
 }
 
 static unsigned long xs(unsigned long *s) {
@@ -85,6 +124,20 @@ int main(int argc, char **argv) {
 
     if (reps > MAXREPS) reps = MAXREPS;
     if (keylen >= MAXK - 1) { fprintf(stderr, "keylen too large\n"); return 1; }
+    if (keylen < 1) { fprintf(stderr, "keylen must be >= 1\n"); return 1; }
+    /* The short regime encodes the index in base-36 across keylen bytes, so it
+     * can only express so many distinct keys. n present + n absent must fit,
+     * or keys collide and every number below is meaningless. */
+    if (keylen < LONGKEY_MIN) {
+        unsigned long cap = short_key_space(keylen);
+        if (cap / 2 < n) {
+            fprintf(stderr,
+                "keylen %d holds only %lu distinct keys; need %lu "
+                "(n present + n absent). Raise keylen or lower n.\n",
+                keylen, cap, 2 * n);
+            return 1;
+        }
+    }
 
     /* sl  = the JudySL key_index (B3 would store the payload in its value word)
      * hs  = the JudyHS value store used by *_INT_HASH and by ADAPTIVE long keys
@@ -102,7 +155,9 @@ int main(int argc, char **argv) {
         *pv = i + 1;
         if (sso) {
             Word_t idx = 0;
-            memcpy(&idx, key, strlen(key));
+            size_t kl = strlen(key);
+            if (kl > sizeof(Word_t)) kl = sizeof(Word_t);   /* defensive: see #118 */
+            memcpy(&idx, key, kl);
             JLI(pv, jl, idx);
             if (pv == PJERR) { fprintf(stderr, "JLI OOM\n"); return 1; }
             *pv = i + 1;
@@ -126,7 +181,7 @@ int main(int argc, char **argv) {
         if (c != n) { fprintf(stderr, "walk got %lu of %lu\n", c, n); return 1; }
     }
     for (unsigned long i = 0; i < n; i++) {
-        make_absent_key(absent + (size_t)i * MAXK, i, keylen);
+        make_absent_key(absent + (size_t)i * MAXK, i, keylen, n);
         /* sanity: must really be absent */
         if (i < 4) {
             PWord_t chk;
@@ -191,8 +246,11 @@ int main(int argc, char **argv) {
             t0 = now_ns();
             for (unsigned long i = 0; i < n; i++) {
                 Word_t idx = 0;
+                size_t kl;
                 k = keys + (size_t)order[i] * MAXK;
-                memcpy(&idx, k, strlen(k));
+                kl = strlen(k);
+                if (kl > sizeof(Word_t)) kl = sizeof(Word_t);   /* defensive: see #118 */
+                memcpy(&idx, k, kl);
                 JLG(pv, jl, idx);
                 if (pv) sink += *pv;
             }


### PR DESCRIPTION
Closes #118.

## The defect is wider than the crash

`probebench` aborted for `keylen < 8`. But `make_key()` only padded up, never truncated, and its format is **16 characters at minimum** (`user:` + 8 digits + `:f` + a digit). So *every* `keylen` below 16 silently produced a 16-byte key — `keylen` wasn't merely mishandled under 8, it was **ignored under 16**. Below 8 the SSO branch then copied those 16 bytes into an 8-byte `Word_t` and tripped the stack protector.

So the `JLG hit (SSO packed)` row the harness exists to produce had never been generated, and any `keylen` between 8 and 15 was quietly measuring 16-byte keys.

## Why not just truncate

Cutting the long format short destroys uniqueness — at 10 bytes, `user:0000…` collides across most of the index range. Keys now come in two shapes, split at `keylen = 16`:

| Regime | Shape |
| --- | --- |
| `keylen >= 16` | existing format, **byte for byte unchanged** — figures stay comparable with #85 |
| `keylen < 16` | fixed-width base-36 counter filling exactly `keylen` bytes |

Also added:

- **A capacity guard.** Base-36 over few bytes runs out; a `(n, keylen)` pair that can't hold *n* present plus *n* absent keys is now rejected with the numbers rather than silently colliding and producing meaningless timings.
- **Regime-aware absent-key offset.** The long regime's `+500e6` exceeds the short regime's entire key space at `keylen <= 5`.
- **Both SSO `memcpy` sites clamp** to `sizeof(Word_t)` defensively.

## Verification

Tested against the **real** `make_key` by including the translation unit, not a reimplementation:

```
exact length for keylen 1..24:                    OK
present+absent unique, keylen 4..15:              OK
keylen>=16 byte-identical to historical shape:    OK   (differential vs the original, 5000 indices)
keylen<8 fits Word_t:                             OK
```

The issue's repro `./probebench 200000 6 1`:

| | |
| --- | --- |
| before | **abort**, exit 133 |
| after | exit 0, emits the SSO row |

Compiler warnings unchanged from baseline (2, both from Judy.h's own `JSLFA`/`JHSFA` macros).

## What this PR deliberately does NOT contain

**An actual SSO measurement.** The machine was at load average **4.47 on 8 cores**, WindowServer at 42%, two Electron apps above 20% — over this repo's own contamination threshold. Any number taken here would be uninterpretable, so none is quoted. The row still needs a run on a quiet machine.

This is the point worth not glossing: the fix makes the probe *runnable*, it does not make the measurement *exist*.

## Docs

`research/README.md` now documents the two key shapes and the boundary (relevant when reading results — a `keylen = 6` run differs from a `keylen = 16` run in shape as well as length, so trie depth isn't comparable across it), states that any pre-#118 claim of an SSO figure is wrong, and records the harness overhead from the issue's second observation: ~31% of DRAM misses in `strlen`/`strcpy` over the key array, ~7% of instructions in `snprintf`. Absolute ns/op is not pure Judy cost; relative comparisons are unaffected, which is what #113's flag-matrix study relies on.

## Scope

`research/` is not shipped — no `package.xml` change, and no `.phpt`, since this is a standalone C harness rather than extension behaviour. The extension is untouched; confirmed it still builds and loads (`judy 2.5.1`).