### PR TITLE
fix(bench): let the PHP control, not the judy median, decide contamination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,10 @@ jobs:
           # arms alternate per benchmark group and repeat over several rounds,
           # so runner drift hits both arms and cancels in the paired ratio —
           # see scripts/bench-compare.php and issue #87 for why running the
-          # two suites back to back reported false regressions instead.
+          # two suites back to back reported false regressions instead. A
+          # pure-PHP control decides whether any residual run-wide shift is
+          # runner movement (contaminated, flags suppressed) or a real
+          # build-wide change (per-cell verdicts stand).
           #
           # Deliberately smaller than the headline benchmark below: this job
           # needs to detect *changes* reliably, not produce publishable
@@ -1275,22 +1278,38 @@ jobs:
                   )
 
                   php_ctl = drift.get("php_control_median_delta_pct")
+                  common = drift.get(
+                      "common_mode_pct", drift.get("median_delta_pct", 0)
+                  )
                   drift_note = (
                       f"Run-wide median delta "
                       f"{drift.get('median_delta_pct', 0):+.2f}% "
                       f"(PHP-array control "
                       + ("n/a" if php_ctl is None else f"{php_ctl:+.2f}%")
-                      + "), divided out of every row."
+                      + f"); runner common-mode {common:+.2f}% "
+                      f"divided out of every row."
                   )
                   if drift.get("contaminated"):
+                      thr = meta.get("drift_threshold_pct", 5)
+                      if php_ctl is None:
+                          why = (
+                              f"No PHP-array control row was usable, and "
+                              f"the whole suite moved together past the "
+                              f"±{thr:.0f}% threshold — read as runner "
+                              f"movement, not code."
+                          )
+                      else:
+                          why = (
+                              f"The control runs no judy code, so its "
+                              f"shift past the ±{thr:.0f}% threshold "
+                              f"means the runner itself changed speed "
+                              f"under the measurement."
+                          )
                       lines.append(
                           f"> ⚠️ **Comparison contaminated.** "
-                          f"{drift_note} That is past the "
-                          f"±{meta.get('drift_threshold_pct', 5):.0f}% "
-                          f"threshold: the whole suite moved together, which "
-                          f"is a slower runner rather than slower code. "
-                          f"Individual flags are suppressed — re-run the "
-                          f"job for a usable comparison.\n"
+                          f"{drift_note} {why} Individual flags are "
+                          f"suppressed — re-run the job for a usable "
+                          f"comparison.\n"
                       )
                   else:
                       lines.append(f"> {drift_note}\n")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,14 +563,17 @@ jobs:
         # the built tarball, so a .phpt missing from package.xml still passes
         # CI while being absent from the shipped package. Compare explicitly.
         run: |
-          ls tests/*.phpt | sort > /tmp/tests-on-disk.txt
+          # git ls-files, not `ls tests/*.phpt`: support files (e.g. an .inc
+          # fixture a .phpt drives) must ship too, or the installed package's
+          # test suite breaks. Mirrors the libjudy/ check below.
+          git ls-files tests/ | sort > /tmp/tests-on-disk.txt
           grep -oP '(?<=name=")tests/[^"]+(?=")' package.xml | sort > /tmp/tests-in-package.txt
           if ! diff -u --label package.xml --label tests/ \
                /tmp/tests-in-package.txt /tmp/tests-on-disk.txt; then
             echo "ERROR: package.xml and tests/ have diverged."
-            echo "  '+' lines: on disk but not in package.xml — add"
-            echo '            <file name="tests/<name>.phpt" role="test" />'
-            echo "  '-' lines: in package.xml but not on disk — remove the entry"
+            echo "  '+' lines: tracked in git but not in package.xml — add"
+            echo '            <file name="tests/<name>" role="test" />'
+            echo "  '-' lines: in package.xml but not tracked — remove the entry"
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,9 +296,12 @@ Reading the report:
   threshold, i.e. there is no measured separation.
 - **`unstable`** — the benchmark's own arms scattered by more than the effect
   being claimed, so it was not evaluated. Expect a few on a busy runner.
-- **"Comparison contaminated"** — the run-wide median delta moved past ±5%,
-  meaning the whole suite shifted together. That is a slower runner, not slower
-  code; individual flags are suppressed and the job should be re-run.
+- **"Comparison contaminated"** — the pure-PHP control (which runs no judy
+  code) moved past ±5%, meaning the runner itself changed speed under the
+  measurement; individual flags are suppressed and the job should be re-run.
+  A uniform shift of the judy benchmarks over a flat control is **not**
+  contamination — that is a real build-wide change (e.g. a libJudy-wide win
+  or regression) and the per-row verdicts stand.
 
 To reproduce a comparison locally:
 

--- a/package.xml
+++ b/package.xml
@@ -91,6 +91,8 @@
          <file name="baselines/latest.json" role="doc" />
          <file md5sum="abc7eb31bb88857463ec941514e5f019" name="tests/001.phpt" role="test" />
          <file name="tests/arrayaccess_void_return_001.phpt" role="test" />
+         <file name="tests/bench_compare_drift_001.phpt" role="test" />
+         <file name="tests/bench_compare_fake_bench.inc" role="test" />
          <file md5sum="43e01c2e189ff2523a83016559b80391" name="tests/bitset_001.phpt" role="test" />
          <file md5sum="9f3363cc4c6d15cb52184351cf710fd7" name="tests/bitset_002.phpt" role="test" />
          <file md5sum="e859b3b92086bc165b3ec98800920f03" name="tests/bitset_003.phpt" role="test" />

--- a/scripts/bench-compare.php
+++ b/scripts/bench-compare.php
@@ -27,12 +27,18 @@
  *     doing during round r hits both members of that round's pair, so it
  *     divides out of the ratio instead of accumulating into a delta between
  *     two independently-estimated medians.
- *  4. Computes the run-wide median delta as a contamination estimate. A clean
- *     run centres near 0%; a run-wide median past the threshold means the
- *     runner state moved under the measurement, and the whole comparison is
- *     marked contaminated rather than emitting a page of individual flags.
- *  5. Divides each benchmark's ratio by that run-wide median, so a benchmark is
- *     only flagged when it moved differently from everything else in the run.
+ *  4. Uses the PHP-array control rows as the contamination detector. The
+ *     control runs no judy code, so it moves only when the runner itself
+ *     changed speed; when its median delta passes the threshold the whole
+ *     comparison is marked contaminated rather than emitting a page of
+ *     individual flags. The .judy run-wide median is NOT the detector: a
+ *     uniform .judy shift over a flat control is a real, build-wide change
+ *     (a libJudy-wide win or regression moves every cell together) and must
+ *     reach the per-cell verdicts. Only when no control row clears the
+ *     min-ms floor does the .judy median fall back to being the detector.
+ *  5. Divides each benchmark's ratio by the runner movement the control
+ *     measured, so runner speed divides out of every cell while whatever the
+ *     extension really did — uniform or not — stays in.
  *
  * A benchmark is flagged only when the *whole* drift-adjusted CI clears the
  * threshold — a point estimate past the threshold with a CI straddling it is
@@ -470,10 +476,27 @@ foreach ($ids as $id) {
 
 // ── Run-wide drift / contamination ──────────────────────────────────────────
 
-$drift        = $raw_deltas ? median($raw_deltas) : 0.0;
-$php_drift    = $php_deltas ? median($php_deltas) : null;
-$contaminated = abs($drift) > $drift_max;
-$scale        = 1.0 + $drift / 100.0;   // multiplicative common-mode factor
+$drift     = $raw_deltas ? median($raw_deltas) : 0.0;
+$php_drift = $php_deltas ? median($php_deltas) : null;
+
+// The control decides contamination. Thresholding the .judy median instead
+// would read any uniform shift as runner noise — muting a build-wide win and,
+// worse, reporting a build-wide regression as "same" with CI green.
+if ($php_drift === null) {
+    // No control row cleared the min-ms floor; without a second read on the
+    // runner, a run-wide shift can only be treated as runner movement.
+    $contaminated = abs($drift) > $drift_max;
+    $common_mode  = $drift;
+} else {
+    $contaminated = abs($php_drift) > $drift_max;
+    // Divide out what the control measured, not the .judy median: dividing by
+    // the .judy median re-centres the population on itself and erases exactly
+    // the uniform real change the control just vouched for. Under
+    // contamination the flags are suppressed anyway, so there the .judy
+    // median stays the better re-centring for the diagnostic numbers.
+    $common_mode  = $contaminated ? $drift : $php_drift;
+}
+$scale = 1.0 + $common_mode / 100.0;   // multiplicative common-mode factor
 
 $counts = ['faster' => 0, 'slower' => 0, 'same' => 0, 'unstable' => 0,
            'new' => count($new), 'removed' => count($removed)];
@@ -592,8 +615,11 @@ $result = [
     'drift' => [
         'median_delta_pct'             => round($drift, 2),
         'php_control_median_delta_pct' => $php_drift === null ? null : round($php_drift, 2),
+        'detector'                     => $php_drift === null ? 'judy_median_fallback' : 'php_control',
+        'common_mode_pct'              => round($common_mode, 2),
         'contaminated'                 => $contaminated,
         'sample_count'                 => count($raw_deltas),
+        'php_control_sample_count'     => count($php_deltas),
     ],
     'counts'     => $counts,
     'benchmarks' => $rows,
@@ -614,7 +640,11 @@ printf(
     "Run-wide median delta: %+.2f%% (PHP-array control %s) -> %s\n",
     $drift,
     $php_drift === null ? 'n/a' : sprintf('%+.2f%%', $php_drift),
-    $contaminated ? 'CONTAMINATED, flags suppressed' : 'clean'
+    $contaminated
+        ? ($php_drift === null
+            ? 'CONTAMINATED (no usable control; run-wide shift), flags suppressed'
+            : 'CONTAMINATED (control moved), flags suppressed')
+        : 'clean'
 );
 printf(
     "Summary: %d faster, %d regressions, %d unchanged, %d unstable, %d new, %d removed\n",

--- a/tests/bench_compare_drift_001.phpt
+++ b/tests/bench_compare_drift_001.phpt
@@ -1,0 +1,125 @@
+--TEST--
+bench-compare: PHP control decides contamination; uniform real shifts keep per-cell verdicts
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) === 'WIN') die('skip POSIX shell required');
+$root = dirname(__DIR__);
+if (!is_file("$root/scripts/bench-compare.php")) die('skip scripts/bench-compare.php not present');
+if (!is_file("$root/modules/judy.so")) die('skip requires in-tree build (modules/judy.so)');
+$ini = php_ini_loaded_file();
+if ($ini !== false && preg_match('#^\s*(zend_)?extension\s*=.*judy#mi', (string)@file_get_contents($ini))) {
+    die('skip main php.ini loads judy; bench-compare preflight refuses this environment');
+}
+?>
+--FILE--
+<?php
+$root   = dirname(__DIR__);
+$so     = "$root/modules/judy.so";
+$script = "$root/scripts/bench-compare.php";
+$fake   = __DIR__ . '/bench_compare_fake_bench.inc';
+
+function run_compare(string $label, array $env): void {
+    global $so, $script, $fake;
+
+    $out = tempnam(sys_get_temp_dir(), 'bcd');
+    $prefix = '';
+    foreach ($env as $k => $v) {
+        $prefix .= $k . '=' . escapeshellarg($v) . ' ';
+    }
+    $cmd = $prefix . escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg($script)
+        . ' --baseline-so ' . escapeshellarg($so)
+        . ' --current-so ' . escapeshellarg($so)
+        . ' --bench ' . escapeshellarg($fake)
+        . ' --groups fake --rounds 3 --quiet'
+        . ' --out ' . escapeshellarg($out)
+        . ' 2>&1';
+    exec($cmd, $output, $status);
+
+    echo "== $label ==\n";
+    echo "exit=$status\n";
+    $j = json_decode((string)file_get_contents($out), true);
+    @unlink($out);
+    if (!is_array($j)) {
+        echo "no json; output:\n" . implode("\n", $output) . "\n";
+        return;
+    }
+
+    $d = $j['drift'];
+    printf("drift: %+.2f\n", $d['median_delta_pct']);
+    printf("control: %s\n", $d['php_control_median_delta_pct'] === null
+        ? 'n/a' : sprintf('%+.2f', $d['php_control_median_delta_pct']));
+    printf("detector: %s\n", $d['detector']);
+    printf("common_mode: %+.2f\n", $d['common_mode_pct']);
+    printf("contaminated: %s\n", $d['contaminated'] ? 'true' : 'false');
+    $c = $j['counts'];
+    printf("counts: faster=%d slower=%d same=%d unstable=%d\n",
+        $c['faster'], $c['slower'], $c['same'], $c['unstable']);
+    foreach ($j['benchmarks'] as $name => $row) {
+        $adj = (float)$row['adj_delta_pct'];
+        if (abs($adj) < 0.005) {
+            $adj = 0.0;   // normalise -0.00 vs +0.00
+        }
+        printf("%s: %s %+.2f%s\n", $name, $row['status'], $adj,
+            isset($row['reason']) ? ' (' . $row['reason'] . ')' : '');
+    }
+}
+
+// A uniform shift of every .judy cell over a flat control is a real,
+// build-wide change: the per-cell verdicts must stand, in both directions.
+run_compare('uniform improvement, flat control',
+    ['FAKE_JUDY_RATIO' => '0.8', 'FAKE_PHP_RATIO' => '1.0']);
+run_compare('uniform regression, flat control',
+    ['FAKE_JUDY_RATIO' => '1.25', 'FAKE_PHP_RATIO' => '1.0']);
+
+// When the control itself moved, the runner changed speed under the
+// measurement: the run is contaminated and would-be flags are suppressed.
+run_compare('control moved: contaminated, flags suppressed',
+    ['FAKE_JUDY_RATIO' => '1.2,1.5', 'FAKE_PHP_RATIO' => '1.2']);
+
+// With no usable control there is no second read on the runner, so a
+// run-wide shift falls back to being treated as contamination.
+run_compare('no usable control: fallback contamination',
+    ['FAKE_JUDY_RATIO' => '1.2']);
+?>
+--EXPECT--
+== uniform improvement, flat control ==
+exit=0
+drift: -20.00
+control: +0.00
+detector: php_control
+common_mode: +0.00
+contaminated: false
+counts: faster=2 slower=0 same=0 unstable=0
+fake.read: FASTER -20.00
+fake.write: FASTER -20.00
+== uniform regression, flat control ==
+exit=0
+drift: +25.00
+control: +0.00
+detector: php_control
+common_mode: +0.00
+contaminated: false
+counts: faster=0 slower=2 same=0 unstable=0
+fake.read: SLOWER +25.00
+fake.write: SLOWER +25.00
+== control moved: contaminated, flags suppressed ==
+exit=0
+drift: +35.00
+control: +20.00
+detector: php_control
+common_mode: +35.00
+contaminated: true
+counts: faster=0 slower=0 same=2 unstable=0
+fake.read: ~same -11.11 (suppressed: run flagged contaminated)
+fake.write: ~same +11.11 (suppressed: run flagged contaminated)
+== no usable control: fallback contamination ==
+exit=0
+drift: +20.00
+control: n/a
+detector: judy_median_fallback
+common_mode: +20.00
+contaminated: true
+counts: faster=0 slower=0 same=2 unstable=0
+fake.read: ~same +0.00 (within ±10%)
+fake.write: ~same +0.00 (within ±10%)

--- a/tests/bench_compare_fake_bench.inc
+++ b/tests/bench_compare_fake_bench.inc
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Deterministic stand-in for judy-bench.php, used by bench_compare_drift_001.phpt
+ * to drive scripts/bench-compare.php with known inputs.
+ *
+ * Emits two timing benchmarks (fake.read, fake.write). The baseline arm always
+ * reports 10 ms; the current arm reports 10 ms scaled by FAKE_JUDY_RATIO for
+ * the .judy entries and FAKE_PHP_RATIO for the .php control entries.
+ * FAKE_JUDY_RATIO may be a comma-separated list applied per benchmark in order.
+ * Leaving FAKE_PHP_RATIO unset omits the control entries entirely.
+ *
+ * The arm is identified by the per-arm ini directory bench-compare.php puts in
+ * PHP_INI_SCAN_DIR ("<tmp>/baseline-ini" vs "<tmp>/current-ini").
+ */
+
+$opts = getopt('', ['group:', 'size:', 'iterations:', 'json:']);
+
+$arm = strpos((string)getenv('PHP_INI_SCAN_DIR'), 'baseline-ini') !== false
+    ? 'baseline' : 'current';
+
+$judy_ratios = array_map('floatval', explode(',', (string)(getenv('FAKE_JUDY_RATIO') ?: '1.0')));
+$php_ratio   = getenv('FAKE_PHP_RATIO');   // false => no control rows
+
+$base  = 10.0;
+$bench = [];
+foreach (['read', 'write'] as $i => $op) {
+    $ratio = $judy_ratios[$i % count($judy_ratios)];
+    $bench["fake.$op.judy"] = [
+        'median_ms' => $arm === 'current' ? $base * $ratio : $base,
+    ];
+    if ($php_ratio !== false) {
+        $bench["fake.$op.php"] = [
+            'median_ms' => $arm === 'current' ? $base * (float)$php_ratio : $base,
+        ];
+    }
+}
+
+file_put_contents($opts['json'], json_encode([
+    'metadata'   => ['judy_version' => "fake-$arm"],
+    'benchmarks' => $bench,
+]));


### PR DESCRIPTION
The interleaved release comparison flagged any uniform cross-cell shift as runner contamination **and** divided the .judy run-wide median out of every row, so a genuine build-wide change was both suppressed and erased from the adjusted CIs. Run 32189100948 on main: judy median −9.39% with the pure-PHP control at +0.03% reported `0 faster, contaminated` despite the real bundled-libJudy wins from #144–#150. A uniform real regression would likewise have read "same" with CI green.

## Change

- **Contamination is decided by the PHP-only control** (it runs no judy code, so it moves only when the runner itself changed speed — the original #87 intent). A uniform judy shift over a flat control is reported as a real change and per-cell verdicts stand.
- **The common-mode factor divided out of each row is what the control measured**, not the .judy median — dividing by the .judy median re-centres the population on itself and erases exactly the uniform real change. Both halves were needed: fixing only the flag would still have normalized the improvements away.
- Control moved past ±5% → previous behavior stands (flags suppressed, judy-median re-centring for diagnostics). No usable control rows → judy median remains the fallback detector.
- Drift JSON gains `detector`, `common_mode_pct`, `php_control_sample_count`; CI report and CONTRIBUTING.md wording updated to match.

## Verification

- New `tests/bench_compare_drift_001.phpt` drives `scripts/bench-compare.php` end to end with a deterministic fake bench, covering all four regimes: uniform win (FASTER stands), uniform regression (SLOWER stands — the masking case #87's acceptance criteria warned about), control moved (suppressed), no control (fallback). Full suite 221/221 pass.
- Replaying the run-32189100948 artifact through the new decision yields **19 FASTER / 0 SLOWER** (bulk ops ×0.77–0.85, int write ×0.82, string reads ×0.87–0.88), matching the per-cell paired CIs.

Trade-off: the PHP-array control is less contention-sensitive than judy's pointer-chasing, so mild contention under the control's ±5% threshold now leaks into per-cell numbers instead of self-normalizing; the CI-must-clear-threshold rule and the unstable-spread guard still contain that.