### PR TITLE
chore: release v2.5.2

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1332,7 +1332,7 @@ php examples/benchmarks/run-benchmarks-robust.php
 
 Our methodology and insights are informed by the [Rusty Russell benchmark comparison](https://rusty.ozlabs.org/2010/11/08/hashtables-vs-judy-arrays-round-1.html) between hashtables and Judy arrays, which demonstrates Judy's strengths in ordered access patterns and memory efficiency.
 
-**Describes**: php-judy 2.5.1
+**Describes**: php-judy 2.5.2
 **Figures measured on**: 2.4.2, verified unchanged on 2.5.0 (0 regressions, run-wide
 median -0.04%; see Benchmarking Environment)
 **Last Updated**: August 2026

--- a/package.xml
+++ b/package.xml
@@ -19,8 +19,8 @@
    <date>2026-08-18</date>
    <time>00:00:00</time>
    <version>
-      <release>2.5.1</release>
-      <api>2.5.1</api>
+      <release>2.5.2</release>
+      <api>2.5.2</api>
    </version>
    <stability>
       <release>stable</release>
@@ -28,17 +28,24 @@
    </stability>
    <license uri="http://www.php.net/license">PHP</license>
    <notes>
-- FIX: string keys containing an embedded NUL byte are now rejected with an
-  exception on all six string-keyed types, instead of being silently truncated
-  at the NUL. Previously STRING_TO_INT and STRING_TO_MIXED truncated the key, so
-  "ab\0cd" and "ab" collided and one value was destroyed with no signal; the
-  four *_HASH/*_ADAPTIVE types already rejected such keys on write but still
-  truncated them on every ordered and range operation (first/last/searchNext/
-  prev/slice/deleteRange and the bounds of keys/values/toArray/size), because
-  all six seek through the same JudySL key index. JudySL keys are NUL-terminated
-  by construction, so rejecting is the only correct behaviour. High-byte keys
-  (0x80-0xFF) are unaffected and remain binary-safe, including 0xFF prefix-carry
-  arithmetic. See MIGRATION_2.5.0.md.
+- PERF: mergeWith() no longer re-descends from the root for a key its own
+  cursor is already standing on. The slot-to-zval conversion is shared with the
+  descending read path so the two cannot drift, and the cursor's slot is reused
+  only where it genuinely holds the value: directly on the integer-keyed and
+  trie types, and on *_HASH / *_ADAPTIVE only when the payload is mirrored
+  (an optimizeIteration instance of STRING_TO_INT_HASH, or long-keyed
+  STRING_TO_INT_ADAPTIVE). Behaviour-preserving: the three new .phpt files pass
+  against the pre-change build too. **No performance number is claimed** — the
+  redundant descend is gone, but no benchmark accompanies the change and none
+  should be inferred pending a run on an idle host. baselines/latest.json and
+  BENCHMARK.md figures are untouched.
+- DOC: API.md now documents that toArray() coerces integer-looking string keys
+  on string-keyed types ("42" comes back as int 42, while "07" and " 42" stay
+  strings) and that feeding such a key back as an offset throws. The warning
+  reached the stub and AGENTS.md in 2.5.1 but not API.md, which is the reference
+  composer.json advertises.
+- DOC: BENCHMARK.md records why php-code-coverage and Infection were examined
+  and rejected as Judy fits.
    </notes>
    <contents>
       <dir name="/">
@@ -341,6 +348,21 @@
       <configureoption default="autodetect" name="with-judy" prompt="Please provide the prefix of libJudy installation" />
    </extsrcrelease>
    <changelog>
+      <release>
+         <date>2026-08-18</date>
+         <version>
+            <release>2.5.1</release>
+            <api>2.5.1</api>
+         </version>
+         <stability>
+            <release>stable</release>
+            <api>stable</api>
+         </stability>
+         <notes>
+- Embedded NUL bytes in string keys are rejected on all six string-keyed types
+  instead of silently truncating; see the 2.5.1 release notes.
+         </notes>
+      </release>
       <release>
          <date>2026-08-17</date>
          <version>

--- a/php_judy.h
+++ b/php_judy.h
@@ -19,7 +19,7 @@
 #ifndef PHP_JUDY_H
 #define PHP_JUDY_H
 
-#define PHP_JUDY_VERSION "2.5.1"
+#define PHP_JUDY_VERSION "2.5.2"
 #define PHP_JUDY_EXTNAME "judy"
 
 /* Windows x64 (LLP64): Force 64-bit Word_t to match libjudy ABI.


### PR DESCRIPTION
## Summary

Ships the eight commits on `main` since v2.5.1 — one extension change, three documentation/research fixes.

| PR | What |
| --- | --- |
| #123 | `mergeWith()` stops re-descending from the root for a key its cursor already holds |
| #124 | `probebench` honours `keylen`, unblocking the ADAPTIVE/SSO probe (#118) |
| #125 | BENCHMARK.md records the php-code-coverage / Infection rejections |
| #126 | API.md finally carries the `toArray()` coercion warning (#116's gap) |

## Version

`php_judy.h` and `package.xml` to 2.5.2 in lockstep; 2.5.1's notes archived into `<changelog>`; BENCHMARK.md document stamp to 2.5.2, measurement stamps unchanged at 2.4.2 as before.

**No migration file and no new migration section** — nothing here changes the API or observable behaviour. `MIGRATION_2.5.0.md` remains the guide for the 2.5.x line.

## No performance number is claimed

The release notes deliberately quote **no speedup** for #123, mirroring that commit's own wording. The redundant descend is gone, but no benchmark accompanies it — and the write-path `memchr` added in 2.5.1 has never been measured either, because the machine has been too loaded all session.

Two unmeasured changes to the write/merge paths are now stacked. The post-release baseline bump is where both finally get measured, and it should be treated as the real check rather than a formality.

#123 is behaviour-preserving by construction: its three new `.phpt` files pass against the pre-change build too.

## Test plan

- [x] 214/214 tests pass
- [x] Zero compiler warnings in extension sources
- [x] `judy_version()` reports `2.5.2` on a fresh build
- [x] Version lockstep `php_judy.h` == `package.xml` (CI-enforced)
- [x] `package.xml` well-formed and in sync with `tests/` (214)
- [x] `API.md` freshness gate passes
- [ ] CI green