### PR TITLE
fix(construct): always run zpp so Judy::__construct() matches its arginfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,52 +440,41 @@ jobs:
             -r 'if (!PHP_DEBUG) { fwrite(STDERR, "not a debug runtime\n"); exit(1); }
                 printf("judy %s loaded into a debug PHP\n", judy_version());'
 
-      - name: Run the suite, minus one test that a known bug fails
-        run: |
-          # tests/debug_info_empty_001.phpt calls `new Judy()`. Judy::__construct
-          # declares $type as required in its arginfo but returns early without
-          # calling zend_parse_parameters when given no arguments, which a
-          # debug PHP rejects outright:
-          #
-          #   Fatal error: Arginfo / zpp mismatch during call of Judy::__construct()
-          #
-          # That is a real unfixed bug in the extension, not a test problem,
-          # and it is being fixed separately. It is excluded here so the other
-          # 214 tests can gate today; the step below pins the exclusion so it
-          # cannot outlive the bug.
-          KNOWN_FAILURE=tests/debug_info_empty_001.phpt
-          SUITE=$(ls tests/*.phpt | grep -vxF "$KNOWN_FAILURE" | tr '\n' ' ')
-          make test TESTS="$SUITE" NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+      - name: Run the full suite on the debug PHP
+        run: make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
 
-      - name: Pin the exclusion — require the known failure to still fail
+      - name: Negative control — restore the mismatch, require the fatal
         run: |
-          # An excluded test is only honest if the exclusion expires. This
-          # step fails the moment tests/debug_info_empty_001.phpt starts
-          # passing on a debug build, i.e. when Judy::__construct is fixed:
-          # that PR should delete this step and drop the exclusion from the
-          # step above, so the whole suite gates again.
+          # The whole suite gates again now that Judy::__construct calls zpp
+          # unconditionally, so the exclusion and the step that pinned it are
+          # gone. This replaces the self-check they provided: an engine check
+          # that has never fired is not known to be switched on, so CI puts the
+          # bug back and requires the abort.
           #
-          # It also fails if the test breaks for some *other* reason, which an
-          # exclusion on its own would hide.
-          KNOWN_FAILURE=tests/debug_info_empty_001.phpt
-          rm -f tests/debug_info_empty_001.out tests/debug_info_empty_001.diff
+          # Restoring the old guard means returning before zpp when called with
+          # no arguments -- exactly the arginfo/zpp mismatch, which only a debug
+          # engine notices.
+          sed -i 's|ZEND_PARSE_PARAMETERS_START(1, 2) /\* judy-arginfo-negative-control \*/|if (ZEND_NUM_ARGS() == 0) { RETURN_NULL(); } /* CI negative control */ ZEND_PARSE_PARAMETERS_START(1, 2)|' php_judy.c
+          grep -q 'CI negative control' php_judy.c \
+            || { echo "::error::negative control did not apply — the anchor line in php_judy.c moved"; exit 1; }
+          make
 
           set +e
-          make test TESTS="$KNOWN_FAILURE" NO_INTERACTION=1 REPORT_EXIT_STATUS=1
+          "$HOME/php-debug/bin/php" -d extension="$(pwd)/modules/judy.so" \
+            -r 'new Judy();' > /tmp/negative-control-arginfo.log 2>&1
           rc=$?
           set -e
+          cat /tmp/negative-control-arginfo.log
 
           if [ "$rc" -eq 0 ]; then
-            echo "::error::$KNOWN_FAILURE now passes on a debug build — Judy::__construct is fixed. Delete this step and drop the exclusion from the previous step so the full suite gates."
+            echo "::error::a deliberate arginfo/zpp mismatch ran to completion — the debug engine checks are not in effect"
             exit 1
           fi
-          if ! grep -q 'Arginfo / zpp mismatch during call of Judy::__construct' \
-               tests/debug_info_empty_001.out; then
-            echo "::error::$KNOWN_FAILURE failed for a different reason than the known Judy::__construct arginfo/zpp mismatch — see the diff below"
-            cat tests/debug_info_empty_001.diff
-            exit 1
-          fi
-          echo "Known failure reproduced: Judy::__construct arginfo/zpp mismatch."
+          grep -q 'Arginfo / zpp mismatch' /tmp/negative-control-arginfo.log \
+            || { echo "::error::process failed but not via the arginfo/zpp check — see the log above"; exit 1; }
+          echo "Negative control passed: the debug build caught the mismatch."
+
+          git checkout -- php_judy.c
 
   validate-pecl:
     runs-on: ubuntu-latest

--- a/package.xml
+++ b/package.xml
@@ -166,6 +166,7 @@
          <file name="tests/free_lifecycle_001.phpt" role="test" />
          <file name="tests/free_reuse_001.phpt" role="test" />
          <file name="tests/constructor_error_001.phpt" role="test" />
+         <file name="tests/construct_required_type_001.phpt" role="test" />
          <file name="tests/clone_int_to_int_001.phpt" role="test" />
          <file name="tests/clone_int_to_mixed_001.phpt" role="test" />
          <file name="tests/clone_string_to_int_001.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -1525,20 +1525,26 @@ PHP_METHOD(Judy, __construct)
 
 	JUDY_METHOD_GET_OBJECT
 
+	/* Parse unconditionally, before any other check. Judy_arginfo.h declares
+	   one required argument, and a PHP debug build aborts any call that returns
+	   without having reached zpp ("Arginfo / zpp mismatch during call of
+	   Judy::__construct()"). Guarding zpp behind ZEND_NUM_ARGS() > 0 meant
+	   `new Judy()` never parsed at all: fatal on a debug build, and on a release
+	   build a silently UNINITIALIZED object whose type is 0 -- getType() and
+	   count() report 0, memoryUsage() reports null, and any write warns
+	   "invalid Judy Array type, please report". $type has always been required
+	   by the documented signature, so it is now enforced. */
+	ZEND_PARSE_PARAMETERS_START(1, 2) /* judy-arginfo-negative-control */
+		Z_PARAM_LONG(type)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(optimize_iteration)
+	ZEND_PARSE_PARAMETERS_END();
+
 	JUDY_METHOD_ERROR_HANDLING;
 
 	if (intern->type) {
 		zend_throw_exception(NULL, "Judy Array already instantiated", 0);
-	} else if (ZEND_NUM_ARGS() > 0) {
-		ZEND_PARSE_PARAMETERS_START(1, 2)
-			Z_PARAM_LONG(type)
-			Z_PARAM_OPTIONAL
-			Z_PARAM_BOOL(optimize_iteration)
-		ZEND_PARSE_PARAMETERS_END_EX(
-			zend_restore_error_handling(&error_handling);
-			return;
-		);
-
+	} else {
 		JTYPE(jtype, type);
 		if (jtype == 0) {
 			zend_restore_error_handling(&error_handling);

--- a/tests/construct_required_type_001.phpt
+++ b/tests/construct_required_type_001.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Judy::__construct() requires $type, and stays arginfo/zpp-consistent on a debug build
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+/* Judy_arginfo.h declares one required argument for __construct(). The
+   implementation used to run zpp only when ZEND_NUM_ARGS() > 0, so `new Judy()`
+   returned without ever parsing: a PHP debug build aborted the call outright
+   ("Arginfo / zpp mismatch during call of Judy::__construct()"), and a release
+   build handed back a silently UNINITIALIZED object. $type has always been
+   required by the documented signature, so it is enforced instead. */
+
+// No arguments at all.
+try {
+    new Judy();
+} catch (ArgumentCountError $e) {
+    echo "no args: ", get_class($e), "\n";
+}
+
+// Explicit re-construction with no arguments is rejected the same way, and the
+// argument check runs before the already-instantiated check.
+$j = new Judy(Judy::INT_TO_INT);
+try {
+    $j->__construct();
+} catch (ArgumentCountError $e) {
+    echo "re-construct, no args: ", get_class($e), "\n";
+}
+
+// A wrong-typed argument still reaches zpp and reports a TypeError.
+try {
+    new Judy("not an int");
+} catch (TypeError $e) {
+    echo "bad type: ", get_class($e), "\n";
+}
+
+// The valid one- and two-argument forms are unaffected.
+$a = new Judy(Judy::BITSET);
+var_dump($a->getType() === Judy::BITSET);
+
+$b = new Judy(Judy::STRING_TO_INT_HASH, true);
+var_dump($b->getType() === Judy::STRING_TO_INT_HASH);
+var_dump($b->isIterationOptimized());
+
+// The object survives a real write, i.e. it is genuinely initialized.
+$b["k"] = 7;
+var_dump(count($b), $b["k"]);
+?>
+--EXPECT--
+no args: ArgumentCountError
+re-construct, no args: ArgumentCountError
+bad type: TypeError
+bool(true)
+bool(true)
+bool(true)
+int(1)
+int(7)

--- a/tests/debug_info_empty_001.phpt
+++ b/tests/debug_info_empty_001.phpt
@@ -24,8 +24,10 @@ $j["a"] = 1;
 unset($j["a"]);
 var_dump($j);
 
-// Never constructed (no type argument): must not crash.
-var_dump(new Judy());
+// Never constructed: __construct() now requires $type, but the UNINITIALIZED
+// state stays reachable through any path that bypasses the constructor, so
+// var_dump() must still not crash on it.
+var_dump((new ReflectionClass(Judy::class))->newInstanceWithoutConstructor());
 ?>
 --EXPECTF--
 object(Judy)#%d (6) {


### PR DESCRIPTION
`Judy::__construct()` declares one required argument in `Judy_arginfo.h` but
runs zpp only inside `if (ZEND_NUM_ARGS() > 0)`, so `new Judy()` returns
without ever parsing:

- **debug PHP** — `Fatal error: Arginfo / zpp mismatch during call of Judy::__construct()`
- **release PHP** — silently returns an object with type 0: `getType()` and
  `count()` report 0, `memoryUsage()` reports null, and any write warns
  `invalid Judy Array type, please report` — an error whose own text treats
  reaching that state as a bug.

This is the bug `debug-php-assertions` (#138) excluded
`tests/debug_info_empty_001.phpt` for, and which its pinning step says should
be retired by the PR that fixes it. Both come out here.

`$type` has always been required by the documented signature (`API.md:70`), so
the implementation now conforms to the published contract rather than the
contract being widened to match the implementation. A missing argument raises
`ArgumentCountError`.

`Judy.stub.php`, `Judy_arginfo.h` and `API.md` are **unchanged** —
`scripts/generate-api-docs.php --check` passes with no regeneration.

### Commits

1. `fix(construct):` — zpp runs unconditionally, before the already-instantiated
   check. Adds `tests/construct_required_type_001.phpt` (+ `package.xml`).
2. `ci(debug):` — drops the `debug_info_empty_001.phpt` exclusion and its
   pinning step, so the full suite gates again. A negative control replaces the
   self-check the pin provided: it restores the old pre-zpp return via the
   `judy-arginfo-negative-control` anchor and requires both a non-zero exit and
   the `Arginfo / zpp mismatch` diagnostic, so the job cannot pass vacuously if
   the engine check ever stops firing. Verified locally — exits 255 with that
   string, then restores the source.

### BC

`new Judy()` appeared exactly once in the tree (`tests/debug_info_empty_001.phpt`)
— no example, doc or README used it, and on a release build it only ever
produced an unusable object.

The UNINITIALIZED state itself stays reachable through any path that bypasses
the constructor (`ReflectionClass::newInstanceWithoutConstructor()`;
`unserialize()` is guarded and throws), so `get_debug_info`'s UNINITIALIZED
branch remains load-bearing and keeps its coverage — that test switches
construction mechanism and its expected output is unchanged byte-for-byte.

### Verification

| | |
|---|---|
| Debug PHP 8.4.11 (NTS DEBUG), full suite, no exclusions | **220/220** |
| Release PHP 8.5.8 | **220/220** |
| Compiler warnings | none in extension sources, both builds |
| `generate-api-docs.php --check` | passes |
| Negative control | exits 255 with `Arginfo / zpp mismatch` |

Rebased onto current `main`: the `config.m4` debug fix this originally carried
landed in e2d9b3a, and the debug CI job it originally added is superseded by
`debug-php-assertions`, so both were dropped.
