### PR TITLE
fix(research): spread key entropy across all bytes, and correct the SSO numbers

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -61,42 +61,67 @@ bytes into an 8-byte `Word_t` and aborted. **The `JLG hit (SSO packed)` row had
 therefore never been produced**; any pre-#118 note claiming a number for it is
 wrong.
 
+The short shape also has to spread the index across all `keylen` bytes rather
+than encode it directly. Base-36 needs only `ceil(log36(n))` digits, so a direct
+encoding left the leading bytes uniformly `'0'` — four of them at n = 500k and
+`keylen` 8, eight at `keylen` 12. That is a degenerate corpus for anything
+trie-shaped, and it made length and entropy impossible to vary independently.
+`make_key()` therefore multiplies the index by a capacity-scaled constant
+coprime with 36 before encoding: still a bijection, so keys stay unique and the
+capacity guard still bounds the space exactly.
+
 ## The ADAPTIVE/SSO probe, measured
 
-`(measured)` 2026-08-18, first run of this probe in its life — it aborted for
-every `keylen < 8` until [#118](https://github.com/orieg/php-judy/issues/118),
-so no earlier figure for it exists and any claim of one predates the fix.
+`(measured)` 2026-08-18. This probe aborted for every `keylen < 8` until
+[#118](https://github.com/orieg/php-judy/issues/118), so no figure for it
+existed before then.
+
+**These numbers supersede an earlier set taken on a degenerate corpus.** The
+short-key generator encoded the index directly, and base-36 needs only
+`ceil(log36(n))` digits — so at n = 500k every `keylen`-8 key carried four
+identical leading `'0'`s and every `keylen`-12 key eight. Length varied while
+entropy stayed fixed, and JudySL compresses a shared run, so the trie was handed
+a corpus that flattered it. The generator now spreads the index across every
+byte (see the mix in `make_key()`); the earlier numbers should not be quoted.
 
 **Environment.** Dedicated Linux x86_64 host — 24 cores, 62 GB, Ubuntu 22.04,
 kernel 6.8. Docker `debian:bookworm`, gcc 12.2.0, libJudy 1.0.5-5+b2. Load
-average `0.00` before and `0.25` after, nothing above 2% CPU: idle, well under
-the cores/2 = 12 threshold.
+average `0.00` throughout, nothing above 2% CPU.
 
-**Parameters.** `probebench 1000000 6 5` — 1,000,000 keys, `keylen = 6`
-(inside the SSO window), 5 reps, median ns/op.
+**Parameters.** `probebench 500000 <keylen> 5`, median ns/op, random-order hits.
+n is held at 500,000 across the sweep so length is the only variable —
+`keylen` 4 is the floor at which base-36 can hold n present plus n absent keys.
 
-| Probe | ns/op | across two runs |
-| --- | ---: | --- |
-| `JSLG` hit, random order | **107.8** | 107.76, 108.07 |
-| `JHSG` hit, random order | **115.8** | 115.70, 115.77 |
-| `JLG` hit (SSO packed), random order | **115.9** | 115.94, 115.96 |
+| keylen | `JHSG` (hash) | `JSLG` (trie) | `JLG` (SSO packed) |
+| ---: | ---: | ---: | ---: |
+| 4 | 102.1 | 110.3 | **100.6** |
+| 5 | **101.5** | 109.4 | 104.7 |
+| 6 | **111.7** | 111.7 | 112.1 |
+| 7 | **103.1** | 111.2 | 107.9 |
+| 8 | **116.6** | 142.8 | — (SSO is `keylen < 8`) |
+| 12 | 150.0 | **141.3** | — |
 
-Reproduced across two independent invocations; the SSO row agreed to within
-0.02 ns.
+**What it says.**
 
-**The result contradicts the branch's premise.** The SSO path exists on the
-theory that packing a short key into a `Word_t` and reading it from a JudyL
-beats hashing it. At 6-byte keys it does not: SSO packed and `JudyHS` are within
-noise of each other, and the plain `JudySL` trie beats both by roughly 7%. For
-random-order point reads at this key length the ADAPTIVE type's SSO store buys
-nothing over `JudyHS`.
+- **SSO's advantage is real but tiny and narrow.** It wins only at `keylen` 4,
+  by ~1.4% over `JudyHS`. At 5 and 7 it is 3-5% slower, and at 6 the three are
+  indistinguishable. Nothing here justifies choosing a type for the SSO path.
+- **`JudyHS` beats the trie for random point lookups at 4-8 byte keys**, by
+  6-8% at 4-7 and by 22% at 8. This supports the existing guidance that the
+  `_HASH` types are the ones to reach for on point lookups.
+- **The trie overtakes by `keylen` 12** (141.3 vs 150.0). Where the crossover
+  sits between 8 and 12 is not measured here.
 
-**Limits of this number, which are wide.** One key length on one machine. 6 sits
-mid-range of the SSO window (1-7) and nothing here says where the curve
-crosses, if it does. It also must not be read next to the 16-byte rows
-elsewhere in this directory: the short regime uses a different key shape (see
-above), so trie depth and fan-out differ, not just key length. A sweep across
-`keylen` 1-7 is what would turn this into an answer rather than a data point.
+**Limits.** One machine, one n, one value distribution. Only random-order hits;
+iteration-order and miss probes are in the full output and behave differently.
+`keylen` 1-3 cannot reach n = 500,000 at all — base-36 over 3 bytes holds 46,656
+keys — so the sweep starts at 4 rather than 1, and any run at those lengths is
+cache-resident and not comparable. Above `keylen` 12 the index space exceeds
+`ULONG_MAX`, so a 64-bit index cannot fill the leading digits and some padding
+returns; that is a property of the index type, not of Judy.
+
+Note also that `keylen >= 16` switches to the long key shape (see above), so the
+16-byte rows elsewhere in this directory are not on the same curve as this table.
 
 ## Reading probebench's absolute numbers
 

--- a/research/write-probe-cost/probebench.c
+++ b/research/write-probe-cost/probebench.c
@@ -80,16 +80,65 @@ static const char key_alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyz";
  * format's 16 characters were emitted regardless of keylen, so every keylen
  * below 16 silently produced a 16-byte key and the SSO branch then memcpy'd
  * 16 bytes into an 8-byte Word_t. See issue #118. */
+static unsigned long short_key_space(int keylen);
+
+/* A multiplier coprime with 36^keylen, sized to the space so the mix actually
+   spans it. A fixed constant does not: at keylen 12 the space is 36^12 ~ 4.7e18
+   while i * 2654435761 tops out near 1.3e15 for a 500k corpus, leaving the two
+   leading digits stuck at '0'. Scaling by the golden-ratio conjugate spreads
+   indices across the whole range (Fibonacci hashing), and forcing the result
+   odd and not divisible by 3 keeps gcd(mix, 36^k) = 1, so it stays a bijection.
+
+   Above keylen 12 the space exceeds ULONG_MAX and a 64-bit index cannot reach
+   the high digits at all — those keys keep some leading '0's no matter what.
+   That is a property of the index type, not something the mix can fix. */
+static unsigned long key_mix_for(unsigned long cap)
+{
+    unsigned long m = (unsigned long)((long double) cap * 0.6180339887498949L);
+    if (m < 3) return 1;
+    if ((m & 1UL) == 0) m++;
+    while (m % 3 == 0) m += 2;
+    return m;
+}
+
 static void make_key(char *buf, unsigned long i, int keylen) {
+    unsigned long v;
+    unsigned long cap;
+    unsigned long mix;
+
     if (keylen >= LONGKEY_MIN) {
         int m = snprintf(buf, MAXK, "user:%08lu:f%lu", i / 10, i % 10);
         while (m < keylen) buf[m++] = 'x';
         buf[m] = '\0';
         return;
     }
+
+    /* Spread the index across every byte before encoding it.
+     *
+     * Encoding i directly leaves a uniform prefix: base-36 needs only
+     * ceil(log36(n)) digits, so at n = 500k every keylen-8 key began with four
+     * identical '0's and every keylen-12 key with eight. That is a degenerate
+     * corpus for anything trie-shaped — JudySL compresses the shared run, so a
+     * "longer key" run measured the same 4 bytes of entropy behind more
+     * padding, and length and entropy could not be varied independently.
+     *
+     * KEY_MIX is odd and not divisible by 3, so it is coprime with 36^keylen
+     * and i -> (i * KEY_MIX) mod 36^keylen is a bijection: every key stays
+     * distinct, and the capacity guard in main() still bounds the space
+     * exactly. Above keylen 12 the space exceeds ULONG_MAX, where the wrap
+     * modulo 2^64 is itself bijective (KEY_MIX odd) and fits in keylen digits.
+     */
+    cap = short_key_space(keylen);
+    mix = key_mix_for(cap);
+    if (cap == ULONG_MAX) {
+        v = i * mix;                      /* wrap mod 2^64; mix odd => bijective */
+    } else {
+        v = (unsigned long)(((unsigned __int128) i * mix) % cap);
+    }
+
     for (int p = keylen - 1; p >= 0; p--) {
-        buf[p] = key_alphabet[i % KEY_RADIX];
-        i /= KEY_RADIX;
+        buf[p] = key_alphabet[v % KEY_RADIX];
+        v /= KEY_RADIX;
     }
     buf[keylen] = '\0';
 }


### PR DESCRIPTION
Closes the "degenerate corpus" half of #122, which #124 did not address, and **supersedes the SSO numbers recorded in #130**.

## The defect

The short-key generator from #124 encoded the index directly. Base-36 needs only `ceil(log36(n))` digits, so at n = 500k:

```
keylen  5: 00000  00001  05cwg  0apsv     -> 1 uniform leading '0'
keylen  8: 00000000  00000001  00005cwg   -> 4 uniform leading '0's
keylen 12: 000000000000  ...  00000000apsv -> 8 uniform leading '0's
```

A `keylen = 12` run was measuring **4 bytes of entropy behind 8 identical ones**. Across a sweep, length varied while entropy stayed fixed.

## It mattered, and it inverted a conclusion

JudySL compresses a shared run, so the trie was handed a corpus that flattered it.

| | old corpus | corrected corpus |
| --- | --- | --- |
| keylen 5-7, trie vs hash | trie **wins** by 16-18% | hash **wins** by 6-8% |
| keylen 6 SSO (same machine, unchanged) | 162.69 ns/op | 186.01 ns/op |

The second row is the same probe on one machine with nothing changed but the key distribution.

**This reverses an alarm I raised.** On the old numbers the trie beating `_HASH` looked like AGENTS.md's "fastest point lookups" guidance was wrong. On a corrected corpus that guidance is **supported** — `JudyHS` wins at 4-8 byte keys. Good thing the doc was not edited on the strength of it.

## The fix

`make_key()` multiplies the index by a capacity-scaled constant coprime with 36 before encoding:

- **Coprime** → bijection → keys stay unique, and the capacity guard still bounds the space exactly.
- **Capacity-scaled** (golden-ratio conjugate) → actually spans the space. A fixed constant does not: at keylen 12, `i * 2654435761` tops out near 1.3e15 against a 4.7e18 space, leaving the leading digits at `'0'`. Measured: **36 distinct values at byte 0** for keylen 5, 8 and 12, where the fixed multiplier gave **1** at keylen 12.

Above keylen 12 the space exceeds `ULONG_MAX` and a 64-bit index cannot reach the high digits, so some padding returns. Documented rather than papered over.

## Corrected sweep (idle 24-core host, load 0.00, n held at 500,000)

| keylen | `JHSG` (hash) | `JSLG` (trie) | `JLG` (SSO) |
| ---: | ---: | ---: | ---: |
| 4 | 102.1 | 110.3 | **100.6** |
| 5 | **101.5** | 109.4 | 104.7 |
| 6 | **111.7** | 111.7 | 112.1 |
| 7 | **103.1** | 111.2 | 107.9 |
| 8 | **116.6** | 142.8 | — |
| 12 | 150.0 | **141.3** | — |

- **SSO wins only at keylen 4, by ~1.4%.** Slower at 5 and 7, tied at 6. Nothing here justifies choosing a type for the SSO path.
- **`JudyHS` beats the trie at 4-8 byte keys** — supports the existing guidance.
- **The trie overtakes by keylen 12**; where between 8 and 12 is not measured.

The corrected result is narrower and less interesting than the one it replaces. That is the point.

## Verification

- [x] Exact length for keylen 1..24
- [x] Present and absent keys unique across keylen 4..15
- [x] keylen >= 16 byte-identical to the historical shape (differential vs the original)
- [x] #118 repro still runs; capacity guard still fires with its numbers
- [x] In-file compiler warnings unchanged from baseline (2, both from Judy.h's own macros)
- [ ] CI green

`research/` is not shipped — no `package.xml` change, no extension code touched.