### PR TITLE
ci(vendor): differential-fuzz gate over the bundled tree + bundled-tree ASan grid (#142 Stage 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,6 +514,25 @@ jobs:
       - name: Build every harness and run the sanitized smoke grid
         run: ./research/ci-smoke.sh 1000
 
+      - name: Run the sanitized grid again against the bundled libJudy
+        # The step above links the harnesses against the system library --
+        # the --with-judy=DIR mode. The default build is the bundled tree
+        # under libjudy/, so the same ASan+UBSan harness grid must cover it
+        # too (#142 Stage 4). build-stock.sh compiles libjudy/src at the
+        # shipped flag set (config.m4's isolated -O2 -fno-lto
+        # -fno-unroll-loops -DJU_64BIT, -mpopcnt when accepted), so the
+        # harnesses exercise the bytes a release build ships. Library-side
+        # sanitization of the bundled tree lives in the differential-fuzz
+        # job below, which drives far more of the API surface.
+        run: |
+          POPCNT=""
+          echo 'int main(void){return 0;}' > /tmp/popcnt-probe.c
+          cc -Werror -mpopcnt -c /tmp/popcnt-probe.c -o /dev/null 2>/dev/null && POPCNT="-mpopcnt"
+          sh research/differential-fuzz/validation/build-stock.sh \
+            "$PWD/libjudy/src" /tmp/judy-bundled \
+            -O2 -fno-lto -fno-unroll-loops $POPCNT
+          JUDY_PREFIX=/tmp/judy-bundled ./research/ci-smoke.sh 1000
+
       - name: Negative control -- reinstate the #122 bug, require the grid to catch it
         run: |
           # Put the defect back: make_key() padding a key up and never
@@ -540,6 +559,135 @@ jobs:
           echo "Negative control passed: the grid caught the reinstated generator bug."
 
           git checkout -- research/write-probe-cost/probebench.c
+
+  differential-fuzz:
+    # Differential fuzzing of the bundled libJudy against exact stdlib
+    # oracles (research/differential-fuzz/, #142 Stage 4): Judy1 vs std::set,
+    # JudyL vs std::map, JudySL/JudyHS vs string maps, every return code and
+    # value slot compared on every op. This is the invariant gate that would
+    # have caught #131 (gcc -O3 silently losing Judy1 keys) in seconds --
+    # see the recorded validation runs in research/differential-fuzz/README.md.
+    #
+    # Profile split (documented in that README): CI runs the bounded profile
+    # only -- the fixed-seed 48-cell smoke grid plus a short random-seed soak
+    # on the production build, and the sanitized smoke grid. The 300s+ soaks
+    # stay a local / pre-release tool.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Build the bundled tree at the shipped production flags
+        # The same isolated flag set config.m4 hands the vendored units
+        # (-O2 -fno-lto -fno-unroll-loops -DJU_64BIT, plus -mpopcnt when the
+        # compiler accepts it; build-stock.sh supplies -std=gnu99 -DJU_64BIT
+        # itself), so the fuzzer exercises the bytes a release build ships,
+        # not only a debug variant.
+        run: |
+          POPCNT=""
+          echo 'int main(void){return 0;}' > /tmp/popcnt-probe.c
+          cc -Werror -mpopcnt -c /tmp/popcnt-probe.c -o /dev/null 2>/dev/null && POPCNT="-mpopcnt"
+          echo "mpopcnt: ${POPCNT:-not accepted by this compiler}"
+          sh research/differential-fuzz/validation/build-stock.sh \
+            "$PWD/libjudy/src" /tmp/judy-prod \
+            -O2 -fno-lto -fno-unroll-loops $POPCNT
+          echo "JUDY_POPCNT=$POPCNT" >> "$GITHUB_ENV"
+
+      - name: Verify the committed pre-generated tables match the generator
+        # The shipped build compiles the committed Judy1Tables.c/JudyLTables.c;
+        # build-stock.sh regenerates both by running the upstream generator.
+        # Byte-compare the fresh output against the committed files' generator
+        # region (between the php-judy header and the compile-time-pins
+        # footer, see libjudy/PATCHES.md) so the library under fuzz and the
+        # library that ships carry the same tables -- and so a size-class
+        # header change cannot leave stale tables in the tree unnoticed.
+        run: |
+          strip_wrapper() {
+            # committed file -> bare generator output
+            awk 'phase==0 { if ($0=="#endif") phase=1; next }
+                 phase==1 { if ($0=="") next; phase=2 }
+                 /^\/\/ php-judy: compile-time pins\./ { exit }
+                 { l[++n]=$0 }
+                 END { while (n && l[n]=="") n--; for(i=1;i<=n;i++) print l[i] }' "$1"
+          }
+          trim_trailing() {
+            awk '{ l[++n]=$0 } END { while (n && l[n]=="") n--; for(i=1;i<=n;i++) print l[i] }' "$1"
+          }
+          for v in 1 L; do
+            committed="libjudy/src/Judy$v/Judy${v}Tables.c"
+            grep -q '^// php-judy: compile-time pins\.' "$committed" \
+              || { echo "::error::footer anchor missing from $committed -- the wrapper format moved"; exit 1; }
+            strip_wrapper "$committed" > "/tmp/committed-$v.c"
+            [ -s "/tmp/committed-$v.c" ] \
+              || { echo "::error::stripping $committed produced no output -- the wrapper format moved"; exit 1; }
+            trim_trailing "/tmp/judy-prod/obj/Judy${v}Tables.c" > "/tmp/generated-$v.c"
+            if ! diff -u --label "generated Judy${v}Tables.c" --label "$committed (generator region)" \
+                 "/tmp/generated-$v.c" "/tmp/committed-$v.c"; then
+              echo "::error::committed Judy${v}Tables.c does not match the generator output -- regenerate it (see libjudy/PATCHES.md)"
+              exit 1
+            fi
+            echo "Judy${v}Tables.c: committed copy matches the generator ($(wc -l < "/tmp/committed-$v.c") lines)"
+          done
+
+      - name: Fuzz the production build -- smoke grid + short soak
+        # smoke: fixed seeds, full 48-cell domain/corpus grid, 60k ops/cell,
+        # bulk sweep included (the #127 Count==31 boundary). soak: fresh
+        # random seeds every run, time-bounded so the job stays flat.
+        run: |
+          make -C research/differential-fuzz JUDY_PREFIX=/tmp/judy-prod
+          cd research/differential-fuzz
+          ./diffuzz smoke
+          ./diffuzz soak 30
+
+      - name: Fuzz the sanitized build -- ASan+UBSan on library and harness
+        # build-stock.sh at sanitizer flags instruments the vendored library
+        # itself, not just the harness -- the configuration that catches
+        # #127-class overflows inside libJudy (validation run V3 in the
+        # README caught the JudyInsArray off-by-one exactly this way).
+        run: |
+          sh research/differential-fuzz/validation/build-stock.sh \
+            "$PWD/libjudy/src" /tmp/judy-asan \
+            -O1 -g -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer
+          make -C research/differential-fuzz diffuzz-san JUDY_PREFIX=/tmp/judy-asan
+          cd research/differential-fuzz
+          UBSAN_OPTIONS=print_stacktrace=1 ./diffuzz-san smoke
+
+      - name: Negative control -- plant the #131 truncation, require a divergence
+        # Re-create the #131 defect deterministically: truncate the immediate
+        # index copy in JudyCascade.c to 8 bytes, which is byte-for-byte what
+        # the gcc -O3 miscompile of the unpatched union did (silent Judy1 key
+        # loss past the eighth member of a splayed sub-expanse). Source-level,
+        # so it fires on any compiler. The fuzzer must fail with the judy1
+        # missing-key signature, or this whole job is a green light with no
+        # bulb in it.
+        run: |
+          cp -R libjudy/src /tmp/judy-broken-src
+          sed -i 's|JU_COPYMEM(PjpJP->jp_1Index, PLeaf + Start,|JU_COPYMEM(PjpJP->jp_1Index, PLeaf + Start, (Pop1 > 8) ? 8 :   /* CI negative control */|' \
+            /tmp/judy-broken-src/JudyCommon/JudyCascade.c
+          grep -q 'CI negative control' /tmp/judy-broken-src/JudyCommon/JudyCascade.c \
+            || { echo "::error::negative control did not apply -- the anchor line in JudyCascade.c moved"; exit 1; }
+
+          sh research/differential-fuzz/validation/build-stock.sh \
+            /tmp/judy-broken-src /tmp/judy-broken \
+            -O2 -fno-lto -fno-unroll-loops $JUDY_POPCNT
+          make -C research/differential-fuzz clean >/dev/null
+          make -C research/differential-fuzz JUDY_PREFIX=/tmp/judy-broken
+
+          set +e
+          (cd research/differential-fuzz && ./diffuzz smoke) > /tmp/diffuzz-negctl.log 2>&1
+          rc=$?
+          set -e
+
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::the smoke grid passed on a library with the #131-class truncation planted"
+            tail -20 /tmp/diffuzz-negctl.log
+            exit 1
+          fi
+          grep -q 'DIVERGENCE domain=judy1' /tmp/diffuzz-negctl.log \
+            || { echo "::error::the fuzzer failed, but not with the judy1 divergence signature -- check the log"; \
+                 tail -20 /tmp/diffuzz-negctl.log; exit 1; }
+          echo "Negative control passed: the fuzzer caught the planted #131-class truncation."
+          grep -m1 -A1 'DIVERGENCE' /tmp/diffuzz-negctl.log
 
   validate-pecl:
     runs-on: ubuntu-latest

--- a/research/differential-fuzz/README.md
+++ b/research/differential-fuzz/README.md
@@ -81,10 +81,11 @@ reproduction holds across platforms and stdlibs). Exit status: 0 ok,
 1 divergence, 2 usage/environment error.
 
 `JUDY_PREFIX` selects the library (default `/opt/homebrew` on macOS, `/usr`
-elsewhere). Point `JUDY_PREFIX` at the vendored bundled build once #142
-Stage 1 lands. `validation/build-stock.sh <src> <prefix> [CFLAGS...]` builds
-a linkable prefix from pristine 1.0.5 sources (e.g. this repo's `libjudy/src`)
-at any flags — that is how the validation below sanitizes the library itself.
+elsewhere). `validation/build-stock.sh <src> <prefix> [CFLAGS...]` builds a
+linkable prefix from Judy-1.0.5-layout sources at any flags — point it at
+this repo's `libjudy/src` to fuzz the bundled tree (what the CI job does),
+or at a pristine import to reproduce the validation runs below; sanitizer
+CFLAGS are how the library itself gets instrumented.
 
 ### `--no-bulk` and stock libraries
 
@@ -152,13 +153,31 @@ divergence.
 
 ## CI
 
-Deliberately not wired into CI yet: #142 Stage 1 owns the `ci.yml` rewrite,
-and wiring this in now would conflict. The smoke mode is shaped for
-`research/ci-smoke.sh` (warning-clean at `-Wall -Wextra -Werror`, sanitized
-build target, seconds-scale fixed-seed run, non-zero exit with reproduction
-line) and should join it — plus a bundled-tree cell in the extension CI —
-once Stage 1 lands. Until Stage 2's P3 lands, a stock system-lib CI cell
-must run `--no-bulk`.
+The `differential-fuzz` job in `.github/workflows/ci.yml` runs this harness
+on every PR against the **bundled** tree (`libjudy/src`, built by
+`validation/build-stock.sh` at config.m4's shipped flag set: `-O2 -fno-lto
+-fno-unroll-loops -DJU_64BIT`, `-mpopcnt` when accepted), so CI fuzzes the
+bytes a release build ships. The job also byte-compares the committed
+pre-generated `Judy1Tables.c`/`JudyLTables.c` against fresh generator
+output, so the fuzzed and shipped tables cannot drift apart.
+
+**Profile split** — CI runs the bounded profile only; the long soaks stay a
+local / pre-release tool:
+
+| where | build | run |
+| --- | --- | --- |
+| CI, every PR | production flags | `smoke` (48 cells x 60k ops, fixed seeds) + `soak 30` (fresh random seeds each run) |
+| CI, every PR | ASan+UBSan, library **and** harness | `smoke` |
+| CI, every PR | production flags, #131-class truncation planted | negative control: `smoke` must diverge with the judy1 missing-key signature |
+| local, pre-release | any of the above | `soak 300`+ per build, plus `--no-bulk` soaks against system libraries |
+
+The negative control re-creates #131's silent-key-loss behavior at the
+source level (truncating the `jp_1Index` immediate copy in `JudyCascade.c`
+to 8 bytes) so the gate is watched-to-fail on every run, on any compiler.
+
+`research/ci-smoke.sh` (the `build-research` job) additionally runs the
+iterbench/probebench ASan+UBSan grid against the same bundled-tree build via
+`JUDY_PREFIX`, alongside its system-library pass.
 
 Nothing in this directory ships: `research/` is excluded from `package.xml`
 by design.


### PR DESCRIPTION
#142 Stage 4 — verification infrastructure. Two changes, both to unshipped files (`package.xml` untouched by design: `research/` and workflows do not ship).

## New `differential-fuzz` job (every PR)

Builds `libjudy/src` with `research/differential-fuzz/validation/build-stock.sh` at the shipped flag set config.m4 gives the vendored units (`-O2 -fno-lto -fno-unroll-loops -DJU_64BIT`, `-mpopcnt` when the compiler accepts it), so CI fuzzes the bytes a release build ships — then:

1. **Table parity**: byte-compares the committed pre-generated `Judy1Tables.c`/`JudyLTables.c` (generator region between the php-judy header and the compile-time-pins footer) against fresh generator output. Closes the one gap between the fuzzed build and the shipped build, and doubles as a staleness gate on the committed tables. Both files verified identical (132 / 219 lines).
2. **Production build**: `smoke` (fixed seeds, full 48-cell domain/corpus grid, 60k ops/cell, bulk sweep incl. the #127 Count==31 boundary) + `soak 30` (fresh random seeds each run, time-bounded).
3. **Sanitized build**: ASan+UBSan on the **library and** the harness (`-O1 -g -fsanitize=address,undefined -fno-sanitize-recover=all`), sanitized `smoke`. This is the configuration that catches #127-class overflows inside libJudy (README validation V3).
4. **Negative control, every run**: plants the #131-class defect in a scratch copy of the tree — truncating the `jp_1Index` immediate copy in `JudyCascade.c` to 8 bytes, source-level and therefore compiler-independent, byte-for-byte what the gcc `-O3` miscompile of the unpatched union did — rebuilds at production flags, and requires `smoke` to fail with the judy1 missing-key signature.

**Profile split** (documented in `research/differential-fuzz/README.md`): CI runs only this bounded profile; the 300s+ soaks and `--no-bulk` system-library soaks stay a local / pre-release tool.

## `build-research` extension

The iterbench/probebench ASan+UBSan grid now runs twice: the existing pass against the system library (`--with-judy=DIR` mode), plus a new pass with `JUDY_PREFIX` at a production-flags `build-stock.sh` build of the bundled tree. Library-side sanitization of the bundled tree lives in the differential-fuzz job, which drives far more of the API surface. The existing #122 negative control is unchanged and still runs last.

## Watched-to-fail evidence

Rehearsed the job's run blocks verbatim in Docker (`gcc:15`, aarch64, `git ls-files` export of this branch), twice:

**A — known-bad vendored tree** (the #131-class truncation planted in `libjudy/src` itself, as a bad PR would carry): the job fails at the production fuzz step, second smoke cell, in seconds, exit 1:

```
DIVERGENCE domain=judy1 corpus=clustered seed=0xe4528abc53dec306 ops=60000 op#=4095 phase=walk
  forward walk pos 13: Judy1 key 0x233e != oracle key 0x22b6
repro: ./diffuzz one judy1 clustered 0xe4528abc53dec306 60000
```

**B — clean tree, full pass**: all five steps green, and the built-in negative control caught its planted truncation with the same judy1 signature:

```
Judy1Tables.c: committed copy matches the generator (132 lines)
JudyLTables.c: committed copy matches the generator (219 lines)
smoke OK: 48 cells, no divergence
soak OK: 413 cells, no divergence          (30s soak, production build)
smoke OK: 48 cells, no divergence          (ASan+UBSan library+harness)
Negative control passed: the fuzzer caught the planted #131-class truncation.
```

The same defect + smoke divergence was also reproduced natively on macOS (clang, arm64) before the workflow was written — the control is compiler-independent as intended.

## #134 detector — verified unconditional, not weakened

`tests/bitset_immed_cascade_integrity_001.phpt`: SKIPIF is `extension_loaded("judy")` only; listed in `package.xml` (role=test); every test-running job executes `TESTS=tests/` — bundled (`build-linux`, `build-alpine`, `debug-php-assertions`, Windows), system-lib (`debug-mirror-assertions`, `--with-judy=/usr`), and the installed PECL package (`validate-pecl`, `tests/*.phpt`). No change needed or made.

## Wall time (measured on this PR's run)

[Run 32202171238](https://github.com/orieg/php-judy/actions/runs/32202171238), all jobs green:

- **`differential-fuzz`: 77s total** — production build+`-mpopcnt` probe 10s, table parity <1s, smoke (48 cells) 3s + soak 30s (772 cells), ASan+UBSan build+smoke 20s, negative control 8s. Median of the run's other jobs is ~2min (build-linux 91-134s, build-windows 177-224s, validate-pecl 98s); this job sits below it, and the trim knob if that ever changes is the soak length.
- **`build-research`: 70s** (was 38s on the last main run) — the added bundled-tree grid pass builds at `-O2 -fno-lto -fno-unroll-loops -mpopcnt` and re-runs the full sanitized grid. Still below the median.

CI-run evidence of the gate's own negative control (every run, this run included):

```
Negative control passed: the fuzzer caught the planted #131-class truncation.
DIVERGENCE domain=judy1 corpus=clustered seed=0xe4528abc53dec306 ops=60000 op#=4095 phase=walk
```
