### PR TITLE
fix(diffuzz): commit the harness Makefile the root .gitignore was hiding

### DIFF
--- a/research/differential-fuzz/.gitignore
+++ b/research/differential-fuzz/.gitignore
@@ -1,3 +1,6 @@
+# The top-level .gitignore ignores every "Makefile" (phpize generates one at
+# the repo root); this harness's Makefile is hand-written and must be tracked.
+!Makefile
 diffuzz
 diffuzz-san
 *.dSYM/

--- a/research/differential-fuzz/Makefile
+++ b/research/differential-fuzz/Makefile
@@ -1,0 +1,50 @@
+# Differential fuzzing harness for libJudy — issue #142 Stage 4.
+#
+# Builds against a SYSTEM libJudy by default (/opt/homebrew on macOS, /usr
+# elsewhere). Point JUDY_PREFIX at any prefix that has include/Judy.h and
+# lib/libJudy.{a,so,dylib} — e.g. at the vendored bundled build once #142
+# Stage 1 lands, or at a scratch build made by validation/build-stock.sh.
+#
+#   make                          # plain -O2 harness
+#   make diffuzz-san              # harness instrumented with ASan+UBSan
+#   make smoke                    # build + fixed-seed smoke run
+#   make JUDY_PREFIX=/some/prefix
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+JUDY_PREFIX ?= /opt/homebrew
+else
+JUDY_PREFIX ?= /usr
+endif
+
+CXX      ?= c++
+STD       = -std=c++17
+WARN      = -Wall -Wextra -Werror
+OPT      ?= -O2 -g
+CPPFLAGS += -I$(JUDY_PREFIX)/include
+LDFLAGS  += -L$(JUDY_PREFIX)/lib
+LDLIBS    = -lJudy
+SAN       = -fsanitize=address,undefined -fno-sanitize-recover=all \
+            -fno-omit-frame-pointer
+
+all: diffuzz
+
+diffuzz: diffuzz.cpp
+	$(CXX) $(STD) $(OPT) $(WARN) $(CPPFLAGS) -o $@ diffuzz.cpp $(LDFLAGS) $(LDLIBS)
+
+# Harness-side sanitizers only: the library is whatever JUDY_PREFIX holds.
+# To sanitize the library itself, build one with validation/build-stock.sh
+# (CFLAGS containing -fsanitize=address) and point JUDY_PREFIX at it.
+diffuzz-san: diffuzz.cpp
+	$(CXX) $(STD) -O1 -g $(SAN) $(WARN) $(CPPFLAGS) -o $@ diffuzz.cpp $(LDFLAGS) $(LDLIBS)
+
+smoke: diffuzz
+	./diffuzz smoke
+
+soak: diffuzz
+	./diffuzz soak 60
+
+clean:
+	rm -f diffuzz diffuzz-san
+
+.PHONY: all smoke soak clean


### PR DESCRIPTION
## Summary

`research/differential-fuzz/README.md` documents `make` / `make diffuzz-san`, and `validation/validate.sh` copies `$HDIR/Makefile` — but no Makefile was ever tracked under `research/differential-fuzz/` (#145 shipped without it). Root cause: the top-level `.gitignore` ignores every `Makefile` unanchored (intended for the phpize-generated one at the repo root), so the harness's hand-written Makefile stayed silently untracked in its authoring worktree — never shown by `git status`, never staged by `git add`.

## Changes

- **`research/differential-fuzz/Makefile`** — recovered verbatim from the authoring worktree; matches the documented interface: `diffuzz` (`-O2 -g`, `-Wall -Wextra -Werror`, links `-lJudy` under `JUDY_PREFIX`, defaulting to `/opt/homebrew` on macOS and `/usr` elsewhere), `diffuzz-san` (ASan+UBSan, `-fno-sanitize-recover=all`), plus `smoke` / `soak` / `clean`.
- **`research/differential-fuzz/.gitignore`** — adds `!Makefile` re-include (with a comment naming the root-level shadow) so the file stays tracked; verified with `git check-ignore -v`.

## Verification

- `make -s clean && make -s CXX=g++ JUDY_PREFIX=/opt/homebrew diffuzz` (validate.sh's exact invocation shape) and `make -s diffuzz-san`: both build warning-clean under `-Werror` (macOS/clang, aarch64).
- Both binaries run divergence-free against Homebrew's stock libJudy: `one judy1 uniform 0x1 20000 --no-bulk` and sanitized `one judyhs mixed 0x2 20000 --no-bulk` (`--no-bulk` because Homebrew's 1.0.5 carries the #127 off-by-one, per the README).
- `package.xml` untouched: it lists no `research/` files — `research/` is excluded from the PECL package by design, so the `validate-pecl` gate is unaffected.

Refs #142, #145.