### PR TITLE
fix(research): make iterbench honour keylen, and re-derive the JSLN flatness claim

### DIFF
--- a/BACKEND_EVALUATION.md
+++ b/BACKEND_EVALUATION.md
@@ -118,14 +118,28 @@ discriminators, all against it:
 
 | Test | Expectation if key materialization dominates | Measured |
 | ---- | -------------------------------------------- | -------- |
-| Key length 16 → 64 bytes (4x the bytes to write) | ~proportional rise | 70.5 → 77.8 ns, **+10%** |
-| n 100K → 1M (10x working set) | cache effects | 66.4 → 70.2 ns, **+6%** |
-| `JSLN − JSLG` replayed in iteration order — same descend and locality, no key written back | falls with shorter keys | 33.1 / 30.7 / 31.1 / 32.9 ns at keylen 16/24/40/64 — **flat** |
+| Key length 8 → 64 bytes (8x the bytes to write) | ~proportional rise | 102.1 → 132.8 ns, **+30%** — a **0.44 ns/byte** marginal slope |
+| `JSLN − JSLG` replayed in iteration order — same descend and locality, no key written back | scales with the bytes written | **0.22 ns/byte** marginal; 8x the bytes costs +44%, not 8x |
+| Same delta, at fixed keylen 16, as n goes 100K → 3.16M | no effect — reconstruction cannot depend on working-set size | 23.0 → **61.7 ns**, 2.7x |
 
-The actual decomposition of that ~70 ns is roughly **37 ns stateless root
-descend + 32 ns successor search + ~1 ns of key bytes.** The cost is JudySL's
+Figures are `(measured)` 2026-08-17, n = 1,000,000, uniform-random keys; see
+[`research/README.md`](research/README.md#the-jsln-flatness-claim-re-derived).
+The third row is the decisive one: a cost that grows with working set at
+constant key length is not key bytes being copied. The cost is JudySL's
 structure and libJudy's *stateless* API — every `JSLN` re-descends from the
 root — not the caller-supplied buffer.
+
+**An earlier version of this table read differently**, and its numbers are
+withdrawn. It reported `JSLN` as flat in key length (+10% over 16→64) and flat
+in working-set size (+6% over 100K→1M), with a decomposition of *"37 ns root
+descend + 32 ns successor search + ~1 ns of key bytes"*. Both flat results were
+artifacts of the `user:%08lu:f%lu` corpus, whose shared prefixes compress into
+a tree that barely grows with n; on uniform-random keys the same working-set
+sweep rises **+140%**. The harness could also not emit a key shorter than 16
+bytes at all ([#122](https://github.com/orieg/php-judy/issues/122)), hiding a
+**2.9x step between keylen 7 and 8** — the machine-word boundary — which is the
+largest key-length effect there is. The conclusion below is unchanged; only the
+evidence for it is, and it is now stronger.
 
 This makes the gap **more** significant, not less. `Judy.h` exposes no cursor
 or iterator primitive, so there is no cheaper call for php-judy to switch to:
@@ -303,14 +317,17 @@ change the keep-Judy verdict, and it did not re-run ART. What it changes here:
   `user:%08lu:f%lu` corpus turned out to be degenerate (every branch a
   `BRANCH_B` at identical density), which is enough to caution against
   generalising any single-corpus result here, including this document's.
-- **The #85 flatness claim itself needs re-deriving.** Its harness could not
-  emit a key shorter than 16 bytes — see
-  [`research/README.md`](research/README.md#re-derivation-owed-the-jsln-flat-in-key-length-claim),
-  [#122](https://github.com/orieg/php-judy/issues/122) and
-  [PR #124](https://github.com/orieg/php-judy/pull/124). The published 16/24/40/64
-  points did vary key length, so this is not a retraction; the short-key half was
-  simply never tested, and `iteration-cost/iterbench.c` still carries the
-  unfixed generator.
+- **The #85 flatness claim has been re-derived, and it does not hold.** The
+  generator in `iteration-cost/iterbench.c` is fixed
+  ([#122](https://github.com/orieg/php-judy/issues/122)) and the sweep re-run
+  across the short half and across two non-degenerate corpora: `JSLN` is
+  **neither flat in key length nor flat in working-set size** — both flat
+  results came from the same degenerate corpus flagged above. The
+  key-reconstruction hypothesis stays refuted on stronger evidence, and the
+  discriminator table in
+  [The iteration number](#the-iteration-number-first-explanation-was-wrong) has
+  been rewritten around it. Full record in
+  [`research/README.md`](research/README.md#the-jsln-flatness-claim-re-derived).
 
 One correctness finding from that investigation is independent of all backend
 questions and applies today: stock libJudy 1.0.5 built with `gcc -O3` silently

--- a/research/README.md
+++ b/research/README.md
@@ -10,56 +10,209 @@ Each subdirectory owns one question and names the artifact it supports.
 | Directory | Question | Supports |
 | --------- | -------- | -------- |
 | [`shm-arena/`](shm-arena/) | Can libJudy live in a shared-memory arena, giving an ordered cache shared across FPM workers? | [issue #83](https://github.com/orieg/php-judy/issues/83) — closed, not planned. Five feasibility gates; writer death corrupts the tree 15% of the time (Wilson CI [8.8%, 24.4%]) and macOS has no robust mutexes. `FINDINGS.md` has the per-gate verdicts. |
-| [`iteration-cost/`](iteration-cost/) | Is JudySL's ordered-iteration cost the caller-supplied key buffer, or a stateless re-descend from the root? | [issue #85](https://github.com/orieg/php-judy/issues/85) and [BACKEND_EVALUATION.md](../BACKEND_EVALUATION.md). Concluded that the key-reconstruction hypothesis is refuted — `JSLN` flat in key length and flat in working-set size. **That conclusion needs re-deriving before it is relied on again**; see [Re-derivation owed](#re-derivation-owed-the-jsln-flat-in-key-length-claim) below. |
+| [`iteration-cost/`](iteration-cost/) | Is JudySL's ordered-iteration cost the caller-supplied key buffer, or a stateless re-descend from the root? | [issue #85](https://github.com/orieg/php-judy/issues/85) and [BACKEND_EVALUATION.md](../BACKEND_EVALUATION.md). The key-reconstruction hypothesis stays refuted, but the evidence originally given for it does not: **`JSLN` is not flat in key length, and not flat in working-set size** — both flat results were artifacts of one degenerate corpus. Re-derived on a fixed generator; see [The `JSLN` flatness claim, re-derived](#the-jsln-flatness-claim-re-derived) below. |
 | [`write-probe-cost/`](write-probe-cost/) | Issue #85 step B3 wants ordered traversal to read the value out of the `key_index` cursor. That means locating the `key_index` slot on every write. What does moving the existence probe from JudyHS to JudySL cost the write path? | [issue #85](https://github.com/orieg/php-judy/issues/85) step B3. The probe swap itself is roughly neutral on a hit (+3% at 16-byte keys, −9% at 40-byte) and a large win on a miss (JudySL fails at the first differing byte; JudyHS digests the whole key first). End-to-end random-order overwrite still regresses, because today's `JHSG`+`JHSI` pair reuses one warm structure and the mirrored write touches two. That regression is why the mirror ships behind the opt-in `optimizeIteration` constructor argument rather than on by default: the unmirrored path keeps the `JHSG` probe and this swap never happens on it. |
 | [`backend-comparison/`](backend-comparison/) | Should the extension keep libJudy, or move to a modern ordered index? | [BACKEND_EVALUATION.md](../BACKEND_EVALUATION.md). `amdahl.c`/`amdahl.php` bound how much a backend swap could possibly buy through the PHP boundary; `cmp.c` runs ART against JudySL. Verdict: keep Judy. Needs libart cloned alongside — not vendored. |
 | [`libjudy-modernization/`](libjudy-modernization/) | Given that we keep Judy, does the incumbent have exploitable headroom — and does realising it mean vendoring libJudy? | [issue #113](https://github.com/orieg/php-judy/issues/113), plus [#131](https://github.com/orieg/php-judy/issues/131) / [#127](https://github.com/orieg/php-judy/issues/127) for the upstream defects it turned up. A first "no headroom" verdict was retracted; round 2 measured popcount-L at 17% cache-resident (JudyL only) and memory-level parallelism at 1.62–1.79x. The decisive finding is correctness, not speed: stock libJudy built with `gcc -O3` silently loses `Judy::BITSET` keys. Verdict: vendor stock 1.0.5 + patches, gated. `FINDINGS.md` has the full record, including the retraction and the negatives. **No harnesses are committed** — they were built in throwaway trees; re-deriving the timings needs them written again. |
 
-## Re-derivation owed: the `JSLN` flat-in-key-length claim
+## The `JSLN` flatness claim, re-derived
 
-This directory's `iteration-cost/` row used to record the #85 result flatly as
-*"refuted the key-reconstruction hypothesis"*. That wording is withdrawn pending
-a re-run. **The claim is not refuted and it may well be true — it is simply not
-currently established**, and the distinction matters.
+`(measured)` 2026-08-17. **Verdict: `JSLN` is not flat in key length, and not
+flat in working-set size.** Both flat results reproduce exactly — but only on
+the structured corpus, and only inside the window that was actually swept. Off
+that corpus they fail by margins far larger than the noise floor.
 
-**Why.** [#122](https://github.com/orieg/php-judy/issues/122) established that
-`make_key()` only ever padded a key *up* and never truncated it, while its format
-(`"user:" + 8 digits + ":f" + >=1 digit`) is **16 characters at minimum**. Every
-requested length at or below 16 therefore produced the identical 16-byte key. The
-`JSLN` sweep's published points are keylen 16 / 24 / 40 / 64, all at or above that
-floor, so those specific points *did* vary the independent variable — this is not
-a claim that the published numbers are wrong. But two things follow that the
-original conclusion did not account for:
+The underlying #85 *conclusion* — that per-key key reconstruction is not what
+makes ordered `JSLN` traversal expensive — survives, and is in fact better
+supported now than it was. What does not survive is the flatness evidence
+offered for it, and any use of "flat" as a general property of `JSLN`.
 
-1. **The short half of "flat in key length" was never testable.** The harness
-   could not emit a key shorter than 16 bytes at all, so "flat" is established
-   only across 16→64, over a range where the trie is already several levels deep.
-2. **The corpus is degenerate.** Enumerating the full key set: 8 of 16 byte
-   positions are invariant, six carry entropy over 10 of 256 values, and 10^6
-   keys exactly saturate a 10^6 key space. With `cJU_BRANCHLMAXJPS` = 7 and 10
-   populated subexpanses, **every branch in the tree is a `BRANCH_B` bitmap at
-   identical density**; `BRANCH_L`, `BRANCH_U` and every transition between them
-   are never observed. Whatever `JSLN` does, it was observed in exactly one
-   node-type regime. The same defect invalidated a popcount conclusion in
-   [#113](https://github.com/orieg/php-judy/issues/113) — see
-   [`libjudy-modernization/FINDINGS.md`](libjudy-modernization/FINDINGS.md) §4.
+### Why this needed re-deriving
 
-**The generator is still unfixed here.**
-[PR #124](https://github.com/orieg/php-judy/pull/124) repaired
-`write-probe-cost/probebench.c` (two key shapes split at `keylen = 16`, a
-capacity guard, an exact-length assertion), **but `iteration-cost/iterbench.c`
-still carries the original `make_key()`** — verify before quoting any figure
-from it.
+[#122](https://github.com/orieg/php-judy/issues/122) established that
+`make_key()` only ever padded a key *up* and never truncated it, while its
+format (`"user:" + 8 digits + ":f" + >=1 digit`) is **16 characters at
+minimum**. Every requested length at or below 16 therefore produced the
+identical 16-byte key:
 
-**What would settle it.** Port PR #124's two-shape generator into
-`iterbench.c`, then re-run the three #85 discriminators across lengths spanning
-both regimes *and* against at least one non-degenerate corpus (uniform-random
-bytes, and variable-length), reporting Judy's node-type histogram per corpus so
-the regime is visible rather than assumed. If flatness survives that, the
-conclusion is re-established and this section goes away — along with the caveat
-it forces onto
-[BACKEND_EVALUATION.md](../BACKEND_EVALUATION.md#what-would-change-the-verdict),
-which carries the same claim.
+```
+old  keylen= 4 -> strlen=16  user:00123456:f7
+old  keylen= 6 -> strlen=16  user:00123456:f7
+old  keylen=12 -> strlen=16  user:00123456:f7
+old  keylen=16 -> strlen=16  user:00123456:f7
+old  keylen=24 -> strlen=24  user:00123456:f7xxxxxxxx
+```
+
+The published sweep points are keylen 16 / 24 / 40 / 64, all at or above that
+floor, so those points *did* vary the independent variable — this was never a
+claim that the published numbers were wrong, and they reproduce here. But the
+short half of the sweep had never executed, and the corpus was degenerate: 8 of
+16 byte positions invariant, six carrying 10 of 256 values, 10^6 keys exactly
+saturating a 10^6 key space, so every branch in the tree is a `BRANCH_B` bitmap
+at identical density.
+
+`iterbench.c` now carries the same two-shape generator as
+`write-probe-cost/probebench.c` ([PR #124](https://github.com/orieg/php-judy/pull/124)),
+plus an unconditional `key_check()` that aborts if an emitted key is not
+exactly the requested length — `assert()` is not used, because a generator that
+silently ignores its length argument is the whole defect. It also takes an
+optional fourth argument selecting the corpus, so the conclusion is no longer
+scoped to one key shape:
+
+- **`struct`** (default) — the original shape above 16 bytes, a mixed
+  fixed-width base-36 counter below it. Byte-for-byte identical to
+  `probebench.c`.
+- **`rand`** — uniform-random bytes, exactly `keylen` of them, drawn from
+  1..255. One shape across the whole sweep, so there is no regime break at 16
+  and key length is the only variable.
+- **`varlen`** — uniform-random bytes with the length drawn uniformly from
+  `[4, keylen]`.
+
+### Method
+
+**Environment.** Dedicated Linux x86_64 host — 24 cores, 62 GB, kernel 6.8.
+Docker `php-judy-bench:latest` (Debian 13, gcc 14.2.0, libJudy 1.0.5-5.1),
+`gcc -O2 -Wall -Wextra`. Load average was 0.00 before the first run and never
+exceeded 1.00 (the benchmark is single-threaded, so 1.00 *is* the job) —
+checked before every one of the 36 configurations.
+
+**Sampling.** `iterbench 1000000 <keylen> 7 <corpus>`, five independent
+processes per configuration, seven reps each — 35 samples per point. Reported
+figure is the median of the five process medians. Process-to-process median
+spread was ≤ 5% for 22 of the 24 key-length configurations, and 9.1% at worst.
+
+**Tolerance for "flat".** A quantity counts as flat across a swept range if its
+median varies by **≤ 10%** end to end. That is roughly twice the worst
+process-to-process spread observed and about double the typical one, so a
+change that clears it is not noise. This threshold is stated up front rather
+than fitted afterwards.
+
+### Key length, at fixed n = 1,000,000
+
+`JSLN` is the ordered walk; `JSLG` replays the same keys in the same order as
+point lookups — same descend, same locality, no key written back — so
+`JSLN − JSLG` is the discriminator #85 leaned on hardest.
+
+| keylen | `JSLN` struct | `JSLN` rand | `JSLN` varlen | Δ struct | Δ rand | Δ varlen |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 4 | 30.8 | 31.8 | 31.7 | 10.2 | 10.2 | 10.1 |
+| 5 | — | 32.2 | — | — | 10.1 | — |
+| 6 | 31.9 | 32.8 | 39.3 | 10.7 | 10.2 | 13.8 |
+| 7 | — | 35.2 | — | — | 12.5 | — |
+| 8 | 113.6 | 102.1 | 55.0 | 31.5 | 35.0 | 18.0 |
+| 9 | — | 114.4 | — | — | 40.6 | — |
+| 10 | — | 114.6 | — | — | 40.7 | — |
+| 12 | 124.1 | 116.1 | 87.3 | 31.3 | 42.1 | 32.2 |
+| 16 | 70.3 | 115.5 | 98.7 | 32.9 | 41.6 | 37.2 |
+| 24 | 78.9 | 118.1 | 114.4 | 31.4 | 43.5 | 46.6 |
+| 40 | 78.5 | 125.4 | 126.6 | 32.4 | 45.8 | 54.2 |
+| 64 | 78.7 | 132.8 | 140.5 | 33.8 | 50.5 | 56.1 |
+
+Median ns/key; Δ is `JSLN − JSLG`. The widest min..max band across all 35 reps
+of any single row is ±4%, so no two rows differing by more than ~8% overlap.
+
+**Against the 10% tolerance:**
+
+| Claim | Corpus and range | Measured | Flat? |
+| ----- | ---------------- | -------- | ----- |
+| `JSLN` flat in key length | struct, 16→64 | 70.3 → 78.7, **+12%** | marginally no (published as +10%) |
+| `JSLN − JSLG` flat | struct, 16→64 | 32.9 → 33.8, **+3%** | **yes** — reproduces |
+| `JSLN` flat in key length | rand, 16→64 | 115.5 → 132.8, **+15%** | no |
+| `JSLN − JSLG` flat | rand, 16→64 | 41.6 → 50.5, **+21%** | no |
+| `JSLN` flat in key length | rand, 4→64 | 31.8 → 132.8, **4.2x** | no |
+| `JSLN` flat in key length | varlen, 8→64 | 55.0 → 140.5, **+155%** | no |
+
+So the flat result is not merely untested below 16 — it is **specific to the
+degenerate corpus**. Swept over the same 16→64 window that was originally
+published, but with uniform-random keys instead of `user:%08lu:f%lu`, the
+discriminator rises 21%.
+
+### The step at 8 bytes
+
+The largest key-length effect in the whole study sits in the half that had
+never run. On the `rand` corpus, `JSLN` is 35.2 ns at keylen 7 and 102.1 ns at
+keylen 8 — a **2.9x discontinuity across one byte** — then essentially level
+at 114.4 / 114.6 for 9 and 10.
+
+That is the machine word boundary: a key of 7 bytes plus its NUL fits in a
+single `Word_t`, so JudySL resolves it in one JudyL level; at 8 bytes it needs
+a second. It is the same boundary the `*_ADAPTIVE` types use for their packed
+short-string path, and it is invisible to any sweep that starts at 16.
+
+Above the step, growth is real but sub-linear. Least-squares over keylen 8→64
+on `rand` gives **0.44 ns/byte** for `JSLN`, **0.22 ns/byte** for `JSLG`, and
+**0.22 ns/byte** for the delta — 8x the bytes buys +30% on `JSLN`, not 8x.
+
+### Working-set size, at fixed keylen = 16
+
+| n | `JSLN` struct | `JSLN` rand |
+| ---: | ---: | ---: |
+| 100,000 | 67.6 | 48.3 |
+| 316,228 | 67.3 | 72.6 |
+| 1,000,000 | 67.7 | 115.9 |
+| 3,162,278 | 71.6 | 134.7 |
+
+`struct` reproduces the published result — +0.1% over 100K→1M, +6% out to
+3.16M, flat by any tolerance. `rand` over the same 100K→1M range is
+**+140%**, and **+179%** out to 3.16M. Flatness in working-set size is an
+artifact of the structured corpus, which shares one `user:` prefix across every
+10 keys and compresses into a tree that barely grows with n.
+
+### What this does and does not change
+
+**Refuted as stated.** "`JSLN` is flat in key length and flat in working-set
+size" is wrong as a property of `JSLN`. It is true only of the
+`user:%08lu:f%lu` corpus, and for key length only over 16→64.
+
+**The #85 conclusion survives — on different evidence.** The hypothesis under
+test was that ordered traversal is expensive because `JSLN` materialises each
+key into a caller buffer, and is therefore fixable inside php-judy. Three
+things still argue against it, more strongly than flatness did:
+
+1. **The delta is far too shallow to be byte copying.** 0.22 ns/byte marginal:
+   8x the key bytes costs +44% on the delta, not 8x.
+2. **The delta grows with n at fixed key length** — 23.0 → 61.7 ns as n goes
+   100K → 3.16M on `rand`, at a constant keylen 16. Key reconstruction cannot
+   depend on working-set size; a memory-bound successor search can. This is
+   evidence the old flat reading could not produce, because the structured
+   corpus does not grow.
+3. **The delta is a roughly constant *share* of `JSLN`, not a constant cost** —
+   34-38% across keylen 8→64 on `rand`. It tracks the traversal, rather than
+   the key.
+
+The `JSLN − JSLG` delta was therefore never a clean measure of key
+reconstruction: it also contains the successor search, and that is what its n
+dependence exposes. The right reading of it is "descend plus successor", not
+"key bytes".
+
+**The decomposition figure is withdrawn.** *"~37 ns stateless root descend +
+32 ns successor search + ~1 ns of key bytes"* was derived on the structured
+corpus at keylen 16 and does not generalise: the marginal per-byte term is
+0.22 ns/byte, all three terms move with corpus, and the second term moves with
+n. Quote the slope, not the split.
+
+**`BACKEND_EVALUATION.md` is unaffected in direction.** Ordered `JSLN`
+traversal is a genuine JudySL property that php-judy cannot call its way out
+of — and on a realistic corpus it is *more* expensive than the structured
+numbers suggested (115.9 vs 67.7 ns/key at n = 1M, keylen 16), not less.
+
+### Limits
+
+- One host, one libJudy build, one n per key-length sweep. Absolute ns/op
+  include harness overhead (see *Reading probebench's absolute numbers* below,
+  which applies equally here) and should not be quoted as pure Judy cost.
+- **No node-type histogram.** `Judy.h` exposes no way to count `BRANCH_L` /
+  `BRANCH_B` / `BRANCH_U` populations from outside the library, so the claim
+  that `rand` and `varlen` are non-degenerate rests on the corpora's
+  construction — every byte position carries ~8 bits, so no position can be
+  invariant — rather than on a measured histogram. Getting the histogram needs
+  the vendored tree that [#113](https://github.com/orieg/php-judy/issues/113)
+  is gated on.
+- `rand` keys diverge within the first two or three bytes whatever their
+  length, so above the 8-byte step it varies bytes-to-copy far more than it
+  varies trie depth. `varlen`, which does vary depth, rises about 2.7x faster
+  per byte. Neither is "the" realistic corpus; the point is that the two
+  non-degenerate ones agree with each other and disagree with `struct`.
 
 ## Running these
 
@@ -72,7 +225,9 @@ benchmark suite produced two wrong conclusions before being discarded.
 ```sh
 # iteration-cost
 gcc -O2 -Wall -Wextra -o iterbench research/iteration-cost/iterbench.c -lJudy
-./iterbench 1000000 16 5        # n, key length, reps
+./iterbench 1000000 16 5        # n, key length, reps, corpus (default struct)
+./iterbench 1000000 16 5 rand   # uniform-random bytes — the non-degenerate one
+./iterbench 1000000 16 5 varlen # random bytes, length uniform in [4, keylen]
 
 # write-probe-cost
 gcc -O2 -Wall -Wextra -o probebench research/write-probe-cost/probebench.c -lJudy
@@ -84,14 +239,16 @@ gcc -O2 -Wall -Wextra -o probebench research/write-probe-cost/probebench.c -lJud
 cd research/shm-arena && make && make run
 ```
 
-## probebench key shapes
+## The structured corpus's key shapes
 
-`probebench` emits two different key shapes, split at `keylen = 16`:
+Both `probebench` and `iterbench`'s default `struct` corpus emit the same two
+key shapes, split at `keylen = 16` — the generators are byte-for-byte identical
+so the two harnesses' figures sit on one curve:
 
-- **`keylen >= 16`** — `user:00001234:f5` padded with `x`, the same shape as
-  `iteration-cost/iterbench.c`, so those figures sit next to the ones in
-  [#85](https://github.com/orieg/php-judy/issues/85). Ten keys share each
-  `user:` prefix.
+- **`keylen >= 16`** — `user:00001234:f5` padded with `x`, the shape used
+  throughout [#85](https://github.com/orieg/php-judy/issues/85). Ten keys share
+  each `user:` prefix. This is the degenerate corpus — see
+  [the re-derivation](#the-jsln-flatness-claim-re-derived) for what it hides.
 - **`keylen < 16`** — a fixed-width base-36 counter filling exactly `keylen`
   bytes. The long format is 16 characters at minimum and cannot be squeezed
   shorter while staying unique, so a second shape is required to reach the

--- a/research/iteration-cost/iterbench.c
+++ b/research/iteration-cost/iterbench.c
@@ -7,11 +7,32 @@
  *   H2 memory-bound re-descend: every JSLN/JSLG restarts at the root.
  *      -> cost should scale with n (working set vs cache), and JSLN ~= JSLG.
  *
- * ./iterbench <n> <keylen> <reps>
+ * ./iterbench <n> <keylen> <reps> [corpus]
+ *
+ * corpus is one of:
+ *   struct   (default) the original two-shape corpus, identical to
+ *            research/write-probe-cost/probebench.c so the two harnesses agree
+ *            byte for byte: "user:00001234:f5" padded with 'x' at
+ *            keylen >= 16, a fixed-width mixed base-36 counter below it.
+ *   rand     uniform-random bytes, exactly keylen of them, drawn from 1..255.
+ *            One shape across the whole sweep, so key length is the only
+ *            variable and there is no regime break at 16.
+ *   varlen   uniform-random bytes with the length itself drawn uniformly from
+ *            [4, keylen]. Deliberately ragged, to exercise a mix of trie
+ *            depths rather than a single uniform depth.
+ *
+ * Why `struct` needs two shapes: the long format is 16 characters at minimum
+ * ("user:" + 8 digits + ":f" + 1 digit), so it cannot express a shorter key at
+ * all. Before issue #122 make_key() only padded a key *up* and never
+ * truncated, so every requested keylen at or below 16 silently produced the
+ * same 16-byte key -- the short half of every key-length sweep run through
+ * this harness never actually executed. See also issue #118 / PR #124, which
+ * fixed the same defect in probebench.c.
  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <time.h>
 #include <Judy.h>
 
@@ -28,34 +49,184 @@ static int cmpd(const void *a, const void *b) {
 static double med(double *v, int k) { qsort(v, k, sizeof(double), cmpd); return v[k / 2]; }
 
 #define MAXK 128
+#define MAXREPS 64
 
-/* keylen = total chars incl. padding, excl. NUL. Prefix structure kept
- * realistic ("user:00001234:f5"), tail padded with 'x' to hit keylen. */
+#define CORPUS_STRUCT 0
+#define CORPUS_RAND   1
+#define CORPUS_VARLEN 2
+static const char *corpus_name[] = { "struct", "rand", "varlen" };
+
+/* Two key shapes, split at keylen = 16. Identical to probebench.c. */
+#define LONGKEY_MIN 16
+#define KEY_RADIX 36
+static const char key_alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/* An exact-length guard that survives -DNDEBUG. assert() is not used: this
+ * repo compiles asserts out in places, and a generator that silently ignores
+ * the requested length is exactly the defect being fixed here (issue #122), so
+ * the check has to be unconditional. */
+static void key_check(const char *buf, int want) {
+    size_t got = strlen(buf);
+    if ((int)got != want) {
+        fprintf(stderr, "make_key: emitted %zu bytes, wanted %d (\"%s\")\n",
+                got, want, buf);
+        abort();
+    }
+}
+
+/* How many distinct keys the short regime can express, saturating rather than
+ * overflowing. Used to reject an (n, keylen) pair that cannot hold n keys
+ * without collisions. */
+static unsigned long short_key_space(int keylen) {
+    unsigned long cap = 1;
+    for (int p = 0; p < keylen; p++) {
+        if (cap > ULONG_MAX / KEY_RADIX) return ULONG_MAX;
+        cap *= KEY_RADIX;
+    }
+    return cap;
+}
+
+/* A multiplier coprime with 36^keylen, sized to the space so the mix actually
+   spans it. A fixed constant does not: at keylen 12 the space is 36^12 ~ 4.7e18
+   while i * 2654435761 tops out near 1.3e15 for a 500k corpus, leaving the two
+   leading digits stuck at '0'. Scaling by the golden-ratio conjugate spreads
+   indices across the whole range (Fibonacci hashing), and forcing the result
+   odd and not divisible by 3 keeps gcd(mix, 36^k) = 1, so it stays a bijection.
+
+   Above keylen 12 the space exceeds ULONG_MAX and a 64-bit index cannot reach
+   the high digits at all -- those keys keep some leading '0's no matter what.
+   That is a property of the index type, not something the mix can fix. */
+static unsigned long key_mix_for(unsigned long cap)
+{
+    unsigned long m = (unsigned long)((long double) cap * 0.6180339887498949L);
+    if (m < 3) return 1;
+    if ((m & 1UL) == 0) m++;
+    while (m % 3 == 0) m += 2;
+    return m;
+}
+
+/* keylen >= LONGKEY_MIN keeps the original shape ("user:00001234:f5" padded
+ * with 'x'; 10 keys share each user: prefix), so figures at 16/24/40/64 stay
+ * on the same curve as the ones already published in issue #85.
+ *
+ * keylen < LONGKEY_MIN emits base-36 of a mixed index, filling exactly keylen
+ * bytes. The mix spreads the index across every byte: encoding i directly
+ * needs only ceil(log36(n)) digits, so the leading bytes would be a uniform
+ * run of '0' and JudySL would compress it -- length would vary while entropy
+ * stayed fixed. */
 static void make_key(char *buf, unsigned long i, int keylen) {
-    int m = snprintf(buf, MAXK, "user:%08lu:f%lu", i / 10, i % 10);
-    while (m < keylen) buf[m++] = 'x';
-    buf[m] = '\0';
+    unsigned long v, cap, mix;
+
+    if (keylen >= LONGKEY_MIN) {
+        int m = snprintf(buf, MAXK, "user:%08lu:f%lu", i / 10, i % 10);
+        while (m < keylen) buf[m++] = 'x';
+        buf[m] = '\0';
+        key_check(buf, keylen);
+        return;
+    }
+
+    cap = short_key_space(keylen);
+    mix = key_mix_for(cap);
+    if (cap == ULONG_MAX) {
+        v = i * mix;                      /* wrap mod 2^64; mix odd => bijective */
+    } else {
+        v = (unsigned long)(((unsigned __int128) i * mix) % cap);
+    }
+
+    for (int p = keylen - 1; p >= 0; p--) {
+        buf[p] = key_alphabet[v % KEY_RADIX];
+        v /= KEY_RADIX;
+    }
+    buf[keylen] = '\0';
+    key_check(buf, keylen);
+}
+
+static unsigned long xs(unsigned long *s) {
+    *s ^= *s << 13; *s ^= *s >> 7; *s ^= *s << 17;
+    return *s;
+}
+
+/* Uniform-random bytes over 1..255. NUL is excluded because JudySL keys are
+ * NUL-terminated. Every byte position carries ~8 bits, so no position is
+ * invariant and the branch mix is not pinned to a single node type -- the
+ * degeneracy that scoped the original #85 conclusion to one regime. */
+static void make_random_key(char *buf, int len, unsigned long *seed) {
+    for (int p = 0; p < len; p++) buf[p] = (char)(1 + (xs(seed) % 255));
+    buf[len] = '\0';
+    key_check(buf, len);
 }
 
 int main(int argc, char **argv) {
     unsigned long n = (argc > 1) ? strtoul(argv[1], NULL, 10) : 1000000;
     int keylen = (argc > 2) ? atoi(argv[2]) : 16;
     int reps = (argc > 3) ? atoi(argv[3]) : 5;
+    int corpus = CORPUS_STRUCT;
     char key[MAXK];
+    unsigned long gen_seed = 0x9e3779b97f4a7c15UL;
+    unsigned long collisions = 0;
+
+    if (argc > 4) {
+        if      (!strcmp(argv[4], "struct")) corpus = CORPUS_STRUCT;
+        else if (!strcmp(argv[4], "rand"))   corpus = CORPUS_RAND;
+        else if (!strcmp(argv[4], "varlen")) corpus = CORPUS_VARLEN;
+        else { fprintf(stderr, "corpus must be struct|rand|varlen\n"); return 1; }
+    }
+
+    if (reps > MAXREPS) reps = MAXREPS;
+    if (keylen >= MAXK - 1) { fprintf(stderr, "keylen too large\n"); return 1; }
+    if (keylen < 1) { fprintf(stderr, "keylen must be >= 1\n"); return 1; }
+    if (corpus == CORPUS_VARLEN && keylen < 4) {
+        fprintf(stderr, "varlen needs keylen >= 4\n"); return 1;
+    }
+    /* The struct corpus's short regime encodes the index in base-36 across
+     * keylen bytes, so it can only express so many distinct keys. n must fit,
+     * or keys collide and every number below is meaningless. */
+    if (corpus == CORPUS_STRUCT && keylen < LONGKEY_MIN) {
+        unsigned long cap = short_key_space(keylen);
+        if (cap < n) {
+            fprintf(stderr,
+                "keylen %d holds only %lu distinct keys; need %lu. "
+                "Raise keylen or lower n.\n", keylen, cap, n);
+            return 1;
+        }
+    }
 
     Pvoid_t sl = (Pvoid_t)NULL, jl = (Pvoid_t)NULL, hs = (Pvoid_t)NULL;
     PWord_t pv;
 
     /* build all three stores over the same n */
     for (unsigned long i = 0; i < n; i++) {
-        make_key(key, i, keylen);
-        JSLI(pv, sl, (uint8_t *)key); *pv = i + 1;
-        JHSI(pv, hs, key, (Word_t)strlen(key)); *pv = i + 1;
-        JLI(pv, jl, (Word_t)i); *pv = i + 1;
+        if (corpus == CORPUS_STRUCT) {
+            make_key(key, i, keylen);
+            JSLI(pv, sl, (uint8_t *)key);
+            if (pv == PJERR) { fprintf(stderr, "JSLI OOM\n"); return 1; }
+        } else {
+            /* Random corpora can collide; redraw until the key is new. The
+             * value word of a freshly inserted JudySL slot is 0, and every
+             * stored value below is i + 1 >= 1, so 0 means "new". */
+            int len = keylen;
+            for (;;) {
+                if (corpus == CORPUS_VARLEN)
+                    len = 4 + (int)(xs(&gen_seed) % (unsigned long)(keylen - 3));
+                make_random_key(key, len, &gen_seed);
+                JSLI(pv, sl, (uint8_t *)key);
+                if (pv == PJERR) { fprintf(stderr, "JSLI OOM\n"); return 1; }
+                if (*pv == 0) break;
+                collisions++;
+            }
+        }
+        *pv = i + 1;
+        JHSI(pv, hs, key, (Word_t)strlen(key));
+        if (pv == PJERR) { fprintf(stderr, "JHSI OOM\n"); return 1; }
+        *pv = i + 1;
+        JLI(pv, jl, (Word_t)i);
+        if (pv == PJERR) { fprintf(stderr, "JLI OOM\n"); return 1; }
+        *pv = i + 1;
     }
 
     /* sorted key list, for replaying iteration order as point lookups */
     char *keys = malloc((size_t)n * MAXK);
+    if (!keys) { fprintf(stderr, "OOM\n"); return 1; }
     {
         unsigned long c = 0;
         key[0] = '\0';
@@ -68,7 +239,8 @@ int main(int argc, char **argv) {
         if (c != n) { fprintf(stderr, "walk got %lu of %lu\n", c, n); return 1; }
     }
 
-    double r_jln[64], r_jsln[64], r_jslg_sorted[64], r_jslg_rand[64], r_jhsg_sorted[64];
+    double r_jln[MAXREPS], r_jsln[MAXREPS], r_jslg_sorted[MAXREPS];
+    double r_jslg_rand[MAXREPS], r_jhsg_sorted[MAXREPS];
     unsigned long sink = 0;
 
     for (int r = 0; r < reps; r++) {
@@ -118,9 +290,12 @@ int main(int argc, char **argv) {
           t1 = now_ns(); r_jhsg_sorted[r] = (t1 - t0) / (double)n; }
     }
 
-    printf("n=%lu keylen=%d reps=%d (median ns/key; min..max)\n", n, keylen, reps);
+    printf("n=%lu keylen=%d reps=%d corpus=%s (median ns/key; min..max)\n",
+           n, keylen, reps, corpus_name[corpus]);
+    if (corpus != CORPUS_STRUCT)
+        printf("  (redraws to avoid duplicate keys: %lu)\n", collisions);
 #define REPORT(label, arr) do { \
-        double tmp[64]; memcpy(tmp, arr, sizeof(double) * reps); \
+        double tmp[MAXREPS]; memcpy(tmp, arr, sizeof(double) * reps); \
         double m = med(tmp, reps); \
         printf("  %-28s %8.2f   [%.2f .. %.2f]\n", label, m, tmp[0], tmp[reps - 1]); \
     } while (0)
@@ -130,5 +305,6 @@ int main(int argc, char **argv) {
     REPORT("JSLG random", r_jslg_rand);
     REPORT("JHSG sorted", r_jhsg_sorted);
     fprintf(stderr, "sink=%lu\n", sink);
+    free(keys);
     return 0;
 }


### PR DESCRIPTION
Closes the second half of #122. PR #124 repaired `make_key()` in
`research/write-probe-cost/probebench.c` but left
`research/iteration-cost/iterbench.c` on the original pad-only version, which
is the harness that produced the load-bearing #85 claim.

## Part 1 — the generator

Ported #124's approach verbatim rather than inventing a second one: the same
`LONGKEY_MIN` split, the same `key_alphabet` / `KEY_RADIX` base-36 short-key
path, the same capacity-scaled coprime mix. The two harnesses now emit
byte-identical corpora.

Exact-length guard is an unconditional `key_check()` that prints and `abort()`s
rather than `assert()` — this repo compiles asserts out in places, and a
generator that silently ignores its length argument is precisely the defect
being fixed. Negative control, the pre-fix generator run through that check:

```
old  keylen= 4 -> strlen=16  user:00123456:f7
old  keylen= 6 -> strlen=16  user:00123456:f7
old  keylen=12 -> strlen=16  user:00123456:f7
old  keylen=16 -> strlen=16  user:00123456:f7
old  keylen=24 -> strlen=24  user:00123456:f7xxxxxxxx
```

After: `[4]8hxy`, `[6]8hxzjy`, `[12]8hxzjvilr96y` — exact lengths, entropy in
every byte. Uniqueness is enforced by the harness's existing `walk got %lu of
%lu` check, which fails loudly on any collision.

An optional fourth argument selects the corpus, so a result is no longer scoped
to a single node-type regime: `struct` (default, unchanged), `rand`
(uniform-random bytes 1..255, one shape across the whole sweep so there is no
regime break at 16), `varlen` (random bytes, length uniform in `[4, keylen]`).

Zero warnings under `gcc 14 -O2 -Wall -Wextra` and under clang on macOS.

## Part 2 — the re-derivation

Idle dedicated 24-core Linux host, load 0.00 before the first run and never
above 1.00 (single-threaded job) across all 36 configurations. n = 1,000,000,
five independent processes x seven reps per point. **"Flat" pre-defined as the
median varying ≤ 10% end to end** — roughly twice the worst process-to-process
spread observed (9.1%, typical ≤ 5%).

### Verdict: `JSLN` is not flat in key length, and not flat in working-set size

Median ns/key, Δ = `JSLN − JSLG`:

| keylen | `JSLN` struct | `JSLN` rand | `JSLN` varlen | Δ struct | Δ rand | Δ varlen |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 30.8 | 31.8 | 31.7 | 10.2 | 10.2 | 10.1 |
| 6 | 31.9 | 32.8 | 39.3 | 10.7 | 10.2 | 13.8 |
| 7 | — | 35.2 | — | — | 12.5 | — |
| 8 | 113.6 | 102.1 | 55.0 | 31.5 | 35.0 | 18.0 |
| 12 | 124.1 | 116.1 | 87.3 | 31.3 | 42.1 | 32.2 |
| 16 | 70.3 | 115.5 | 98.7 | 32.9 | 41.6 | 37.2 |
| 24 | 78.9 | 118.1 | 114.4 | 31.4 | 43.5 | 46.6 |
| 40 | 78.5 | 125.4 | 126.6 | 32.4 | 45.8 | 54.2 |
| 64 | 78.7 | 132.8 | 140.5 | 33.8 | 50.5 | 56.1 |

| Claim | Corpus and range | Measured | Flat? |
| --- | --- | --- | --- |
| `JSLN` flat in key length | struct, 16→64 | +12% | marginally no (published +10%) |
| `JSLN − JSLG` flat | struct, 16→64 | +3% | **yes — reproduces** |
| `JSLN` flat in key length | rand, 16→64 | +15% | no |
| `JSLN − JSLG` flat | rand, 16→64 | +21% | no |
| `JSLN` flat in key length | rand, 4→64 | **4.2x** | no |
| `JSLN` flat in key length | varlen, 8→64 | **+155%** | no |

Two things the original sweep could not see:

**A 2.9x step between 7 and 8 bytes.** `rand` gives 35.2 ns at keylen 7 and
102.1 at keylen 8, then level at 114.4 / 114.6 for 9 and 10. That is the
machine-word boundary — 7 bytes plus NUL fit one `Word_t`, so JudySL resolves in
a single JudyL level. It is the largest key-length effect in the study and it
sits entirely inside the half that had never executed.

**Working-set flatness is corpus-specific.** At fixed keylen 16:

| n | `JSLN` struct | `JSLN` rand |
| ---: | ---: | ---: |
| 100,000 | 67.6 | 48.3 |
| 1,000,000 | 67.7 | 115.9 |
| 3,162,278 | 71.6 | 134.7 |

+0.1% on the structured corpus over 100K→1M, **+140%** on random keys.

So the framing in #122 resolves to **refuted as stated**, not merely
"not currently re-derivable". The published 16/24/40/64 points reproduce
exactly — `struct` 16→64 gives +12% on `JSLN` and +3% on the delta against the
+10% and "flat" originally reported. They were correct measurements of a corpus
whose shared `user:` prefixes compress into a tree that barely grows with n.
They are not a property of `JSLN`.

### What survives

The #85 *conclusion* — that per-key key reconstruction is not what makes
ordered traversal expensive — holds, on better evidence than flatness ever was:

1. The delta's marginal slope is **0.22 ns/byte**; 8x the key bytes costs +44%,
   not 8x.
2. The delta **grows 2.7x with n at constant key length** (23.0 → 61.7 ns,
   100K → 3.16M). Key reconstruction cannot depend on working-set size; a
   memory-bound successor search can. The old flat reading could not produce
   this evidence, because the structured corpus does not grow.
3. The delta is a roughly constant *share* of `JSLN` (34–38%), not a constant
   cost — it tracks the traversal, not the key.

`BACKEND_EVALUATION.md`'s direction is unchanged, and on a realistic corpus the
cost is *larger* than the structured numbers suggested (115.9 vs 67.7 ns/key at
n = 1M, keylen 16), not smaller.

### Withdrawn

The decomposition *"~37 ns root descend + 32 ns successor search + ~1 ns of key
bytes"* was derived on the structured corpus at keylen 16 and does not
generalise — all three terms move with corpus and the second moves with n.

## Docs

- `research/README.md` — the "Re-derivation owed" section becomes
  "The `JSLN` flatness claim, re-derived" with the full record, method,
  tolerance, tables and limits; index row updated; runner snippet shows the new
  corpus argument; the key-shapes section now covers both harnesses.
- `BACKEND_EVALUATION.md` — the three-discriminator table rewritten around the
  new evidence, with the withdrawn numbers stated explicitly; the
  "what would change the verdict" bullet updated from *owed* to *done*.
  No restructuring beyond that.

## Known limits, stated rather than papered over

- **No node-type histogram.** `Judy.h` exposes no way to count `BRANCH_L` /
  `BRANCH_B` / `BRANCH_U` from outside the library, so "non-degenerate" rests on
  the corpora's construction (every byte position carries ~8 bits, so none can be
  invariant) rather than on a measured histogram. That needs the vendored tree
  #113 is gated on.
- One host, one libJudy build, one n per key-length sweep. Absolute ns/op
  include harness overhead and are comparable to each other, not quotable as
  pure Judy cost.
- `rand` keys diverge within the first few bytes at any length, so above the
  8-byte step it varies bytes-copied more than trie depth; `varlen`, which does
  vary depth, rises ~2.7x faster per byte. Neither is *the* realistic corpus —
  the point is that the two non-degenerate ones agree with each other and
  disagree with `struct`.

`research/` stays excluded from `package.xml`; `baselines/latest.json`
untouched.

Refs #122, #85
