### PR TITLE
fix(release): apply the 0xffL LLP64 replacement to Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,12 @@ jobs:
             $text = [regex]::Replace($text, '\b1UL\s*<<', '(Word_t)1 <<')
             $text = [regex]::Replace($text, '\b1L\s*<<',  '(Word_t)1 <<')
             $text = $text.Replace('0x100UL', '(Word_t)0x100')
+            # Byte-mask base constant (cJU_MASKATSTATE in JudyPrivateBranch.h).
+            # ci.yml has applied this since the LLP64 sweep landed; release.yml
+            # had drifted and shipped DLLs without it (wrong masks for JudySL
+            # long strings, State >= 5 on x64). Keep the two sets in lockstep
+            # until the vendored tree (#142) deletes both.
+            $text = $text.Replace('0xffL', '(Word_t)0xff')
             if ($text -ne $orig) {
               Set-Content $_.FullName -Value $text -NoNewline
               $fixCount++


### PR DESCRIPTION
**Stage 0a of #142** — independent one-line hotfix, ahead of the vendoring work.

## The drift

`ci.yml`'s Windows job patches libJudy's UL constants with **six** replacements before building. The near-duplicate patch block in `release.yml` carries only **five** — it is missing:

```powershell
$text = $text.Replace('0xffL', '(Word_t)0xff')
```

On MSVC x64 (LLP64), `0xffL` is a 32-bit `long`, so `cJU_MASKATSTATE` (`JudyPrivateBranch.h`) yields 0 for `State >= 5`, breaking `JU_SETDIGIT`/cascade for JudySL with long strings. **Released Windows DLLs have been built without a fix that CI builds apply.**

## The fix

Add the missing replacement to `release.yml`, with a comment recording the drift and noting both copies are deleted by the vendored tree (#142). The `-DJU_64BIT` arch-conditionality difference between the two files is deliberate in release.yml (it builds x86 too) and is left as is.

No extension sources touched; `baselines/latest.json` untouched.