### PR TITLE
ci(debug): run the test suite against an --enable-debug PHP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,164 @@ jobs:
 
           git checkout -- php_judy.c
 
+  debug-php-assertions:
+    # A --enable-debug PHP compiles in checks that a release build drops,
+    # among them the arginfo cross-checks: zend_verify_internal_return_type
+    # compares what an internal function returns against what its arginfo
+    # declares, and the zpp bookkeeping catches a function whose parameter
+    # parsing disagrees with its declared signature. No other job here runs
+    # against such a PHP, and that gap is why Judy::offsetSet()/offsetUnset()
+    # could be declared IS_VOID while returning a bool -- an abort on every
+    # call under a debug build -- without CI noticing (#137).
+    #
+    # This job depends on the config.m4 fix that ships alongside it: PHP
+    # normalises PHP_DEBUG from "yes" to 1 before an extension's config.m4
+    # runs, so the old `!= "yes"` guard matched debug builds too and appended
+    # -DNDEBUG, which Zend/zend_portability.h rejects with a hard #error.
+    # Before that fix the extension could not be compiled against a debug PHP
+    # at all.
+    #
+    # setup-php ships no --enable-debug builds, so the PHP is compiled from
+    # source here and cached on its version.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Judy library
+        run: sudo apt-get update && sudo apt-get install -y libjudy-dev
+
+      - name: Resolve the PHP 8.4 release to build
+        run: |
+          # Track the current 8.4 patch release so the assertions stay current,
+          # and fall back to a known-good pin if the release feed changes
+          # shape: the patch level is not what this job is testing, so a feed
+          # hiccup should not turn the job red.
+          FALLBACK=8.4.24
+          VERSION=$(curl -fsSL --max-time 30 \
+                      'https://www.php.net/releases/?json&version=8.4' \
+                    | grep -oE '"version":"8\.4\.[0-9]+"' \
+                    | grep -oE '8\.4\.[0-9]+' | head -1 || true)
+          if [ -z "$VERSION" ]; then
+            echo "::warning::could not resolve the current PHP 8.4 release — falling back to $FALLBACK"
+            VERSION=$FALLBACK
+          fi
+          echo "PHP_DEBUG_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Debug PHP to build: $VERSION"
+
+      - name: Restore the cached debug PHP
+        id: php-debug-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/php-debug
+          # The configure line is part of the key: a build made with different
+          # flags is a different PHP and must not be reused.
+          key: php-debug-${{ runner.os }}-${{ env.PHP_DEBUG_VERSION }}-enable-debug-disable-all-cli
+
+      - name: Build PHP ${{ env.PHP_DEBUG_VERSION }} with --enable-debug
+        if: steps.php-debug-cache.outputs.cache-hit != 'true'
+        run: |
+          # --disable-all keeps the build to what the suite actually needs:
+          # json and pcre cannot be disabled and are the only extensions the
+          # .phpt files use, and the whole suite runs under it with zero
+          # skipped tests. Add an extension back here if a test starts
+          # needing one, rather than enabling everything.
+          curl -fsSL --retry 3 -o /tmp/php.tar.xz \
+            "https://www.php.net/distributions/php-${PHP_DEBUG_VERSION}.tar.xz"
+          tar -xf /tmp/php.tar.xz -C /tmp
+          cd "/tmp/php-${PHP_DEBUG_VERSION}"
+          ./configure --enable-debug --disable-all --enable-cli --without-pear \
+            --prefix="$HOME/php-debug"
+          make -j"$(nproc)"
+          make install
+
+      - name: Confirm the PHP really is a debug build
+        run: |
+          # Without this the job degrades into a slower duplicate of
+          # build-linux the moment --enable-debug stops taking effect, and a
+          # PHP with no assertions in it would make every step below pass
+          # vacuously.
+          "$HOME/php-debug/bin/php" -v
+          "$HOME/php-debug/bin/php" -r 'var_dump(PHP_DEBUG);' | grep -qx 'bool(true)' \
+            || { echo "::error::PHP_DEBUG is not true — this is not a debug PHP"; exit 1; }
+          "$HOME/php-debug/bin/php" -i | grep -qE '^Debug Build => yes$' \
+            || { echo "::error::php -i does not report a debug build"; exit 1; }
+          echo "Confirmed: NTS DEBUG PHP ${PHP_DEBUG_VERSION}."
+
+      - name: Build the extension against the debug PHP
+        run: |
+          # A phpize build inherits PHP_DEBUG from the installed PHP; pass
+          # --enable-debug anyway so the intent does not rest on inheritance.
+          "$HOME/php-debug/bin/phpize"
+          ./configure --with-php-config="$HOME/php-debug/bin/php-config" \
+            --with-judy=/usr --enable-debug
+          set -o pipefail
+          make 2>&1 | tee /tmp/build-debug-php.log
+
+      - name: Fail on compiler warnings
+        run: |
+          if grep -E '(php_judy|judy_handlers|judy_arrayaccess|judy_iterator)\.[ch]:[0-9]+:[0-9]+: warning:' /tmp/build-debug-php.log; then
+            echo "::error::Compiler warnings detected building against a debug PHP"
+            exit 1
+          fi
+          echo "No compiler warnings in extension sources."
+
+      - name: Confirm the extension loads into the debug PHP
+        run: |
+          # A module built for a release PHP cannot load into a debug one --
+          # the build IDs differ -- so a successful load is also the proof
+          # that the .so under test was compiled with ZEND_DEBUG on.
+          "$HOME/php-debug/bin/php" -d extension="$(pwd)/modules/judy.so" \
+            -r 'if (!PHP_DEBUG) { fwrite(STDERR, "not a debug runtime\n"); exit(1); }
+                printf("judy %s loaded into a debug PHP\n", judy_version());'
+
+      - name: Run the suite, minus one test that a known bug fails
+        run: |
+          # tests/debug_info_empty_001.phpt calls `new Judy()`. Judy::__construct
+          # declares $type as required in its arginfo but returns early without
+          # calling zend_parse_parameters when given no arguments, which a
+          # debug PHP rejects outright:
+          #
+          #   Fatal error: Arginfo / zpp mismatch during call of Judy::__construct()
+          #
+          # That is a real unfixed bug in the extension, not a test problem,
+          # and it is being fixed separately. It is excluded here so the other
+          # 214 tests can gate today; the step below pins the exclusion so it
+          # cannot outlive the bug.
+          KNOWN_FAILURE=tests/debug_info_empty_001.phpt
+          SUITE=$(ls tests/*.phpt | grep -vxF "$KNOWN_FAILURE" | tr '\n' ' ')
+          make test TESTS="$SUITE" NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+
+      - name: Pin the exclusion — require the known failure to still fail
+        run: |
+          # An excluded test is only honest if the exclusion expires. This
+          # step fails the moment tests/debug_info_empty_001.phpt starts
+          # passing on a debug build, i.e. when Judy::__construct is fixed:
+          # that PR should delete this step and drop the exclusion from the
+          # step above, so the whole suite gates again.
+          #
+          # It also fails if the test breaks for some *other* reason, which an
+          # exclusion on its own would hide.
+          KNOWN_FAILURE=tests/debug_info_empty_001.phpt
+          rm -f tests/debug_info_empty_001.out tests/debug_info_empty_001.diff
+
+          set +e
+          make test TESTS="$KNOWN_FAILURE" NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+          rc=$?
+          set -e
+
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::$KNOWN_FAILURE now passes on a debug build — Judy::__construct is fixed. Delete this step and drop the exclusion from the previous step so the full suite gates."
+            exit 1
+          fi
+          if ! grep -q 'Arginfo / zpp mismatch during call of Judy::__construct' \
+               tests/debug_info_empty_001.out; then
+            echo "::error::$KNOWN_FAILURE failed for a different reason than the known Judy::__construct arginfo/zpp mismatch — see the diff below"
+            cat tests/debug_info_empty_001.diff
+            exit 1
+          fi
+          echo "Known failure reproduced: Judy::__construct arginfo/zpp mismatch."
+
   validate-pecl:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,55 @@ and the payload comparison are driven from `key_index` outwards. A value-store
 entry that `key_index` does not list is reachable only through the population
 counter or as a valgrind leak.
 
+### Building against a debug PHP
+
+A PHP built with `--enable-debug` compiles in cross-checks that a release build
+drops, among them the arginfo checks: what an internal function actually
+returns, and how it parses its parameters, are compared against what its
+arginfo declares. They catch a class of bug nothing else here sees —
+`offsetSet()`/`offsetUnset()` were declared `IS_VOID` while returning a bool,
+which aborts *every* call under such a PHP, and the whole existing test suite
+passed anyway.
+
+`shivammathur/setup-php` ships no debug builds, so this means compiling PHP.
+From a PHP source tree:
+
+```sh
+./configure --enable-debug --disable-all --enable-cli --without-pear \
+  --prefix="$HOME/php-debug"
+make -j"$(nproc)" && make install
+```
+
+`--disable-all` is enough for this suite: `json` and `pcre` cannot be disabled
+and are the only extensions the `.phpt` files use. Then build the extension
+against it — a phpize build inherits `PHP_DEBUG` from the installed PHP, but
+pass `--enable-debug` explicitly so the intent does not rest on inheritance:
+
+```sh
+phpize --clean && "$HOME/php-debug/bin/phpize"
+./configure --with-php-config="$HOME/php-debug/bin/php-config" \
+  --with-judy=/usr --enable-debug
+make
+make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+```
+
+Check the PHP you built really is a debug one before trusting a clean run:
+`php -r 'var_dump(PHP_DEBUG);'` must print `bool(true)` and `php -i` must say
+`Debug Build => yes`. Note also that the extension only compiles against such a
+PHP at all because `config.m4` accepts `PHP_DEBUG=1` as well as `"yes"` —
+PHP normalises the value before `config.m4` runs, and the production branch
+adds `-DNDEBUG`, which `Zend/zend_portability.h` rejects with a hard `#error`.
+
+CI runs this as the `debug-php-assertions` job, which compiles the PHP once and
+caches it on its version. One test is excluded there for now:
+`debug_info_empty_001.phpt` calls `new Judy()`, and `Judy::__construct`
+declares `$type` required in its arginfo while returning early without calling
+`zend_parse_parameters` at zero arguments, which a debug PHP rejects with
+`Arginfo / zpp mismatch during call of Judy::__construct()`. The job's last
+step re-runs that one test and requires it to keep failing *for that reason*,
+so the exclusion turns CI red the moment the constructor is fixed rather than
+quietly outliving the bug.
+
 ## Debugging the extension itself (lldb)
 
 This is the C-side story — a crash, a core dump, or a stop inside `php_judy.c`


### PR DESCRIPTION
Adds a `debug-php-assertions` job that builds the extension against a PHP
compiled with `--enable-debug` and runs the suite under it.

## Why

A debug PHP compiles in cross-checks that a release build drops, among them
the arginfo checks: `zend_verify_internal_return_type` compares what an
internal function actually returns against what its arginfo declares, and the
zpp bookkeeping catches a function whose parameter parsing disagrees with its
declared signature. Nothing in CI ran against such a PHP, so those checks
never ran here at all. Two real bugs are downstream of that gap:

- `Judy::offsetSet()`/`offsetUnset()` declared `IS_VOID` while returning a
  bool — SIGABRT on every call under a debug build, whole suite green.
  Fixed in #137.
- `Judy::__construct()` declares `$type` required in arginfo but returns
  early without calling `zend_parse_parameters` at zero arguments, so
  `new Judy()` is a fatal `Arginfo / zpp mismatch` on a debug build. Still
  open; being fixed separately.

## Relationship to #137

Branched off `fix/arrayaccess-void-return`, which has since merged, so the diff
here is just the two commits above. The dependency is worth recording anyway:
before that branch's `config.m4` commit (e2d9b3a) the extension could not be
compiled against a debug PHP at all. PHP normalises `PHP_DEBUG` from `yes` to
`1` before an extension's `config.m4` runs, so the old `!= "yes"` guard matched
debug builds too and appended `-DNDEBUG`, which `Zend/zend_portability.h:51`
rejects with a hard `#error`. This PR does not touch that change; it is what
makes the job possible.

## What the job does

`shivammathur/setup-php` ships no `--enable-debug` builds, so the job compiles
PHP 8.4 from source:

`./configure --enable-debug --disable-all --enable-cli --without-pear --prefix=$HOME/php-debug`

`--disable-all` is sufficient: `json` and `pcre` cannot be disabled and are the
only extensions the `.phpt` files use — the suite runs with **0 skipped tests**
under it. The build is cached with `actions/cache` keyed on the resolved patch
version plus the configure line, so it is compiled once per PHP release rather
than per run. The patch version is resolved from php.net's release feed with a
pinned fallback, so a change in that feed cannot turn the job red for a reason
unrelated to what it tests.

Two guards keep the job from passing vacuously:

- After installing PHP, it asserts `PHP_DEBUG` is `bool(true)` **and** that
  `php -i` reports `Debug Build => yes`. A silently non-debug PHP fails the
  job instead of quietly making it a slow duplicate of `build-linux`.
- After building, it asserts the module loads into that PHP. A module built
  for a release PHP cannot load into a debug one (differing build IDs), so a
  successful load is also proof the `.so` under test has `ZEND_DEBUG` on.

Structure, naming and the compiler-warning gate follow the existing
`debug-mirror-assertions` job.

## How `debug_info_empty_001` is handled

That test is the one failure of the 215 on a debug build today (214 pass), and
it fails because of the open `__construct` bug above, not because of anything
in this PR. It is **excluded from the gating run and then pinned**, rather than
excluded silently or waved through with `continue-on-error`:

- The suite step runs every `.phpt` except that one, and gates on it — 214
  tests, exit status honoured as everywhere else.
- The last step re-runs that one test on its own and requires it to **still
  fail, for that exact reason** (`grep` on `Arginfo / zpp mismatch during call
  of Judy::__construct`). It fails the job if the test starts passing, with an
  error saying to delete the step and the exclusion; and it fails the job if
  the test breaks for any *other* reason, which a bare exclusion would hide.

So the exclusion expires on its own: the `__construct` fix will turn this job
red, and that PR removes the last step and the exclusion in the step above,
after which the whole suite gates. This is the same idiom as the negative
controls in `debug-mirror-assertions` — an allowance that has to be justified
on every run.

The alternative of marking the whole job `continue-on-error` was rejected: it
would hide every *future* debug-build regression too, not just this one test,
and nothing would force its removal.

## Verification

**In CI on this PR** — the job is green on its first (cold-cache) run: it built
PHP 8.4.24, logged `Confirmed: NTS DEBUG PHP 8.4.24`, loaded the module into
it, ran **218 tests, 218 passed, 0 skipped**, and the pinning step reported
`Known failure reproduced: Judy::__construct arginfo/zpp mismatch.`

**Locally, before pushing** — the approach was not assumed to work; it was run
end to end in an `ubuntu:24.04` container against a from-source PHP 8.4.24
`NTS DEBUG` build, executing the job's step scripts verbatim as extracted from
the YAML:

- PHP builds, installs, and reports `NTS DEBUG` / `PHP_DEBUG => bool(true)` /
  `Debug Build => yes`; `run-tests.php` lands in the installed prefix, so
  `make test` works for a phpize build against it.
- Extension builds with no compiler warnings and loads into the debug PHP.
- Full suite on that branch: 214 pass, 1 fail — exactly
  `debug_info_empty_001.phpt`, with
  `Fatal error: Arginfo / zpp mismatch during call of Judy::__construct()`.
- **Both failure modes of the pinning step were exercised**, not just reasoned
  about: replacing that test with a passing one produced the "now passes —
  delete this step" error, and replacing it with a differently-failing one
  produced the "failed for a different reason" error.

YAML parses (`yaml.safe_load`). No new files, so `package.xml` is unchanged;
`baselines/latest.json` untouched.
