### PR TITLE
test(bitset): detect a miscompiled system libJudy at test time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,14 @@ is [orieg/judy-cache](https://github.com/orieg/judy-cache).
 - **Test**: `make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1`.
   Every behavior change needs a `.phpt` regression test in `tests/`.
 - **Zero compiler warnings** — CI fails on any warning in extension sources.
+- **The system libJudy must not be built with `gcc -O3`.** Stock 1.0.5 copies
+  up to 15 bytes into an 8-byte `jp_1Index`, and gcc at `-O3` truncates the
+  copy — `Judy::BITSET` then loses keys silently, with `count()` over-reporting
+  while iteration and `isset()` under-report.
+  `tests/bitset_immed_cascade_integrity_001.phpt` fails on such a build; a
+  failure there means the installed library needs rebuilding at `-O2`, not that
+  the extension regressed. See
+  [#131](https://github.com/orieg/php-judy/issues/131).
 - **API changes**: edit `Judy.stub.php` (canonical), regenerate arginfo, and
   regenerate `API.md` with `php scripts/generate-api-docs.php` — CI fails if
   `API.md` is stale.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,17 @@ needed to build, test, and submit changes.
   - Windows: build libJudy from source (see the Windows section in [README.md](README.md))
 - Standard C toolchain (`gcc`/`clang`, `make`, `autoconf`)
 
+**If you build libJudy yourself, build it at `-O2` — never `gcc -O3`.** Stock
+libJudy 1.0.5 writes up to 15 bytes into an 8-byte `jp_1Index` field when a
+Judy1 leaf splays into immediates, and gcc at `-O3` exploits the out-of-bounds
+write by truncating the copy, which **silently loses `Judy::BITSET` keys**:
+`count()` over-reports while iteration and `isset()` under-report. Debian,
+Ubuntu and Fedora ship the widening patch; Homebrew ships stock sources but
+builds with clang, which does not exploit it. `tests/bitset_immed_cascade_integrity_001.phpt`
+detects a miscompiled library at `make test` time — if it fails, the installed
+libJudy is the problem, not this extension. Full analysis:
+[#131](https://github.com/orieg/php-judy/issues/131).
+
 ## Building from source
 
 ```sh

--- a/package.xml
+++ b/package.xml
@@ -98,6 +98,7 @@
          <file md5sum="a401657315fae5182d412cbc0b02e312" name="tests/bitset_006.phpt" role="test" />
          <file md5sum="be3498c9fa543d91672b839ca190b3b4" name="tests/bitset_007.phpt" role="test" />
          <file name="tests/bitset_diff_001.phpt" role="test" />
+         <file name="tests/bitset_immed_cascade_integrity_001.phpt" role="test" />
          <file name="tests/bitset_intersect_001.phpt" role="test" />
          <file name="tests/bitset_setops_independence_001.phpt" role="test" />
          <file name="tests/bitset_setops_type_error_001.phpt" role="test" />

--- a/tests/bitset_immed_cascade_integrity_001.phpt
+++ b/tests/bitset_immed_cascade_integrity_001.phpt
@@ -1,0 +1,138 @@
+--TEST--
+Judy::BITSET immediate-leaf cascade integrity (detects a miscompiled libJudy, issue #131)
+--DESCRIPTION--
+libJudy 1.0.5 declares the Judy1 immediate index array as 8 bytes
+(JudyPrivateBranch.h, uint8_t j_pi_1Index[sizeof(Word_t)]) while every Judy1
+immediate type needs 15 (Judy1.h, cJ1_IMMED1_MAXPOP1). JudyCascade.c copies up
+to 15 bytes into it when a 2-byte leaf splays into per-sub-expanse immediates.
+A compiler that exploits the out-of-bounds write truncates the copy, and the
+keys past the eighth in each 9..15-member sub-expanse are silently lost: J1S
+reports success, J1T then denies the key, iteration skips it, and the J1C
+population cache over-reports. gcc does exploit it at -O3; clang does not.
+Note the "iteration 8 invokes undefined behavior
+[-Waggressive-loop-optimizations]" warning gcc emits is not the discriminator
+-- gcc 15 emits it at -O2 as well, where the generated code is still correct
+-- so only runtime behaviour distinguishes a usable library from a broken one,
+which is why this needs to be a test rather than a build-log check.
+
+This test drives that exact transition and asserts that count(), iteration and
+isset() all agree. It fails against a libJudy built with gcc -O3 against stock
+sources. It is a detection test for the system library, not a test of this
+extension: a failure here means the installed libJudy is miscompiled and must
+be rebuilt at -O2 (or with the index-array widening patch that Debian, Ubuntu
+and Fedora carry). See https://github.com/orieg/php-judy/issues/131.
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+
+/**
+ * Assert that the three independent views of the population agree:
+ * count() reads libJudy's population cache, iteration walks the tree, and
+ * isset() does a point lookup per key. The miscompile makes the first
+ * over-report while the other two under-report, so only comparing all three
+ * against the keys we actually inserted catches it.
+ */
+function check(Judy $j, array $expected, string $label): void
+{
+    $count = count($j);
+
+    $walked = [];
+    foreach ($j as $k => $v) {
+        $walked[$k] = true;
+    }
+
+    $hits = 0;
+    foreach ($expected as $k => $_) {
+        if (isset($j[$k])) {
+            $hits++;
+        }
+    }
+
+    $missing = count(array_diff_key($expected, $walked));
+    $extra   = count(array_diff_key($walked, $expected));
+
+    printf(
+        "%s: inserted=%d count=%d walked=%d isset=%d missing=%d extra=%d\n",
+        $label,
+        count($expected),
+        $count,
+        count($walked),
+        $hits,
+        $missing,
+        $extra
+    );
+}
+
+// Phase 1 -- the cascade itself.
+//
+// A Judy1 2-byte leaf holds at most 128 keys; the 129th insertion splays it
+// into one immediate per high byte. 15 keys per high byte is the maximum
+// population of a 1-byte immediate, i.e. the 15-byte copy into the 8-byte
+// field. Nine groups of 15 is 135 keys: just past the leaf maximum, and the
+// smallest shape that reaches the transition.
+$j = new Judy(Judy::BITSET);
+$expected = [];
+for ($h = 0; $h < 9; $h++) {
+    for ($l = 0; $l < 15; $l++) {
+        $key = ($h << 8) | $l;
+        $j[$key] = true;
+        $expected[$key] = true;
+    }
+}
+check($j, $expected, 'cascade');
+
+// Phase 2 -- more sub-expanses, so the splay runs repeatedly.
+for ($h = 9; $h < 48; $h++) {
+    for ($l = 0; $l < 15; $l++) {
+        $key = ($h << 8) | $l;
+        $j[$key] = true;
+        $expected[$key] = true;
+    }
+}
+check($j, $expected, 'wide');
+
+// Phase 3 -- delete back below the immediate maximum, then re-insert.
+// Deletion walks the decascade path, and re-filling re-runs the copy.
+for ($h = 0; $h < 48; $h += 2) {
+    for ($l = 8; $l < 15; $l++) {
+        $key = ($h << 8) | $l;
+        unset($j[$key]);
+        unset($expected[$key]);
+    }
+}
+check($j, $expected, 'after-unset');
+
+for ($h = 0; $h < 48; $h += 2) {
+    for ($l = 8; $l < 15; $l++) {
+        $key = ($h << 8) | $l;
+        $j[$key] = true;
+        $expected[$key] = true;
+    }
+}
+check($j, $expected, 'refilled');
+
+// Phase 4 -- the same transition one level deeper in the tree, so the leaf
+// being splayed sits under a branch rather than directly under the root.
+$deep = new Judy(Judy::BITSET);
+$deepExpected = [];
+for ($b = 1; $b <= 3; $b++) {
+    for ($h = 0; $h < 12; $h++) {
+        for ($l = 0; $l < 15; $l++) {
+            $key = ($b << 20) | ($h << 8) | $l;
+            $deep[$key] = true;
+            $deepExpected[$key] = true;
+        }
+    }
+}
+check($deep, $deepExpected, 'deep');
+
+echo "Done\n";
+?>
+--EXPECT--
+cascade: inserted=135 count=135 walked=135 isset=135 missing=0 extra=0
+wide: inserted=720 count=720 walked=720 isset=720 missing=0 extra=0
+after-unset: inserted=552 count=552 walked=552 isset=552 missing=0 extra=0
+refilled: inserted=720 count=720 walked=720 isset=720 missing=0 extra=0
+deep: inserted=540 count=540 walked=540 isset=540 missing=0 extra=0
+Done


### PR DESCRIPTION
Detection test for #131. No fix — php-judy cannot control how the system libJudy was built, so this converts "hope the packager patched it" into a visible failure at `make test` / PECL-install time on every platform.

## What it catches

Stock libJudy 1.0.5 declares the Judy1 immediate index array as 8 bytes (`JudyPrivateBranch.h:83`) while every Judy1 immediate type needs 15 (`Judy1.h:386`, `cJ1_IMMED1_MAXPOP1`). `JudyCascade.c:604` copies up to 15 bytes into it. gcc at `-O3` exploits the out-of-bounds write and truncates the copy, so `Judy::BITSET` loses keys silently: `count()` reads the population cache and over-reports while iteration and `isset()` miss the keys past the eighth in each 9..15-member sub-expanse.

## Key pattern

Derived from the structure rather than copied from the issue's random-key reproduction, so it is deterministic and small:

- A Judy1 2-byte leaf holds at most `cJ1_LEAF2_MAXPOP1` = 128 keys. The 129th insertion splays it into one immediate per high byte (`j__udyCascade2`).
- 15 keys per high byte is exactly the 1-byte immediate maximum, i.e. the 15-byte copy into the 8-byte field.
- Nine groups of 15 — keys `(h << 8) | l` for `h` in 0..8, `l` in 0..14, 135 keys — is just past the leaf maximum and the smallest shape that reaches the transition.

Four further phases widen the pattern to 48 sub-expanses, delete back below the immediate maximum and refill (the decascade path), and repeat the transition one level deeper in the tree (`(b << 20) | (h << 8) | l`). Every phase asserts `count()`, the iterated key set and the `isset()` hit count all agree with the keys actually inserted — the bug makes the first over-report while the other two under-report, so only comparing all three catches it.

No RNG: the sequence is a plain nested loop, reproducible on every platform.

## Validated against a deliberately miscompiled build

libJudy 1.0.5 (`sha256 d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb`) built twice from identical sources with the same compiler, php-judy rebuilt against each:

| libJudy build | result |
| --- | --- |
| gcc-15 `-O3` | **FAILS every phase** — `cascade: count=135 walked=71 isset=87`; `after-unset: inserted=552 count=576 walked=512` |
| gcc-15 `-O2` | passes, output matches `--EXPECT--` byte for byte |
| Homebrew (stock sources, clang) | passes |
| Alpine `judy-1.0.5-r1` (aarch64, `php:8.4-cli-alpine`) | passes |

The Alpine row is a new data point for #131: the issue lists Alpine as an unguarded gamble, and on aarch64 at least it is not miscompiled.

Worth recording: `-Waggressive-loop-optimizations` fires at `-O2` as well as `-O3` on gcc-15, so the warning is not the discriminator — only runtime behaviour is. That is precisely why a test is needed rather than a build-log grep.

## Cost

Whole test runs in 0.039 s on Alpine, 0.15 s locally including `run-tests.php` overhead. 1215 insertions, 168 deletions, three traversals.

## Also in this PR

- `CONTRIBUTING.md` prerequisites: build libJudy at `-O2`, never `gcc -O3`, with a pointer to #131 and to this test as the check.
- `AGENTS.md`: same note as one bullet, framed so an agent seeing this test fail looks at the system library rather than at a supposed extension regression.
- `package.xml`: the new test.

No C changes, no benchmark or baseline changes, no performance claim.

Refs #131