### PR TITLE
Stage 1 (#142): bundled libJudy as the default build; system-lib mode kept

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Install Judy library
-        run: sudo apt-get update && sudo apt-get install -y libjudy-dev
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -38,9 +35,11 @@ jobs:
           coverage: none
 
       - name: Build the extension
+        # No --with-judy: the bundled libJudy (libjudy/) is the default build,
+        # so this job also proves the tree builds with no system libJudy at all.
         run: |
           phpize
-          ./configure --with-judy=/usr
+          ./configure
           # Fail the build on any compiler warning (captured to a log so the
           # next step can gate on it). The extension is expected to compile
           # cleanly; a new warning is usually a real portability/UB signal.
@@ -57,6 +56,9 @@ jobs:
           # (form "<file>.c:<line>:<col>: warning:"). Ignore unrelated noise
           # such as autoconf's AC_PROG_LIBTOOL-obsolete and the LTO
           # lto-wrapper "serial compilation" notes.
+          # The vendored libjudy/ sources are deliberately excluded: third-party
+          # code at -Wall warns copiously, and patch hygiene (libjudy/PATCHES.md)
+          # beats chasing upstream warnings.
           if grep -E '(php_judy|judy_handlers|judy_arrayaccess|judy_iterator)\.[ch]:[0-9]+:[0-9]+: warning:' /tmp/build.log; then
             echo "::error::Compiler warnings detected in extension sources — see log above"
             exit 1
@@ -92,6 +94,11 @@ jobs:
           # Compare against the most recent stable release (release-over-
           # release regression detection). Bump this to the just-published
           # release on each release — see the "Releasing" section in README.
+          #
+          # The 2.5.2 baseline predates the vendored libJudy, so IT still
+          # needs the system library; installed only now, after the bundled
+          # build above already proved itself without one.
+          sudo apt-get update && sudo apt-get install -y libjudy-dev
           sudo pie install --skip-enable-extension orieg/judy:2.5.2 \
             --with-judy=/usr
           BASELINE_SO="$(php-config --extension-dir)/judy.so"
@@ -172,6 +179,11 @@ jobs:
             make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
 
   debug-mirror-assertions:
+    # Permanent system-lib guard: this job deliberately keeps installing
+    # libjudy-dev and building --with-judy=/usr so the system-lib mode of
+    # config.m4 stays exercised forever (issue #142). Everything else is CI
+    # policy for the mirror assertions:
+    #
     # The four *_HASH / *_ADAPTIVE types keep the key set in a JudySL
     # key_index and the values in a separate store. A path that updates one
     # and not the other produces two valid pointers holding different answers:
@@ -353,9 +365,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Install Judy library
-        run: sudo apt-get update && sudo apt-get install -y libjudy-dev
-
       - name: Resolve the PHP 8.4 release to build
         run: |
           # Track the current 8.4 patch release so the assertions stay current,
@@ -418,13 +427,16 @@ jobs:
           # A phpize build inherits PHP_DEBUG from the installed PHP; pass
           # --enable-debug anyway so the intent does not rest on inheritance.
           "$HOME/php-debug/bin/phpize"
+          # Bundled libJudy (no --with-judy); the vendored units keep their
+          # own -O2 -fno-lto flags even in a debug build.
           ./configure --with-php-config="$HOME/php-debug/bin/php-config" \
-            --with-judy=/usr --enable-debug
+            --enable-debug
           set -o pipefail
           make 2>&1 | tee /tmp/build-debug-php.log
 
       - name: Fail on compiler warnings
         run: |
+          # Vendored libjudy/ sources deliberately excluded (see build-linux).
           if grep -E '(php_judy|judy_handlers|judy_arrayaccess|judy_iterator)\.[ch]:[0-9]+:[0-9]+: warning:' /tmp/build-debug-php.log; then
             echo "::error::Compiler warnings detected building against a debug PHP"
             exit 1
@@ -559,8 +571,21 @@ jobs:
             exit 1
           fi
 
-      - name: Install Judy library
-        run: sudo apt-get update && sudo apt-get install -y libjudy-dev
+      - name: Verify package.xml lists every file under libjudy/
+        # Same rationale as the tests/ check above: the bundled libJudy only
+        # builds from the shipped tarball if every git-tracked file under
+        # libjudy/ is in package.xml (and package.xml lists nothing stale).
+        # .gitattributes is repo plumbing and deliberately not shipped.
+        run: |
+          git ls-files libjudy/ | grep -v '^libjudy/\.gitattributes$' | sort > /tmp/libjudy-on-disk.txt
+          grep -oP '(?<=name=")libjudy/[^"]+(?=")' package.xml | sort > /tmp/libjudy-in-package.txt
+          if ! diff -u --label package.xml --label libjudy/ \
+               /tmp/libjudy-in-package.txt /tmp/libjudy-on-disk.txt; then
+            echo "ERROR: package.xml and libjudy/ have diverged."
+            echo "  '+' lines: on disk but not in package.xml — add a <file> entry"
+            echo "  '-' lines: in package.xml but not on disk — remove the entry"
+            exit 1
+          fi
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -613,151 +638,9 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
-      - name: Build libjudy from source
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $ProgressPreference = "SilentlyContinue"
-
-          # Download Judy-1.0.5 source from SourceForge
-          Write-Host "Downloading Judy-1.0.5 source..."
-          & curl.exe -fsSL -o judy.tar.gz --retry 5 --retry-delay 5 -L `
-            "https://downloads.sourceforge.net/project/judy/judy/Judy-1.0.5/Judy-1.0.5.tar.gz"
-          if ($LASTEXITCODE -ne 0) { throw "Failed to download Judy source" }
-
-          # Extract
-          tar -xzf judy.tar.gz
-          $judyDir = Get-ChildItem -Directory | Where-Object { $_.Name -match '^[Jj]udy-' } | Select-Object -First 1
-          if (-not $judyDir) { throw "Could not find extracted Judy directory" }
-          $srcDir = Join-Path $judyDir.FullName "src"
-          if (-not (Test-Path (Join-Path $srcDir "build.bat"))) {
-            throw "build.bat not found in $srcDir"
-          }
-          Write-Host "Source: $srcDir"
-
-          # Patch Judy.h: Fix Word_t for 64-bit Windows and PJERR sentinel
-          Write-Host "Patching Judy.h..."
-          $judyH = Join-Path $srcDir "Judy.h"
-          $content = Get-Content $judyH -Raw
-
-          # Fix Word_t: unsigned long is only 4 bytes on MSVC x64 (LLP64),
-          # use unsigned __int64 for proper 64-bit Word_t
-          $wordTPatch = @'
-          #if defined(_WIN64)
-          typedef unsigned __int64    Word_t, * PWord_t;
-          #else
-          typedef unsigned long       Word_t, * PWord_t;
-          #endif
-          '@
-          # Trim indentation added by YAML here-string
-          $wordTPatch = ($wordTPatch.Trim() -split "`n" | ForEach-Object { $_.Trim() }) -join "`n"
-          $content = $content -replace 'typedef\s+unsigned\s+long\s+Word_t\s*,\s*\*\s*PWord_t\s*;', $wordTPatch
-
-          # Fix PJERR/PPJERR: ~0UL is 32-bit on MSVC x64, use ~(size_t)0
-          # to get the correct 64-bit error sentinel
-          $content = $content.Replace('(~0UL)', '(~(size_t)0)')
-
-          # Validate patches applied
-          if ($content -notmatch 'unsigned __int64\s+Word_t') { throw "Failed to patch Word_t in Judy.h" }
-          if ($content -notmatch '~\(size_t\)0') { throw "Failed to patch PJERR in Judy.h" }
-          Set-Content $judyH -Value $content -NoNewline
-          Write-Host "Patched Judy.h"
-
-          # Patch build.bat: Add -DJU_64BIT for proper 64-bit internal data structures
-          # and /MD to use the dynamic C runtime (matching PHP's CRT linkage)
-          Write-Host "Patching build.bat..."
-          $buildBat = Join-Path $srcDir "build.bat"
-          $batContent = Get-Content $buildBat -Raw
-          $batContent = $batContent.Replace('-DJU_WIN', '-DJU_WIN -DJU_64BIT /MD')
-          if ($batContent -notmatch 'JU_64BIT') { throw "Failed to patch build.bat" }
-          Set-Content $buildBat -Value $batContent -NoNewline
-          Write-Host "Patched build.bat"
-
-          # Fix all unsigned-long constants that break on MSVC x64 (LLP64 model).
-          # On MSVC x64, `unsigned long` is 4 bytes, so any UL constant used in a
-          # 64-bit context silently truncates:
-          #
-          #   ~0UL       -> 0xFFFFFFFF  (breaks cJU_ALLONES, memory ceiling, etc.)
-          #   (-1UL)     -> 0xFFFFFFFF  (breaks max-pop sentinels in JudyPrivateBranch.h)
-          #   1UL << N   -> 0 when N>=32 (breaks JudyInsArray.c, JudyPrevNextEmpty.c)
-          #   1L  << N   -> sign-extends to 0xFFFFFFFF80000000 when N=31; 0 when N>=32
-          #                 (breaks JU_BITPOSMASKB/L in JudyPrivate.h)
-          #   0x100UL    -> 0x100 as 32-bit; JU_LEASTBYTESMASK wrong for BYTES>4
-          #   0xffL      -> 0xff as 32-bit; cJU_MASKATSTATE yields 0 for State>=5
-          #                 (breaks JU_SETDIGIT/cascade for JudySL with long strings)
-          #
-          # The root cause of the 17-min hang in PrevNextEmpty: bitposmaskL was
-          # initialised to `1UL << 63` = 0 on MSVC x64, creating an infinite loop.
-          Write-Host "Fixing UL constants in Judy source files..."
-          $fixCount = 0
-          Get-ChildItem -Path $judyDir.FullName -Recurse -Include "*.c","*.h" | ForEach-Object {
-            $orig = Get-Content $_.FullName -Raw
-            $text = $orig
-            # All-ones patterns
-            $text = $text.Replace('~0UL',    '~(Word_t)0')
-            $text = $text.Replace('(-1UL)',  '(~(Word_t)0)')
-            # Shift-base patterns (order matters: 1UL before 1L to avoid double-replace)
-            $text = [regex]::Replace($text, '\b1UL\s*<<', '(Word_t)1 <<')
-            $text = [regex]::Replace($text, '\b1L\s*<<',  '(Word_t)1 <<')
-            # Least-bytes mask base constant
-            $text = $text.Replace('0x100UL', '(Word_t)0x100')
-            # Byte-mask base constant (cJU_MASKATSTATE in JudyPrivateBranch.h)
-            $text = $text.Replace('0xffL', '(Word_t)0xff')
-            if ($text -ne $orig) {
-              Set-Content $_.FullName -Value $text -NoNewline
-              $fixCount++
-            }
-          }
-          Write-Host "Fixed UL constants in $fixCount files"
-
-          # Build
-          Write-Host "Building libjudy..."
-          Push-Location $srcDir
-          & cmd.exe /c "build.bat 2>&1"
-          Pop-Location
-
-          # Verify build output
-          $judyLib = Get-ChildItem -Path $srcDir -Recurse -Filter "Judy.lib" -ErrorAction SilentlyContinue |
-            Sort-Object Length -Descending | Select-Object -First 1
-          if (-not $judyLib) {
-            Write-Host "Build artifacts found:"
-            Get-ChildItem -Path $srcDir -Recurse -Include "*.lib","*.dll","*.obj" -ErrorAction SilentlyContinue |
-              ForEach-Object { Write-Host "  $($_.FullName) ($($_.Length) bytes)" }
-            throw "Judy.lib not found after build"
-          }
-          Write-Host "Built: $($judyLib.FullName) ($($judyLib.Length) bytes)"
-
-          # Install to libjudy/{include,lib,bin} outside workspace.
-          # php-windows-builder runs git clean -ffdx which removes untracked
-          # files from the workspace, so we install to RUNNER_TEMP instead.
-          $installDir = Join-Path $env:RUNNER_TEMP "libjudy"
-          foreach ($sub in @("include", "lib", "bin")) {
-            New-Item -ItemType Directory -Force (Join-Path $installDir $sub) | Out-Null
-          }
-
-          Copy-Item $judyH "$installDir\include\"
-          Copy-Item $judyLib.FullName "$installDir\lib\libJudy.lib"
-          Copy-Item $judyLib.FullName "$installDir\lib\libJudy_a.lib"
-
-          # Copy DLL if produced (for dynamic linking)
-          $judyDll = Get-ChildItem -Path $srcDir -Recurse -Filter "Judy.dll" -ErrorAction SilentlyContinue |
-            Select-Object -First 1
-          if ($judyDll) {
-            Copy-Item $judyDll.FullName "$installDir\bin\"
-            Write-Host "Installed DLL: $($judyDll.Length) bytes"
-          }
-
-          Write-Host "=== libjudy installed ==="
-          Get-ChildItem -Path $installDir -Recurse -File | ForEach-Object {
-            $rel = $_.FullName.Substring($installDir.Length)
-            Write-Host "  $rel ($($_.Length) bytes)"
-          }
-
-      - name: Add libjudy to PATH
-        shell: pwsh
-        run: |
-          Add-Content $env:GITHUB_PATH "${{ runner.temp }}\libjudy\bin"
-
+      # The bundled libJudy (libjudy/) builds via config.w32, and the P5 LLP64
+      # patches are real source diffs now — the historical SourceForge
+      # download + regex-patch step is gone (issue #142).
       - name: Disable Windows Error Reporting
         shell: pwsh
         run: |
@@ -781,7 +664,6 @@ jobs:
           php-version: ${{ matrix.php-version }}
           arch: ${{ matrix.arch }}
           ts: ${{ matrix.ts }}
-          args: --with-judy=${{ runner.temp }}\libjudy
           test-workers: "1"
           test-runner-args: "--set-timeout 30"
         env:
@@ -862,15 +744,7 @@ jobs:
         run: |
           $ErrorActionPreference = "Continue"
 
-          Write-Host "=== libjudy install ==="
-          $dir = Join-Path $env:RUNNER_TEMP "libjudy"
-          if (Test-Path $dir) {
-            Get-ChildItem -Path $dir -Recurse -File | ForEach-Object {
-              Write-Host "  $($_.FullName.Substring($dir.Length)) ($($_.Length) bytes)"
-            }
-          }
-
-          Write-Host "`n=== Configure log (tail) ==="
+          Write-Host "=== Configure log (tail) ==="
           Get-ChildItem -Path ".\build" -Recurse -Filter "config*.log" -ErrorAction SilentlyContinue |
             Select-Object -First 1 | ForEach-Object { Get-Content $_.FullName -Tail 50 }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,112 +58,16 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
-      - name: Build libjudy from source
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $ProgressPreference = "SilentlyContinue"
-
-          Write-Host "Downloading Judy-1.0.5 source..."
-          & curl.exe -fsSL -o judy.tar.gz --retry 5 --retry-delay 5 -L `
-            "https://downloads.sourceforge.net/project/judy/judy/Judy-1.0.5/Judy-1.0.5.tar.gz"
-          if ($LASTEXITCODE -ne 0) { throw "Failed to download Judy source" }
-
-          tar -xzf judy.tar.gz
-          $judyDir = Get-ChildItem -Directory | Where-Object { $_.Name -match '^[Jj]udy-' } | Select-Object -First 1
-          if (-not $judyDir) { throw "Could not find extracted Judy directory" }
-          $srcDir = Join-Path $judyDir.FullName "src"
-          Write-Host "Source: $srcDir"
-
-          # Patch Judy.h: fix Word_t typedef for 64-bit Windows (LLP64: unsigned long = 4 bytes)
-          Write-Host "Patching Judy.h..."
-          $judyH = Join-Path $srcDir "Judy.h"
-          $content = Get-Content $judyH -Raw
-          $wordTPatch = @'
-          #if defined(_WIN64)
-          typedef unsigned __int64    Word_t, * PWord_t;
-          #else
-          typedef unsigned long       Word_t, * PWord_t;
-          #endif
-          '@
-          $wordTPatch = ($wordTPatch.Trim() -split "`n" | ForEach-Object { $_.Trim() }) -join "`n"
-          $content = $content -replace 'typedef\s+unsigned\s+long\s+Word_t\s*,\s*\*\s*PWord_t\s*;', $wordTPatch
-          $content = $content.Replace('(~0UL)', '(~(size_t)0)')
-          if ($content -notmatch 'unsigned __int64\s+Word_t') { throw "Failed to patch Word_t in Judy.h" }
-          Set-Content $judyH -Value $content -NoNewline
-          Write-Host "Patched Judy.h"
-
-          # Patch build.bat: /MD to match PHP's CRT; -DJU_64BIT only for 64-bit builds
-          Write-Host "Patching build.bat..."
-          $buildBat = Join-Path $srcDir "build.bat"
-          $batContent = Get-Content $buildBat -Raw
-          if ("${{ matrix.arch }}" -eq "x64") {
-            $batContent = $batContent.Replace('-DJU_WIN', '-DJU_WIN -DJU_64BIT /MD')
-          } else {
-            $batContent = $batContent.Replace('-DJU_WIN', '-DJU_WIN /MD')
-          }
-          Set-Content $buildBat -Value $batContent -NoNewline
-          Write-Host "Patched build.bat"
-
-          # Fix all unsigned-long constants that produce wrong values on MSVC x64 (LLP64).
-          # Safe to apply on x86 too: (Word_t)1 is still 32-bit there.
-          Write-Host "Fixing UL constants in Judy source files..."
-          $fixCount = 0
-          Get-ChildItem -Path $judyDir.FullName -Recurse -Include "*.c","*.h" | ForEach-Object {
-            $orig = Get-Content $_.FullName -Raw
-            $text = $orig
-            $text = $text.Replace('~0UL',    '~(Word_t)0')
-            $text = $text.Replace('(-1UL)',  '(~(Word_t)0)')
-            $text = [regex]::Replace($text, '\b1UL\s*<<', '(Word_t)1 <<')
-            $text = [regex]::Replace($text, '\b1L\s*<<',  '(Word_t)1 <<')
-            $text = $text.Replace('0x100UL', '(Word_t)0x100')
-            # Byte-mask base constant (cJU_MASKATSTATE in JudyPrivateBranch.h).
-            # ci.yml has applied this since the LLP64 sweep landed; release.yml
-            # had drifted and shipped DLLs without it (wrong masks for JudySL
-            # long strings, State >= 5 on x64). Keep the two sets in lockstep
-            # until the vendored tree (#142) deletes both.
-            $text = $text.Replace('0xffL', '(Word_t)0xff')
-            if ($text -ne $orig) {
-              Set-Content $_.FullName -Value $text -NoNewline
-              $fixCount++
-            }
-          }
-          Write-Host "Fixed UL constants in $fixCount files"
-
-          Write-Host "Building libjudy..."
-          Push-Location $srcDir
-          & cmd.exe /c "build.bat 2>&1"
-          Pop-Location
-
-          $judyLib = Get-ChildItem -Path $srcDir -Recurse -Filter "Judy.lib" -ErrorAction SilentlyContinue |
-            Sort-Object Length -Descending | Select-Object -First 1
-          if (-not $judyLib) { throw "Judy.lib not found after build" }
-          Write-Host "Built: $($judyLib.FullName) ($($judyLib.Length) bytes)"
-
-          $installDir = Join-Path $env:RUNNER_TEMP "libjudy"
-          foreach ($sub in @("include", "lib", "bin")) {
-            New-Item -ItemType Directory -Force (Join-Path $installDir $sub) | Out-Null
-          }
-          Copy-Item $judyH "$installDir\include\"
-          Copy-Item $judyLib.FullName "$installDir\lib\libJudy.lib"
-          Copy-Item $judyLib.FullName "$installDir\lib\libJudy_a.lib"
-          $judyDll = Get-ChildItem -Path $srcDir -Recurse -Filter "Judy.dll" -ErrorAction SilentlyContinue |
-            Select-Object -First 1
-          if ($judyDll) { Copy-Item $judyDll.FullName "$installDir\bin\" }
-          Write-Host "=== libjudy installed to $installDir ==="
-
-      - name: Add libjudy to PATH
-        shell: pwsh
-        run: |
-          Add-Content $env:GITHUB_PATH "${{ runner.temp }}\libjudy\bin"
-
+      # The bundled libJudy (libjudy/) builds via config.w32, and the P5 LLP64
+      # patches are real source diffs now — the historical SourceForge
+      # download + regex-patch step (and its patch-set-drift hazard, #143) is
+      # gone (issue #142).
       - name: Build the extension
         uses: php/php-windows-builder/extension@v1
         with:
           php-version: ${{ matrix.php-version }}
           arch: ${{ matrix.arch }}
           ts: ${{ matrix.ts }}
-          args: --with-judy=${{ runner.temp }}\libjudy
           # Skip tests during release — they are already gated by the CI workflow
           run-tests: 'false'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM php:8.4-cli
 
 # Install dependencies for judy extension
+# No libjudy-dev: the bundled libJudy (libjudy/) is the default build.
 RUN apt-get update && apt-get install -y \
     build-essential \
     git \
-    libjudy-dev \
     valgrind
 
 # Copy the extension source code into the container
@@ -14,7 +14,7 @@ WORKDIR /usr/src/php-judy
 # Build and install the judy extension (clean first to remove stale build artifacts)
 RUN find . -name "*.lo" -delete && find . -name "*.dep" -delete && rm -f Makefile Makefile.objects Makefile.fragments \
     && phpize \
-    && ./configure --with-judy=/usr \
+    && ./configure \
     && make \
     && make install
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,8 +9,9 @@
 
 FROM php:8.4-cli-alpine
 
-RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS judy-dev \
-    && apk add --no-cache judy
+# No judy/judy-dev packages: the bundled libJudy (libjudy/) is the default
+# build, so a clean musl environment only needs the toolchain.
+RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS
 
 COPY . /usr/src/php-judy
 WORKDIR /usr/src/php-judy
@@ -18,13 +19,14 @@ WORKDIR /usr/src/php-judy
 RUN find . -name "*.lo" -delete && find . -name "*.dep" -delete \
     && rm -f Makefile Makefile.objects Makefile.fragments \
     && phpize \
-    && ./configure --with-judy=/usr \
+    && ./configure \
     && make 2>&1 | tee /tmp/build.log \
     && make install \
     && docker-php-ext-enable judy
 
 # Same warning gate as the Linux CI job: a musl-only warning is a real
-# portability signal.
+# portability signal. The vendored libjudy/ sources are deliberately excluded
+# (third-party at -Wall warns copiously; see libjudy/PATCHES.md).
 RUN if grep -E '(php_judy|judy_handlers|judy_arrayaccess|judy_iterator)\.[ch]:[0-9]+:[0-9]+: warning:' /tmp/build.log; then \
         echo "Compiler warnings detected in extension sources"; exit 1; \
     fi; \

--- a/Dockerfile.validate
+++ b/Dockerfile.validate
@@ -1,8 +1,6 @@
 FROM php:8.4-cli
 
-# Install dependencies for judy extension
-RUN apt-get update && apt-get install -y libjudy-dev
-
+# No libjudy-dev: the PECL package builds the bundled libJudy by default.
 # Copy the new package into the container
 COPY Judy-*.tgz /tmp/judy.tgz
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "configure-options": [
             {
                 "name": "with-judy",
-                "description": "Specify the path to the libJudy installation prefix",
+                "description": "libJudy install prefix to link a system libJudy; omit (or pass \"bundled\") to compile the bundled copy",
                 "needs-value": true
             }
         ]

--- a/config.m4
+++ b/config.m4
@@ -3,8 +3,11 @@ dnl $Id$
 dnl
 
 PHP_ARG_WITH(judy, for Judy support,
-[  --with-judy[=DIR]       Include Judy support.
-                          DIR is the Judy install prefix [default=BUNDLED]])
+[  --with-judy[=DIR]       Include Judy support. Without DIR (or with "yes"/
+                          "bundled") the bundled libJudy under libjudy/ is
+                          compiled in [default=BUNDLED]. Pass the install
+                          prefix of a system libJudy as DIR to dynamically
+                          link against it instead.], yes)
 
 PHP_ARG_ENABLE(judy-debug-mirror, whether to enable Judy consistency assertions,
 [  --enable-judy-debug-mirror
@@ -15,48 +18,114 @@ PHP_ARG_ENABLE(judy-debug-mirror, whether to enable Judy consistency assertions,
 
 judy_sources="judy_handlers.c judy_arrayaccess.c judy_iterator.c"
 
+dnl # The bundled libJudy (libjudy/, pristine Judy-1.0.5 plus the documented
+dnl # patch series -- see libjudy/PATCHES.md). The wrappers compile each
+dnl # JudyCommon TU once per variant (JUDY1/JUDYL, some twice with extra
+dnl # defines); the enumeration follows upstream's per-variant Makefile.am
+dnl # (issue #142). Judy1Tables.c/JudyLTables.c are pre-generated (JU_64BIT).
+judy_bundled_sources="\
+  libjudy/src/JudyCommon/JudyMalloc.c \
+  libjudy/src/JudySL/JudySL.c \
+  libjudy/src/JudyHS/JudyHS.c \
+  libjudy/src/Judy1/Judy1Tables.c \
+  libjudy/src/JudyL/JudyLTables.c \
+  libjudy/src/wrappers/judy_static_asserts.c \
+  libjudy/src/wrappers/Judy1Test.c \
+  libjudy/src/wrappers/Judy1TestInline.c \
+  libjudy/src/wrappers/Judy1Set.c \
+  libjudy/src/wrappers/Judy1SetArray.c \
+  libjudy/src/wrappers/Judy1Unset.c \
+  libjudy/src/wrappers/Judy1Cascade.c \
+  libjudy/src/wrappers/Judy1Decascade.c \
+  libjudy/src/wrappers/Judy1Count.c \
+  libjudy/src/wrappers/Judy1ByCount.c \
+  libjudy/src/wrappers/Judy1CreateBranch.c \
+  libjudy/src/wrappers/Judy1InsertBranch.c \
+  libjudy/src/wrappers/Judy1First.c \
+  libjudy/src/wrappers/Judy1Next.c \
+  libjudy/src/wrappers/Judy1Prev.c \
+  libjudy/src/wrappers/Judy1NextEmpty.c \
+  libjudy/src/wrappers/Judy1PrevEmpty.c \
+  libjudy/src/wrappers/Judy1FreeArray.c \
+  libjudy/src/wrappers/Judy1MallocIF.c \
+  libjudy/src/wrappers/Judy1MemActive.c \
+  libjudy/src/wrappers/Judy1MemUsed.c \
+  libjudy/src/wrappers/JudyLGet.c \
+  libjudy/src/wrappers/JudyLGetInline.c \
+  libjudy/src/wrappers/JudyLIns.c \
+  libjudy/src/wrappers/JudyLInsArray.c \
+  libjudy/src/wrappers/JudyLDel.c \
+  libjudy/src/wrappers/JudyLCascade.c \
+  libjudy/src/wrappers/JudyLDecascade.c \
+  libjudy/src/wrappers/JudyLCount.c \
+  libjudy/src/wrappers/JudyLByCount.c \
+  libjudy/src/wrappers/JudyLCreateBranch.c \
+  libjudy/src/wrappers/JudyLInsertBranch.c \
+  libjudy/src/wrappers/JudyLFirst.c \
+  libjudy/src/wrappers/JudyLNext.c \
+  libjudy/src/wrappers/JudyLPrev.c \
+  libjudy/src/wrappers/JudyLNextEmpty.c \
+  libjudy/src/wrappers/JudyLPrevEmpty.c \
+  libjudy/src/wrappers/JudyLFreeArray.c \
+  libjudy/src/wrappers/JudyLMallocIF.c \
+  libjudy/src/wrappers/JudyLMemActive.c \
+  libjudy/src/wrappers/JudyLMemUsed.c"
+
 if test "$PHP_JUDY" != "no"; then
 
-  dnl # --with-judy -> check with-path
-  SEARCH_PATH="/usr/local /usr"
-  SEARCH_FOR="/include/Judy.h"
+  dnl # Bundled unless a real DIR (or the legacy "autodetect") was given.
+  if test "$PHP_JUDY" = "yes" || test "$PHP_JUDY" = "bundled"; then
+    judy_bundled=yes
+  else
+    judy_bundled=no
+  fi
+
   AC_MSG_CHECKING([for Judy library to use])
-  if test -r $PHP_JUDY/$SEARCH_FOR; then
-    JUDY_DIR=$PHP_JUDY
+  if test "$judy_bundled" = "yes"; then
+    AC_MSG_RESULT([bundled (libjudy/)])
   else
-    for i in $SEARCH_PATH ; do
-      if test -r $i/$SEARCH_FOR; then
-        JUDY_DIR=$i
-      fi
-    done
+    dnl # --with-judy=DIR -> system-lib mode: search prefix, then defaults.
+    SEARCH_PATH="/usr/local /usr"
+    SEARCH_FOR="/include/Judy.h"
+    if test -r $PHP_JUDY/$SEARCH_FOR; then
+      JUDY_DIR=$PHP_JUDY
+    else
+      for i in $SEARCH_PATH ; do
+        if test -r $i/$SEARCH_FOR; then
+          JUDY_DIR=$i
+        fi
+      done
+    fi
+
+    if test -z "$JUDY_DIR"; then
+      AC_MSG_RESULT([not found])
+      AC_MSG_ERROR([Please install the Judy libraries, or build the bundled copy with --with-judy=bundled])
+    else
+      AC_MSG_RESULT([found in $JUDY_DIR])
+    fi
+
+    PHP_ADD_INCLUDE($JUDY_DIR/include)
+
+    dnl # --with-judy=DIR -> check for lib and symbol presence
+    LIBNAME=Judy
+    LIBSYMBOL=Judy1Set
+
+    PHP_CHECK_LIBRARY($LIBNAME, $LIBSYMBOL,
+    [
+      PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $JUDY_DIR/$PHP_LIBDIR, JUDY_SHARED_LIBADD)
+      AC_DEFINE(HAVE_JUDYLIB,1,[ ])
+    ],[
+      AC_MSG_ERROR([wrong Judy lib version or lib not found using -L$JUDY_DIR/$PHP_LIBDIR -lJudy])
+    ],[
+      -L$JUDY_DIR/$PHP_LIBDIR -lJudy
+    ])
   fi
-
-  if test -z "$JUDY_DIR"; then
-    AC_MSG_RESULT([not found])
-    AC_MSG_ERROR([Please install the Judy libraries])
-  else
-    AC_MSG_RESULT([found in $JUDY_DIR])
-  fi
-
-  PHP_ADD_INCLUDE($JUDY_DIR/include)
-
-  dnl # --with-judy -> check for lib and symbol presence
-  LIBNAME=Judy
-  LIBSYMBOL=Judy1Set
-
-  PHP_CHECK_LIBRARY($LIBNAME, $LIBSYMBOL,
-  [
-    PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $JUDY_DIR/$PHP_LIBDIR, JUDY_SHARED_LIBADD)
-    AC_DEFINE(HAVE_JUDYLIB,1,[ ])
-  ],[
-    AC_MSG_ERROR([wrong Judy lib version or lib not found using -L$JUDY_DIR/$PHP_LIBDIR -lJudy])
-  ],[
-    -L$JUDY_DIR/$PHP_LIBDIR -lJudy
-  ])
 
   PHP_INSTALL_HEADERS([ext/judy], [php_judy.h judy_handlers.h judy_arrayaccess.h judy_iterator.h])
 
   dnl # Opt-in internal consistency assertions (see JUDY_ASSERT_MIRROR).
+  dnl # Global CFLAGS on purpose: the assertions live in the extension
+  dnl # sources, so this works identically in bundled and system-lib mode.
   if test "$PHP_JUDY_DEBUG_MIRROR" = "yes"; then
     AC_MSG_NOTICE([Judy mirror consistency assertions enabled])
     CFLAGS="$CFLAGS -DJUDY_DEBUG_MIRROR"
@@ -69,6 +138,12 @@ if test "$PHP_JUDY" != "no"; then
   dnl # which Zend/zend_portability.h rejects outright ("NDEBUG must not be
   dnl # defined when ZEND_DEBUG is enabled") -- the extension could not be built
   dnl # against a debug PHP at all. Both spellings are accepted here.
+  dnl #
+  dnl # These flags reach ONLY the extension's own sources: the vendored
+  dnl # libJudy units below carry their own per-source flags that override
+  dnl # these (a later -O2 beats this -O3, -fno-lto beats -flto). Stock
+  dnl # libJudy at gcc -O3 silently loses Judy1 keys (#131) -- never let
+  dnl # these flags reach the vendored units.
   if test "$PHP_DEBUG" != "yes" && test "$PHP_DEBUG" != "1"; then
     dnl # Add optimization flags for production
     CFLAGS="$CFLAGS -O3"
@@ -79,10 +154,87 @@ if test "$PHP_JUDY" != "no"; then
     CFLAGS="$CFLAGS -funroll-loops"
     CFLAGS="$CFLAGS -flto"
   fi
-  
+
   PHP_NEW_EXTENSION(judy, php_judy.c $judy_sources, $ext_shared)
   PHP_ADD_EXTENSION_DEP(judy, json)
-  PHP_ADD_BUILD_DIR($ext_builddir/lib, 1)
+
+  if test "$judy_bundled" = "yes"; then
+    dnl # ---------------------------------------------------------------
+    dnl # Bundled libJudy build integration.
+    dnl # ---------------------------------------------------------------
+
+    dnl # The committed Judy1Tables.c/JudyLTables.c were generated under
+    dnl # JU_64BIT and are wrong for 32-bit words. Refuse rather than
+    dnl # miscompile; a system libJudy still works on such targets.
+    AC_MSG_CHECKING([whether long is 64-bit (required by the bundled libJudy)])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      typedef char judy_long_is_64bit[sizeof(long) == 8 ? 1 : -1];
+    ]], [[]])], [
+      AC_MSG_RESULT([yes])
+    ], [
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([the bundled libJudy currently supports 64-bit targets only (its pre-generated tables assume JU_64BIT); use --with-judy=DIR to link a system libJudy instead])
+    ])
+
+    dnl # Vendored-only compile flags. -O2 -fno-lto is LOAD-BEARING, not a
+    dnl # preference: stock libJudy miscompiles at gcc -O3 (silently lost
+    dnl # Judy1/BITSET keys, #131), and LTO would let the link step
+    dnl # re-optimize across the same boundary. PHP_ADD_SOURCES_X places
+    dnl # these AFTER the global $(CFLAGS_CLEAN) on each vendored compile
+    dnl # line, and with gcc/clang the later flag wins -- so the -O3/-flto
+    dnl # set above never takes effect for these units. Verified by
+    dnl # tests/bitset_immed_cascade_integrity_001.phpt (the #131 detector).
+    dnl # JU_64BIT lives here, not in the wrapper files, so a 32-bit build
+    dnl # remains possible later. No other platform define is needed on
+    dnl # unix: JudyPrivate.h keys only on JU_WIN (Windows) and the Itanium
+    dnl # JU_*_IPF defines beyond it.
+    judy_vendor_cflags="-O2 -fno-lto -DJU_64BIT"
+
+    dnl # -mpopcnt: probe compiler acceptance (x86-64 gcc/clang accept it,
+    dnl # other targets reject it, so acceptance doubles as the arch test).
+    dnl # Deliberately INERT for now: the vendored sources have no
+    dnl # __POPCNT__ arm yet -- that is Stage 3's O1 patch (#142). Probing
+    dnl # now keeps the vendored compile lines stable across that stage.
+    AC_MSG_CHECKING([whether $CC accepts -mpopcnt])
+    judy_save_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS -Werror -mpopcnt"
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])], [
+      judy_have_mpopcnt=yes
+    ], [
+      judy_have_mpopcnt=no
+    ])
+    CFLAGS="$judy_save_CFLAGS"
+    AC_MSG_RESULT([$judy_have_mpopcnt])
+    if test "$judy_have_mpopcnt" = "yes"; then
+      judy_vendor_cflags="$judy_vendor_cflags -mpopcnt"
+    fi
+
+    dnl # Bundled headers must win over any system Judy.h (prepend).
+    PHP_ADD_INCLUDE([$ext_srcdir/libjudy/src], 1)
+    PHP_ADD_INCLUDE([$ext_srcdir/libjudy/src/JudyCommon], 1)
+    PHP_ADD_INCLUDE([$ext_srcdir/libjudy/src/Judy1], 1)
+    PHP_ADD_INCLUDE([$ext_srcdir/libjudy/src/JudyL], 1)
+
+    dnl # Attach the vendored sources with their own flags. Mirrors what
+    dnl # PHP_NEW_EXTENSION does internally for each build mode (the same
+    dnl # mechanism php-src's ext/opcache uses for its IR sources).
+    if test "$ext_shared" = "yes" || test "$ext_shared" = "shared"; then
+      PHP_ADD_SOURCES_X([$ext_dir], [$judy_bundled_sources], [$judy_vendor_cflags], [shared_objects_judy], [yes])
+    else
+      PHP_ADD_SOURCES([$ext_dir], [$judy_bundled_sources], [$judy_vendor_cflags])
+    fi
+
+    PHP_ADD_BUILD_DIR([$ext_builddir/libjudy/src/JudyCommon], 1)
+    PHP_ADD_BUILD_DIR([$ext_builddir/libjudy/src/Judy1], 1)
+    PHP_ADD_BUILD_DIR([$ext_builddir/libjudy/src/JudyL], 1)
+    PHP_ADD_BUILD_DIR([$ext_builddir/libjudy/src/JudySL], 1)
+    PHP_ADD_BUILD_DIR([$ext_builddir/libjudy/src/JudyHS], 1)
+    PHP_ADD_BUILD_DIR([$ext_builddir/libjudy/src/wrappers], 1)
+
+    AC_DEFINE(HAVE_JUDYLIB, 1, [ ])
+    AC_DEFINE(HAVE_JUDY_BUNDLED, 1, [Judy support uses the bundled libJudy])
+  fi
+
   PHP_SUBST(JUDY_SHARED_LIBADD)
 
 fi

--- a/config.m4
+++ b/config.m4
@@ -176,19 +176,24 @@ if test "$PHP_JUDY" != "no"; then
       AC_MSG_ERROR([the bundled libJudy currently supports 64-bit targets only (its pre-generated tables assume JU_64BIT); use --with-judy=DIR to link a system libJudy instead])
     ])
 
-    dnl # Vendored-only compile flags. -O2 -fno-lto is LOAD-BEARING, not a
-    dnl # preference: stock libJudy miscompiles at gcc -O3 (silently lost
-    dnl # Judy1/BITSET keys, #131), and LTO would let the link step
-    dnl # re-optimize across the same boundary. PHP_ADD_SOURCES_X places
-    dnl # these AFTER the global $(CFLAGS_CLEAN) on each vendored compile
-    dnl # line, and with gcc/clang the later flag wins -- so the -O3/-flto
-    dnl # set above never takes effect for these units. Verified by
-    dnl # tests/bitset_immed_cascade_integrity_001.phpt (the #131 detector).
-    dnl # JU_64BIT lives here, not in the wrapper files, so a 32-bit build
-    dnl # remains possible later. No other platform define is needed on
-    dnl # unix: JudyPrivate.h keys only on JU_WIN (Windows) and the Itanium
-    dnl # JU_*_IPF defines beyond it.
-    judy_vendor_cflags="-O2 -fno-lto -DJU_64BIT"
+    dnl # Vendored-only compile flags. These are LOAD-BEARING, not a
+    dnl # preference: stock libJudy's out-of-bounds immediate-index copy
+    dnl # (#131) miscompiles under aggressive loop optimization -- gcc
+    dnl # silently loses Judy1/BITSET keys -- and LTO would let the link
+    dnl # step re-optimize across the same boundary. PHP_ADD_SOURCES_X
+    dnl # places these AFTER the global $(CFLAGS_CLEAN) on each vendored
+    dnl # compile line, and with gcc/clang the later flag wins, so the
+    dnl # global -O3/-flto never take effect for these units. The global
+    dnl # -funroll-loops needs its own negation: a later -O2 does NOT
+    dnl # cancel it, and measured on gcc 13/14 it is -funroll-loops (at
+    dnl # -O2 or -O3 alike) that makes gcc exploit the UB and truncate the
+    dnl # copy -- caught by tests/bitset_immed_cascade_integrity_001.phpt
+    dnl # (the #131 detector) when this flag set briefly lacked
+    dnl # -fno-unroll-loops. JU_64BIT lives here, not in the wrapper
+    dnl # files, so a 32-bit build remains possible later. No other
+    dnl # platform define is needed on unix: JudyPrivate.h keys only on
+    dnl # JU_WIN (Windows) and the Itanium JU_*_IPF defines beyond it.
+    judy_vendor_cflags="-O2 -fno-lto -fno-unroll-loops -DJU_64BIT"
 
     dnl # -mpopcnt: probe compiler acceptance (x86-64 gcc/clang accept it,
     dnl # other targets reject it, so acceptance doubles as the arch test).

--- a/config.w32
+++ b/config.w32
@@ -1,10 +1,60 @@
 // $Id$
 // vim:ft=javascript
 
-ARG_WITH("judy", "Judy support", "no");
+ARG_WITH("judy", "Judy support: bundled libJudy (yes/bundled, the default) or DIR of a system libJudy", "no");
 
 if (PHP_JUDY != "no") {
-	if (CHECK_LIB("libJudy_a.lib;libJudy.lib", "judy", PHP_JUDY) && CHECK_HEADER_ADD_INCLUDE("Judy.h", "CFLAGS_JUDY", PHP_JUDY + ";" + PHP_JUDY + "\\include")) {
+	if (PHP_JUDY == "yes" || PHP_JUDY == "bundled") {
+		// Bundled libJudy (libjudy/, Judy-1.0.5 + the documented patch
+		// series -- see libjudy/PATCHES.md). The P5 LLP64 patches are
+		// real source diffs now, so no download/patch step is needed.
+		EXTENSION("judy", "php_judy.c judy_arrayaccess.c judy_handlers.c judy_iterator.c");
+		ADD_EXTENSION_DEP("judy", "json");
+		AC_DEFINE('HAVE_JUDY', 1, 'Have Judy library');
+		AC_DEFINE('HAVE_JUDY_BUNDLED', 1, 'Judy support uses the bundled libJudy');
+
+		var judy_src = configure_module_dirname + "\\libjudy\\src";
+		ADD_FLAG("CFLAGS_JUDY", '/I "' + judy_src + '" /I "' + judy_src + '\\JudyCommon" /I "' + judy_src + '\\Judy1" /I "' + judy_src + '\\JudyL"');
+
+		// JU_WIN selects upstream's Windows arms; JU_64BIT only on x64
+		// (LLP64 correctness comes from the P5 source patches, but the
+		// internal structures are sized by JU_64BIT, and the committed
+		// tables were generated under it -- x86 builds must not get it,
+		// and would need regenerated 32-bit tables besides).
+		ADD_FLAG("CFLAGS_JUDY", "/D JU_WIN");
+		if (X64) {
+			ADD_FLAG("CFLAGS_JUDY", "/D JU_64BIT");
+		}
+		// No aggressive optimization flags for the vendored units: MSVC
+		// has no -O3/LTO equivalent hazard here (#131 is a gcc -O3
+		// miscompile), but the default /O2 is all they get.
+
+		ADD_SOURCES(configure_module_dirname + "\\libjudy\\src\\JudyCommon", "JudyMalloc.c", "judy");
+		ADD_SOURCES(configure_module_dirname + "\\libjudy\\src\\Judy1", "Judy1Tables.c", "judy");
+		ADD_SOURCES(configure_module_dirname + "\\libjudy\\src\\JudyL", "JudyLTables.c", "judy");
+		ADD_SOURCES(configure_module_dirname + "\\libjudy\\src\\JudySL", "JudySL.c", "judy");
+		ADD_SOURCES(configure_module_dirname + "\\libjudy\\src\\JudyHS", "JudyHS.c", "judy");
+		ADD_SOURCES(configure_module_dirname + "\\libjudy\\src\\wrappers",
+			"judy_static_asserts.c " +
+			"Judy1Test.c Judy1TestInline.c Judy1Set.c Judy1SetArray.c " +
+			"Judy1Unset.c Judy1Cascade.c Judy1Decascade.c Judy1Count.c " +
+			"Judy1ByCount.c Judy1CreateBranch.c Judy1InsertBranch.c " +
+			"Judy1First.c Judy1Next.c Judy1Prev.c Judy1NextEmpty.c " +
+			"Judy1PrevEmpty.c Judy1FreeArray.c Judy1MallocIF.c " +
+			"Judy1MemActive.c Judy1MemUsed.c " +
+			"JudyLGet.c JudyLGetInline.c JudyLIns.c JudyLInsArray.c " +
+			"JudyLDel.c JudyLCascade.c JudyLDecascade.c JudyLCount.c " +
+			"JudyLByCount.c JudyLCreateBranch.c JudyLInsertBranch.c " +
+			"JudyLFirst.c JudyLNext.c JudyLPrev.c JudyLNextEmpty.c " +
+			"JudyLPrevEmpty.c JudyLFreeArray.c JudyLMallocIF.c " +
+			"JudyLMemActive.c JudyLMemUsed.c",
+			"judy");
+
+		if (PHP_JUDY_SHARED) {
+			ADD_FLAG("CFLAGS_JUDY", "/D PHP_JUDY_EXPORTS ");
+		}
+	} else if (CHECK_LIB("libJudy_a.lib;libJudy.lib", "judy", PHP_JUDY) && CHECK_HEADER_ADD_INCLUDE("Judy.h", "CFLAGS_JUDY", PHP_JUDY + ";" + PHP_JUDY + "\\include")) {
+		// --with-judy=DIR: link a system/prebuilt libJudy.
 		EXTENSION("judy", "php_judy.c judy_arrayaccess.c judy_handlers.c judy_iterator.c");
 		ADD_EXTENSION_DEP("judy", "json");
 		AC_DEFINE('HAVE_JUDY', 1, 'Have Judy library');

--- a/libjudy/PATCHES.md
+++ b/libjudy/PATCHES.md
@@ -28,6 +28,4 @@ appear in the ledger below.
 
 | Patch | Category | Files | Why | Date | Issue |
 | ----- | -------- | ----- | --- | ---- | ----- |
-
-_None yet — the tree is pristine Judy-1.0.5 (Stage 0 of the vendoring
-plan, tracked in [#142](https://github.com/orieg/php-judy/issues/142))._
+| P5 | Portability/Correctness | `src/Judy.h`, `src/JudyCommon/JudyInsArray.c`, `src/JudyCommon/JudyMallocIF.c`, `src/JudyCommon/JudyPrevNextEmpty.c`, `src/JudyCommon/JudyPrivate.h`, `src/JudyCommon/JudyPrivateBranch.h`, `src/JudySL/JudySL.c` | LLP64 (Windows/MSVC x64): `unsigned long` is 4 bytes there, so `Word_t` must be `unsigned __int64` under `_WIN64`, and every all-ones / shifted / masked `UL`/`L` constant used in a `Word_t` context truncated (`~0UL`, `(-1UL)`, `0x100UL`, `0xffL`) or vanished (`1UL << N` and sign-extending `1L << N` for N ≥ 32 — the `JudyPrevNextEmpty` infinite loop). These are the six mechanical fixes CI/release previously applied as download-time regexes, absorbed as real source diffs so the tree builds on Windows unpatched. | 2026-08-18 | [#127](https://github.com/orieg/php-judy/issues/127), [#142](https://github.com/orieg/php-judy/issues/142) |

--- a/libjudy/PATCHES.md
+++ b/libjudy/PATCHES.md
@@ -17,6 +17,13 @@ modification since that import follows one discipline:
 No reformatting, no drive-by cleanups: a diff against the pristine
 import must show only deliberate, documented changes.
 
+The pre-generated table files (`src/Judy1/Judy1Tables.c`,
+`src/JudyL/JudyLTables.c`) and the build shims under `src/wrappers/`
+are php-judy **additions**, not modifications of upstream files —
+upstream generates its equivalents at build time — so they carry their
+own provenance headers instead of §2(b) change notices and do not
+appear in the ledger below.
+
 ## Patches
 
 | Patch | Category | Files | Why | Date | Issue |

--- a/libjudy/README.md
+++ b/libjudy/README.md
@@ -34,9 +34,11 @@ and the root [THIRD-PARTY.md](../THIRD-PARTY.md).
 - `src/JudyHS/JudyHS.h` — a standalone compatibility header for
   pre-JudyHS `Judy.h`; nothing includes it (the `#include` in
   `JudyHS.c` is commented out upstream)
-- The Judy1/JudyL wrapper sources and generated tables — upstream
-  generates these at build time; Stage 1 of the vendoring plan adds
-  them as clearly-marked non-upstream files
+- Upstream's build-time-generated Judy1/JudyL wrapper sources and
+  size-class tables — php-judy ships its own clearly-marked equivalents
+  instead: the build shims under `src/wrappers/` and the pre-generated
+  `src/Judy1/Judy1Tables.c` / `src/JudyL/JudyLTables.c` (see the
+  provenance headers in those files)
 
 ## Modifications
 

--- a/libjudy/README.md
+++ b/libjudy/README.md
@@ -50,8 +50,11 @@ modifications — see PATCHES.md.
 
 ## Build integration
 
-These sources are **not compiled yet**. Stage 1 of the vendoring plan
-([#142](https://github.com/orieg/php-judy/issues/142)) wires them into
-`config.m4`/`config.w32`, compiling them at `-O2 -fno-lto` only — never
-`-O3`/LTO (see [#131](https://github.com/orieg/php-judy/issues/131);
-`-O2` is load-bearing for correctness).
+These sources are the **default build** (`--with-judy` absent, `yes`
+or `bundled`): `config.m4`/`config.w32` compile them into the extension
+directly. `--with-judy=DIR` instead links against a system libJudy and
+compiles nothing under this directory. The vendored units are compiled
+at `-O2 -fno-lto` only — never `-O3`/LTO, and the flags are attached
+per-source so the extension's own optimization flags cannot leak in
+(see [#131](https://github.com/orieg/php-judy/issues/131); `-O2` is
+load-bearing for correctness).

--- a/libjudy/README.md
+++ b/libjudy/README.md
@@ -54,7 +54,10 @@ These sources are the **default build** (`--with-judy` absent, `yes`
 or `bundled`): `config.m4`/`config.w32` compile them into the extension
 directly. `--with-judy=DIR` instead links against a system libJudy and
 compiles nothing under this directory. The vendored units are compiled
-at `-O2 -fno-lto` only — never `-O3`/LTO, and the flags are attached
-per-source so the extension's own optimization flags cannot leak in
-(see [#131](https://github.com/orieg/php-judy/issues/131); `-O2` is
-load-bearing for correctness).
+at `-O2 -fno-lto -fno-unroll-loops` only — never `-O3`/LTO/loop
+unrolling — and the flags are attached per-source so the extension's
+own optimization flags cannot leak in (see
+[#131](https://github.com/orieg/php-judy/issues/131); measured on
+gcc 13/14, `-funroll-loops` at any -O level makes gcc exploit the
+out-of-bounds immediate copy and silently lose keys, so these flags
+are load-bearing for correctness).

--- a/libjudy/README.md
+++ b/libjudy/README.md
@@ -44,7 +44,9 @@ and the root [THIRD-PARTY.md](../THIRD-PARTY.md).
 
 Every change to these sources is documented in [PATCHES.md](PATCHES.md)
 and available as a git diff against the pristine import commit.
-Currently: none — the tree is pristine.
+Currently: P5 (the LLP64/Windows-x64 constant-width fixes). Files added
+by php-judy (wrappers, pre-generated tables) are additions, not
+modifications — see PATCHES.md.
 
 ## Build integration
 

--- a/libjudy/src/Judy.h
+++ b/libjudy/src/Judy.h
@@ -1,3 +1,7 @@
+// Modified for php-judy on 2026-08-18 (patch P5, LLP64/Windows-x64
+// correctness -- see libjudy/PATCHES.md, issues #127/#142):
+// Word_t is unsigned __int64 under _WIN64 (unsigned long is 4 bytes on LLP64); PJERR/PPJERR use ~(size_t)0 instead of the 32-bit-truncating ~0UL.
+//
 #ifndef _JUDY_INCLUDED
 #define _JUDY_INCLUDED
 // _________________
@@ -91,7 +95,11 @@ typedef void ** PPvoid_t;
 
 #ifndef _WORD_T
 #define _WORD_T
-typedef unsigned long    Word_t, * PWord_t;  // expect 32-bit or 64-bit words.
+#if defined(_WIN64)
+typedef unsigned __int64    Word_t, * PWord_t;
+#else
+typedef unsigned long       Word_t, * PWord_t;
+#endif  // expect 32-bit or 64-bit words.
 #endif
 
 #ifndef NULL
@@ -197,12 +205,12 @@ typedef struct J_UDY_ERROR_STRUCT
 // For checking return values from various Judy functions:
 //
 // Note:  Define JERR as -1, not as the seemingly more portable (Word_t)
-// (~0UL), to avoid a compiler "overflow in implicit constant conversion"
+// (~(size_t)0), to avoid a compiler "overflow in implicit constant conversion"
 // warning.
 
 #define   JERR (-1)                     /* functions returning int or Word_t */
-#define  PJERR ((Pvoid_t)  (~0UL))      /* mainly for use here, see below    */
-#define PPJERR ((PPvoid_t) (~0UL))      /* functions that return PPvoid_t    */
+#define  PJERR ((Pvoid_t)  (~(size_t)0))      /* mainly for use here, see below    */
+#define PPJERR ((PPvoid_t) (~(size_t)0))      /* functions that return PPvoid_t    */
 
 // Convenience macro for when detailed error information (PJError_t) is not
 // desired by the caller; a purposely short name:

--- a/libjudy/src/Judy1/Judy1Tables.c
+++ b/libjudy/src/Judy1/Judy1Tables.c
@@ -1,0 +1,190 @@
+// php-judy: pre-generated Judy1 size-class tables for the bundled libJudy.
+// NOT an upstream Judy-1.0.5 source file -- upstream generates this file at
+// build time.  Generated 2026-08-18 by compiling
+// src/JudyCommon/JudyTables.c with -DJUDY1 -DJU_64BIT -O2 from the pristine
+// Judy-1.0.5 import, then running the resulting generator; the output was
+// verified byte-identical between arm64 (Apple clang 17) and x86-64
+// (gcc 13, Docker).  Everything between this header and the "php-judy:
+// compile-time pins" footer is the generator's output, unmodified.
+// Regenerate on both architectures and re-verify identity whenever the
+// size-class definitions in Judy1.h / JudyPrivate.h change.
+// See libjudy/PATCHES.md and issue #142.
+//
+// Upstream compiles this translation unit with -DJUDY1; define it here so the
+// variant headers resolve identically however the file is wired in.
+#ifndef JUDY1
+#define JUDY1 1
+#endif
+
+// @(#) From generation tool: $Revision: 4.37 $ $Source: /judy/src/JudyCommon/JudyTables.c $
+//
+
+#include "Judy1.h"
+// Leave the malloc() sizes readable in the binary (via strings(1)):
+const char * Judy1MallocSizes = "Judy1MallocSizes = 3, 5, 7, 11, 15, 23, 32, 47, 64,";
+
+
+//	object uses 64 words
+//	cJU_BITSPERSUBEXPB = 32
+const uint8_t
+j__1_BranchBJPPopToWords[cJU_BITSPERSUBEXPB + 1] =
+{
+	 0,
+	 3,  5,  7, 11, 11, 15, 15, 23, 
+	23, 23, 23, 32, 32, 32, 32, 32, 
+	47, 47, 47, 47, 47, 47, 47, 64, 
+	64, 64, 64, 64, 64, 64, 64, 64
+};
+
+//	object uses 32 words
+//	cJ1_LEAF2_MAXPOP1 = 128
+const uint8_t
+j__1_Leaf2PopToWords[cJ1_LEAF2_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  3,  3,  3,  3,  3,  3, 
+	 3,  3,  3,  3,  5,  5,  5,  5, 
+	 5,  5,  5,  5,  7,  7,  7,  7, 
+	 7,  7,  7,  7, 11, 11, 11, 11, 
+	11, 11, 11, 11, 11, 11, 11, 11, 
+	11, 11, 11, 11, 15, 15, 15, 15, 
+	15, 15, 15, 15, 15, 15, 15, 15, 
+	15, 15, 15, 15, 23, 23, 23, 23, 
+	23, 23, 23, 23, 23, 23, 23, 23, 
+	23, 23, 23, 23, 23, 23, 23, 23, 
+	23, 23, 23, 23, 23, 23, 23, 23, 
+	23, 23, 23, 23, 32, 32, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32
+};
+
+//	object uses 32 words
+//	cJ1_LEAF3_MAXPOP1 = 85
+const uint8_t
+j__1_Leaf3PopToWords[cJ1_LEAF3_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  3,  3,  3,  3,  3,  3, 
+	 5,  5,  5,  5,  5,  7,  7,  7, 
+	 7,  7, 11, 11, 11, 11, 11, 11, 
+	11, 11, 11, 11, 11, 15, 15, 15, 
+	15, 15, 15, 15, 15, 15, 15, 15, 
+	23, 23, 23, 23, 23, 23, 23, 23, 
+	23, 23, 23, 23, 23, 23, 23, 23, 
+	23, 23, 23, 23, 23, 32, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	32, 32, 32, 32, 32
+};
+
+//	object uses 32 words
+//	cJ1_LEAF4_MAXPOP1 = 64
+const uint8_t
+j__1_Leaf4PopToWords[cJ1_LEAF4_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  3,  3,  3,  3,  5,  5, 
+	 5,  5,  7,  7,  7,  7, 11, 11, 
+	11, 11, 11, 11, 11, 11, 15, 15, 
+	15, 15, 15, 15, 15, 15, 23, 23, 
+	23, 23, 23, 23, 23, 23, 23, 23, 
+	23, 23, 23, 23, 23, 23, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32
+};
+
+//	object uses 32 words
+//	cJ1_LEAF5_MAXPOP1 = 51
+const uint8_t
+j__1_Leaf5PopToWords[cJ1_LEAF5_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  3,  3,  5,  5,  5,  5, 
+	 7,  7,  7, 11, 11, 11, 11, 11, 
+	11, 15, 15, 15, 15, 15, 15, 15, 
+	23, 23, 23, 23, 23, 23, 23, 23, 
+	23, 23, 23, 23, 32, 32, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	32, 32, 32
+};
+
+//	object uses 32 words
+//	cJ1_LEAF6_MAXPOP1 = 42
+const uint8_t
+j__1_Leaf6PopToWords[cJ1_LEAF6_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  3,  3,  5,  5,  7,  7, 
+	 7, 11, 11, 11, 11, 11, 15, 15, 
+	15, 15, 15, 15, 23, 23, 23, 23, 
+	23, 23, 23, 23, 23, 23, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	32, 32
+};
+
+//	object uses 32 words
+//	cJ1_LEAF7_MAXPOP1 = 36
+const uint8_t
+j__1_Leaf7PopToWords[cJ1_LEAF7_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  3,  5,  5,  7,  7,  7, 
+	11, 11, 11, 11, 15, 15, 15, 15, 
+	15, 23, 23, 23, 23, 23, 23, 23, 
+	23, 23, 32, 32, 32, 32, 32, 32, 
+	32, 32, 32, 32
+};
+
+//	object uses 32 words
+//	cJ1_LEAFW_MAXPOP1 = 31
+const uint8_t
+j__1_LeafWPopToWords[cJ1_LEAFW_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  5,  5,  7,  7, 11, 11, 
+	11, 11, 15, 15, 15, 15, 23, 23, 
+	23, 23, 23, 23, 23, 23, 32, 32, 
+	32, 32, 32, 32, 32, 32, 32
+};
+
+// php-judy: compile-time pins.  The initializers above were baked in by the
+// generator against the header constants named in each dimension; C silently
+// accepts an initializer list SHORTER than the declared dimension, so a
+// header drift would otherwise ship half-initialized tables.  These pins
+// fail the build instead, forcing regeneration.  The immediate-capacity
+// (cJ1_IMMED*_MAXPOP1) pins are deliberately deferred to the Stage 2 P1
+// patch: on pristine Judy-1.0.5 sources they FAIL (cJ1_IMMED1_MAXPOP1 = 15
+// does not fit jp_1Index -- that is the #131 bug), so they can only be
+// added together with the fix they guard.
+#define JUDY_PHP_TABLES_ASSERT(cond, name) \
+        typedef char judy_php_tables_assert_ ## name [(cond) ? 1 : -1]
+
+// This file was generated under JU_64BIT: a 32-bit build must regenerate
+// it, not reuse it.
+JUDY_PHP_TABLES_ASSERT(sizeof(Word_t) == 8, word_t_is_8_bytes);
+
+// Dimensions the generator baked into the initializer lists above.
+JUDY_PHP_TABLES_ASSERT(cJU_BITSPERSUBEXPB == 32, branchb_subexpanse_is_32);
+JUDY_PHP_TABLES_ASSERT(cJ1_LEAF2_MAXPOP1 == 128, leaf2_maxpop1_is_128);
+JUDY_PHP_TABLES_ASSERT(cJ1_LEAF3_MAXPOP1 ==  85, leaf3_maxpop1_is_85);
+JUDY_PHP_TABLES_ASSERT(cJ1_LEAF4_MAXPOP1 ==  64, leaf4_maxpop1_is_64);
+JUDY_PHP_TABLES_ASSERT(cJ1_LEAF5_MAXPOP1 ==  51, leaf5_maxpop1_is_51);
+JUDY_PHP_TABLES_ASSERT(cJ1_LEAF6_MAXPOP1 ==  42, leaf6_maxpop1_is_42);
+JUDY_PHP_TABLES_ASSERT(cJ1_LEAF7_MAXPOP1 ==  36, leaf7_maxpop1_is_36);
+JUDY_PHP_TABLES_ASSERT(cJ1_LEAFW_MAXPOP1 ==  31, leafw_maxpop1_is_31);
+
+// The word sizes above (3, 5, 7, 11, 15, 23, 32, 47, 64) come from
+// ALLOCSIZES in Judy1.h: nine sizes plus the generator's TERMINATOR (999).
+// Element values cannot be checked at compile time; pin the count.
+#define TERMINATOR 999 /* JudyTables.c's TERMINATOR */
+#if defined(__GNUC__)
+__attribute__((unused))
+#endif
+static const int judy_php_alloc_sizes_pin[] = ALLOCSIZES;
+#undef TERMINATOR
+JUDY_PHP_TABLES_ASSERT(
+        sizeof(judy_php_alloc_sizes_pin) / sizeof(judy_php_alloc_sizes_pin[0])
+                == 10,
+        allocsizes_is_9_sizes_plus_terminator);

--- a/libjudy/src/JudyCommon/JudyInsArray.c
+++ b/libjudy/src/JudyCommon/JudyInsArray.c
@@ -1,3 +1,7 @@
+// Modified for php-judy on 2026-08-18 (patch P5, LLP64/Windows-x64
+// correctness -- see libjudy/PATCHES.md, issues #127/#142):
+// 1UL << N shifts use (Word_t)1 (1UL is 32-bit on LLP64, so N >= 32 shifted to 0).
+//
 // Copyright (C) 2000 - 2002 Hewlett-Packard Company
 //
 // This program is free software; you can redistribute it and/or modify it
@@ -849,7 +853,7 @@ BuildBranch2:   // come here directly for Level = levelsub = cJU_ROOTSTATE.
         Pjp               = Pjbu->jbu_jp;           // for convenience in loop.
         numJPs            = 0;                      // non-null in the BranchU.
         digitmask         = cJU_MASKATSTATE(levelsub);   // see above.
-        digitshincr       = 1UL << (cJU_BITSPERBYTE * (levelsub - 1));
+        digitshincr       = (Word_t)1 << (cJU_BITSPERBYTE * (levelsub - 1));
         retval            = TRUE;
 
 // Scan and populate JPs (subexpanses):

--- a/libjudy/src/JudyCommon/JudyMallocIF.c
+++ b/libjudy/src/JudyCommon/JudyMallocIF.c
@@ -1,3 +1,7 @@
+// Modified for php-judy on 2026-08-18 (patch P5, LLP64/Windows-x64
+// correctness -- see libjudy/PATCHES.md, issues #127/#142):
+// j__uMaxWords initializer uses ~(Word_t)0 instead of the 32-bit-truncating ~0UL.
+//
 // Copyright (C) 2000 - 2002 Hewlett-Packard Company
 //
 // This program is free software; you can redistribute it and/or modify it
@@ -55,7 +59,7 @@
 // Note:  To keep the MALLOC macro faster and simpler, set j__uMaxWords to
 // MAXINT, not zero, by default.
 
-Word_t j__uMaxWords = ~0UL;
+Word_t j__uMaxWords = ~(Word_t)0;
 
 // This macro hides the faking of a malloc failure:
 //

--- a/libjudy/src/JudyCommon/JudyPrevNextEmpty.c
+++ b/libjudy/src/JudyCommon/JudyPrevNextEmpty.c
@@ -1,3 +1,7 @@
+// Modified for php-judy on 2026-08-18 (patch P5, LLP64/Windows-x64
+// correctness -- see libjudy/PATCHES.md, issues #127/#142):
+// 1UL << N shift uses (Word_t)1 (1UL << 63 evaluated to 0 on LLP64, an infinite loop).
+//
 // Copyright (C) 2000 - 2002 Hewlett-Packard Company
 //
 // This program is free software; you can redistribute it and/or modify it
@@ -1238,7 +1242,7 @@ LeafB1NextSubexp:	// return here to check next bitmap subexpanse.
 	    if (subexp-- > 0)		// more subexpanses.
 	    {
 		LEAFB1_STARTSUBEXP(SETLEASTDIGITS_D);
-		bitposmaskL = (1UL << (cJU_BITSPERSUBEXPL - 1));
+		bitposmaskL = ((Word_t)1 << (cJU_BITSPERSUBEXPL - 1));
 		goto LeafB1NextSubexp;
 	    }
 

--- a/libjudy/src/JudyCommon/JudyPrivate.h
+++ b/libjudy/src/JudyCommon/JudyPrivate.h
@@ -1,3 +1,7 @@
+// Modified for php-judy on 2026-08-18 (patch P5, LLP64/Windows-x64
+// correctness -- see libjudy/PATCHES.md, issues #127/#142):
+// cJU_ALLONES, JU_LEASTBYTESMASK and JU_BITPOSMASKB/L use Word_t-width constants instead of UL/L constants that truncate or sign-extend on LLP64.
+//
 #ifndef _JUDYPRIVATE_INCLUDED
 #define _JUDYPRIVATE_INCLUDED
 // _________________
@@ -307,7 +311,7 @@ typedef int bool_t;
 
 // A word that is all-ones, normally equal to -1UL, but safer with ~0:
 
-#define cJU_ALLONES  (~0UL)
+#define cJU_ALLONES  (~(Word_t)0)
 
 // Note, these are forward references, but thats OK:
 
@@ -411,7 +415,7 @@ typedef PWord_t Pjv_t;   // pointer to JudyL value area.
 // processors.
 
 #define JU_LEASTBYTESMASK(BYTES) \
-        ((0x100UL << (cJU_BITSPERBYTE * ((BYTES) - 1))) - 1)
+        (((Word_t)0x100 << (cJU_BITSPERBYTE * ((BYTES) - 1))) - 1)
 
 #define JU_LEASTBYTES(INDEX,BYTES)  ((INDEX) & JU_LEASTBYTESMASK(BYTES))
 
@@ -801,8 +805,8 @@ static inline BITMAPL_t j__udyCountBitsL(BITMAPL_t word)
 //
 // TBD:  Perhaps use an array[32] of masks instead of calculating them.
 
-#define JU_BITPOSMASKB(BITNUM) (1L << ((BITNUM) % cJU_BITSPERSUBEXPB))
-#define JU_BITPOSMASKL(BITNUM) (1L << ((BITNUM) % cJU_BITSPERSUBEXPL))
+#define JU_BITPOSMASKB(BITNUM) ((Word_t)1 << ((BITNUM) % cJU_BITSPERSUBEXPB))
+#define JU_BITPOSMASKL(BITNUM) ((Word_t)1 << ((BITNUM) % cJU_BITSPERSUBEXPL))
 
 
 // TEST/SET/CLEAR A BIT IN A BITMAP LEAF:
@@ -1365,7 +1369,7 @@ assert((Word_t) (OFFSET) <= (Word_t) (POP1));                   \
 // return int or Word_t using JERR, which is type Word_t, for errors.  Lint
 // complains about this for functions that return int.  So, internally use
 // JERRI for error returns from the int functions.  Experiments show that
-// callers which compare int Foo() to (Word_t) JERR (~0UL) are OK, since JERRI
+// callers which compare int Foo() to (Word_t) JERR (~(Word_t)0) are OK, since JERRI
 // sign-extends to match JERR.
 
 #define JERRI ((int) ~0)                // see above.

--- a/libjudy/src/JudyCommon/JudyPrivateBranch.h
+++ b/libjudy/src/JudyCommon/JudyPrivateBranch.h
@@ -1,3 +1,7 @@
+// Modified for php-judy on 2026-08-18 (patch P5, LLP64/Windows-x64
+// correctness -- see libjudy/PATCHES.md, issues #127/#142):
+// JU_BRANCHL/B_MAX_POP and cJU_MASKATSTATE use Word_t-width constants (0xffL made cJU_MASKATSTATE 0 for State >= 5 on LLP64).
+//
 #ifndef _JUDY_PRIVATE_BRANCH_INCLUDED
 #define _JUDY_PRIVATE_BRANCH_INCLUDED
 // _________________
@@ -340,10 +344,10 @@ typedef struct J__UDY_BRANCH_UNCOMPRESSED
 
 // These are set up to have conservative conversion schedules to BranchU:
 
-#define JU_BRANCHL_MAX_POP      (-1UL)
+#define JU_BRANCHL_MAX_POP      (~(Word_t)0)
 #define JU_BTOU_POP_INCREMENT      300
 #define JU_BRANCHB_MIN_POP        1000
-#define JU_BRANCHB_MAX_POP      (-1UL)
+#define JU_BRANCHB_MAX_POP      (~(Word_t)0)
 
 #endif // NO_BRANCHU
 
@@ -361,7 +365,7 @@ typedef struct J__UDY_BRANCH_UNCOMPRESSED
 
 // Produce 1-digit mask at specified state:
 
-#define cJU_MASKATSTATE(State)  (0xffL << (((State) - 1) * cJU_BITSPERBYTE))
+#define cJU_MASKATSTATE(State)  ((Word_t)0xff << (((State) - 1) * cJU_BITSPERBYTE))
 
 // Get byte (digit) from Index at the specified state, right justified:
 //

--- a/libjudy/src/JudyL/JudyLTables.c
+++ b/libjudy/src/JudyL/JudyLTables.c
@@ -1,0 +1,277 @@
+// php-judy: pre-generated JudyL size-class tables for the bundled libJudy.
+// NOT an upstream Judy-1.0.5 source file -- upstream generates this file at
+// build time.  Generated 2026-08-18 by compiling
+// src/JudyCommon/JudyTables.c with -DJUDYL -DJU_64BIT -O2 from the pristine
+// Judy-1.0.5 import, then running the resulting generator; the output was
+// verified byte-identical between arm64 (Apple clang 17) and x86-64
+// (gcc 13, Docker).  Everything between this header and the "php-judy:
+// compile-time pins" footer is the generator's output, unmodified.
+// Regenerate on both architectures and re-verify identity whenever the
+// size-class definitions in JudyL.h / JudyPrivate.h change.
+// See libjudy/PATCHES.md and issue #142.
+//
+// Upstream compiles this translation unit with -DJUDYL; define it here so the
+// variant headers resolve identically however the file is wired in.
+#ifndef JUDYL
+#define JUDYL 1
+#endif
+
+// @(#) From generation tool: $Revision: 4.37 $ $Source: /judy/src/JudyCommon/JudyTables.c $
+//
+
+#include "JudyL.h"
+// Leave the malloc() sizes readable in the binary (via strings(1)):
+const char * JudyLMallocSizes = "JudyLMallocSizes = 3, 5, 7, 11, 15, 23, 32, 47, 64, Leaf1 = 13";
+
+
+//	object uses 64 words
+//	cJU_BITSPERSUBEXPB = 32
+const uint8_t
+j__L_BranchBJPPopToWords[cJU_BITSPERSUBEXPB + 1] =
+{
+	 0,
+	 3,  5,  7, 11, 11, 15, 15, 23, 
+	23, 23, 23, 32, 32, 32, 32, 32, 
+	47, 47, 47, 47, 47, 47, 47, 64, 
+	64, 64, 64, 64, 64, 64, 64, 64
+};
+
+//	object uses 15 words
+//	cJL_LEAF1_MAXPOP1 = 13
+const uint8_t
+j__L_Leaf1PopToWords[cJL_LEAF1_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  5,  5,  7,  7, 11, 11, 
+	11, 15, 15, 15, 15
+};
+const uint8_t
+j__L_Leaf1Offset[cJL_LEAF1_MAXPOP1 + 1] =
+{
+	 0,
+	 1,  1,  1,  1,  1,  1,  2,  2, 
+	 2,  2,  2,  2,  2
+};
+
+//	object uses 64 words
+//	cJL_LEAF2_MAXPOP1 = 51
+const uint8_t
+j__L_Leaf2PopToWords[cJL_LEAF2_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  5,  5,  7, 11, 11, 11, 
+	15, 15, 15, 15, 23, 23, 23, 23, 
+	23, 23, 32, 32, 32, 32, 32, 32, 
+	32, 47, 47, 47, 47, 47, 47, 47, 
+	47, 47, 47, 47, 47, 64, 64, 64, 
+	64, 64, 64, 64, 64, 64, 64, 64, 
+	64, 64, 64
+};
+const uint8_t
+j__L_Leaf2Offset[cJL_LEAF2_MAXPOP1 + 1] =
+{
+	 0,
+	 1,  1,  1,  1,  2,  3,  3,  3, 
+	 3,  3,  3,  3,  5,  5,  5,  5, 
+	 5,  5,  7,  7,  7,  7,  7,  7, 
+	 7, 10, 10, 10, 10, 10, 10, 10, 
+	10, 10, 10, 10, 10, 13, 13, 13, 
+	13, 13, 13, 13, 13, 13, 13, 13, 
+	13, 13, 13
+};
+
+//	object uses 64 words
+//	cJL_LEAF3_MAXPOP1 = 46
+const uint8_t
+j__L_Leaf3PopToWords[cJL_LEAF3_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  5,  7,  7, 11, 11, 11, 
+	15, 15, 23, 23, 23, 23, 23, 23, 
+	32, 32, 32, 32, 32, 32, 32, 47, 
+	47, 47, 47, 47, 47, 47, 47, 47, 
+	47, 47, 64, 64, 64, 64, 64, 64, 
+	64, 64, 64, 64, 64, 64
+};
+const uint8_t
+j__L_Leaf3Offset[cJL_LEAF3_MAXPOP1 + 1] =
+{
+	 0,
+	 1,  1,  2,  2,  2,  3,  3,  3, 
+	 4,  4,  6,  6,  6,  6,  6,  6, 
+	 9,  9,  9,  9,  9,  9,  9, 13, 
+	13, 13, 13, 13, 13, 13, 13, 13, 
+	13, 13, 18, 18, 18, 18, 18, 18, 
+	18, 18, 18, 18, 18, 18
+};
+
+//	object uses 63 words
+//	cJL_LEAF4_MAXPOP1 = 42
+const uint8_t
+j__L_Leaf4PopToWords[cJL_LEAF4_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  3,  5,  7, 11, 11, 11, 15, 
+	15, 15, 23, 23, 23, 23, 23, 32, 
+	32, 32, 32, 32, 32, 47, 47, 47, 
+	47, 47, 47, 47, 47, 47, 47, 63, 
+	63, 63, 63, 63, 63, 63, 63, 63, 
+	63, 63
+};
+const uint8_t
+j__L_Leaf4Offset[cJL_LEAF4_MAXPOP1 + 1] =
+{
+	 0,
+	 1,  1,  2,  2,  4,  4,  4,  5, 
+	 5,  5,  8,  8,  8,  8,  8, 11, 
+	11, 11, 11, 11, 11, 16, 16, 16, 
+	16, 16, 16, 16, 16, 16, 16, 21, 
+	21, 21, 21, 21, 21, 21, 21, 21, 
+	21, 21
+};
+
+//	object uses 64 words
+//	cJL_LEAF5_MAXPOP1 = 39
+const uint8_t
+j__L_Leaf5PopToWords[cJL_LEAF5_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  5,  5,  7, 11, 11, 15, 15, 
+	15, 23, 23, 23, 23, 23, 32, 32, 
+	32, 32, 32, 47, 47, 47, 47, 47, 
+	47, 47, 47, 47, 64, 64, 64, 64, 
+	64, 64, 64, 64, 64, 64, 64
+};
+const uint8_t
+j__L_Leaf5Offset[cJL_LEAF5_MAXPOP1 + 1] =
+{
+	 0,
+	 2,  2,  2,  3,  4,  4,  6,  6, 
+	 6,  9,  9,  9,  9,  9, 12, 12, 
+	12, 12, 12, 18, 18, 18, 18, 18, 
+	18, 18, 18, 18, 25, 25, 25, 25, 
+	25, 25, 25, 25, 25, 25, 25
+};
+
+//	object uses 63 words
+//	cJL_LEAF6_MAXPOP1 = 36
+const uint8_t
+j__L_Leaf6PopToWords[cJL_LEAF6_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  5,  7,  7, 11, 11, 15, 15, 
+	23, 23, 23, 23, 23, 32, 32, 32, 
+	32, 32, 47, 47, 47, 47, 47, 47, 
+	47, 47, 63, 63, 63, 63, 63, 63, 
+	63, 63, 63, 63
+};
+const uint8_t
+j__L_Leaf6Offset[cJL_LEAF6_MAXPOP1 + 1] =
+{
+	 0,
+	 1,  3,  3,  3,  5,  5,  6,  6, 
+	10, 10, 10, 10, 10, 14, 14, 14, 
+	14, 14, 20, 20, 20, 20, 20, 20, 
+	20, 20, 27, 27, 27, 27, 27, 27, 
+	27, 27, 27, 27
+};
+
+//	object uses 64 words
+//	cJL_LEAF7_MAXPOP1 = 34
+const uint8_t
+j__L_Leaf7PopToWords[cJL_LEAF7_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  5,  7, 11, 11, 15, 15, 15, 
+	23, 23, 23, 23, 32, 32, 32, 32, 
+	32, 47, 47, 47, 47, 47, 47, 47, 
+	47, 64, 64, 64, 64, 64, 64, 64, 
+	64, 64
+};
+const uint8_t
+j__L_Leaf7Offset[cJL_LEAF7_MAXPOP1 + 1] =
+{
+	 0,
+	 1,  3,  3,  5,  5,  7,  7,  7, 
+	11, 11, 11, 11, 15, 15, 15, 15, 
+	15, 22, 22, 22, 22, 22, 22, 22, 
+	22, 30, 30, 30, 30, 30, 30, 30, 
+	30, 30
+};
+
+//	object uses 63 words
+//	cJL_LEAFW_MAXPOP1 = 31
+const uint8_t
+j__L_LeafWPopToWords[cJL_LEAFW_MAXPOP1 + 1] =
+{
+	 0,
+	 3,  5,  7, 11, 11, 15, 15, 23, 
+	23, 23, 23, 32, 32, 32, 32, 47, 
+	47, 47, 47, 47, 47, 47, 47, 63, 
+	63, 63, 63, 63, 63, 63, 63
+};
+const uint8_t
+j__L_LeafWOffset[cJL_LEAFW_MAXPOP1 + 1] =
+{
+	 0,
+	 2,  3,  4,  6,  6,  8,  8, 12, 
+	12, 12, 12, 16, 16, 16, 16, 24, 
+	24, 24, 24, 24, 24, 24, 24, 32, 
+	32, 32, 32, 32, 32, 32, 32
+};
+
+//	object uses 64 words
+//	cJU_BITSPERSUBEXPL = 64
+const uint8_t
+j__L_LeafVPopToWords[cJU_BITSPERSUBEXPL + 1] =
+{
+	 0,
+	 3,  3,  3,  5,  5,  7,  7, 11, 
+	11, 11, 11, 15, 15, 15, 15, 23, 
+	23, 23, 23, 23, 23, 23, 23, 32, 
+	32, 32, 32, 32, 32, 32, 32, 32, 
+	47, 47, 47, 47, 47, 47, 47, 47, 
+	47, 47, 47, 47, 47, 47, 47, 64, 
+	64, 64, 64, 64, 64, 64, 64, 64, 
+	64, 64, 64, 64, 64, 64, 64, 64
+};
+
+// php-judy: compile-time pins.  The initializers above were baked in by the
+// generator against the header constants named in each dimension; C silently
+// accepts an initializer list SHORTER than the declared dimension, so a
+// header drift would otherwise ship half-initialized tables.  These pins
+// fail the build instead, forcing regeneration.  The immediate-capacity
+// (cJL_IMMED*_MAXPOP1) pins are deliberately deferred to the Stage 2 P1
+// patch (see Judy1Tables.c for why).
+#define JUDY_PHP_TABLES_ASSERT(cond, name) \
+        typedef char judy_php_tables_assert_ ## name [(cond) ? 1 : -1]
+
+// This file was generated under JU_64BIT: a 32-bit build must regenerate
+// it, not reuse it.
+JUDY_PHP_TABLES_ASSERT(sizeof(Word_t) == 8, word_t_is_8_bytes);
+
+// Dimensions the generator baked into the initializer lists above.
+JUDY_PHP_TABLES_ASSERT(cJU_BITSPERSUBEXPB == 32, branchb_subexpanse_is_32);
+JUDY_PHP_TABLES_ASSERT(cJU_BITSPERSUBEXPL == 64, leafv_subexpanse_is_64);
+JUDY_PHP_TABLES_ASSERT(cJL_LEAF1_MAXPOP1 ==  13, leaf1_maxpop1_is_13);
+JUDY_PHP_TABLES_ASSERT(cJL_LEAF2_MAXPOP1 ==  51, leaf2_maxpop1_is_51);
+JUDY_PHP_TABLES_ASSERT(cJL_LEAF3_MAXPOP1 ==  46, leaf3_maxpop1_is_46);
+JUDY_PHP_TABLES_ASSERT(cJL_LEAF4_MAXPOP1 ==  42, leaf4_maxpop1_is_42);
+JUDY_PHP_TABLES_ASSERT(cJL_LEAF5_MAXPOP1 ==  39, leaf5_maxpop1_is_39);
+JUDY_PHP_TABLES_ASSERT(cJL_LEAF6_MAXPOP1 ==  36, leaf6_maxpop1_is_36);
+JUDY_PHP_TABLES_ASSERT(cJL_LEAF7_MAXPOP1 ==  34, leaf7_maxpop1_is_34);
+JUDY_PHP_TABLES_ASSERT(cJL_LEAFW_MAXPOP1 ==  31, leafw_maxpop1_is_31);
+
+// The word sizes above (3, 5, 7, 11, 15, 23, 32, 47, 64) come from
+// ALLOCSIZES in JudyL.h: nine sizes plus the generator's TERMINATOR (999).
+// Element values cannot be checked at compile time; pin the count.
+#define TERMINATOR 999 /* JudyTables.c's TERMINATOR */
+#if defined(__GNUC__)
+__attribute__((unused))
+#endif
+static const int judy_php_alloc_sizes_pin[] = ALLOCSIZES;
+#undef TERMINATOR
+JUDY_PHP_TABLES_ASSERT(
+        sizeof(judy_php_alloc_sizes_pin) / sizeof(judy_php_alloc_sizes_pin[0])
+                == 10,
+        allocsizes_is_9_sizes_plus_terminator);

--- a/libjudy/src/JudySL/JudySL.c
+++ b/libjudy/src/JudySL/JudySL.c
@@ -1,3 +1,7 @@
+// Modified for php-judy on 2026-08-18 (patch P5, LLP64/Windows-x64
+// correctness -- see libjudy/PATCHES.md, issues #127/#142):
+// LASTWORD_BY_VALUE and JudySLPrevSub use Word_t-width constants instead of 0xffL / ~0UL.
+//
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the term of the GNU Lesser General Public License as published by the
@@ -101,7 +105,7 @@
 // word is null (assume big-endian, including in a register on a little-endian
 // machine):
 
-#define LASTWORD_BY_VALUE(WORD) (! ((WORD) & 0xffL))
+#define LASTWORD_BY_VALUE(WORD) (! ((WORD) & (Word_t)0xff))
 
 #ifdef JU_64BIT
 
@@ -836,7 +840,7 @@ JudySLPrevSub(Pcvoid_t PArray, uint8_t * Index, int orig,
             return (&PSCLVALUE(PArray));
         }
 
-        indexword = ~0UL;
+        indexword = ~(Word_t)0;
         if ((PPValue = JudyLLast(PArray, &indexword, PJError)) == PPJERR)
         {
             JudySLModifyErrno(PJError, PArray, orig ? PArray : (Pvoid_t)NULL);

--- a/libjudy/src/wrappers/Judy1ByCount.c
+++ b/libjudy/src/wrappers/Judy1ByCount.c
@@ -1,0 +1,7 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyByCount.c with -DNOSMARTJBB -DNOSMARTJBU -DNOSMARTJLB: Judy1ByCount / JudyLByCount. */
+#define JUDY1 1
+#define NOSMARTJBB 1
+#define NOSMARTJBU 1
+#define NOSMARTJLB 1
+#include "../JudyCommon/JudyByCount.c"

--- a/libjudy/src/wrappers/Judy1Cascade.c
+++ b/libjudy/src/wrappers/Judy1Cascade.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyCascade.c: Judy1Cascade / JudyLCascade. */
+#define JUDY1 1
+#include "../JudyCommon/JudyCascade.c"

--- a/libjudy/src/wrappers/Judy1Count.c
+++ b/libjudy/src/wrappers/Judy1Count.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyCount.c: Judy1Count / JudyLCount. */
+#define JUDY1 1
+#include "../JudyCommon/JudyCount.c"

--- a/libjudy/src/wrappers/Judy1CreateBranch.c
+++ b/libjudy/src/wrappers/Judy1CreateBranch.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyCreateBranch.c: j__udyCreateBranch* (per-variant). */
+#define JUDY1 1
+#include "../JudyCommon/JudyCreateBranch.c"

--- a/libjudy/src/wrappers/Judy1Decascade.c
+++ b/libjudy/src/wrappers/Judy1Decascade.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyDecascade.c: Judy1Decascade / JudyLDecascade. */
+#define JUDY1 1
+#include "../JudyCommon/JudyDecascade.c"

--- a/libjudy/src/wrappers/Judy1First.c
+++ b/libjudy/src/wrappers/Judy1First.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyFirst.c: Judy1First/Last/... / JudyLFirst/Last/.... */
+#define JUDY1 1
+#include "../JudyCommon/JudyFirst.c"

--- a/libjudy/src/wrappers/Judy1FreeArray.c
+++ b/libjudy/src/wrappers/Judy1FreeArray.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyFreeArray.c: Judy1FreeArray / JudyLFreeArray. */
+#define JUDY1 1
+#include "../JudyCommon/JudyFreeArray.c"

--- a/libjudy/src/wrappers/Judy1InsertBranch.c
+++ b/libjudy/src/wrappers/Judy1InsertBranch.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyInsertBranch.c: j__udyInsertBranch (per-variant). */
+#define JUDY1 1
+#include "../JudyCommon/JudyInsertBranch.c"

--- a/libjudy/src/wrappers/Judy1MallocIF.c
+++ b/libjudy/src/wrappers/Judy1MallocIF.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyMallocIF.c: j__udy*Alloc/Free memory interface (per-variant). */
+#define JUDY1 1
+#include "../JudyCommon/JudyMallocIF.c"

--- a/libjudy/src/wrappers/Judy1MemActive.c
+++ b/libjudy/src/wrappers/Judy1MemActive.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyMemActive.c: Judy1MemActive / JudyLMemActive. */
+#define JUDY1 1
+#include "../JudyCommon/JudyMemActive.c"

--- a/libjudy/src/wrappers/Judy1MemUsed.c
+++ b/libjudy/src/wrappers/Judy1MemUsed.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyMemUsed.c: Judy1MemUsed / JudyLMemUsed. */
+#define JUDY1 1
+#include "../JudyCommon/JudyMemUsed.c"

--- a/libjudy/src/wrappers/Judy1Next.c
+++ b/libjudy/src/wrappers/Judy1Next.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyPrevNext.c with -DJUDYNEXT: Judy1Next / JudyLNext. */
+#define JUDY1 1
+#define JUDYNEXT 1
+#include "../JudyCommon/JudyPrevNext.c"

--- a/libjudy/src/wrappers/Judy1NextEmpty.c
+++ b/libjudy/src/wrappers/Judy1NextEmpty.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyPrevNextEmpty.c with -DJUDYNEXT: Judy1NextEmpty / JudyLNextEmpty. */
+#define JUDY1 1
+#define JUDYNEXT 1
+#include "../JudyCommon/JudyPrevNextEmpty.c"

--- a/libjudy/src/wrappers/Judy1Prev.c
+++ b/libjudy/src/wrappers/Judy1Prev.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyPrevNext.c with -DJUDYPREV: Judy1Prev / JudyLPrev. */
+#define JUDY1 1
+#define JUDYPREV 1
+#include "../JudyCommon/JudyPrevNext.c"

--- a/libjudy/src/wrappers/Judy1PrevEmpty.c
+++ b/libjudy/src/wrappers/Judy1PrevEmpty.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyPrevNextEmpty.c with -DJUDYPREV: Judy1PrevEmpty / JudyLPrevEmpty. */
+#define JUDY1 1
+#define JUDYPREV 1
+#include "../JudyCommon/JudyPrevNextEmpty.c"

--- a/libjudy/src/wrappers/Judy1Set.c
+++ b/libjudy/src/wrappers/Judy1Set.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyIns.c: Judy1Set / JudyLIns. */
+#define JUDY1 1
+#include "../JudyCommon/JudyIns.c"

--- a/libjudy/src/wrappers/Judy1SetArray.c
+++ b/libjudy/src/wrappers/Judy1SetArray.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyInsArray.c: Judy1SetArray / JudyLInsArray. */
+#define JUDY1 1
+#include "../JudyCommon/JudyInsArray.c"

--- a/libjudy/src/wrappers/Judy1Test.c
+++ b/libjudy/src/wrappers/Judy1Test.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyGet.c: Judy1Test / JudyLGet. */
+#define JUDY1 1
+#include "../JudyCommon/JudyGet.c"

--- a/libjudy/src/wrappers/Judy1TestInline.c
+++ b/libjudy/src/wrappers/Judy1TestInline.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyGet.c with -DJUDYGETINLINE: j__udy1Test / j__udyLGet (internal inline copy). */
+#define JUDY1 1
+#define JUDYGETINLINE 1
+#include "../JudyCommon/JudyGet.c"

--- a/libjudy/src/wrappers/Judy1Unset.c
+++ b/libjudy/src/wrappers/Judy1Unset.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDY1 variant of JudyCommon/JudyDel.c: Judy1Unset / JudyLDel. */
+#define JUDY1 1
+#include "../JudyCommon/JudyDel.c"

--- a/libjudy/src/wrappers/JudyLByCount.c
+++ b/libjudy/src/wrappers/JudyLByCount.c
@@ -1,0 +1,7 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyByCount.c with -DNOSMARTJBB -DNOSMARTJBU -DNOSMARTJLB: Judy1ByCount / JudyLByCount. */
+#define JUDYL 1
+#define NOSMARTJBB 1
+#define NOSMARTJBU 1
+#define NOSMARTJLB 1
+#include "../JudyCommon/JudyByCount.c"

--- a/libjudy/src/wrappers/JudyLCascade.c
+++ b/libjudy/src/wrappers/JudyLCascade.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyCascade.c: Judy1Cascade / JudyLCascade. */
+#define JUDYL 1
+#include "../JudyCommon/JudyCascade.c"

--- a/libjudy/src/wrappers/JudyLCount.c
+++ b/libjudy/src/wrappers/JudyLCount.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyCount.c: Judy1Count / JudyLCount. */
+#define JUDYL 1
+#include "../JudyCommon/JudyCount.c"

--- a/libjudy/src/wrappers/JudyLCreateBranch.c
+++ b/libjudy/src/wrappers/JudyLCreateBranch.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyCreateBranch.c: j__udyCreateBranch* (per-variant). */
+#define JUDYL 1
+#include "../JudyCommon/JudyCreateBranch.c"

--- a/libjudy/src/wrappers/JudyLDecascade.c
+++ b/libjudy/src/wrappers/JudyLDecascade.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyDecascade.c: Judy1Decascade / JudyLDecascade. */
+#define JUDYL 1
+#include "../JudyCommon/JudyDecascade.c"

--- a/libjudy/src/wrappers/JudyLDel.c
+++ b/libjudy/src/wrappers/JudyLDel.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyDel.c: Judy1Unset / JudyLDel. */
+#define JUDYL 1
+#include "../JudyCommon/JudyDel.c"

--- a/libjudy/src/wrappers/JudyLFirst.c
+++ b/libjudy/src/wrappers/JudyLFirst.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyFirst.c: Judy1First/Last/... / JudyLFirst/Last/.... */
+#define JUDYL 1
+#include "../JudyCommon/JudyFirst.c"

--- a/libjudy/src/wrappers/JudyLFreeArray.c
+++ b/libjudy/src/wrappers/JudyLFreeArray.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyFreeArray.c: Judy1FreeArray / JudyLFreeArray. */
+#define JUDYL 1
+#include "../JudyCommon/JudyFreeArray.c"

--- a/libjudy/src/wrappers/JudyLGet.c
+++ b/libjudy/src/wrappers/JudyLGet.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyGet.c: Judy1Test / JudyLGet. */
+#define JUDYL 1
+#include "../JudyCommon/JudyGet.c"

--- a/libjudy/src/wrappers/JudyLGetInline.c
+++ b/libjudy/src/wrappers/JudyLGetInline.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyGet.c with -DJUDYGETINLINE: j__udy1Test / j__udyLGet (internal inline copy). */
+#define JUDYL 1
+#define JUDYGETINLINE 1
+#include "../JudyCommon/JudyGet.c"

--- a/libjudy/src/wrappers/JudyLIns.c
+++ b/libjudy/src/wrappers/JudyLIns.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyIns.c: Judy1Set / JudyLIns. */
+#define JUDYL 1
+#include "../JudyCommon/JudyIns.c"

--- a/libjudy/src/wrappers/JudyLInsArray.c
+++ b/libjudy/src/wrappers/JudyLInsArray.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyInsArray.c: Judy1SetArray / JudyLInsArray. */
+#define JUDYL 1
+#include "../JudyCommon/JudyInsArray.c"

--- a/libjudy/src/wrappers/JudyLInsertBranch.c
+++ b/libjudy/src/wrappers/JudyLInsertBranch.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyInsertBranch.c: j__udyInsertBranch (per-variant). */
+#define JUDYL 1
+#include "../JudyCommon/JudyInsertBranch.c"

--- a/libjudy/src/wrappers/JudyLMallocIF.c
+++ b/libjudy/src/wrappers/JudyLMallocIF.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyMallocIF.c: j__udy*Alloc/Free memory interface (per-variant). */
+#define JUDYL 1
+#include "../JudyCommon/JudyMallocIF.c"

--- a/libjudy/src/wrappers/JudyLMemActive.c
+++ b/libjudy/src/wrappers/JudyLMemActive.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyMemActive.c: Judy1MemActive / JudyLMemActive. */
+#define JUDYL 1
+#include "../JudyCommon/JudyMemActive.c"

--- a/libjudy/src/wrappers/JudyLMemUsed.c
+++ b/libjudy/src/wrappers/JudyLMemUsed.c
@@ -1,0 +1,4 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyMemUsed.c: Judy1MemUsed / JudyLMemUsed. */
+#define JUDYL 1
+#include "../JudyCommon/JudyMemUsed.c"

--- a/libjudy/src/wrappers/JudyLNext.c
+++ b/libjudy/src/wrappers/JudyLNext.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyPrevNext.c with -DJUDYNEXT: Judy1Next / JudyLNext. */
+#define JUDYL 1
+#define JUDYNEXT 1
+#include "../JudyCommon/JudyPrevNext.c"

--- a/libjudy/src/wrappers/JudyLNextEmpty.c
+++ b/libjudy/src/wrappers/JudyLNextEmpty.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyPrevNextEmpty.c with -DJUDYNEXT: Judy1NextEmpty / JudyLNextEmpty. */
+#define JUDYL 1
+#define JUDYNEXT 1
+#include "../JudyCommon/JudyPrevNextEmpty.c"

--- a/libjudy/src/wrappers/JudyLPrev.c
+++ b/libjudy/src/wrappers/JudyLPrev.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyPrevNext.c with -DJUDYPREV: Judy1Prev / JudyLPrev. */
+#define JUDYL 1
+#define JUDYPREV 1
+#include "../JudyCommon/JudyPrevNext.c"

--- a/libjudy/src/wrappers/JudyLPrevEmpty.c
+++ b/libjudy/src/wrappers/JudyLPrevEmpty.c
@@ -1,0 +1,5 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compiles the JUDYL variant of JudyCommon/JudyPrevNextEmpty.c with -DJUDYPREV: Judy1PrevEmpty / JudyLPrevEmpty. */
+#define JUDYL 1
+#define JUDYPREV 1
+#include "../JudyCommon/JudyPrevNextEmpty.c"

--- a/libjudy/src/wrappers/judy_static_asserts.c
+++ b/libjudy/src/wrappers/judy_static_asserts.c
@@ -1,0 +1,28 @@
+/* php-judy build shim -- NOT an upstream Judy-1.0.5 file (see libjudy/PATCHES.md).
+ * Compile-time environment pins for the bundled libJudy.  This TU is
+ * variant-free (no JUDY1/JUDYL): it checks only what must hold before any
+ * variant compiles.  Table-dimension pins live in Judy1Tables.c /
+ * JudyLTables.c next to the data they guard; the immediate-capacity pins
+ * are deferred to the Stage 2 P1 patch (they fail on pristine sources --
+ * that is the #131 bug). */
+
+#include "Judy.h"
+
+#define JUDY_PHP_STATIC_ASSERT(cond, name) \
+        typedef char judy_php_static_assert_ ## name [(cond) ? 1 : -1]
+
+/* Word_t must be exactly the machine word: every Judy structure, mask and
+ * shift is derived from it.  On LLP64 (MSVC x64) this is what the P5 patch
+ * to Judy.h guarantees. */
+JUDY_PHP_STATIC_ASSERT(sizeof(Word_t) == sizeof(void *),
+        word_t_is_pointer_sized);
+
+#ifdef JU_64BIT
+/* The build defines JU_64BIT (config.m4 / config.w32): internal structures
+ * assume 8-byte words, and the pre-generated tables were produced under it. */
+JUDY_PHP_STATIC_ASSERT(sizeof(Word_t) == 8, word_t_is_8_bytes_under_ju_64bit);
+#else
+/* A 32-bit build must NOT reuse the committed 64-bit tables; this pin is the
+ * matching guard on the environment side. */
+JUDY_PHP_STATIC_ASSERT(sizeof(Word_t) == 4, word_t_is_4_bytes_without_ju_64bit);
+#endif

--- a/package.xml
+++ b/package.xml
@@ -323,6 +323,7 @@
          <file md5sum="22726a237f203a685b2f6b81c1bad5d1" name="php_judy.h" role="src" />
          <file name="libjudy/src/Judy.h" role="src" />
          <file name="libjudy/src/Judy1/Judy1.h" role="src" />
+         <file name="libjudy/src/Judy1/Judy1Tables.c" role="src" />
          <file name="libjudy/src/JudyCommon/JudyByCount.c" role="src" />
          <file name="libjudy/src/JudyCommon/JudyCascade.c" role="src" />
          <file name="libjudy/src/JudyCommon/JudyCount.c" role="src" />
@@ -348,7 +349,49 @@
          <file name="libjudy/src/JudyCommon/JudyTables.c" role="src" />
          <file name="libjudy/src/JudyHS/JudyHS.c" role="src" />
          <file name="libjudy/src/JudyL/JudyL.h" role="src" />
+         <file name="libjudy/src/JudyL/JudyLTables.c" role="src" />
          <file name="libjudy/src/JudySL/JudySL.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1ByCount.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1Cascade.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1Count.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1CreateBranch.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1Decascade.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1First.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1FreeArray.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1InsertBranch.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1MallocIF.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1MemActive.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1MemUsed.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1Next.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1NextEmpty.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1Prev.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1PrevEmpty.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1Set.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1SetArray.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1Test.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1TestInline.c" role="src" />
+         <file name="libjudy/src/wrappers/Judy1Unset.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLByCount.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLCascade.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLCount.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLCreateBranch.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLDecascade.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLDel.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLFirst.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLFreeArray.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLGet.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLGetInline.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLIns.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLInsArray.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLInsertBranch.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLMallocIF.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLMemActive.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLMemUsed.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLNext.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLNextEmpty.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLPrev.c" role="src" />
+         <file name="libjudy/src/wrappers/JudyLPrevEmpty.c" role="src" />
+         <file name="libjudy/src/wrappers/judy_static_asserts.c" role="src" />
          <file name="libjudy/COPYING" role="doc" />
          <file name="libjudy/PATCHES.md" role="doc" />
          <file name="libjudy/README.md" role="doc" />
@@ -383,7 +426,7 @@
    </dependencies>
    <providesextension>Judy</providesextension>
    <extsrcrelease>
-      <configureoption default="autodetect" name="with-judy" prompt="Please provide the prefix of libJudy installation" />
+      <configureoption default="bundled" name="with-judy" prompt="libJudy to build against: &quot;bundled&quot; compiles the bundled copy (default); give the install prefix DIR of a system libJudy to link against it instead" />
    </extsrcrelease>
    <changelog>
       <release>


### PR DESCRIPTION
Stage 1 of the libJudy vendoring plan (#142): the bundled `libjudy/` tree becomes the **default build**, `--with-judy=DIR` remains the system-lib mode. `phpize && ./configure && make` now works on a machine with no libJudy installed.

## What landed (per #142's 1a–1f)

- **1a — Pre-generated tables**: `Judy1Tables.c` / `JudyLTables.c` generated from `JudyCommon/JudyTables.c` (`-DJUDY1|-DJUDYL -DJU_64BIT -O2`), byte-identical between arm64 (Apple clang 17) and x86-64 (gcc 13, Docker). Each file carries a provenance header and compile-time pins (Word_t size, every baked table dimension, ALLOCSIZES count; negative-controlled — a flipped pin fails the build). Immediate-capacity pins deferred to Stage 2 P1 as planned (they fail on pristine sources — that IS the #131 bug).
- **1b — Wrappers**: the full 40-wrapper set from the authoritative per-variant `Makefile.am` enumeration (comment on #142), incl. the three specials (JudyGet twice per variant with `JUDYGETINLINE`; JudyPrevNext/JudyPrevNextEmpty twice with `JUDYNEXT`/`JUDYPREV`; JudyByCount with the three `NOSMART*` defines), plus a variant-free `judy_static_asserts.c`. `JudyMalloc.c`/`JudySL.c`/`JudyHS.c` compile directly. `JU_64BIT` lives in build flags, not wrappers.
- **1e — P5**: the six LLP64 fixes CI applied as download-time regexes are now real source diffs (7 files, each with the §2(b) change notice; one P5 ledger row in `libjudy/PATCHES.md`). Every hunk reviewed — no false positives; `JudySLPrevSub`'s `~0UL` (JudySL.c:839) confirmed converted.
- **1c/1d — config.m4 / config.w32**: dual mode. Bundled unless a real DIR is given; DIR keeps exactly the previous search/`PHP_CHECK_LIBRARY` behavior. `-mpopcnt` probed and appended to vendored-only flags (deliberately inert until Stage 3 O1 adds the `__POPCNT__` arm). `--enable-judy-debug-mirror` works in both modes. Bundled mode refuses non-64-bit-long targets with a pointer at `--with-judy=DIR`. config.w32: `/D JU_WIN`, `/D JU_64BIT` on x64 only, no aggressive MSVC opts.
- **1f — CI**: build-linux / build-alpine / debug-php-assertions / validate-pecl / Dockerfiles → bundled (the PIE 2.5.2 baseline installs libjudy-dev inside its own step — that release predates vendoring). build-windows and release.yml lose the whole SourceForge download+patch step and the `--with-judy=RUNNER_TEMP` arg — the patch block just hotfixed in #143 dies here. `debug-mirror-assertions` unchanged: the permanent system-lib guard. validate-pecl gains a `libjudy/` ↔ package.xml completeness check. Warning gates deliberately not extended to vendored sources (documented at each grep). package.xml: 43 new `role="src"` files; `configureoption` default `autodetect` → `bundled`.

## The flag-isolation story (the load-bearing part)

Mechanism: vendored sources are attached via `PHP_ADD_SOURCES_X` with per-source flags, which the PHP build system emits **after** the global `$(CFLAGS_CLEAN)` on each vendored compile line — later flags win with gcc/clang. Verified compile line (Linux gcc, same shape on macOS clang):

```
cc ... -g -O2 -O3 -fomit-frame-pointer -DNDEBUG -fno-common -funroll-loops -flto -D_GNU_SOURCE   -O2 -fno-lto -fno-unroll-loops -DJU_64BIT -mpopcnt -c .../wrappers/Judy1Test.c ...
```

**The gate caught a real leak.** The first Linux gcc bundled build failed exactly one test: `tests/bitset_immed_cascade_integrity_001.phpt` — the #131 detector. A later `-O2` overrides `-O3`, but the global `-funroll-loops` has no implicit off switch and leaked through. Bisected against a minimal C driver of the same cascade shape (gcc 13.4, x86-64):

| vendored flags | detector |
| --- | --- |
| `-O2 -fno-lto` | OK |
| `-O2 -fno-lto -funroll-loops` | **BROKEN** (walked 71/135, isset 82/135) |
| `-O2 -fno-lto -fomit-frame-pointer -DNDEBUG -fno-common` | OK |
| exact build-line residue (globals + old overrides) | **BROKEN** |
| `-O3` alone | OK on gcc 13/14 |
| `-O3 -funroll-loops` / full global set | OK on gcc 13/14 |

Completing the matrix: `-O3 -funroll-loops` and the full global set (`-O3 -fomit-frame-pointer -DNDEBUG -fno-common -funroll-loops`) are OK at object level on gcc 13.4, and a config-level forced control (overrides removed from `judy_vendor_cflags`, `phpize && ./configure && make clean && make`, compile line verified to carry only the globals) also passes the detector on the image's gcc 14.2. So on **current** gcc the reproducible miscompile is specifically **`-O2 -funroll-loops`** — exactly the combination partial isolation produced — while the historically-blamed bare `-O3` (#131) happens to generate correct code on gcc 13/14. The UB is real either way (gcc's `-Warray-bounds`/aggressive-loop warnings fire on the vendored build; Debian/Fedora patch it; Stage 2 P1 removes it); which -O/flag combination a given gcc miscompiles is luck, which is why the flags are pinned and the detector stays in the suite unconditionally. Fix: `-fno-unroll-loops` added to the vendored-only flags.

**The two required isolation observations**, reported exactly as observed (Linux gcc, real build, real `.phpt` detector):
1. **Hazardous flags reaching vendored units → detector FAILS**: the pre-fix image — vendored units at effective `-O2` with the leaked global `-funroll-loops` — failed `bitset_immed_cascade_integrity_001.phpt` (and only it) in two independent full-suite runs; the minimal driver shows the loss (walked 71/135, isset 82/135). This is the real-world "isolation off" state and the detector caught it.
2. **Isolated flags → detector PASSES**: with `-O2 -fno-lto -fno-unroll-loops` per-source, the full suite is 220/220 including the detector (Linux gcc, macOS clang, Alpine musl).

The literal "force `-O3` and watch the detector fail" experiment was run (config-level, clean rebuild, compile line verified) and does **not** fail on gcc 13/14 — bare `-O3` generates correct code there. Honest caveat rather than a manufactured pass: the hazardous combination current gcc actually miscompiles is the one the detector demonstrably fires on.

## Gate 1 results

| Gate | Result |
| --- | --- |
| macOS bundled (`./configure`, no --with-judy) | 220/220; fresh .so probed; Judy symbols embedded, no libJudy dylib dep |
| macOS system (`--with-judy=/opt/homebrew`) | 220/220; dynamic `libJudy.1.dylib` |
| Linux gcc bundled (Docker, x86-64) | 220/220 incl. #131 detector; negative control above |
| `--enable-judy-debug-mirror` bundled | 220/220; checker symbol confirmed in .so |
| Alpine/musl bundled (Docker, x86-64) | 220/220; zero extension-source warnings on musl gcc |
| `pecl package` → tarball → `pecl install` (Docker) | tarball builds; libjudy completeness verified (74 entries); `pecl install` of the .tgz in a clean Debian image succeeds and the extension loads |
| Compile-line evidence | above; both platforms |
| `php scripts/generate-api-docs.php --check` | unchanged, passing (no API change) |
| Zero warnings in extension sources (gcc + clang builds) | pass |
| Out-of-tree phpize build (srcdir ≠ builddir) | builds and loads |

**Windows is not verifiable locally** — it relies on this PR's CI `build-windows` matrix (bundled config.w32 + the P5 source diffs; the builder derives `--with-judy=shared` from composer.json, which maps to bundled). x86 (32-bit) Windows would need regenerated 32-bit tables and is correctly refused JU_64BIT; the release matrix currently builds x64 only.

Not touched, per the stage boundary: `baselines/latest.json`, BENCHMARK.md, Stage 2 patches (P1–P4, P6, P7), popcount source arm / JU_NOVEC / bswap (Stage 3).
