### PR TITLE
perf(unset): drop the redundant JHSG probe on STRING_TO_INT_HASH unset

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -303,6 +303,9 @@
          <file name="tests/regression_mixed_destructor_reentrancy_001.phpt" role="test" />
          <file name="tests/regression_packed_equals_001.phpt" role="test" />
          <file name="tests/regression_unserialize_reinit_leak_001.phpt" role="test" />
+         <file name="tests/regression_unset_hash_adaptive_untouched_001.phpt" role="test" />
+         <file name="tests/regression_unset_string_to_int_hash_001.phpt" role="test" />
+         <file name="tests/regression_unset_string_to_int_hash_002.phpt" role="test" />
          <file md5sum="f4c1dde3511c574eef8fbf6a99f9d27b" name="config.m4" role="src" />
          <file md5sum="14c238115fee50dfe70b13bc8da311d3" name="config.w32" role="src" />
          <file name="Judy.stub.php" role="src" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -1376,20 +1376,23 @@ int judy_object_unset_dimension_helper(zval *object, zval *offset) /* {{{ */
 			}
 		}
 	} else if (intern->type == TYPE_STRING_TO_INT_HASH) {
-		Pvoid_t     *HValue;
 		Word_t key_len = (Word_t)Z_STRLEN_P(pstring_key);
 
-		JHSG(HValue, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-		if (HValue != NULL && HValue != PJERR) {
-			/* No zval to free — value is stored inline as Word_t */
-			JHSD(Rc_int, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
-			if (Rc_int == 1) {
-				int Rc_del = 0;
-				JSLD(Rc_del, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
-				if (Rc_del == 1) {
-					intern->counter--;
-					judy_string_bytes_sub(intern, key_len);
-				}
+		/* No zval to free — the value is stored inline as a Word_t — so
+		 * nothing here needs to read the slot before dropping it. Delete
+		 * straight away rather than probing with JHSG first: JudyHSDel is
+		 * itself the existence test, returning 1 only when it removed a key
+		 * and 0 when the key was absent, which is exactly the signal the
+		 * key_index removal and the counter below are gated on. Probing
+		 * first would cost an extra full hash pass over the key plus two
+		 * JudyL descents for an answer JHSD already gives us. */
+		JHSD(Rc_int, intern->array, (uint8_t *)Z_STRVAL_P(pstring_key), key_len);
+		if (Rc_int == 1) {
+			int Rc_del = 0;
+			JSLD(Rc_del, intern->key_index, (uint8_t *)Z_STRVAL_P(pstring_key));
+			if (Rc_del == 1) {
+				intern->counter--;
+				judy_string_bytes_sub(intern, key_len);
 			}
 		}
 	}

--- a/tests/regression_unset_hash_adaptive_untouched_001.phpt
+++ b/tests/regression_unset_hash_adaptive_untouched_001.phpt
@@ -1,0 +1,147 @@
+--TEST--
+Judy unset(): STRING_TO_MIXED_HASH and both *_ADAPTIVE branches keep their probe-then-delete ordering
+--SKIPIF--
+<?php
+if (!extension_loaded("judy")) print "skip";
+?>
+--FILE--
+<?php
+/* Guard for the unset branches that were deliberately NOT simplified: the
+ * _MIXED variants must still fetch the slot before deleting it, because the
+ * stored zval has to be captured for its destructor, and the delete-before-
+ * free ordering is a destructor-re-entrancy guard. The _ADAPTIVE types must
+ * still route short keys through the packed JudyL and long keys through
+ * JudyHS. */
+
+class Tracer
+{
+    public function __construct(public string $name) {}
+    public function __destruct() { echo "    dtor ", $this->name, "\n"; }
+}
+
+function state(Judy $j): string
+{
+    $keys = $j->keys();
+    $walk = [];
+    foreach ($j as $k => $v) {
+        $walk[] = $k . "=" . (is_object($v) ? "obj:" . $v->name : var_export($v, true));
+    }
+    return sprintf("count=%d keys=[%s] walk=[%s]",
+        count($j), implode(",", $keys), implode(",", $walk));
+}
+
+/* ---- STRING_TO_MIXED_HASH: the value destructor must run on unset ---- */
+echo "STRING_TO_MIXED_HASH\n";
+$m = new Judy(Judy::STRING_TO_MIXED_HASH);
+$m["alpha"] = new Tracer("alpha");
+$m["beta"]  = new Tracer("beta");
+$m["gamma"] = "plain";
+echo "  ", state($m), "\n";
+echo "  unset absent:\n";
+unset($m["delta"]);
+echo "  ", state($m), "\n";
+echo "  unset present (destructor expected):\n";
+unset($m["beta"]);
+echo "  ", state($m), "\n";
+echo "  unset same key again:\n";
+unset($m["beta"]);
+echo "  ", state($m), "\n";
+echo "  drain:\n";
+unset($m["alpha"], $m["gamma"]);
+echo "  ", state($m), " mem=", $m->memoryUsage(), "\n";
+
+/* A destructor that re-enters and unsets the same key must not double-free:
+ * this is what the probe-then-delete ordering in that branch protects. */
+echo "  re-entrant destructor:\n";
+class Reenter
+{
+    public static ?Judy $target = null;
+    public function __construct(public string $key) {}
+    public function __destruct()
+    {
+        echo "    dtor re-enters for ", $this->key, "\n";
+        if (self::$target !== null) {
+            unset(self::$target[$this->key]);
+        }
+    }
+}
+$r = new Judy(Judy::STRING_TO_MIXED_HASH);
+Reenter::$target = $r;
+$r["loop"] = new Reenter("loop");
+unset($r["loop"]);
+Reenter::$target = null;
+echo "  ", state($r), "\n";
+
+/* ---- STRING_TO_INT_ADAPTIVE: short (packed) and long (JudyHS) keys ---- */
+echo "STRING_TO_INT_ADAPTIVE\n";
+foreach ([false, true] as $opt) {
+    $a = new Judy(Judy::STRING_TO_INT_ADAPTIVE, optimizeIteration: $opt);
+    echo "  optimizeIteration=", var_export($opt, true),
+         " honoured=", var_export($a->isIterationOptimized(), true), "\n";
+    $a["s"]                  = 1;   /* short: packed JudyL path */
+    $a["short7"]             = 2;   /* still short */
+    $a["longkey_eight"]      = 3;   /* long: JudyHS path */
+    $a[str_repeat("z", 64)]  = 4;
+    echo "    ", state($a), "\n";
+    unset($a["absent"], $a["absentlongkey_xxxxxx"]);
+    echo "    absent: ", state($a), "\n";
+    unset($a["short7"], $a["longkey_eight"]);
+    echo "    mixed unset: ", state($a), "\n";
+    unset($a["s"], $a[str_repeat("z", 64)]);
+    echo "    drained: ", state($a), " mem=", $a->memoryUsage(), "\n";
+}
+
+/* ---- STRING_TO_MIXED_ADAPTIVE: destructors on both paths ---- */
+echo "STRING_TO_MIXED_ADAPTIVE\n";
+$ma = new Judy(Judy::STRING_TO_MIXED_ADAPTIVE);
+$ma["s"]             = new Tracer("short");
+$ma["longkey_eight"] = new Tracer("long");
+echo "  ", state($ma), "\n";
+echo "  unset absent:\n";
+unset($ma["nope"], $ma["nope_long_key_here"]);
+echo "  ", state($ma), "\n";
+echo "  unset short (destructor expected):\n";
+unset($ma["s"]);
+echo "  unset long (destructor expected):\n";
+unset($ma["longkey_eight"]);
+echo "  ", state($ma), " mem=", $ma->memoryUsage(), "\n";
+
+echo "Done\n";
+?>
+--EXPECT--
+STRING_TO_MIXED_HASH
+  count=3 keys=[alpha,beta,gamma] walk=[alpha=obj:alpha,beta=obj:beta,gamma='plain']
+  unset absent:
+  count=3 keys=[alpha,beta,gamma] walk=[alpha=obj:alpha,beta=obj:beta,gamma='plain']
+  unset present (destructor expected):
+    dtor beta
+  count=2 keys=[alpha,gamma] walk=[alpha=obj:alpha,gamma='plain']
+  unset same key again:
+  count=2 keys=[alpha,gamma] walk=[alpha=obj:alpha,gamma='plain']
+  drain:
+    dtor alpha
+  count=0 keys=[] walk=[] mem=0
+  re-entrant destructor:
+    dtor re-enters for loop
+  count=0 keys=[] walk=[]
+STRING_TO_INT_ADAPTIVE
+  optimizeIteration=false honoured=false
+    count=4 keys=[longkey_eight,s,short7,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz] walk=[longkey_eight=3,s=1,short7=2,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=4]
+    absent: count=4 keys=[longkey_eight,s,short7,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz] walk=[longkey_eight=3,s=1,short7=2,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=4]
+    mixed unset: count=2 keys=[s,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz] walk=[s=1,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=4]
+    drained: count=0 keys=[] walk=[] mem=0
+  optimizeIteration=true honoured=true
+    count=4 keys=[longkey_eight,s,short7,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz] walk=[longkey_eight=3,s=1,short7=2,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=4]
+    absent: count=4 keys=[longkey_eight,s,short7,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz] walk=[longkey_eight=3,s=1,short7=2,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=4]
+    mixed unset: count=2 keys=[s,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz] walk=[s=1,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=4]
+    drained: count=0 keys=[] walk=[] mem=0
+STRING_TO_MIXED_ADAPTIVE
+  count=2 keys=[longkey_eight,s] walk=[longkey_eight=obj:long,s=obj:short]
+  unset absent:
+  count=2 keys=[longkey_eight,s] walk=[longkey_eight=obj:long,s=obj:short]
+  unset short (destructor expected):
+    dtor short
+  unset long (destructor expected):
+    dtor long
+  count=0 keys=[] walk=[] mem=0
+Done

--- a/tests/regression_unset_string_to_int_hash_001.phpt
+++ b/tests/regression_unset_string_to_int_hash_001.phpt
@@ -1,0 +1,115 @@
+--TEST--
+Judy STRING_TO_INT_HASH: unset() bookkeeping for present, absent and empty-array keys
+--SKIPIF--
+<?php
+if (!extension_loaded("judy")) print "skip";
+?>
+--FILE--
+<?php
+/* The unset path for STRING_TO_INT_HASH deletes straight out of the JudyHS
+ * value store and gates the key_index removal, the element counter and the
+ * key-byte accounting on JudyHSDel's return value. This test pins that
+ * bookkeeping: both stores and the counter must agree after every operation,
+ * and an absent key must move nothing at all. */
+
+function state(Judy $j): string
+{
+    /* keys() walks the key_index; the offsetGet probes read the value store;
+     * count() reads the element counter. All three must agree. */
+    $keys = $j->keys();
+    $via_store = [];
+    foreach ($keys as $k) {
+        $via_store[] = $k . "=" . ($j[$k] ?? "MISSING");
+    }
+    $walk = [];
+    foreach ($j as $k => $v) {
+        $walk[] = $k . "=" . $v;
+    }
+    return sprintf(
+        "count=%d size=%d keys=[%s] store=[%s] walk=[%s]",
+        count($j),
+        $j->size(),
+        implode(",", $keys),
+        implode(",", $via_store),
+        implode(",", $walk)
+    );
+}
+
+foreach ([false, true] as $opt) {
+    echo "--- optimizeIteration=", var_export($opt, true), " ---\n";
+    $j = new Judy(Judy::STRING_TO_INT_HASH, optimizeIteration: $opt);
+    echo "honoured: ", var_export($j->isIterationOptimized(), true), "\n";
+
+    /* Unset on an empty array: no error, no bookkeeping movement. */
+    unset($j["nothing"]);
+    echo "empty:   ", state($j), " mem=", $j->memoryUsage(), "\n";
+
+    $j["alpha"] = 1;
+    $j["beta"]  = 2;
+    $j["gamma"] = 3;
+    $filled_mem = $j->memoryUsage();
+    echo "filled:  ", state($j), "\n";
+
+    /* Absent key: nothing moves — not the counter, not the key_index, not
+     * the byte accounting. This is the case that used to be short-circuited
+     * by a JHSG probe and is now decided by JudyHSDel's return value. */
+    unset($j["delta"]);
+    echo "absent:  ", state($j),
+         " mem_unchanged=", var_export($j->memoryUsage() === $filled_mem, true), "\n";
+
+    /* Present key: dropped from the value store, from the ordered key index
+     * and from the counter, exactly once. */
+    unset($j["beta"]);
+    echo "present: ", state($j), " isset_beta=", var_export(isset($j["beta"]), true),
+         " mem_shrunk=", var_export($j->memoryUsage() < $filled_mem, true), "\n";
+
+    /* Second unset of the same key is now the absent case. */
+    $after = $j->memoryUsage();
+    unset($j["beta"]);
+    echo "again:   ", state($j),
+         " mem_unchanged=", var_export($j->memoryUsage() === $after, true), "\n";
+
+    /* Ordered navigation must not see the removed key either. */
+    echo "nav:     first=", var_export($j->first(), true),
+         " next=", var_export($j->searchNext("alpha"), true),
+         " last=", var_export($j->last(), true), "\n";
+
+    /* Drain: counter, both stores and the byte accounting return to empty. */
+    unset($j["alpha"], $j["gamma"]);
+    echo "drained: ", state($j), " mem=", $j->memoryUsage(), "\n";
+
+    /* Unsetting again on the now-empty array stays a no-op. */
+    unset($j["alpha"]);
+    echo "post:    ", state($j), " mem=", $j->memoryUsage(), "\n";
+
+    /* Reinsert after the drain to prove nothing was left behind. */
+    $j["alpha"] = 11;
+    echo "reinsert:", state($j), "\n";
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+--- optimizeIteration=false ---
+honoured: false
+empty:   count=0 size=0 keys=[] store=[] walk=[] mem=0
+filled:  count=3 size=3 keys=[alpha,beta,gamma] store=[alpha=1,beta=2,gamma=3] walk=[alpha=1,beta=2,gamma=3]
+absent:  count=3 size=3 keys=[alpha,beta,gamma] store=[alpha=1,beta=2,gamma=3] walk=[alpha=1,beta=2,gamma=3] mem_unchanged=true
+present: count=2 size=2 keys=[alpha,gamma] store=[alpha=1,gamma=3] walk=[alpha=1,gamma=3] isset_beta=false mem_shrunk=true
+again:   count=2 size=2 keys=[alpha,gamma] store=[alpha=1,gamma=3] walk=[alpha=1,gamma=3] mem_unchanged=true
+nav:     first='alpha' next='gamma' last='gamma'
+drained: count=0 size=0 keys=[] store=[] walk=[] mem=0
+post:    count=0 size=0 keys=[] store=[] walk=[] mem=0
+reinsert:count=1 size=1 keys=[alpha] store=[alpha=11] walk=[alpha=11]
+--- optimizeIteration=true ---
+honoured: true
+empty:   count=0 size=0 keys=[] store=[] walk=[] mem=0
+filled:  count=3 size=3 keys=[alpha,beta,gamma] store=[alpha=1,beta=2,gamma=3] walk=[alpha=1,beta=2,gamma=3]
+absent:  count=3 size=3 keys=[alpha,beta,gamma] store=[alpha=1,beta=2,gamma=3] walk=[alpha=1,beta=2,gamma=3] mem_unchanged=true
+present: count=2 size=2 keys=[alpha,gamma] store=[alpha=1,gamma=3] walk=[alpha=1,gamma=3] isset_beta=false mem_shrunk=true
+again:   count=2 size=2 keys=[alpha,gamma] store=[alpha=1,gamma=3] walk=[alpha=1,gamma=3] mem_unchanged=true
+nav:     first='alpha' next='gamma' last='gamma'
+drained: count=0 size=0 keys=[] store=[] walk=[] mem=0
+post:    count=0 size=0 keys=[] store=[] walk=[] mem=0
+reinsert:count=1 size=1 keys=[alpha] store=[alpha=11] walk=[alpha=11]
+Done

--- a/tests/regression_unset_string_to_int_hash_002.phpt
+++ b/tests/regression_unset_string_to_int_hash_002.phpt
@@ -1,0 +1,163 @@
+--TEST--
+Judy STRING_TO_INT_HASH: unset() over an adversarial key corpus and under collision churn
+--SKIPIF--
+<?php
+if (!extension_loaded("judy")) print "skip";
+?>
+--FILE--
+<?php
+/* The JudyHS hash is length-sensitive and byte-sensitive, so the unset path
+ * has to be exercised with more than ASCII words: high bytes, the empty key,
+ * one-byte keys, keys long enough to leave the short-key fast paths, and
+ * numeric-looking strings. Values are asserted by type as well as by content
+ * so a silently coerced key cannot pass. */
+
+$corpus = [
+    "empty"     => "",
+    "one"       => "a",
+    "two"       => "\x00",          /* NOT a key: embedded NUL, must throw */
+    "highff"    => "\xff",
+    "highmix"   => "\x80\xfe\x01\xff",
+    "numeric"   => "42",
+    "numzero"   => "07",
+    "negzero"   => "-0",
+    "space"     => " 42",
+    "long256"   => str_repeat("L", 256),
+    "long4096"  => str_repeat("x", 4096),
+    "prefix"    => "ab",
+    "prefixlen" => "abc",
+];
+
+foreach ([false, true] as $opt) {
+    echo "--- optimizeIteration=", var_export($opt, true), " ---\n";
+    $j = new Judy(Judy::STRING_TO_INT_HASH, optimizeIteration: $opt);
+
+    /* An embedded NUL is refused on unset just as on any other key-taking
+     * method — the validation sits ahead of the branch that was changed. */
+    $j["seed"] = 0;
+    try {
+        unset($j["a\0b"]);
+        echo "NUL: no exception\n";
+    } catch (Throwable $e) {
+        echo "NUL: ", get_class($e), ": ", $e->getMessage(), "\n";
+    }
+    echo "NUL left count=", count($j), "\n";
+    unset($j["seed"]);
+
+    $n = 0;
+    foreach ($corpus as $label => $key) {
+        if ($label === "two") {
+            continue;
+        }
+        $j[$key] = ++$n;
+    }
+    $filled = count($j);
+    $filled_mem = $j->memoryUsage();
+    echo "filled count=", $filled, "\n";
+
+    /* Absent keys that are near-misses of stored ones: same prefix, same
+     * length-minus-one, same bytes with one flipped. None may move anything. */
+    $near = ["abd", "abcd", "b", "\xfe", "\x80\xfe\x01\xfd", "43", "7",
+             str_repeat("L", 255), str_repeat("L", 257), str_repeat("x", 4095)];
+    foreach ($near as $probe) {
+        unset($j[$probe]);
+    }
+    echo "after near-miss unsets: count=", count($j),
+         " unchanged=", var_export(count($j) === $filled, true),
+         " mem_unchanged=", var_export($j->memoryUsage() === $filled_mem, true), "\n";
+
+    /* Remove each corpus key one at a time; the counter must fall by exactly
+     * one per removal, the key must leave both stores, and a repeat removal
+     * must be a no-op. */
+    $expect = $filled;
+    $bad = [];
+    foreach ($corpus as $label => $key) {
+        if ($label === "two") {
+            continue;
+        }
+        unset($j[$key]);
+        $expect--;
+        if (count($j) !== $expect) {
+            $bad[] = "$label: counter " . count($j) . " != $expect";
+        }
+        if (isset($j[$key])) {
+            $bad[] = "$label: still in value store";
+        }
+        if (in_array($key, $j->keys(), true)) {
+            $bad[] = "$label: still in key_index";
+        }
+        unset($j[$key]);          /* repeat: absent case */
+        if (count($j) !== $expect) {
+            $bad[] = "$label: repeat unset moved the counter";
+        }
+    }
+    echo "one-at-a-time: count=", count($j), " problems=",
+         ($bad === [] ? "none" : implode("; ", $bad)), "\n";
+    echo "drained mem=", $j->memoryUsage(), " keys=", count($j->keys()), "\n";
+
+    /* Collision churn: many same-length keys (which is what drives JudyHS
+     * into its per-length collision trees), repeatedly unset and reinserted,
+     * interleaved with unsets of keys that are not there. */
+    $churn = new Judy(Judy::STRING_TO_INT_HASH, optimizeIteration: $opt);
+    for ($i = 0; $i < 512; $i++) {
+        $churn[sprintf("k%07d", $i)] = $i;
+    }
+    for ($round = 0; $round < 3; $round++) {
+        for ($i = 0; $i < 512; $i += 2) {
+            unset($churn[sprintf("k%07d", $i)]);
+            unset($churn[sprintf("absent%03d", $i)]);   /* never inserted */
+        }
+        if (count($churn) !== 256) {
+            echo "churn round $round: count=", count($churn), " (expected 256)\n";
+        }
+        for ($i = 0; $i < 512; $i += 2) {
+            $churn[sprintf("k%07d", $i)] = $i;
+        }
+        if (count($churn) !== 512) {
+            echo "churn round $round: refill count=", count($churn), " (expected 512)\n";
+        }
+    }
+    $keys = $churn->keys();
+    $sorted = $keys;
+    sort($sorted, SORT_STRING);
+    $values_ok = true;
+    foreach ($keys as $k) {
+        if ($churn[$k] !== (int)substr($k, 1)) {
+            $values_ok = false;
+            break;
+        }
+    }
+    echo "churn: count=", count($churn), " keys=", count($keys),
+         " ordered=", var_export($keys === $sorted, true),
+         " values_ok=", var_export($values_ok, true), "\n";
+
+    /* Full drain through unset only, then confirm the array is truly empty. */
+    foreach ($churn->keys() as $k) {
+        unset($churn[$k]);
+    }
+    echo "churn drained: count=", count($churn), " keys=", count($churn->keys()),
+         " mem=", $churn->memoryUsage(), "\n";
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+--- optimizeIteration=false ---
+NUL: Exception: Judy STRING_TO_INT_HASH keys must not contain embedded null bytes
+NUL left count=1
+filled count=12
+after near-miss unsets: count=12 unchanged=true mem_unchanged=true
+one-at-a-time: count=0 problems=none
+drained mem=0 keys=0
+churn: count=512 keys=512 ordered=true values_ok=true
+churn drained: count=0 keys=0 mem=0
+--- optimizeIteration=true ---
+NUL: Exception: Judy STRING_TO_INT_HASH keys must not contain embedded null bytes
+NUL left count=1
+filled count=12
+after near-miss unsets: count=12 unchanged=true mem_unchanged=true
+one-at-a-time: count=0 problems=none
+drained mem=0 keys=0
+churn: count=512 keys=512 ordered=true values_ok=true
+churn drained: count=0 keys=0 mem=0
+Done


### PR DESCRIPTION
## What

The `TYPE_STRING_TO_INT_HASH` branch of `judy_object_unset_dimension_helper`
fetched the value slot with `JHSG` and then never dereferenced it. Its own
comment said as much — *"No zval to free — value is stored inline as
`Word_t`"* — so the probe was doing nothing but answering "is this key
present?", and `JudyHSDel` already answers that: it returns `1` when it
removed a key and `0` when the key was absent, which is exactly the signal
the `key_index` `JSLD`, the element counter and the key-byte accounting
were gated on.

This deletes straight away instead. Removed per unset on that path: one
full hash pass over the key (`JUDYHASHSTR` is a byte-at-a-time
`c*31 + b` loop with a serial dependency) plus two JudyL descents.

**No performance claim is made.** No benchmark was run — the only host
available is shared and loaded, so any number from it would be
uninterpretable. `BENCHMARK.md` and `baselines/latest.json` are untouched.
The effect is unmeasured pending an idle host.

Same defect class as #121 / #123 — a probe result discarded and then
re-derived.

## Why it is safe

`Rc_int` ends at the same value in every path:

| case | before | after |
| --- | --- | --- |
| key present | `JHSG` hits → `JHSD` → `1` | `JHSD` → `1` |
| key absent | `JHSG` misses → `JHSD` skipped → stays at its `0` initialiser | `JHSD` → `0` |
| empty array | never reached — the `array == NULL && hs_array == NULL` guard at the top of the function returns `FAILURE` first | unchanged |

So `JSLD` on `key_index`, `intern->counter--` and `judy_string_bytes_sub`
still fire exactly when the key was really removed and never when it was
absent, and the function's `Rc_int == JERR ? FAILURE : SUCCESS` result is
unchanged.

`JudyHSDel`'s contract was verified empirically rather than assumed — a
standalone C probe linked against the installed libJudy 1.0.5 confirms it
returns `1` iff the key was present and `0` otherwise, on a `NULL` root, a
zero-length key, a one-byte key, a 4096-byte key and keys carrying high
bytes (`0x80`, `0xfe`, `0xff`). It never returned `JERR` on any of those.

## Scope: what deliberately did NOT change

Every `JHSG` site in `php_judy.c`, `judy_handlers.c` and `judy_iterator.c`
was audited. 33 of them consume the fetched value (read it, copy it,
compare it, or return it) and cannot be touched. The two that are pure
existence tests both stay:

- `judy_string_slot_acquire`, the `STRING_TO_INT_HASH` and long-key
  `STRING_TO_INT_ADAPTIVE` write paths — `0` is a legal stored value there,
  so the slot contents cannot say whether the key is new, and the following
  `JHSI` returns a slot pointer that cannot report newness either. The
  comment block above those probes explains the mirrored/unmirrored swap;
  it is untouched.
- the `STRING_TO_MIXED_HASH` and both `*_ADAPTIVE` unset branches — they
  read the stored `zval *` before deleting, and the ordering there is a
  deliberate destructor-re-entrancy guard.

## Two further candidates, reported not fixed

The audit turned up two more sites of the same family. Both are left alone
here deliberately — they are conditional rather than unconditional, so they
need their own change and their own tests:

- `judy_object_unset_dimension_helper`, the long-key `*_ADAPTIVE` branch:
  the fetched pointer is dereferenced only when
  `type == TYPE_STRING_TO_MIXED_ADAPTIVE`. For `STRING_TO_INT_ADAPTIVE` it
  is a pure existence test whose only consumer is the following `JHSD`.
  Note `Rc_int` is declared outside the block and the `Rc_int == 1` check
  currently sits *inside* the `if (HValue …)`, so a fix has to lift the
  `JHSD` out unconditionally.
- `Judy::deleteRange`, two sites: same shape, and there the bookkeeping is
  gated on the `key_index` `JSLD` rather than on the probe at all.

Say the word and I will do those as a follow-up.

## Upstream observation (not fixed, not verified here)

The review that prompted this change reported that `JudyHSDel` itself calls
`JudyHSGet` internally as a pre-check, which would mean the key is hashed
three times per unset on this path and this change removes only one of the
three. **I could not verify that claim** — libJudy ships as a bottle here
with no source, and this environment has no network access to fetch
`JudyHS.c`. It is recorded as an observation about upstream, not as
something this PR fixes or confirms.

## Tests

Three new `.phpt` files, all listed in `package.xml`:

- `regression_unset_string_to_int_hash_001.phpt` — present, absent, repeated
  and empty-array unsets; asserts the counter, `keys()` (the `key_index`),
  `offsetGet` (the value store), `size()`, `foreach`, `first`/`searchNext`/
  `last` and `memoryUsage()` all agree after each operation; both
  `optimizeIteration` modes; reinsertion after a full drain.
- `regression_unset_string_to_int_hash_002.phpt` — adversarial key corpus
  (empty key, one-byte, `\xff`, `\x80\xfe\x01\xff`, 256- and 4096-byte,
  `"42"`, `"07"`, `"-0"`, `" 42"`, shared prefixes at different lengths),
  near-miss absent keys, embedded-NUL rejection, and 512-key collision churn
  over same-length keys with interleaved unsets of keys that were never
  inserted; both `optimizeIteration` modes.
- `regression_unset_hash_adaptive_untouched_001.phpt` — regression guard for
  the branches left alone: `STRING_TO_MIXED_HASH` destructor firing (plus a
  re-entrant destructor that unsets its own key), and both `*_ADAPTIVE`
  types across the short packed-`JudyL` and long-`JudyHS` paths.

All three pass **unmodified against `origin/main`**, which is what makes
them a behaviour-preservation check rather than a spec change.

Mutation controls, so the tests are not sympathetic:

- reading `JudyHSDel`'s success value as anything but `1` → both tests fail. ✔
- removing both gates so an absent unset moves the counter → both tests fail. ✔
- two other mutations (`Rc_int == 0 || Rc_int == 1`, `Rc_del == 0 || Rc_del == 1`)
  are **not** caught, and cannot be by any test: they are genuinely
  equivalent while the two stores agree, which is the invariant the
  debug-mirror checker enforces separately.

## Verification

- Zero compiler warnings on a clean rebuild.
- Full suite **217/217** on the release build.
- Full suite **217/217** with `--enable-judy-debug-mirror`; no
  `MIRROR INVARIANT VIOLATED`.
- `USE_ZEND_ALLOC=0 valgrind --leak-check=full` on all three new test bodies
  plus a heavy churn script (20 rounds x 2000 keys x both modes, plus
  high-byte/empty/4096-byte keys x 500 rounds): **0 errors, 0 definitely
  lost** on each. Run in the `php-judy-bench` container against a
  `git ls-files` export, per the repo recipe.
- Injected-fault control, because a clean valgrind run proves nothing if the
  harness never reached the code: removing `efree(value)` from the
  `MIXED_HASH` unset branch turns that clean run into `definitely lost: 64
  bytes in 4 blocks`, exit 42. ✔
- Leak-growth check across 12 rounds of 20k insert + 20k unset + 20k absent
  unset: `count()`, `memoryUsage()` and `memory_get_usage()` return to their
  starting values every round and peak RSS is flat from round 6 (26,636 kB)
  through round 12.

No API change, so `Judy.stub.php`, `Judy_arginfo.h`, `API.md` and AGENTS.md
are untouched.
