### PR TITLE
fix(arrayaccess): offsetSet()/offsetUnset() must return nothing

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -62,8 +62,14 @@ if test "$PHP_JUDY" != "no"; then
     CFLAGS="$CFLAGS -DJUDY_DEBUG_MIRROR"
   fi
 
-  dnl # Performance optimizations for production builds
-  if test "$PHP_DEBUG" != "yes"; then
+  dnl # Performance optimizations for production builds.
+  dnl # PHP normalises PHP_DEBUG to 1/0 before an extension's config.m4 runs, so
+  dnl # a debug build arrives here as PHP_DEBUG=1, not "yes". Testing only
+  dnl # against "yes" therefore matched debug builds too and forced -DNDEBUG in,
+  dnl # which Zend/zend_portability.h rejects outright ("NDEBUG must not be
+  dnl # defined when ZEND_DEBUG is enabled") -- the extension could not be built
+  dnl # against a debug PHP at all. Both spellings are accepted here.
+  if test "$PHP_DEBUG" != "yes" && test "$PHP_DEBUG" != "1"; then
     dnl # Add optimization flags for production
     CFLAGS="$CFLAGS -O3"
     CFLAGS="$CFLAGS -fomit-frame-pointer"

--- a/judy_arrayaccess.c
+++ b/judy_arrayaccess.c
@@ -19,7 +19,7 @@
 #include "php_judy.h"
 #include "judy_arrayaccess.h"
 
-/* {{{ proto int Judy::offsetSet(mixed offset, mixed value)
+/* {{{ proto void Judy::offsetSet(mixed offset, mixed value)
    Set the value at the given offset in the Judy Array */
 PHP_METHOD(Judy, offsetSet)
 {
@@ -30,14 +30,18 @@ PHP_METHOD(Judy, offsetSet)
 		Z_PARAM_ZVAL(value)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (judy_object_write_dimension_helper(getThis(), offset, value) == SUCCESS) {
-		RETURN_TRUE;
-	}
-	RETURN_FALSE;
+	/* ArrayAccess::offsetSet() is `void`, so nothing may be returned here:
+	   returning a bool under an IS_VOID arginfo trips
+	   zend_verify_internal_return_type() on a debug build. The helper's
+	   FAILURE is not lost — every failure it can report has already thrown
+	   (bad key type, NUL in key, over-long key, keyless append on a
+	   string-keyed array) or is an allocation failure userland cannot act
+	   on. judy_object_write_dimension() discards it the same way. */
+	judy_object_write_dimension_helper(getThis(), offset, value);
 }
 /* }}} */
 
-/* {{{ proto int Judy::offsetUnset(mixed offset)
+/* {{{ proto void Judy::offsetUnset(mixed offset)
    Unset the given offset in the Judy Array */
 PHP_METHOD(Judy, offsetUnset)
 {
@@ -47,10 +51,12 @@ PHP_METHOD(Judy, offsetUnset)
 		Z_PARAM_ZVAL(offset)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (judy_object_unset_dimension_helper(getThis(), offset) == SUCCESS) {
-		RETURN_TRUE;
-	}
-	RETURN_FALSE;
+	/* `void`, as in offsetSet() above. The discarded bool was also actively
+	   misleading: the helper reports SUCCESS for a no-op delete of an absent
+	   key but FAILURE when neither backing array is allocated yet, so it read
+	   as "false on a fresh Judy, true on a populated one" — internal
+	   allocation state, not whether anything was unset. */
+	judy_object_unset_dimension_helper(getThis(), offset);
 }
 /* }}} */
 

--- a/package.xml
+++ b/package.xml
@@ -90,6 +90,7 @@
          <file name="examples/benchmarks/run_comprehensive_benchmarks.php" role="doc" />
          <file name="baselines/latest.json" role="doc" />
          <file md5sum="abc7eb31bb88857463ec941514e5f019" name="tests/001.phpt" role="test" />
+         <file name="tests/arrayaccess_void_return_001.phpt" role="test" />
          <file md5sum="43e01c2e189ff2523a83016559b80391" name="tests/bitset_001.phpt" role="test" />
          <file md5sum="9f3363cc4c6d15cb52184351cf710fd7" name="tests/bitset_002.phpt" role="test" />
          <file md5sum="e859b3b92086bc165b3ec98800920f03" name="tests/bitset_003.phpt" role="test" />

--- a/tests/arrayaccess_void_return_001.phpt
+++ b/tests/arrayaccess_void_return_001.phpt
@@ -1,0 +1,251 @@
+--TEST--
+Judy ArrayAccess offsetSet()/offsetUnset() return nothing, as their void declaration requires
+--SKIPIF--
+<?php
+if (!extension_loaded("judy")) print "skip";
+try { new Judy(Judy::INT_TO_MIXED); } catch (Exception $e) { print "skip MIXED types not supported"; }
+?>
+--FILE--
+<?php
+/*
+Invariant: Judy implements ArrayAccess, so offsetSet() and offsetUnset() are
+declared `void` and must write nothing to return_value.
+
+Both used to RETURN_TRUE/RETURN_FALSE on the helper's SUCCESS/FAILURE under an
+IS_VOID arginfo. On a release build the declared type is not enforced, so the
+bool leaked to callers; on an --enable-debug build the same call trips
+zend_verify_internal_return_type(). The bool was not merely undeclared but
+wrong: judy_object_unset_dimension_helper() reports SUCCESS for a no-op delete
+of an absent key and FAILURE only when neither backing array is allocated yet,
+so offsetUnset() read as false on a fresh Judy and true on a populated one --
+internal allocation state, not whether anything was unset.
+
+Nothing is lost by dropping it: every failure the helpers can report has
+already thrown (bad key type, NUL in key, over-long key, keyless append on a
+string-keyed array) or is an allocation failure userland cannot act on. The
+$j[$k] / unset($j[$k]) object handlers have always discarded it the same way.
+*/
+
+$types = [
+    'BITSET'                   => [Judy::BITSET,                   0,     true],
+    'INT_TO_INT'               => [Judy::INT_TO_INT,               1,     42],
+    'INT_TO_MIXED'             => [Judy::INT_TO_MIXED,             1,     'v'],
+    'INT_TO_PACKED'            => [Judy::INT_TO_PACKED,            1,     1.5],
+    'STRING_TO_INT'            => [Judy::STRING_TO_INT,            'k',   42],
+    'STRING_TO_MIXED'          => [Judy::STRING_TO_MIXED,          'k',   'v'],
+    'STRING_TO_INT_HASH'       => [Judy::STRING_TO_INT_HASH,       'k',   42],
+    'STRING_TO_MIXED_HASH'     => [Judy::STRING_TO_MIXED_HASH,     'k',   'v'],
+    'STRING_TO_INT_ADAPTIVE'   => [Judy::STRING_TO_INT_ADAPTIVE,   'k',   42],
+    'STRING_TO_MIXED_ADAPTIVE' => [Judy::STRING_TO_MIXED_ADAPTIVE, 'k',   'v'],
+];
+
+// 1. The declared signature is the interface's, not merely "some void".
+echo "== signature ==\n";
+foreach (['offsetSet', 'offsetUnset'] as $m) {
+    $judy = (string) (new ReflectionMethod('Judy', $m))->getReturnType();
+    // ArrayAccess declares its return types tentatively, so the interface side
+    // is only visible through getTentativeReturnType().
+    $r = new ReflectionMethod('ArrayAccess', $m);
+    $iface = (string) ($r->getTentativeReturnType() ?? $r->getReturnType());
+    var_dump($judy === 'void', $judy === $iface);
+}
+
+// 2. Both return null, and keep returning null once a value is actually
+//    returned by the helper's every branch: unallocated array, absent key,
+//    present key, overwrite.
+foreach ($types as $name => [$type, $key, $value]) {
+    echo "== $name ==\n";
+
+    // Fresh instance: neither backing array is allocated. This is the case
+    // that used to evaluate to false while every later one evaluated to true.
+    $j = new Judy($type);
+    var_dump($j->offsetUnset($key) === null);
+
+    // Insert, overwrite, delete absent, delete present.
+    var_dump(
+        $j->offsetSet($key, $value) === null,
+        $j->offsetSet($key, $value) === null,
+        $j->offsetUnset($key) === null,
+        $j->offsetUnset($key) === null
+    );
+
+    // 3. Discarding the return value did not discard the side effect.
+    $j = new Judy($type);
+    $j->offsetSet($key, $value);
+    var_dump(isset($j[$key]), $j->count() === 1, $j[$key] === $value);
+    $j->offsetUnset($key);
+    var_dump(isset($j[$key]), $j->count() === 0);
+
+    // 4. The object handlers reach the same state as the explicit calls.
+    $viaHandler = new Judy($type);
+    $viaHandler[$key] = $value;
+    $viaMethod = new Judy($type);
+    $viaMethod->offsetSet($key, $value);
+    var_dump($viaHandler->equals($viaMethod));
+    unset($viaHandler[$key]);
+    $viaMethod->offsetUnset($key);
+    var_dump($viaHandler->equals($viaMethod));
+}
+
+// 5. The other half of the quartet keeps its own declared types: offsetExists
+//    is bool and offsetGet is mixed, so neither had this mismatch.
+echo "== quartet ==\n";
+$j = new Judy(Judy::STRING_TO_INT);
+$j['a'] = 1;
+var_dump($j->offsetExists('a'), $j->offsetExists('b'), $j->offsetGet('a'));
+
+// 6. Failures still surface as exceptions rather than as a return value.
+echo "== errors ==\n";
+try { $j->offsetSet(123, 1); } catch (Throwable $e) { echo get_class($e), "\n"; }
+try { $j->offsetUnset(123); } catch (Throwable $e) { echo get_class($e), "\n"; }
+try { $j->offsetSet("a\0b", 1); } catch (Throwable $e) { echo get_class($e), "\n"; }
+try { $j->offsetUnset("a\0b"); } catch (Throwable $e) { echo get_class($e), "\n"; }
+// The insert that threw must not have landed.
+var_dump($j->count() === 1);
+?>
+--EXPECT--
+== signature ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+== BITSET ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== INT_TO_INT ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== INT_TO_MIXED ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== INT_TO_PACKED ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== STRING_TO_INT ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== STRING_TO_MIXED ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== STRING_TO_INT_HASH ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== STRING_TO_MIXED_HASH ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== STRING_TO_INT_ADAPTIVE ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== STRING_TO_MIXED_ADAPTIVE ==
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+== quartet ==
+bool(true)
+bool(false)
+int(1)
+== errors ==
+TypeError
+TypeError
+Exception
+Exception
+bool(true)


### PR DESCRIPTION
`Judy` implements `ArrayAccess`, so `Judy.stub.php` declares `offsetSet()` and
`offsetUnset()` as `void` and `Judy_arginfo.h` emits `IS_VOID`. Both
implementations returned `RETURN_TRUE`/`RETURN_FALSE` on their helper's
SUCCESS/FAILURE anyway.

A release build does not enforce the declared type, so the bool leaked to
callers. A debug build asserts on exactly this, and both methods aborted with
SIGABRT on the first call:

```
Assertion failed: (!(call->func->common.fn_flags & (1 << 13)) ||
  zend_verify_internal_return_type(call->func, ret)),
  function ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_TAILCALL_HANDLER
```

Fixed by making the implementation match the stub. Declaring `bool` instead was
not an option: `ArrayAccess::offsetSet`/`offsetUnset` carry tentative `void`
return types, so it would violate the interface.

### The bool was not merely undeclared, it was wrong

`judy_object_unset_dimension_helper()` reports SUCCESS for a no-op delete of an
absent key, but FAILURE when neither backing array is allocated yet. So
`offsetUnset()` read `false` on a fresh `Judy` and `true` on a populated one —
internal allocation state, not whether anything was unset:

```php
$j = new Judy(Judy::STRING_TO_INT);
var_dump($j->offsetUnset('absent'));   // before: bool(false)
$j['a'] = 1;
var_dump($j->offsetUnset('absent'));   // before: bool(true)
```

Nothing is lost by dropping it. Every failure the helpers report has already
thrown (bad key type and NUL-in-key via `CHECK_ARRAY_AND_ARG_TYPE`, over-long
key, keyless append on a string-keyed array) or is an allocation failure
userland cannot act on — and userland could not tell those apart from the bool
anyway. `judy_object_write_dimension()` and `judy_object_unset_dimension()`, the
`$j[$k] = $v` and `unset($j[$k])` paths, have always discarded it the same way,
which is why only the explicit method calls were affected. `judy-polyfill`,
which must honour `ArrayAccess`, already declares both `void`; this makes the
extension agree with it.

### Why this was never caught: the extension could not build against a debug PHP

The first commit is a prerequisite. PHP normalises `PHP_DEBUG` from `yes` to `1`
before an extension's `config.m4` runs, so `config.m4`'s guard tested only
against `"yes"`, matched debug builds too, and appended `-DNDEBUG` to them —
which `Zend/zend_portability.h:51` rejects outright. The build that would have
caught this class of bug was unreachable.

Production builds are unaffected: a fresh `phpize` + `configure` against the
release PHP emits the identical CFLAGS line as before.

### Scope

All six `IS_VOID` methods (`offsetSet`, `offsetUnset`, `rewind`, `forEach`,
`mergeWith`, `__unserialize`) were checked for `RETURN_*`, `RETVAL_*` and direct
`return_value` writes. Only these two were affected; the rest were already
clean. `offsetExists` (`_IS_BOOL`) and `offsetGet` (`IS_MIXED`, where a `false`
return is type-legal) do not have this mismatch.

The stub is unchanged, so arginfo is unchanged and `API.md` is unaffected
(`generate-api-docs.php --check` reports it up to date). No doc claimed a return
value for either method.

### BC

`$j->offsetSet(...)` and `$j->offsetUnset(...)` now evaluate to `null` instead of
a bool. The value was undeclared, undocumented and inconsistent; nothing in the
tree consumed it. Worth a line in the next release's `<notes>`.

### Testing

`tests/arrayaccess_void_return_001.phpt` covers all ten types: both methods
return `null` across every helper branch (unallocated array, absent key, present
key, overwrite), the declared type matches `ArrayAccess`'s own tentative return
type, side effects and the object-handler paths still agree, `offsetExists` /
`offsetGet` keep their types, and failures still surface as exceptions. It fails
against the pre-change build with all five `null` assertions flipping.

- 215/215 on the release build, zero compiler warnings.
- 214/215 against a PHP 8.5.8 `--enable-debug` build built from source, where
  the pre-change extension aborts on the first `offsetSet()`/`offsetUnset()`.

### Known, pre-existing, not fixed here

That one debug-build failure is `debug_info_empty_001`, and it is unrelated.
`Judy::__construct()` has the same family of mismatch: arginfo declares `$type`
required, but the implementation skips zpp entirely at zero args, so the
`new Judy()` that test deliberately exercises is fatal on a debug build and
silent on a release one. Left alone because whether zero-arg construction stays
supported is a behaviour decision, not a type one. Tracked separately.

CI has no debug-build job, which is the structural reason both mismatches went
unnoticed; a follow-up can add one now that the first commit makes it possible.
