### PR TITLE
ci(research): build research/ in CI, and close the last two items on #122

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,6 +487,56 @@ jobs:
           fi
           echo "Known failure reproduced: Judy::__construct arginfo/zpp mismatch."
 
+  build-research:
+    # research/ holds standalone C harnesses that back measured claims in
+    # BENCHMARK.md and BACKEND_EVALUATION.md. Nothing there ships, so until
+    # this job existed nothing compiled it and nothing ran it -- which is how
+    # a generator came to ignore its own length argument for years (#122) and
+    # how a documented probe path shipped without ever having executed (#118).
+    #
+    # The parameter grid is what does the work here, not the sample size.
+    # Every defect those two issues found is reachable at n = 1000; none of
+    # them are reachable at the single (corpus, keylen, absent-key) point the
+    # harnesses were habitually run at. The last step is the negative control:
+    # an unfired gate is not a known-working gate.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Judy library
+        run: sudo apt-get update && sudo apt-get install -y libjudy-dev
+
+      - name: Build every harness and run the sanitized smoke grid
+        run: ./research/ci-smoke.sh 1000
+
+      - name: Negative control -- reinstate the #122 bug, require the grid to catch it
+        run: |
+          # Put the defect back: make_key() padding a key up and never
+          # truncating it, so every keylen below 16 silently emits the same
+          # 16-byte key. Then require the grid to reject the tree.
+          sed -i 's|if (keylen >= LONGKEY_MIN) {|if (keylen >= 0) {   /* CI negative control */|' \
+            research/write-probe-cost/probebench.c
+          grep -q 'CI negative control' research/write-probe-cost/probebench.c \
+            || { echo "::error::negative control did not apply -- the anchor line in probebench.c moved"; exit 1; }
+
+          set +e
+          ./research/ci-smoke.sh 1000 > /tmp/research-negative-control.log 2>&1
+          rc=$?
+          set -e
+
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::the smoke grid passed on a tree with the issue #122 generator bug reinstated"
+            tail -40 /tmp/research-negative-control.log
+            exit 1
+          fi
+          grep -q 'make_key: emitted 16 bytes, wanted' /tmp/research-negative-control.log \
+            || { echo "::error::the grid failed, but not via the key-length guard -- check the log"; \
+                 tail -40 /tmp/research-negative-control.log; exit 1; }
+          echo "Negative control passed: the grid caught the reinstated generator bug."
+
+          git checkout -- research/write-probe-cost/probebench.c
+
   validate-pecl:
     runs-on: ubuntu-latest
     steps:

--- a/research/README.md
+++ b/research/README.md
@@ -11,7 +11,7 @@ Each subdirectory owns one question and names the artifact it supports.
 | --------- | -------- | -------- |
 | [`shm-arena/`](shm-arena/) | Can libJudy live in a shared-memory arena, giving an ordered cache shared across FPM workers? | [issue #83](https://github.com/orieg/php-judy/issues/83) — closed, not planned. Five feasibility gates; writer death corrupts the tree 15% of the time (Wilson CI [8.8%, 24.4%]) and macOS has no robust mutexes. `FINDINGS.md` has the per-gate verdicts. |
 | [`iteration-cost/`](iteration-cost/) | Is JudySL's ordered-iteration cost the caller-supplied key buffer, or a stateless re-descend from the root? | [issue #85](https://github.com/orieg/php-judy/issues/85) and [BACKEND_EVALUATION.md](../BACKEND_EVALUATION.md). The key-reconstruction hypothesis stays refuted, but the evidence originally given for it does not: **`JSLN` is not flat in key length, and not flat in working-set size** — both flat results were artifacts of one degenerate corpus. Re-derived on a fixed generator; see [The `JSLN` flatness claim, re-derived](#the-jsln-flatness-claim-re-derived) below. |
-| [`write-probe-cost/`](write-probe-cost/) | Issue #85 step B3 wants ordered traversal to read the value out of the `key_index` cursor. That means locating the `key_index` slot on every write. What does moving the existence probe from JudyHS to JudySL cost the write path? | [issue #85](https://github.com/orieg/php-judy/issues/85) step B3. The probe swap itself is roughly neutral on a hit (+3% at 16-byte keys, −9% at 40-byte) and a large win on a miss (JudySL fails at the first differing byte; JudyHS digests the whole key first). End-to-end random-order overwrite still regresses, because today's `JHSG`+`JHSI` pair reuses one warm structure and the mirrored write touches two. That regression is why the mirror ships behind the opt-in `optimizeIteration` constructor argument rather than on by default: the unmirrored path keeps the `JHSG` probe and this swap never happens on it. |
+| [`write-probe-cost/`](write-probe-cost/) | Issue #85 step B3 wants ordered traversal to read the value out of the `key_index` cursor. That means locating the `key_index` slot on every write. What does moving the existence probe from JudyHS to JudySL cost the write path? | [issue #85](https://github.com/orieg/php-judy/issues/85) step B3. The probe swap itself is roughly neutral on a hit (+3% at 16-byte keys, −9% at 40-byte) and a large win on a miss (JudySL fails at the first differing byte; JudyHS digests the whole key first) — but see [Absent keys and divergence depth](#absent-keys-and-divergence-depth): the miss figure was taken at the one divergence depth most favourable to the trie, so for long keys it is granted rather than measured. End-to-end random-order overwrite still regresses, because today's `JHSG`+`JHSI` pair reuses one warm structure and the mirrored write touches two. That regression is why the mirror ships behind the opt-in `optimizeIteration` constructor argument rather than on by default: the unmirrored path keeps the `JHSG` probe and this swap never happens on it. |
 | [`backend-comparison/`](backend-comparison/) | Should the extension keep libJudy, or move to a modern ordered index? | [BACKEND_EVALUATION.md](../BACKEND_EVALUATION.md). `amdahl.c`/`amdahl.php` bound how much a backend swap could possibly buy through the PHP boundary; `cmp.c` runs ART against JudySL. Verdict: keep Judy. Needs libart cloned alongside — not vendored. |
 | [`libjudy-modernization/`](libjudy-modernization/) | Given that we keep Judy, does the incumbent have exploitable headroom — and does realising it mean vendoring libJudy? | [issue #113](https://github.com/orieg/php-judy/issues/113), plus [#131](https://github.com/orieg/php-judy/issues/131) / [#127](https://github.com/orieg/php-judy/issues/127) for the upstream defects it turned up. A first "no headroom" verdict was retracted; round 2 measured popcount-L at 17% cache-resident (JudyL only) and memory-level parallelism at 1.62–1.79x. The decisive finding is correctness, not speed: stock libJudy built with `gcc -O3` silently loses `Judy::BITSET` keys. Verdict: vendor stock 1.0.5 + patches, gated. `FINDINGS.md` has the full record, including the retraction and the negatives. **No harnesses are committed** — they were built in throwaway trees; re-deriving the timings needs them written again. |
 
@@ -231,13 +231,52 @@ gcc -O2 -Wall -Wextra -o iterbench research/iteration-cost/iterbench.c -lJudy
 
 # write-probe-cost
 gcc -O2 -Wall -Wextra -o probebench research/write-probe-cost/probebench.c -lJudy
-./probebench 1000000 16 5       # n, key length, reps; keylen < 8 adds the
-                                # ADAPTIVE short-string (SSO) probe
+./probebench 1000000 16 5       # n, key length, reps, corpus, absent-key
+                                # divergence (defaults: struct, offset);
+                                # keylen < 8 adds the ADAPTIVE short-string
+                                # (SSO) probe
 ./probebench 200000 6 5         # the SSO probe itself
+./probebench 1000000 16 5 rand  # same corpus options as iterbench
+./probebench 1000000 16 5 struct last   # absent keys that diverge at the
+                                        # final byte, not at byte 5
 
 # shm-arena
 cd research/shm-arena && make && make run
 ```
+
+Both harnesses take the corpus as their fourth argument, with the same three
+names and the same generation code, so a figure from one sits on the same
+curve as a figure from the other. `probebench` takes the absent-key
+divergence as a fifth.
+
+## The CI gate
+
+`research/ci-smoke.sh` builds every harness here with `-Wall -Wextra -Werror`
+and runs a small ASan/UBSan pass across the whole parameter grid — every
+corpus, key lengths bracketing 8 and 16, and every absent-key divergence.
+`.github/workflows/ci.yml`'s `build-research` job runs it on every PR, ending
+with a negative control that reinstates the [#122](https://github.com/orieg/php-judy/issues/122)
+generator bug and requires the grid to reject the tree.
+
+It exists because this directory had no CI at all, and that is how both of the
+defects recorded above survived: nothing compiled `research/`, so a generator
+could ignore its own length argument for years and a documented probe path
+could ship without ever having executed. Run it before committing anything
+here:
+
+```sh
+./research/ci-smoke.sh          # n = 1000; seconds, not minutes
+```
+
+Two things it does not cover, both deliberately:
+
+- **`backend-comparison/cmp.c`** is not built. It includes `art.h` from
+  libart, which is cloned alongside rather than vendored, and vendoring a
+  dependency into a tree whose whole point is that nothing in it ships is the
+  wrong trade.
+- **`shm-arena/`** is compiled but not run. Its gates fork, kill writers
+  mid-write and probe robust mutexes; that is a feasibility study, not a smoke
+  test, and issue #83 is already closed on its results.
 
 ## The structured corpus's key shapes
 
@@ -326,6 +365,48 @@ returns; that is a property of the index type, not of Judy.
 
 Note also that `keylen >= 16` switches to the long key shape (see above), so the
 16-byte rows elsewhere in this directory are not on the same curve as this table.
+
+## Absent keys and divergence depth
+
+`probebench`'s miss cases exist to compare a trie miss against a hash miss. A
+trie can fail at the first byte that differs from anything stored; a hash has
+to digest the whole key before it can answer. So how deep into the key the
+absent keys diverge is not a detail of the corpus — it is the independent
+variable of that comparison, and holding it at one value reports a point where
+a curve is needed.
+
+The original generator held it at one value, and at the value most favourable
+to the trie. Absent keys were the present ones offset by `ABSENT_OFFSET_LONG`
+(500,000,000), which pushes `i / 10` into 8-digit territory and therefore
+changes the third digit of the `user:%08lu` field. At `keylen >= 16` **every**
+absent key diverged at byte 5 of 16 — the earliest position the format can
+express — while JudyHS still digested all 16 bytes. For long keys the miss
+comparison was granted to the trie by construction rather than measured, and
+the generator's comment asserted the opposite.
+
+The fifth argument now selects it:
+
+| value | absent key first differs at |
+| ----- | --------------------------- |
+| `offset` (default) | wherever the historical index offset happens to put it — byte 5 of 16 for the long shape |
+| `shallow` | byte 0 |
+| `mid` | byte `len / 2` |
+| `deep` | byte `len - 2` |
+| `last` | the final byte |
+
+The four named modes copy a stored key and change exactly one byte at that
+position, so the absent key keeps the stored key's length: the hash's work is
+held constant while the trie's varies, which is the contrast the comparison
+is about. `offset` is kept as the default so every miss figure published
+before this option existed stays reproducible without a flag.
+
+Two limits. The realised divergence is a **lower bound**, not an exact depth:
+the mutated key shares `depth` bytes with its source, but some other stored key
+may share more, and Judy exposes no way to read back the longest common prefix
+it actually walked. And **the curve has not been run** — this change makes the
+measurement possible and states that the existing long-key miss number is a
+best case; it does not replace that number. Doing so needs an idle host, per
+the warning above.
 
 ## Reading probebench's absolute numbers
 

--- a/research/ci-smoke.sh
+++ b/research/ci-smoke.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+# Build every harness under research/ warning-free, then run a sanitized smoke
+# pass across the parameter grid.
+#
+# Why this exists: research/ is not part of the extension build. Nothing
+# compiled it and nothing ran it, and that is how a generator came to ignore
+# its own length argument for years, and how a documented probe path
+# (issue #118) shipped without ever having executed. See issue #122.
+#
+# The grid matters more than the size. Every historical defect here was
+# reachable at n = 1000; none of them were reachable at the single
+# (corpus, keylen, absent-key) point the harnesses were usually run at.
+#
+#   research/ci-smoke.sh [n]        n defaults to 1000
+#
+# Honours CC and JUDY_PREFIX. ASAN_OPTIONS/UBSAN_OPTIONS are set only if the
+# caller has not already set them.
+set -eu
+
+N="${1:-1000}"
+CC="${CC:-cc}"
+case "$(uname -s)" in
+    Darwin) JUDY_PREFIX="${JUDY_PREFIX:-/opt/homebrew}" ;;
+    *)      JUDY_PREFIX="${JUDY_PREFIX:-/usr}" ;;
+esac
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+BUILD=$(mktemp -d)
+trap 'rm -rf "$BUILD"' EXIT
+
+WARN="-Wall -Wextra -Werror"
+CPPF="-I$JUDY_PREFIX/include"
+LDF="-L$JUDY_PREFIX/lib -lJudy"
+SAN="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-abort_on_error=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-print_stacktrace=1}"
+
+fail=0
+say() { printf '\n== %s\n' "$*"; }
+
+# Run one configuration; on a non-zero exit print the command and its output.
+# Sanitizer diagnostics go to stderr, so both streams are captured.
+smoke() {
+    if out=$("$@" 2>&1); then
+        :
+    else
+        printf '  FAIL (exit %s): %s\n' "$?" "$*"
+        printf '%s\n' "$out" | sed 's/^/    | /'
+        fail=1
+    fi
+}
+
+# ---------------------------------------------------------------- build gate
+say "warning gate: -Wall -Wextra -Werror"
+for src in research/iteration-cost/iterbench.c \
+           research/write-probe-cost/probebench.c \
+           research/backend-comparison/amdahl.c; do
+    printf '  %s\n' "$src"
+    # shellcheck disable=SC2086
+    $CC -O2 $WARN $CPPF -o "$BUILD/$(basename "$src" .c)" "$ROOT/$src" $LDF
+done
+
+# research/shm-arena has its own Makefile (static-archive link, -lrt/-lpthread,
+# platform feature macros), so it is built through that rather than reproduced
+# here. Built in a copy so the checkout stays clean. Compile only: the gates
+# fork, kill writers mid-write and probe robust mutexes, which is a feasibility
+# study rather than a smoke test.
+printf '  research/shm-arena (via its Makefile, compile only)\n'
+cp -R "$ROOT/research/shm-arena" "$BUILD/shm-arena"
+make -C "$BUILD/shm-arena" \
+     CFLAGS="-std=c11 -O2 -g $WARN -Wno-unused-result" >/dev/null
+
+# research/backend-comparison/cmp.c is deliberately not built: it includes
+# "art.h" from libart, which README.md says must be cloned alongside and is not
+# vendored. Building it here would mean vendoring a dependency into a tree
+# whose whole point is that nothing in it ships.
+printf '  research/backend-comparison/cmp.c SKIPPED (needs libart, not vendored)\n'
+
+# ------------------------------------------------------------- sanitized run
+say "sanitized build (ASan + UBSan)"
+# shellcheck disable=SC2086
+$CC -O1 -g $SAN $WARN $CPPF -o "$BUILD/iterbench-san" \
+    "$ROOT/research/iteration-cost/iterbench.c" $LDF
+# shellcheck disable=SC2086
+$CC -O1 -g $SAN $WARN $CPPF -o "$BUILD/probebench-san" \
+    "$ROOT/research/write-probe-cost/probebench.c" $LDF
+
+# Key lengths bracket every boundary the generators switch on: below 8 (the
+# ADAPTIVE/SSO packed path, and the machine-word step PR #139 found), around
+# 16 (LONGKEY_MIN, where the struct corpus changes shape), and above it. The
+# short half is the half that had never executed.
+ITER_STRUCT="4 5 6 7 8 9 12 15 16 17 24 40"
+ITER_RAND="2 3 4 5 6 7 8 9 12 15 16 17 24 40"
+ITER_VARLEN="4 5 6 7 8 12 15 16 17 24 40"
+
+PROBE_STRUCT="4 5 6 7 8 9 12 15 16 17 24"
+PROBE_RAND="3 4 5 6 7 8 9 12 15 16 17 24"
+PROBE_VARLEN="4 6 8 12 15 16 17 24"
+PROBE_ABSENT="offset shallow mid deep last"
+
+say "iterbench smoke (n=$N)"
+for corpus in struct rand varlen; do
+    case "$corpus" in
+        struct) lens="$ITER_STRUCT" ;;
+        rand)   lens="$ITER_RAND" ;;
+        varlen) lens="$ITER_VARLEN" ;;
+    esac
+    printf '  %-7s keylen: %s\n' "$corpus" "$lens"
+    for k in $lens; do
+        smoke "$BUILD/iterbench-san" "$N" "$k" 1 "$corpus"
+    done
+done
+
+say "probebench smoke (n=$N, every absent-key divergence)"
+for corpus in struct rand varlen; do
+    case "$corpus" in
+        struct) lens="$PROBE_STRUCT" ;;
+        rand)   lens="$PROBE_RAND" ;;
+        varlen) lens="$PROBE_VARLEN" ;;
+    esac
+    printf '  %-7s keylen: %s\n' "$corpus" "$lens"
+    for k in $lens; do
+        for d in $PROBE_ABSENT; do
+            smoke "$BUILD/probebench-san" "$N" "$k" 1 "$corpus" "$d"
+        done
+    done
+done
+
+# A generator that emits nothing would sail through the grid above, so make one
+# configuration prove it produced keys of the length it was asked for.
+say "self-check: the grid is actually running the harnesses"
+"$BUILD/probebench-san" "$N" 6 1 struct shallow 2>/dev/null | grep -q 'JLG hit (SSO packed)' \
+    || { printf '  FAIL: the SSO probe row is missing from a keylen 6 run\n'; fail=1; }
+"$BUILD/iterbench-san" "$N" 16 1 rand 2>/dev/null | grep -q 'corpus=rand' \
+    || { printf '  FAIL: iterbench did not report the corpus it was given\n'; fail=1; }
+
+if [ "$fail" -ne 0 ]; then
+    printf '\n== research/ smoke pass FAILED\n'
+    exit 1
+fi
+printf '\n== research/ smoke pass OK\n'

--- a/research/iteration-cost/iterbench.c
+++ b/research/iteration-cost/iterbench.c
@@ -146,6 +146,20 @@ static unsigned long xs(unsigned long *s) {
     return *s;
 }
 
+/* How many distinct keys the random corpora can express at a given length,
+ * saturating rather than overflowing. 255 values per byte, NUL excluded.
+ * Without this the redraw loop below spins forever once n approaches the
+ * space -- a hang rather than a wrong number, but the same class of defect
+ * as a generator that ignores its length argument (issue #122). */
+static unsigned long rand_key_space(int len) {
+    unsigned long cap = 1;
+    for (int p = 0; p < len; p++) {
+        if (cap > ULONG_MAX / 255) return ULONG_MAX;
+        cap *= 255;
+    }
+    return cap;
+}
+
 /* Uniform-random bytes over 1..255. NUL is excluded because JudySL keys are
  * NUL-terminated. Every byte position carries ~8 bits, so no position is
  * invariant and the branch mix is not pinned to a single node type -- the
@@ -177,6 +191,20 @@ int main(int argc, char **argv) {
     if (keylen < 1) { fprintf(stderr, "keylen must be >= 1\n"); return 1; }
     if (corpus == CORPUS_VARLEN && keylen < 4) {
         fprintf(stderr, "varlen needs keylen >= 4\n"); return 1;
+    }
+    if (corpus != CORPUS_STRUCT) {
+        /* varlen's shortest draw is 4 bytes, so that is where its space is
+         * tightest. Demand headroom of 2n, not n: the redraw loop's expected
+         * cost blows up as the corpus saturates its own key space. */
+        int shortest = (corpus == CORPUS_VARLEN) ? 4 : keylen;
+        unsigned long cap = rand_key_space(shortest);
+        if (cap / 2 < n) {
+            fprintf(stderr,
+                "%s at keylen %d draws from only %lu distinct keys; need "
+                "headroom for %lu. Raise keylen or lower n.\n",
+                corpus_name[corpus], keylen, cap, n);
+            return 1;
+        }
     }
     /* The struct corpus's short regime encodes the index in base-36 across
      * keylen bytes, so it can only express so many distinct keys. n must fit,
@@ -305,6 +333,11 @@ int main(int argc, char **argv) {
     REPORT("JSLG random", r_jslg_rand);
     REPORT("JHSG sorted", r_jhsg_sorted);
     fprintf(stderr, "sink=%lu\n", sink);
+
+    /* Released rather than left to exit(2) so a leak checker has something to
+     * say. long, not Word_t: the J*FA macros compare against JERR (-1). */
+    { long freed;
+      JSLFA(freed, sl); JHSFA(freed, hs); JLFA(freed, jl); (void)freed; }
     free(keys);
     return 0;
 }

--- a/research/write-probe-cost/probebench.c
+++ b/research/write-probe-cost/probebench.c
@@ -33,7 +33,30 @@
  *                 branch, whose probe today is a JudyL lookup on the packed
  *                 index rather than a JHSG.
  *
- * ./probebench <n> <keylen> <reps>
+ * ./probebench <n> <keylen> <reps> [corpus] [absent]
+ *
+ * corpus is one of, matching research/iteration-cost/iterbench.c exactly so
+ * the two harnesses emit comparable corpora:
+ *   struct   (default) the original two-shape corpus: "user:00001234:f5"
+ *            padded with 'x' at keylen >= 16, a fixed-width mixed base-36
+ *            counter below it.
+ *   rand     uniform-random bytes, exactly keylen of them, drawn from 1..255.
+ *            One shape across the whole sweep, so key length is the only
+ *            variable and there is no regime break at 16.
+ *   varlen   uniform-random bytes with the length itself drawn uniformly from
+ *            [4, keylen]. Deliberately ragged, to exercise a mix of trie
+ *            depths rather than a single uniform depth.
+ *
+ * absent selects how far into the key an absent key first differs from a
+ * stored one. This is the independent variable of the miss comparison -- see
+ * make_divergent_key() below for why a single setting of it is not a
+ * measurement:
+ *   offset   (default) the historical generator, kept so every miss figure
+ *            published before this option existed stays reproducible.
+ *   shallow  diverge at byte 0
+ *   mid      diverge at byte len/2
+ *   deep     diverge at byte len-2
+ *   last     diverge at the final byte
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -57,6 +80,22 @@ static double med(double *v, int k) { qsort(v, k, sizeof(double), cmpd); return 
 #define MAXK 128
 #define MAXREPS 64
 
+/* Corpus selection, identical to research/iteration-cost/iterbench.c. A single
+ * corpus hides real effects: issue #122 / PR #139 found "JSLN is flat in key
+ * length" to be a property of the structured corpus rather than of JudySL. */
+#define CORPUS_STRUCT 0
+#define CORPUS_RAND   1
+#define CORPUS_VARLEN 2
+static const char *corpus_name[] = { "struct", "rand", "varlen" };
+
+/* Where an absent key first differs from a stored one. */
+#define DIVERGE_OFFSET  0
+#define DIVERGE_SHALLOW 1
+#define DIVERGE_MID     2
+#define DIVERGE_DEEP    3
+#define DIVERGE_LAST    4
+static const char *diverge_name[] = { "offset", "shallow", "mid", "deep", "last" };
+
 /* The long format is at minimum 16 characters ("user:" + 8 digits + ":f" +
  * 1 digit), so it cannot express a shorter key at all. Keys below that width
  * therefore use a different shape: a fixed-width base-36 counter, which fills
@@ -65,9 +104,30 @@ static double med(double *v, int k) { qsort(v, k, sizeof(double), cmpd); return 
 #define KEY_RADIX 36
 static const char key_alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
-/* Absent keys are drawn from an index range disjoint from the populated one.
- * The long regime has room to spare; the short regime does not, so it offsets
- * by n and main() checks the space is big enough. */
+/* An exact-length guard that survives -DNDEBUG. assert() is not used: this
+ * repo compiles asserts out in places, and a generator that silently ignores
+ * the requested length is exactly the defect issue #122 is about, so the check
+ * has to be unconditional. Identical to iterbench.c's. */
+static void key_check(const char *buf, int want) {
+    size_t got = strlen(buf);
+    if ((int)got != want) {
+        fprintf(stderr, "make_key: emitted %zu bytes, wanted %d (\"%s\")\n",
+                got, want, buf);
+        abort();
+    }
+}
+
+/* The DIVERGE_OFFSET absent-key generator draws from an index range disjoint
+ * from the populated one. The long regime has room to spare; the short regime
+ * does not, so it offsets by n and main() checks the space is big enough.
+ *
+ * This offset is NOT depth-neutral, and an earlier version of this file said
+ * it was. Pushing i/10 into 8-digit territory changes the third byte of the
+ * "user:%08lu" field, so at keylen >= LONGKEY_MIN every absent key diverges
+ * from the stored set at byte 5 of 16 -- the earliest position the format can
+ * express -- while JudyHS still digests all 16 bytes. Under this mode the
+ * long-key miss comparison is therefore granted to the trie by construction.
+ * The DIVERGE_* modes exist to measure it instead; see make_divergent_key(). */
 #define ABSENT_OFFSET_LONG 500000000UL
 
 /* keylen >= LONGKEY_MIN keeps the exact shape of
@@ -75,8 +135,9 @@ static const char key_alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyz";
  * ones in issue #85: "user:00001234:f5" padded with 'x'. 10 keys share each
  * user: prefix.
  *
- * keylen < LONGKEY_MIN emits base-36 of i, zero-padded to exactly keylen. This
- * is what makes the ADAPTIVE/SSO probe (keylen < 8) reachable: before, the
+ * keylen < LONGKEY_MIN emits base-36 of a mixed index (see key_mix_for), in
+ * exactly keylen bytes. This is what makes the ADAPTIVE/SSO probe (keylen < 8)
+ * reachable: before, the
  * format's 16 characters were emitted regardless of keylen, so every keylen
  * below 16 silently produced a 16-byte key and the SSO branch then memcpy'd
  * 16 bytes into an 8-byte Word_t. See issue #118. */
@@ -110,6 +171,7 @@ static void make_key(char *buf, unsigned long i, int keylen) {
         int m = snprintf(buf, MAXK, "user:%08lu:f%lu", i / 10, i % 10);
         while (m < keylen) buf[m++] = 'x';
         buf[m] = '\0';
+        key_check(buf, keylen);
         return;
     }
 
@@ -141,10 +203,7 @@ static void make_key(char *buf, unsigned long i, int keylen) {
         v /= KEY_RADIX;
     }
     buf[keylen] = '\0';
-}
-
-static void make_absent_key(char *buf, unsigned long i, int keylen, unsigned long n) {
-    make_key(buf, i + (keylen >= LONGKEY_MIN ? ABSENT_OFFSET_LONG : n), keylen);
+    key_check(buf, keylen);
 }
 
 /* How many distinct keys the short regime can express, saturating rather than
@@ -164,26 +223,136 @@ static unsigned long xs(unsigned long *s) {
     return *s;
 }
 
+/* How many distinct keys the random corpora can express at a given length,
+ * saturating rather than overflowing. 255 values per byte, NUL excluded.
+ * Without this the redraw loop below spins forever once n approaches the
+ * space -- a hang rather than a wrong number, but the same class of defect
+ * as a generator that ignores its length argument (issue #122). */
+static unsigned long rand_key_space(int len) {
+    unsigned long cap = 1;
+    for (int p = 0; p < len; p++) {
+        if (cap > ULONG_MAX / 255) return ULONG_MAX;
+        cap *= 255;
+    }
+    return cap;
+}
+
+/* Uniform-random bytes over 1..255. NUL is excluded because JudySL keys are
+ * NUL-terminated. Every byte position carries ~8 bits, so no position is
+ * invariant and the branch mix is not pinned to a single node type -- the
+ * degeneracy that scoped the original issue #85 conclusion to one regime.
+ * Identical to iterbench.c's. */
+static void make_random_key(char *buf, int len, unsigned long *seed) {
+    for (int p = 0; p < len; p++) buf[p] = (char)(1 + (xs(seed) % 255));
+    buf[len] = '\0';
+    key_check(buf, len);
+}
+
+/* Byte position at which an absent key should first differ from a stored one. */
+static int absent_depth(int mode, int len) {
+    switch (mode) {
+        case DIVERGE_SHALLOW: return 0;
+        case DIVERGE_MID:     return len / 2;
+        case DIVERGE_DEEP:    return len >= 2 ? len - 2 : 0;
+        default:              return len - 1;          /* DIVERGE_LAST */
+    }
+}
+
+/* Copy a stored key and change exactly one byte, at `depth`, keeping the
+ * length. The result is absent (checked against the tree) and shares a
+ * `depth`-byte prefix with a stored key.
+ *
+ * Divergence depth is the independent variable the miss comparison needs. A
+ * trie fails at the first differing byte, so its miss cost tracks `depth`; a
+ * hash digests all `len` bytes whatever `depth` is. Sweeping `depth` at fixed
+ * length turns "the trie wins on a miss" from one favourable point into a
+ * curve, and the point DIVERGE_OFFSET happens to land on for long keys is the
+ * most favourable one there is (byte 5 of 16).
+ *
+ * The realised divergence is *at least* `depth`, not exactly it: the mutated
+ * key shares `depth` bytes with its source, but another stored key may share
+ * more. Judy exposes no way to read back the longest common prefix it actually
+ * walked, so this is a lower bound on depth, not a measured one. */
+static int make_divergent_key(char *dst, const char *src, int depth,
+                              int corpus, Pvoid_t sl, unsigned long *seed) {
+    size_t len = strlen(src);
+    PWord_t chk;
+
+    if (depth < 0 || (size_t)depth >= len) return -1;
+    memcpy(dst, src, len + 1);
+    for (int t = 0; t < 512; t++) {
+        /* Prefer a replacement from the corpus's own alphabet, so the absent
+         * keys stay the same shape as the present ones; fall back to arbitrary
+         * bytes only if every in-alphabet candidate is already stored. */
+        char c = (corpus == CORPUS_STRUCT && t < KEY_RADIX)
+                     ? key_alphabet[t]
+                     : (char)(1 + (xs(seed) % 255));
+        if (c == src[depth]) continue;
+        dst[depth] = c;
+        JSLG(chk, sl, (uint8_t *)dst);
+        if (chk == NULL) return 0;
+    }
+    return -1;
+}
+
 int main(int argc, char **argv) {
     unsigned long n = (argc > 1) ? strtoul(argv[1], NULL, 10) : 1000000;
     int keylen = (argc > 2) ? atoi(argv[2]) : 16;
     int reps = (argc > 3) ? atoi(argv[3]) : 5;
+    int corpus = CORPUS_STRUCT;
+    int diverge = DIVERGE_OFFSET;
     char key[MAXK];
+    unsigned long gen_seed = 0x9e3779b97f4a7c15UL;
+    unsigned long collisions = 0;
     PWord_t pv;
+
+    if (argc > 4) {
+        if      (!strcmp(argv[4], "struct")) corpus = CORPUS_STRUCT;
+        else if (!strcmp(argv[4], "rand"))   corpus = CORPUS_RAND;
+        else if (!strcmp(argv[4], "varlen")) corpus = CORPUS_VARLEN;
+        else { fprintf(stderr, "corpus must be struct|rand|varlen\n"); return 1; }
+    }
+    if (argc > 5) {
+        if      (!strcmp(argv[5], "offset"))  diverge = DIVERGE_OFFSET;
+        else if (!strcmp(argv[5], "shallow")) diverge = DIVERGE_SHALLOW;
+        else if (!strcmp(argv[5], "mid"))     diverge = DIVERGE_MID;
+        else if (!strcmp(argv[5], "deep"))    diverge = DIVERGE_DEEP;
+        else if (!strcmp(argv[5], "last"))    diverge = DIVERGE_LAST;
+        else { fprintf(stderr, "absent must be offset|shallow|mid|deep|last\n"); return 1; }
+    }
 
     if (reps > MAXREPS) reps = MAXREPS;
     if (keylen >= MAXK - 1) { fprintf(stderr, "keylen too large\n"); return 1; }
     if (keylen < 1) { fprintf(stderr, "keylen must be >= 1\n"); return 1; }
-    /* The short regime encodes the index in base-36 across keylen bytes, so it
-     * can only express so many distinct keys. n present + n absent must fit,
-     * or keys collide and every number below is meaningless. */
-    if (keylen < LONGKEY_MIN) {
-        unsigned long cap = short_key_space(keylen);
+    if (corpus == CORPUS_VARLEN && keylen < 4) {
+        fprintf(stderr, "varlen needs keylen >= 4\n"); return 1;
+    }
+    if (corpus != CORPUS_STRUCT) {
+        /* varlen's shortest draw is 4 bytes, so that is where its space is
+         * tightest. Demand headroom of 2n, not n: the redraw loop's expected
+         * cost blows up as the corpus saturates its own key space. */
+        int shortest = (corpus == CORPUS_VARLEN) ? 4 : keylen;
+        unsigned long cap = rand_key_space(shortest);
         if (cap / 2 < n) {
             fprintf(stderr,
-                "keylen %d holds only %lu distinct keys; need %lu "
-                "(n present + n absent). Raise keylen or lower n.\n",
-                keylen, cap, 2 * n);
+                "%s at keylen %d draws from only %lu distinct keys; need "
+                "headroom for %lu. Raise keylen or lower n.\n",
+                corpus_name[corpus], keylen, cap, n);
+            return 1;
+        }
+    }
+    /* The struct corpus's short regime encodes the index in base-36 across
+     * keylen bytes, so it can only express so many distinct keys. They must
+     * fit, or keys collide and every number below is meaningless. DIVERGE_OFF-
+     * SET draws its absent keys from the same space, so it needs room for 2n;
+     * the DIVERGE_* modes mutate a stored key instead and only need n. */
+    if (corpus == CORPUS_STRUCT && keylen < LONGKEY_MIN) {
+        unsigned long cap = short_key_space(keylen);
+        unsigned long need = (diverge == DIVERGE_OFFSET) ? 2 * n : n;
+        if (cap < need) {
+            fprintf(stderr,
+                "keylen %d holds only %lu distinct keys; need %lu. "
+                "Raise keylen or lower n.\n", keylen, cap, need);
             return 1;
         }
     }
@@ -195,9 +364,25 @@ int main(int argc, char **argv) {
     int sso = (keylen < 8);
 
     for (unsigned long i = 0; i < n; i++) {
-        make_key(key, i, keylen);
-        JSLI(pv, sl, (uint8_t *)key);
-        if (pv == PJERR) { fprintf(stderr, "JSLI OOM\n"); return 1; }
+        if (corpus == CORPUS_STRUCT) {
+            make_key(key, i, keylen);
+            JSLI(pv, sl, (uint8_t *)key);
+            if (pv == PJERR) { fprintf(stderr, "JSLI OOM\n"); return 1; }
+        } else {
+            /* Random corpora can collide; redraw until the key is new. The
+             * value word of a freshly inserted JudySL slot is 0, and every
+             * stored value below is i + 1 >= 1, so 0 means "new". */
+            int len = keylen;
+            for (;;) {
+                if (corpus == CORPUS_VARLEN)
+                    len = 4 + (int)(xs(&gen_seed) % (unsigned long)(keylen - 3));
+                make_random_key(key, len, &gen_seed);
+                JSLI(pv, sl, (uint8_t *)key);
+                if (pv == PJERR) { fprintf(stderr, "JSLI OOM\n"); return 1; }
+                if (*pv == 0) break;
+                collisions++;
+            }
+        }
         *pv = i + 1;
         JHSI(pv, hs, key, (Word_t)strlen(key));
         if (pv == PJERR) { fprintf(stderr, "JHSI OOM\n"); return 1; }
@@ -230,11 +415,36 @@ int main(int argc, char **argv) {
         if (c != n) { fprintf(stderr, "walk got %lu of %lu\n", c, n); return 1; }
     }
     for (unsigned long i = 0; i < n; i++) {
-        make_absent_key(absent + (size_t)i * MAXK, i, keylen, n);
-        /* sanity: must really be absent */
-        if (i < 4) {
+        char *a = absent + (size_t)i * MAXK;
+        const char *src = keys + (size_t)i * MAXK;
+
+        if (diverge != DIVERGE_OFFSET) {
+            int depth = absent_depth(diverge, (int)strlen(src));
+            if (make_divergent_key(a, src, depth, corpus, sl, &gen_seed) != 0) {
+                fprintf(stderr, "no absent key diverging at byte %d of \"%s\"\n",
+                        depth, src);
+                return 1;
+            }
+        } else if (corpus == CORPUS_STRUCT) {
+            /* The historical generator, kept verbatim so every miss figure
+             * published before this option existed stays reproducible. */
+            make_key(a, i + (keylen >= LONGKEY_MIN ? ABSENT_OFFSET_LONG : n), keylen);
+        } else {
+            /* The random corpora's equivalent of an independent index range:
+             * an independently drawn key, redrawn until it is absent. */
             PWord_t chk;
-            JSLG(chk, sl, (uint8_t *)(absent + (size_t)i * MAXK));
+            int len = (int)strlen(src);
+            for (;;) {
+                make_random_key(a, len, &gen_seed);
+                JSLG(chk, sl, (uint8_t *)a);
+                if (chk == NULL) break;
+            }
+        }
+        /* Every absent key is checked, not just a sample of them: a miss
+         * benchmark that is quietly measuring hits reports nothing at all. */
+        {
+            PWord_t chk;
+            JSLG(chk, sl, (uint8_t *)a);
             if (chk != NULL) { fprintf(stderr, "absent key %lu is present\n", i); return 1; }
         }
     }
@@ -395,7 +605,9 @@ int main(int argc, char **argv) {
         for (int pass = 0; pass < 2; pass++) {
             int which = (r % 2 == 0) ? pass : (1 - pass);
             Pvoid_t s2 = (Pvoid_t)NULL, h2 = (Pvoid_t)NULL;
-            Word_t freed;
+            /* long, not Word_t: JSLFA/JHSFA compare the result against JERR
+             * (-1), which is -Wsign-compare noise on an unsigned. */
+            long freed;
 
             if (which == 0) {           /* A: today's insert */
                 t0 = now_ns();
@@ -425,12 +637,15 @@ int main(int argc, char **argv) {
                 }
                 t1 = now_ns(); r_ins_b[r] = (t1 - t0) / (double)n;
             }
-            JSLFA(freed, s2); sink += freed;
-            JHSFA(freed, h2); sink += freed;
+            JSLFA(freed, s2); sink += (unsigned long)freed;
+            JHSFA(freed, h2); sink += (unsigned long)freed;
         }
     }
 
-    printf("n=%lu keylen=%d reps=%d (median ns/op; min..max)\n", n, keylen, reps);
+    printf("n=%lu keylen=%d reps=%d corpus=%s absent=%s (median ns/op; min..max)\n",
+           n, keylen, reps, corpus_name[corpus], diverge_name[diverge]);
+    if (corpus != CORPUS_STRUCT)
+        printf("  (redraws to avoid duplicate keys: %lu)\n", collisions);
 #define REPORT(label, arr) do { \
         double tmp[MAXREPS]; memcpy(tmp, arr, sizeof(double) * reps); \
         double m = med(tmp, reps); \
@@ -451,6 +666,10 @@ int main(int argc, char **argv) {
     REPORT("insert B: JSLG+JHSI+JSLI (B3 swap)", r_ins_b);
     fprintf(stderr, "sink=%lu\n", sink);
 
+    /* Released rather than left to exit(2) so a leak checker has something to
+     * say. long, not Word_t: the J*FA macros compare against JERR (-1). */
+    { long freed;
+      JSLFA(freed, sl); JHSFA(freed, hs); JLFA(freed, jl); (void)freed; }
     free(keys); free(absent); free(order);
     return 0;
 }


### PR DESCRIPTION
Closes the two items left open by the [status comment](https://github.com/orieg/php-judy/issues/122#issuecomment) on #122. Items 1-3 there were already closed by #124, #118 and #139.

## Item 4 — the miss benchmark was granted its result for long keys

`probebench` inherited #124's base-36 alphabet but not #139's corpus switch, so every measurement taken with it was silently scoped to one key shape. It now takes the same fourth argument as `iterbench` — `struct` | `rand` | `varlen` — with the same generation code, so the two harnesses emit comparable corpora, and carries `iterbench`'s unconditional `key_check()`.

`ABSENT_OFFSET_LONG` (500,000,000) pushes `i / 10` into 8-digit territory, so at `keylen >= 16` **every** absent key diverged at byte 5 of 16 — the earliest position the format can express — while JudyHS still digested all 16 bytes. The long-key miss comparison was definitional rather than measured, and the comment at the generator asserted the opposite. A fifth argument now selects the divergence depth:

| value | absent key first differs at |
| ----- | --------------------------- |
| `offset` (default) | wherever the historical index offset lands it — byte 5 of 16 for the long shape |
| `shallow` | byte 0 |
| `mid` | byte `len / 2` |
| `deep` | byte `len - 2` |
| `last` | the final byte |

`shallow`/`mid`/`deep`/`last` copy a stored key and change exactly one byte at that position, so length is held constant — the hash's work is fixed while the trie's varies. `offset` stays the default so every figure published before this option existed reproduces without a flag.

Two honest limits, both stated in `research/README.md`: the realised divergence is a **lower bound** on depth (another stored key may share more of the prefix, and Judy exposes no way to read back the LCP it walked), and **the curve has not been run** — this makes the measurement possible and labels the existing number a best case; it does not replace it. That needs an idle host.

Also fixed while in here: the two `-Wsign-compare` warnings (`J*FA` compares its result against `JERR` = -1, so the destination has to be signed); an unguarded redraw loop in the random corpora (`iterbench 1000 1 1 rand` hung); the absent-key sanity check now covers every key rather than the first four; and both harnesses free their Judy arrays at exit.

## Item 5 — `research/` now builds in CI

`ci.yml` had zero references to `research/`. That exemption is the root cause: nothing compiled this directory, so a generator could ignore its own length argument for years and a documented probe path could ship without ever having executed.

`research/ci-smoke.sh` builds every harness with `-Wall -Wextra -Werror` and runs an ASan/UBSan pass over the parameter grid — every corpus, key lengths bracketing 8 and 16 (`4 5 6 7 8 9 12 15 16 17 24 40`), and every absent-key divergence. 168 configurations. The grid is what does the work, not the sample size: both historical defects are reachable at `n = 1000` and neither is reachable at the single point the harnesses were habitually run at.

**Measured runtime on the runner** (`ubuntu-latest`, x86_64, [job 95630177366](https://github.com/orieg/php-judy/actions/runs/32110990438/job/95630177366)): the smoke gate step is **7.8s** for build + 168 sanitized runs; the negative control step is 14.8s (it rebuilds and reruns the grid); `apt-get install libjudy-dev` is 19.5s. **Whole job: 47s.**

Scoped out, deliberately:

- **`backend-comparison/cmp.c` is not built.** It includes `art.h` from libart, which `research/README.md` says is cloned alongside rather than vendored. Vendoring a dependency into a tree whose whole point is that nothing in it ships is the wrong trade.
- **`shm-arena/` is compiled but not run.** It builds warning-free through its own Makefile under `-Werror`. Its gates fork, kill writers mid-write and probe robust mutexes — a feasibility study, not a smoke test, and #83 is already closed on its results.

## Validation — the gate was checked against both historical bug classes

Run on Debian/Ubuntu 24.04 + gcc 13.3 in a container, against copies of the tree so the working tree stayed clean. A gate that passes on a known-broken tree is worse than no gate, so this was verified rather than assumed.

**1. Generator bug (#124/#139 class) — `probebench`.** Reverted `make_key()` to the pre-#124 pad-only form (long branch taken unconditionally, so it pads up and never truncates):

```
SCRIPT EXIT: 1
failing configs: 40
  FAIL (exit 134): probebench-san 1000 4 1 struct offset
    | make_key: emitted 16 bytes, wanted 4 ("user:00000000:f0")
    | Aborted
== research/ smoke pass FAILED
```

**2. Same bug in `iterbench`** (the #139 defect), reverted the same way:

```
SCRIPT EXIT: 1
failing configs: 8
  FAIL (exit 134): iterbench-san 1000 4 1 struct
    | make_key: emitted 16 bytes, wanted 4 ("user:00000000:f0")
== research/ smoke pass FAILED
```

**3. Out-of-bounds write (#118 class).** Reinstated the full pre-#118 tree — pad-only generator, `key_check()` removed from `make_key()`, and both `if (kl > sizeof(Word_t)) kl = sizeof(Word_t)` clamps deleted — so the SSO branch memcpys a 16-byte key into an 8-byte `Word_t`:

```
SCRIPT EXIT: 1
failing configs: 20
  FAIL (exit 1): probebench-san 1000 4 1 struct offset
    | ==2955==ERROR: AddressSanitizer: stack-buffer-overflow
    | WRITE of size 16 at 0x... thread T0
    |     #0 in memcpy
    |     #1 in main probebench.c:391
== research/ smoke pass FAILED
```

Note the shape of case 3: with `key_check()` in place the generator bug aborts *before* reaching the memcpy, so reproducing #118 required removing the guard too. Both layers are load-bearing, and the grid catches the tree either way.

Case 1 is wired into the job permanently as a negative control, matching `debug-mirror-assertions`: the step reinstates the pad-only generator with `sed`, requires the grid to fail, requires the failure to be the key-length guard specifically rather than any error, then restores the file.

## Caveats

- The container used for validation is arm64 (Apple Silicon); CI runs x86_64. The defects reproduced are not architecture-dependent, but the ASan stack layout in the trace above is arm64's.
- LeakSanitizer does not run inside that container (ptrace restrictions), so the added `J*FA` calls at exit could not be checked locally. The first CI run has since passed with leak detection left at its default (on, for gcc + ASan on Linux) and reported nothing, so `libJudy` does not appear to leak across the grid — but that is one run's evidence, not a deliberate leak-detection test.
- No measured claim was re-derived here. #139 did that work; nothing in this PR re-runs a benchmark or changes a published number.
- `research/` is deliberately absent from `package.xml` and stays that way. `baselines/latest.json`, `BENCHMARK.md` and the extension sources are untouched.

Refs #122, #118, #124, #139.
