### PR TITLE
docs(api): put the toArray() coercion warning in API.md, where it was missing

### DIFF
--- a/API.md
+++ b/API.md
@@ -433,6 +433,14 @@ public function toArray(mixed $start = null, mixed $end = null): array
 
 Converts the Judy array to a PHP array. Uses native C iteration internally, 2-3x faster than manual `foreach`. With `$start` and/or `$end`, only the inclusive `[$start, $end]` key range is returned; `null` leaves that side unbounded.
 
+**On string-keyed types, a key that looks like an integer comes back as one.** The result is a PHP array, and PHP array keys cannot hold the string `"42"` — a canonical decimal integer within `PHP_INT` range is coerced, so `"42"` and `"-7"` return as `int`, while `"07"`, `"-0"`, `" 42"`, `"4.0"` and out-of-range values stay strings. Feeding such a key straight back into the array throws `TypeError`, because a string-keyed Judy rejects an integer offset:
+
+```php
+foreach ($judy->toArray() as $k => $v) { unset($judy[$k]); }  // TypeError
+```
+
+`keys()` does not coerce — it returns every key as a string. Use it when keys need to round-trip, or cast with `(string)` when iterating `toArray()`.
+
 **Supported types**: All types. String-keyed types require string bounds and compare them lexicographically.
 
 ```php

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,15 @@ Single test: `make test TESTS=tests/<name>.phpt`. Failures leave
 - **`Judy.stub.php` is the canonical API definition.** After changing it,
   regenerate arginfo and run `php scripts/generate-api-docs.php` (CI gates
   `API.md` freshness). Keep AGENTS.md's type table in sync for API changes.
+- **A stub docblock edit does NOT reach `API.md` on its own.** The generator
+  prefers the `description` in `scripts/api-metadata.php` and only falls back to
+  the stub PHPDoc when there isn't one — and 33 methods have one. So prose meant
+  for readers of `API.md` must be added *there*, not just to the stub. The
+  freshness gate cannot catch this: regeneration reproduces the committed file
+  byte-for-byte and `--check` passes, which is exactly how #116's `toArray()`
+  coercion warning reached the stub and AGENTS.md but never `API.md`.
+  **Verify `git diff --stat API.md` shows a change, rather than trusting the
+  gate.**
 - **Version lockstep**: `PHP_JUDY_VERSION` in `php_judy.h` == version in
   `package.xml`. Full release checklist: README.md "Releasing" section.
 - **`package.xml` lists every shipped file** — adding/moving tests, examples,

--- a/scripts/api-metadata.php
+++ b/scripts/api-metadata.php
@@ -7,6 +7,16 @@
  * This file provides everything else: type groupings, examples,
  * supported-type annotations, behavioral notes, and the compatibility matrix.
  */
+/*
+ * NOTE ON PRECEDENCE: generate-api-docs.php prefers a 'description' here over
+ * the method's PHPDoc in Judy.stub.php, falling back to the stub only when no
+ * description is set. A method listed here with a description therefore takes
+ * ALL of its API.md prose from this file — editing its stub docblock changes
+ * IDE/PHPStan output and nothing else. Add reader-facing warnings in both
+ * places, and confirm API.md actually changed rather than trusting
+ * `generate-api-docs.php --check`, which passes whenever the committed file
+ * matches what regeneration produces.
+ */
 return [
     // ── Document header ─────────────────────────────────────────
     'title' => 'PHP Judy API Reference',
@@ -315,7 +325,10 @@ PHP,
             'example' => '$judy = Judy::fromArray(Judy::INT_TO_INT, [0 => 100, 5 => 200, 10 => 300]);',
         ],
         'toArray' => [
-            'description' => 'Converts the Judy array to a PHP array. Uses native C iteration internally, 2-3x faster than manual `foreach`. With `$start` and/or `$end`, only the inclusive `[$start, $end]` key range is returned; `null` leaves that side unbounded.',
+            'description' => 'Converts the Judy array to a PHP array. Uses native C iteration internally, 2-3x faster than manual `foreach`. With `$start` and/or `$end`, only the inclusive `[$start, $end]` key range is returned; `null` leaves that side unbounded.'
+                . "\n\n" . '**On string-keyed types, a key that looks like an integer comes back as one.** The result is a PHP array, and PHP array keys cannot hold the string `"42"` — a canonical decimal integer within `PHP_INT` range is coerced, so `"42"` and `"-7"` return as `int`, while `"07"`, `"-0"`, `" 42"`, `"4.0"` and out-of-range values stay strings. Feeding such a key straight back into the array throws `TypeError`, because a string-keyed Judy rejects an integer offset:'
+                . "\n\n" . '```php' . "\n" . 'foreach ($judy->toArray() as $k => $v) { unset($judy[$k]); }  // TypeError' . "\n" . '```'
+                . "\n\n" . '`keys()` does not coerce — it returns every key as a string. Use it when keys need to round-trip, or cast with `(string)` when iterating `toArray()`.',
             'supported_types' => 'All types. String-keyed types require string bounds and compare them lexicographically.',
             'example' => <<<'PHP'
 $judy = Judy::fromArray(Judy::INT_TO_INT, [1 => 10, 5 => 50, 10 => 100]);


### PR DESCRIPTION
## The gap

#116 added the numeric-string key-coercion warning to `Judy.stub.php` and `AGENTS.md`, pinned it with a test, and its PR body said API.md was regenerated and the freshness gate passed.

Both statements were true. **The warning still never reached `API.md`** — which is byte-identical between `v2.5.0` and `main`.

## Why the gate couldn't catch it

`generate-api-docs.php` prefers the `description` in `scripts/api-metadata.php` and falls back to the stub PHPDoc only when there isn't one:

```php
// Description: prefer metadata override, fall back to stub PHPDoc
if (!empty($methodMeta['description'])) {
```

`toArray` has one, so its docblock is never consulted. Regeneration reproduced the committed file byte-for-byte, `--check` passed, CI stayed green.

The gate works exactly as written. "Up to date" means *matches what regeneration produces* — not *reflects the stub*. It is blind to this class of drift by construction.

## Why it matters

`API.md` is what `composer.json` advertises as the docs URL. The trap was documented for IDE/PHPStan users (stub) and for agents (`AGENTS.md`), but **not for anyone reading the reference** — and it is the exact bug that broke judy-cache's `prune()`.

## Audit: is `toArray` the only one?

Yes. I checked all 33 methods that have both a metadata description and a stub docblock.

The two texts differing is **normal** — metadata descriptions are independently authored prose, not copies of the stub. The substantive points in the largest gaps (`size`, `memoryUsage`) are already present in `API.md`. `toArray` is the only case where content was added to the stub *and* never mirrored.

On the suggested systemic check: an automated text-drift comparison would be nearly all false positives given that design. My first attempt flagged all 33. **Not worth building** — the fix belongs in the instructions, not the tooling.

## Root cause fixed

`CLAUDE.md` told contributors that changing the stub and running the generator was sufficient. That is what I followed in #116. It now states that a stub edit does **not** reach `API.md` on its own, that reader-facing prose belongs in `api-metadata.php`, and that the real check is `git diff --stat API.md` showing a change rather than the gate passing. `api-metadata.php` carries the same note at the point of use.

## Test plan

- [x] **`API.md` actually changed (+8 lines)** and the `toArray()` section renders the warning — verified by diff, not by the gate
- [x] `generate-api-docs.php --check` passes after regeneration
- [x] `tests/to_array_numeric_key_coercion_001.phpt` still passes
- [x] Warning now present in all three surfaces: `API.md`, `AGENTS.md`, `Judy.stub.php`
- [ ] CI green