### PR TITLE
fix(build): guard the bundled Windows build against 32-bit targets; constrain the release matrix to x64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,6 +906,128 @@ jobs:
           Get-ChildItem -Path ".\build" -Recurse -Filter "build*.log" -ErrorAction SilentlyContinue |
             Select-Object -First 1 | ForEach-Object { Get-Content $_.FullName -Tail 30 }
 
+  # Negative control for the 32-bit bundled-build guards (#159). Inverted, in
+  # the same spirit as the differential-fuzz negative control (#142 Stage 4):
+  # this job is GREEN when the guards correctly REFUSE a 32-bit bundled build,
+  # and RED if a guard is ever removed, weakened, or its message drifts.
+  #
+  # Why this and not an x86 leg in build-windows: an x86 leg is red-when-correct,
+  # which reads as a broken board and invites someone to "fix" it by deleting the
+  # guard. The one-time proof that the config.w32 guard fires on real MSVC x86 is
+  # recorded in issue #159 (CI job 95934686125: configure aborts with
+  # "ERROR: the bundled libJudy currently supports 64-bit targets only ..."). What
+  # can silently drift afterwards is the guard's own source, and that is exactly
+  # what this job pins -- deterministically, on a Linux runner, in seconds.
+  #
+  # Each assertion matches the guard's MESSAGE, not merely a nonzero exit, so an
+  # unrelated breakage cannot masquerade as the guard working.
+  guard-32bit:
+    name: 32-bit bundled build is refused (negative control)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # config.w32 is JScript. Drive it through the php-src Windows build API,
+      # stubbed, with X64 set the way php-src sets it (win32/build/config.w32:
+      # "X64 = TARGET_ARCH != 'x86'"). ERROR() throws here, standing in for
+      # confutils.js's WScript.Quit(3).
+      - name: config.w32 refuses a 32-bit target
+        run: |
+          cat > /tmp/harness.js <<'HARNESS'
+          var fs = require('fs');
+          var st = { flags: [], errors: [], warnings: [], extensions: [] };
+          function ARG_WITH() {}
+          function EXTENSION() { st.extensions.push(Array.prototype.slice.call(arguments)); }
+          function ADD_EXTENSION_DEP() {}
+          function AC_DEFINE() {}
+          function ADD_FLAG(n, v) { st.flags.push(n + ' ' + v); }
+          function ADD_SOURCES() {}
+          function CHECK_LIB() { return false; }
+          function CHECK_HEADER_ADD_INCLUDE() { return false; }
+          function WARNING(m) { st.warnings.push(m); }
+          function ERROR(m) { st.errors.push(m); throw { __abort: true }; }
+          var configure_module_dirname = 'C:\\php\\pecl\\judy';
+          var PHP_JUDY = 'yes';
+          var PHP_JUDY_SHARED = true;
+          var X64 = (process.argv[3] !== 'x86');
+          try { eval(fs.readFileSync(process.argv[2], 'utf8')); }
+          catch (e) { if (!e || !e.__abort) throw e; }
+          console.log(JSON.stringify(st));
+          HARNESS
+
+          echo "--- x86: must ERROR with the 64-bit-only message ---"
+          node /tmp/harness.js config.w32 x86 > /tmp/x86.json
+          cat /tmp/x86.json
+          node -e '
+            var r = require("/tmp/x86.json");
+            var m = r.errors.join("\n");
+            if (r.errors.length !== 1) {
+              throw new Error("expected exactly 1 ERROR() on x86, got " + r.errors.length +
+                " -- the config.w32 32-bit guard is missing or no longer aborts");
+            }
+            if (!/bundled libJudy currently supports 64-bit targets only/.test(m) ||
+                !/JU_64BIT/.test(m) || !/--with-judy=DIR/.test(m)) {
+              throw new Error("ERROR() message drifted; it must still name the cause " +
+                "(64-bit only / JU_64BIT) and the way out (--with-judy=DIR). Got: " + m);
+            }
+            if (r.extensions.length !== 0) {
+              throw new Error("configure kept going after the guard fired");
+            }
+            console.log("OK: x86 refused with the expected message");
+          '
+
+          echo "--- x64: must proceed and define JU_64BIT ---"
+          node /tmp/harness.js config.w32 x64 > /tmp/x64.json
+          cat /tmp/x64.json
+          node -e '
+            var r = require("/tmp/x64.json");
+            if (r.errors.length !== 0) {
+              throw new Error("x64 must not be refused, got: " + r.errors.join("; "));
+            }
+            if (r.flags.indexOf("CFLAGS_JUDY /D JU_64BIT") === -1) {
+              throw new Error("x64 build lost /D JU_64BIT; flags were: " + r.flags.join(" | "));
+            }
+            if (r.extensions.length !== 1) {
+              throw new Error("x64 build did not register the extension");
+            }
+            console.log("OK: x64 proceeds with /D JU_64BIT");
+          '
+
+      # Backstop that lives with the data: the pre-generated tables must refuse
+      # to compile without JU_64BIT whatever build system wires them in.
+      - name: Pre-generated tables refuse a 32-bit word
+        run: |
+          # Simulate MSVC x86 / any ILP32 target: claim Judy.h's _WORD_T guard
+          # with a genuinely 4-byte Word_t and leave JU_64BIT undefined.
+          cat > /tmp/word32.h <<'EOF'
+          #define _WORD_T
+          typedef unsigned int Word_t, * PWord_t;
+          EOF
+
+          INC="-Ilibjudy/src -Ilibjudy/src/JudyCommon -Ilibjudy/src/Judy1 -Ilibjudy/src/JudyL"
+          rc=0
+          for f in libjudy/src/Judy1/Judy1Tables.c libjudy/src/JudyL/JudyLTables.c; do
+            echo "--- $f: 32-bit word must be rejected ---"
+            if cc -fsyntax-only -include /tmp/word32.h $INC "$f" 2>/tmp/err.txt; then
+              echo "FAIL: $f compiled with a 4-byte Word_t and no JU_64BIT"; rc=1; continue
+            fi
+            if ! grep -q "require a 64-bit build" /tmp/err.txt; then
+              echo "FAIL: $f was rejected, but not by the JU_64BIT guard."
+              echo "      The #error backstop is missing or its message drifted."
+              head -20 /tmp/err.txt; rc=1; continue
+            fi
+            echo "OK: rejected by the JU_64BIT #error guard"
+
+            echo "--- $f: 64-bit build must still be clean ---"
+            if ! cc -c -Wall -Werror -O2 -DJU_64BIT $INC "$f" -o /tmp/ok.o 2>/tmp/err64.txt; then
+              echo "FAIL: $f no longer compiles for a normal 64-bit build"
+              head -20 /tmp/err64.txt; rc=1; continue
+            fi
+            echo "OK: 64-bit build unaffected"
+          done
+          exit $rc
+
   report-results:
     needs: [build-linux, build-windows]
     if: ${{ !cancelled() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,17 @@ jobs:
       - name: Get the extension matrix
         id: extension-matrix
         uses: php/php-windows-builder/extension-matrix@v1
+        with:
+          # The action defaults to arch-list "x64,x86". The bundled libJudy
+          # is 64-bit-only -- its pre-generated Judy1Tables.c/JudyLTables.c
+          # assume JU_64BIT -- so config.w32 hard-fails a 32-bit configure.
+          # Left unconstrained, every x86 leg would fail and (with the
+          # default fail-fast) take the whole release down, publishing no
+          # DLLs at all. x64 is what this project supports and tests; keep
+          # this list in sync with ci.yml's build-windows matrix.
+          arch-list: x64
 
-  # Build Windows DLLs for every PHP version / arch / thread-safety combination
+  # Build Windows DLLs for every PHP version / thread-safety combination (x64)
   build-windows:
     needs: get-extension-matrix
     runs-on: ${{ matrix.os }}

--- a/config.w32
+++ b/config.w32
@@ -8,6 +8,21 @@ if (PHP_JUDY != "no") {
 		// Bundled libJudy (libjudy/, Judy-1.0.5 + the documented patch
 		// series -- see libjudy/PATCHES.md). The P5 LLP64 patches are
 		// real source diffs now, so no download/patch step is needed.
+
+		// The bundled build is 64-bit-only: the committed
+		// Judy1Tables.c/JudyLTables.c were pre-generated under JU_64BIT
+		// and are wrong for 32-bit words. Refuse the target here, the
+		// way config.m4 does on unix, instead of letting the build run
+		// on and die inside a generated table file on its
+		// sizeof(Word_t) == 8 pin -- correct, but a dozen cryptic C2118
+		// errors deep in vendored sources. php-src sets
+		// X64 = TARGET_ARCH != 'x86', so x64 and arm64 both pass here
+		// and only a 32-bit target is rejected. ERROR() aborts the
+		// configure; a WARNING would still emit a broken DLL.
+		if (!X64) {
+			ERROR("the bundled libJudy currently supports 64-bit targets only (its pre-generated tables assume JU_64BIT); use --with-judy=DIR to link a system libJudy instead");
+		}
+
 		EXTENSION("judy", "php_judy.c judy_arrayaccess.c judy_handlers.c judy_iterator.c");
 		ADD_EXTENSION_DEP("judy", "json");
 		AC_DEFINE('HAVE_JUDY', 1, 'Have Judy library');

--- a/libjudy/src/Judy1/Judy1Tables.c
+++ b/libjudy/src/Judy1/Judy1Tables.c
@@ -162,7 +162,14 @@ j__1_LeafWPopToWords[cJ1_LEAFW_MAXPOP1 + 1] =
         typedef char judy_php_tables_assert_ ## name [(cond) ? 1 : -1]
 
 // This file was generated under JU_64BIT: a 32-bit build must regenerate
-// it, not reuse it.
+// it, not reuse it.  The #error states the cause in one line; the pin below
+// is the belt to its suspenders, and still catches a build that forces
+// JU_64BIT on despite a 32-bit word.  config.m4 and config.w32 both refuse a
+// 32-bit target before reaching this file -- these two are the backstop for
+// any other build system, and for a hand-rolled compile of these sources.
+#ifndef JU_64BIT
+#error "php-judy: these pre-generated libJudy tables require a 64-bit build (-DJU_64BIT). Regenerate them for 32-bit words, or link a system libJudy instead (--with-judy=DIR)."
+#endif
 JUDY_PHP_TABLES_ASSERT(sizeof(Word_t) == 8, word_t_is_8_bytes);
 
 // Dimensions the generator baked into the initializer lists above.

--- a/libjudy/src/JudyL/JudyLTables.c
+++ b/libjudy/src/JudyL/JudyLTables.c
@@ -247,7 +247,14 @@ j__L_LeafVPopToWords[cJU_BITSPERSUBEXPL + 1] =
         typedef char judy_php_tables_assert_ ## name [(cond) ? 1 : -1]
 
 // This file was generated under JU_64BIT: a 32-bit build must regenerate
-// it, not reuse it.
+// it, not reuse it.  The #error states the cause in one line; the pin below
+// is the belt to its suspenders, and still catches a build that forces
+// JU_64BIT on despite a 32-bit word.  config.m4 and config.w32 both refuse a
+// 32-bit target before reaching this file -- these two are the backstop for
+// any other build system, and for a hand-rolled compile of these sources.
+#ifndef JU_64BIT
+#error "php-judy: these pre-generated libJudy tables require a 64-bit build (-DJU_64BIT). Regenerate them for 32-bit words, or link a system libJudy instead (--with-judy=DIR)."
+#endif
 JUDY_PHP_TABLES_ASSERT(sizeof(Word_t) == 8, word_t_is_8_bytes);
 
 // Dimensions the generator baked into the initializer lists above.


### PR DESCRIPTION
Fixes #159.

## What was wrong

`config.m4` hard-errors when `sizeof(long) != 8` for the bundled build — the
committed `Judy1Tables.c` / `JudyLTables.c` are pre-generated under `-DJU_64BIT`
and are wrong for 32-bit words. `config.w32` had no equivalent guard: it
correctly omits `/D JU_64BIT` when `X64` is false, and its own comment states
the problem, but it then compiled the 64-bit-generated tables anyway.

Meanwhile `release.yml` generates its Windows matrix with
`php/php-windows-builder/extension-matrix@v1`, whose `ARCH_LIST` defaults to
`"x64,x86"`. `ci.yml` is pinned `arch: ["x64"]`, so CI never builds x86.

## Correcting the premise: this is not a silent failure

This was originally suspected to be a #131-class silent-wrongness bug — an x86
DLL that compiles clean and behaves wrong. **That is not what happens, and the
issue records the evidence.**

`judy_static_asserts.c` does pass on x86 (its geometry pins are under
`#ifdef JU_64BIT`; the `#else` branch asserts `sizeof(Word_t) == 4`). But both
table files carry their own pin, added at vendoring time:

```c
JUDY_PHP_TABLES_ASSERT(sizeof(Word_t) == 8, word_t_is_8_bytes);
```

On MSVC x86 `_WIN64` is undefined, so `Judy.h` selects a 4-byte
`unsigned long Word_t` and that pin fails. Reproduced locally by compiling both
table files with `Word_t` forced to a 4-byte type and `JU_64BIT` undefined
(clang 17, arm64): **11 hard errors per file**, including
`'judy_php_tables_assert_word_t_is_8_bytes' declared as an array with a
negative size`.

So the real defect is **diagnostics + release-matrix hygiene**, not data
corruption. No silently-broken x86 DLL is reachable. What was missing is a
readable failure: x86 died on a dozen cryptic C2118 "negative subscript" errors
inside a generated vendored source instead of the one-line configure message
Unix gets. The exposure is still real and still release-blocking — see below.

## Verified exposure

The v2.5.2 release run (`32100574626`, 2026-08-18) produced **10 x86 build jobs**
alongside 11 x64 ones. They passed only because `git show v2.5.2:config.w32` has
no bundled branch — that tag predates the vendoring and linked a downloaded
system libJudy. On current `main` all 10 would fail.

`build-windows` in `release.yml` does not set `fail-fast: false`, so the first
x86 failure cancels the surviving x64 legs; and `release` has
`needs: [build-windows, pecl-package]`, so it would be skipped. **The next
release would publish no Windows DLLs and no PECL tarball at all.**

## The fix

1. **`config.w32`** — `ERROR()` out of the bundled branch when `!X64`, mirroring
   `config.m4`'s message. php-src sets `X64 = TARGET_ARCH != 'x86'`
   (`win32/build/config.w32:20`), so x64 and arm64 both pass and only a 32-bit
   target is rejected. `ERROR()` quits the configure; `WARNING()` would still
   emit a DLL.
2. **`release.yml`** — pass `arch-list: x64` to `extension-matrix@v1`.

   *Why constrain rather than let the guard fail loudly:* a hard configure
   failure inside a release run is not merely noisy here — with default
   `fail-fast` plus the `needs:` edge it takes the entire release down,
   including the x64 DLLs and the PECL tarball. And "the guard fires" is the
   right signal for a developer who *chose* a 32-bit target, not for a matrix
   the project never asked for. Declaring the supported arch up front is the
   clearer statement; the arch list now matches `ci.yml`'s `arch: ["x64"]`, and
   both carry a comment saying to keep them in sync.
3. **Defense in depth** — `#ifndef JU_64BIT` → `#error` in both table files,
   beside the existing compile-time pins, so the diagnostic stream names the
   cause in one line instead of leaving only the negative-array-size spelling of
   it, and so the guard holds for *any* build system rather than only the two in
   this repo.

   It sits in the **footer** pins region, not the header. CI byte-compares the
   region between the header and the `// php-judy: compile-time pins.` anchor
   against a fresh generator run, so anything added above that anchor fails the
   generator-parity gate. The first revision of this PR put it in the header and
   `differential-fuzz` caught it — `committed Judy1Tables.c does not match the
   generator output`. The stripped region is now byte-identical to `main`.

   To be precise about the benefit: the `#error` does **not** precede the
   size-class errors, it appears among them. It makes the cause explicit and
   greppable; it does not reduce the error count.

   *Patch discipline:* `libjudy/PATCHES.md` classes the pre-generated table
   files, together with the `src/wrappers/` shims, as php-judy **additions**
   rather than modifications of upstream Judy-1.0.5 — they "carry their own
   provenance headers instead of §2(b) change notices". So this needs no
   LGPL-2.1 §2(b) notice and no ledger row; the change is self-documenting
   in-file. No upstream source is touched.

## Verification

- **Guard logic** — `config.w32` syntax-checked with `node --check`; the branch
  simulated against php-src's own `X64 = TARGET_ARCH != 'x86'`:
  `x64 → proceeds`, `arm64 → proceeds`, `x86 → ERROR`.
- **`#error` fires, and fires first** — simulated 32-bit compile of both table
  files now reports the readable message at line 27, ahead of the size-class
  noise.
- **64-bit unaffected** — both table files still compile clean at
  `-Wall -O2 -DJU_64BIT`.
- **Full suite** — bundled build (`phpize && ./configure && make`), **222/222
  pass**, zero compiler warnings.
- **Real MSVC, one-time proof** — an x86 leg was run on this branch to confirm
  the guard fires on an actual MSVC x86 configure. CI job `95934686125`:

  ```
  ERROR: the bundled libJudy currently supports 64-bit targets only (its
  pre-generated tables assume JU_64BIT); use --with-judy=DIR to link a system
  libJudy instead
  NMAKE : fatal error U1064: MAKEFILE not found and no target specified
  ✗ judy  Failed to build the extension
  ```

  That leg is **not** in this PR — see below.
- **x64 unaffected** — all six Windows legs (8.1–8.6, x64, nts) passed on the
  same run.

### Permanent negative control instead of a red x86 leg

Rather than delete the x86 leg, it is **inverted** into a `guard-32bit` job that
is **green when the guards correctly refuse** — the same pattern the
differential-fuzz control uses (#142 Stage 4), where planting the defect is what
makes the job pass.

A red-when-correct x86 leg reads as a broken board and invites someone to "fix"
it by deleting the guard. And without *any* control, nothing in CI exercises the
guard again and a future refactor could silently drop it — precisely the
`0xffL` drift in #143. What can drift after the one-time MSVC proof is the
guard's own source, and that is what this job pins: deterministically, on a
Linux runner, in seconds, with no MSVC or PHP-SDK dependency to go flaky.

Two steps, each matching the guard's **message** rather than merely a nonzero
exit, so an unrelated breakage cannot masquerade as the guard working:

- `config.w32` is driven through the php-src Windows build API, stubbed, with
  `X64` set as php-src sets it and `ERROR()` throwing in place of
  `confutils.js`'s `WScript.Quit(3)`. x86 must abort with a message still naming
  the cause and the way out; x64 must proceed and still carry `/D JU_64BIT`.
- Both table files must fail to compile with a 4-byte `Word_t` and no
  `JU_64BIT`, **specifically via the `#error` backstop**, and must still compile
  clean at `-Wall -Werror -O2 -DJU_64BIT`.

All 21 other checks pass, including all six Windows x64 legs and the
generator-parity gate.

Mutation-tested — each of these turns the job red with a message naming the
cause:

| Mutation | Result |
| --- | --- |
| Guard deleted from `config.w32` | `expected exactly 1 ERROR() on x86, got 0` |
| `ERROR()` downgraded to `WARNING()` | `expected exactly 1 ERROR() on x86, got 0` |
| Guard message drifted | `ERROR() message drifted; it must still name the cause ...` |
| Tables' `#error` removed | `rejected, but not by the JU_64BIT guard` |
| 64-bit table compile broken | `no longer compiles for a normal 64-bit build` |

The `#error` removal case is the important one: it does **not** pass on the
residual `sizeof(Word_t) == 8` pin, so the control tests the backstop it claims
to test.

`release.yml` YAML validated. `package.xml` needs no change: no files added, and
`config.w32` and both table files are already listed.

## Not in scope

The README / support-statement side is already covered by #158, which adds
"CI builds and tests the **x64** configuration" to the Windows section and "The
bundled build requires a 64-bit target; on a 32-bit platform, use
`--with-judy=DIR`" to the Installation preamble. No edit here, to avoid
conflicting hunks.
