### PR TITLE
perf(bench): three-arm benchmark — PHP array vs system libJudy vs bundled libJudy

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1436,6 +1436,381 @@ read at any size.
 
 ---
 
+## Three-arm benchmark: array vs system libJudy vs bundled libJudy (measured)
+
+Every other measured section on this page answers "is php-judy fast?". This one
+answers the two questions users actually ask before adopting or upgrading:
+
+- **What did the libJudy vendoring work buy me?** — arm **B** against arm **C**.
+- **Should I use php-judy at all instead of a PHP array?** — arm **A** against
+  arm **C**. The honest answer is *sometimes*, and the losing cells are
+  published below alongside the winning ones.
+
+| arm | what it is | why it is here |
+| --- | --- | --- |
+| **A** | PHP native array (`$a[$k]`, `array_*`) | the "why bother" baseline |
+| **B** | php-judy linked against a **system** libJudy (`--with-judy=DIR`) | what PECL plus a distro/Homebrew libJudy gives you today |
+| **C** | php-judy linked against the **bundled** vendored tree (default build) | what you get after the vendoring work |
+
+Runner: [`scripts/bench-threearm.php`](scripts/bench-threearm.php). Raw JSON and
+console output for every run quoted here are committed under
+`research/three-arm-benchmark/results/`.
+
+### What "system libJudy" actually means — it is not one thing
+
+A B-vs-C number is meaningless without saying which library arm B linked,
+because the distros do not ship the same code:
+
+| platform | package | upstream | Baskins `jp_1Index` fix | how it is built |
+| --- | --- | --- | --- | --- |
+| Debian 13 / Ubuntu | `libjudy-dev` 1.0.5-5.1 | Judy 1.0.5 | **applied** — `debian/patches/04_fix_undefined_bahavior_during_aggressive_loop_optimizations.patch`, credited to Doug Baskins (SourceForge patch #5) | shared library, dpkg hardening flags (`-fstack-protector-strong`, `_FORTIFY_SOURCE`, PIE) |
+| Alpine (musl) | `main/judy` 1.0.5-r1 | Judy 1.0.5 | **not applied** — the APKBUILD lists only the upstream tarball, with no patch files and no `prepare()` patching | shared library |
+| macOS Homebrew | `judy` 1.0.5 (bottle) | Judy 1.0.5 | **not applied** — the formula has no `patch` stanza | shared library |
+
+Verified, not assumed: the Debian patch list was read from `apt-get source judy`,
+and the Alpine and Homebrew build recipes from their upstream repositories.
+
+This matters directly. Debian's patch 04 fixes the *same* undefined behaviour
+that the bundled tree fixes as **P1** (`jp_1Index` written past its declared
+width — see [`libjudy/PATCHES.md`](libjudy/PATCHES.md)), by a different edit.
+So **on Debian/Ubuntu, B already has the P1-equivalent correctness fix and the
+B-vs-C delta does not include it. On Alpine and macOS it does.** A Debian
+B-vs-C number is the *conservative* measurement of what vendoring bought.
+
+### What the B-vs-C delta is composed of
+
+B vs C is not "the O-series optimizations in isolation". Holding the extension
+source, compiler and PHP identical still leaves five differences bundled
+together, and all five are part of what a user actually receives:
+
+1. correctness patches **P2-P7** (and **P1** everywhere except Debian/Ubuntu);
+2. **O1** hardware popcount, **O3** word-access node metadata, **O4** string-layer;
+3. pinned vendored CFLAGS `-O2 -fno-lto -fno-unroll-loops -mpopcnt` — note that
+   `-mpopcnt` is what *activates* O1;
+4. **linkage model**: the bundled tree compiles into the extension's own `.so`,
+   so Judy calls are direct; arm B calls through the PLT into a shared object
+   (42 undefined `Judy*` symbols in the arm-B binary confirm this);
+5. the distro's hardening flags, which arm C does not carry.
+
+Both optimizations were confirmed present in C and absent in B at the
+instruction level rather than inferred from the build log:
+
+| | arm C (bundled) | arm B (Debian shared libJudy) |
+| --- | --- | --- |
+| `popcnt` instructions (O1) | **89** | **0** |
+| `bswap` instructions (O3) | **985** | 12 (incidental) |
+
+### Methodology, and the traps it exists to avoid
+
+Each of these rules is here because ignoring it has previously produced a wrong
+published number in this project.
+
+- **Same source, same toolchain, both arms.** Both `.so` files are built from
+  one working tree with one compiler and one PHP, changing only `--with-judy`.
+  Comparing against a distro- or PECL-installed `judy.so` is invalid: a prior
+  GHA comparison did that and its ~9.4% "win" turned out to bundle toolchain
+  provenance differences (FINDINGS §11.10).
+- **Arms interleaved, never sequential.** Timing runs one benchmark group at a
+  time and alternates arm order every round (ABBA). All statistics are computed
+  on per-round *paired ratios*, so machine state during a round divides out.
+  Sequential suites produced a wall of false regressions before (#87).
+- **A vs C is paired inside one process.** `judy-bench.php` measures its
+  PHP-array rows and its Judy rows microseconds apart in the same child, so that
+  ratio carries no between-process drift at all.
+- **Only genuine PHP-array rows count as arm A.** `judy-bench.php` names rows
+  `.judy` and `.php`, but `.php` does not uniformly mean "PHP array" — in
+  `api.batch`, `api.setops` (except the BITSET arms) and all of `adv.iter`, the
+  `.php` closure builds into and iterates over a **Judy instance**. Those rows
+  measure a PHP userland loop against a Judy native method, which is a real but
+  *different* question; they are reported separately and never quoted as "PHP
+  array vs Judy". The same restriction governs the control (below).
+- **Per-residency claim floors, measured in this run rather than assumed.**
+  ~3% cache-resident, ~1.3% out-of-cache (FINDINGS §11.10). A cell claims a
+  direction only when its **whole** bootstrap CI clears the floor; a point
+  estimate past the floor with a straddling CI is reported as null.
+- **Two controls.** (a) a PHP-array-only control, whose rows execute no libJudy
+  instruction, so any B-vs-C movement on them is pure runner drift and is
+  divided back out of every Judy cell; (b) a **C-vs-C rebuild control** — two
+  independently linked builds of identical source, offset so no round compares a
+  binary against itself. Every C-vs-C cell must read null; cells that do not are
+  measuring page/cache layout, not libJudy.
+- **Three independent builds per arm, rotated across rounds.** A cell whose
+  per-build spread exceeds its own delta is demoted to null: that is binary
+  layout, not a library change.
+- **Host hygiene gated at load N/2 *and* on co-tenancy.** Load is sampled before,
+  between and after every phase; over threshold the run self-marks contaminated
+  and every verdict is suppressed.
+
+  **Load average alone is necessary but not sufficient, and this is the single
+  most important thing to know before re-running these numbers.** During the
+  first attempt at this benchmark, a second, unrelated benchmark campaign was
+  running on the same 24-core host. *Both* campaigns individually passed the
+  load < N/2 gate — the box sat at load ~2 of a possible 12 — and both were
+  corrupted anyway. The other campaign's completely untouched baseline arm
+  shifted **2.2x** (69.4 ns/op to 147-172 ns/op on one cell), and its move
+  coincided exactly with this run's container starting. A co-resident
+  memory-bound benchmark contends for last-level cache and memory bandwidth
+  regardless of which cores the scheduler picks, and 30 MB of shared L3 is not
+  partitioned by core affinity.
+
+  Worse, **the PHP-array drift control is structurally blind to this**. It read
+  +0.36% while every Judy cell moved by tens of percent, because PHP array
+  operations are neither pointer-chasing nor DRAM-bound while Judy's descend is
+  both — the contention steals exactly what the Judy arms need and barely
+  touches the control. A flat control is therefore *not* evidence of a quiet
+  host.
+
+  The generalizable rule, and the reason this paragraph is in a benchmark
+  document rather than a commit message: **a drift control must share the
+  memory-access character of the thing it controls, or it cannot see the failure
+  modes that matter.** A control that is cheaper, smaller-working-set, or more
+  cache-friendly than the arms under test will certify a run that contention has
+  already ruined. The PHP-array control here is still the right instrument for
+  detecting *runner* drift — interpreter speed, CPU frequency, process
+  startup — and it is retained for that. It is simply not an instrument for
+  detecting memory-system contention, and it must not be read as one.
+
+  The runner consequently gates on co-tenancy directly. Load snapshots are taken
+  at phase boundaries, when none of the driver's own children are running, so
+  any process above 5% CPU at that instant is by construction somebody else's
+  work; the run self-marks contaminated when foreign CPU exceeds half a core,
+  independent of load average. When re-running, also take the host exclusively —
+  the convention on this project's bench host is a `/var/tmp/BENCH_LOCK` file
+  naming the agent and phases — and pin the workload
+  (`docker run --cpuset-cpus=...` or `taskset`). Pinning does not eliminate
+  LLC/bandwidth contention, but it removes scheduler migration as a variable and
+  makes a collision detectable rather than silent.
+
+### Memory — the headline, and the least equivocal result
+
+Peak RSS of a child process that builds one structure, median of 3 runs, with a
+per-arm empty-process floor subtracted so neither the interpreter nor the loaded
+extension is charged to the data. This is measured with `getrusage()` rather
+than `memory_get_usage()` on purpose: libJudy allocates through `malloc`,
+outside PHP's emalloc heap, so `memory_get_usage()` cannot see most of a Judy
+index and badly understates it. **Claim-grade, Linux x86-64 / gcc 14.2.0 /
+PHP 8.4.24, exclusive pinned host.**
+
+| workload | n | A: PHP array | B: system | C: bundled | **A/C** | B/C |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `int_to_int` (dense) | 100k | 2.8 MB | 960 KB | 1.1 MB | **2.50x** | 0.83x |
+| | 1M | 17.5 MB | 8.4 MB | 8.2 MB | **2.12x** | 1.02x |
+| | 8M | 129.6 MB | 66.0 MB | 66.2 MB | **1.96x** | 1.00x |
+| `int_sparse` (stride 4099) | 100k | 6.9 MB | 1.3 MB | 1.3 MB | **5.29x** | 1.00x |
+| | 1M | 41.1 MB | 12.6 MB | 12.8 MB | **3.22x** | 0.98x |
+| | 8M | 310.6 MB | 99.4 MB | 99.6 MB | **3.12x** | 1.00x |
+| `int_to_mixed` | 100k | 3.6 MB | 3.8 MB | 3.8 MB | **0.95x** | 1.00x |
+| | 1M | 30.4 MB | 38.6 MB | 38.8 MB | **0.78x** | 0.99x |
+| | 8M | 244.3 MB | 310.5 MB | 310.5 MB | **0.79x** | 1.00x |
+| `string_to_int` | 100k | 7.7 MB | 2.2 MB | 2.2 MB | **3.42x** | 1.00x |
+| | 1M | 76.7 MB | 20.4 MB | 20.4 MB | **3.75x** | 1.00x |
+| | 8M | 614.9 MB | 185.4 MB | 185.4 MB | **3.32x** | 1.00x |
+| `bitset` | 100k | 6.9 MB | 192 KB | 384 KB | **18.50x** | 0.50x |
+| | 1M | 41.1 MB | 1.9 MB | 1.9 MB | **21.92x** | 1.00x |
+| | 8M | 310.6 MB | 13.5 MB | 13.7 MB | **22.69x** | 0.99x |
+
+`A/C` above 1.00 means the PHP array uses that many times more memory.
+
+Reading this honestly:
+
+- **`Judy::BITSET` is the strongest case in the library**: 22.7x smaller than a
+  PHP array at 8M, and the advantage *grows* with scale (18.5x -> 22.7x). At 8M
+  the array costs ~40.7 bytes per element and Judy ~1.8.
+- **Sparse integer keys 3.1x, string keys 3.3x, dense integer keys 2.0x.** The
+  dense-integer case is the weakest because PHP's packed-array representation is
+  genuinely good — 17 bytes per element — and Judy's 8.7 only doubles it.
+- **`Judy::INT_TO_MIXED` LOSES, and the loss is stable at 0.78-0.79x from 1M
+  upward.** Storing arbitrary zvals means Judy holds a pointer to a separately
+  allocated zval per element (~40.7 bytes/element) where PHP's hashtable packs
+  them (~32). If your values are not integers, php-judy is not a memory win —
+  use it for the ordering or the API, not the footprint.
+- **B/C is 1.00 nearly everywhere**: the vendoring did **not** change memory.
+  That is expected and is a deliberate check — the O-series patches are
+  instruction-level changes, and `J1MU`/`JLMU` accounting is byte-identical
+  pre/post. The two exceptions are page-granularity artifacts at the smallest
+  size (192 KB vs 384 KB is one page rounding, not a regression).
+
+### Where PHP arrays win: per-element scalar operations
+
+The same run, timing rather than memory. **These are the cells where php-judy
+loses, and they are the majority.** Only rows whose PHP arm is a genuine PHP
+array are included.
+
+| operation | PHP array | php-judy | judy/array | winner |
+| --- | ---: | ---: | ---: | --- |
+| `bitset` write | 3.00 ms | 5.10 ms | 1.70x | PHP array |
+| `int_to_int` write | 3.07 ms | 7.10 ms | 2.31x | PHP array |
+| `string_to_int` write | 11.61 ms | 26.11 ms | 2.25x | PHP array |
+| `int_to_int` read | 1.07 ms | 3.44 ms | 3.21x | PHP array |
+| `string_to_int` read | 2.22 ms | 9.75 ms | 4.39x | PHP array |
+| `int_to_int` iterate | 0.91 ms | 6.04 ms | 6.62x | PHP array |
+| `string_to_int` iterate | 1.38 ms | 13.83 ms | 10.05x | PHP array |
+| `increment` (int keys) | 2.91 ms | 7.19 ms | 2.47x | PHP array |
+| `intersect` (bitset) | 4.60 ms | 4.34 ms | **0.94x** | **php-judy** |
+
+**Across the whole suite the PHP array won 42 of 43 comparable cells**, median
+4.19x, and the single php-judy win (`intersect` on BITSET) is inside the noise
+floor at 0.94x. The cause is not that Judy is a bad data structure — it is that
+every php-judy operation crosses the PHP/C boundary, which costs on the order of
+16 ns, while `$a[$k]` is an engine opcode. At 300k elements that per-call
+overhead dominates anything the C code below it saves.
+
+**So do not adopt php-judy for raw per-element speed.** Adopt it when you need
+one of the things the table above cannot show: a much smaller footprint, keys
+that come out **sorted** without an `ksort()`, bounded range reads, or set
+operations that stay in C.
+
+That last point is where the API earns its place. These rows compare a Judy
+native method against a PHP userland loop over the *same Judy object* — not
+against a PHP array, so they are a different question, but they show what moving
+a whole operation into C is worth:
+
+| operation | PHP loop over Judy | Judy native | ratio |
+| --- | ---: | ---: | ---: |
+| `populationCount()` | 5.86 ms | ~0.00 ms | O(1) vs O(n) |
+| `keys($start, $end)` range read | 7.08 ms | 0.31 ms | **0.04x** |
+| `equals()` | 13.78 ms | 3.26 ms | 0.24x |
+| `sumValues()` | 5.75 ms | 2.30 ms | 0.40x |
+| set `diff` / `xor` (int keys) | 12.75 / 25.55 ms | 5.23 / 10.41 ms | 0.41x |
+
+Ordered iteration deserves its own note, because the comparison above is not
+quite fair to Judy: a PHP array *cannot* iterate in key order at all without
+sorting first. The 6.62x and 10.05x iterate rows compare Judy's ordered walk
+against an array's **insertion-order** walk. If your code needs sorted order,
+the array arm must add a `ksort()` — which this benchmark does not charge it
+for. Read those rows as "the cost of ordering", not as a like-for-like loss.
+
+### B vs C — what the vendoring actually bought, decomposed
+
+**Claim-grade**, Linux x86-64 / gcc 14.2.0 / PHP 8.4.24, 300k elements
+(cache-resident, ~3% floor), 7 interleaved ABBA rounds, 3 independently linked
+builds per arm rotated across rounds, exclusive pinned host.
+
+The delivered difference between "PECL plus your distro's libJudy" and "the
+default bundled build" is **90 cells faster, 0 slower, 4 null**, against a
+PHP-array control reading **+0.00% [-0.12, +0.17]** across 43 rows.
+
+But that number bundles our source patches together with the switch from a
+shared distro library to a static in-extension one. Publishing it as "the
+vendoring speedup" would misattribute it, so a third arm **S** was built to
+split it: pristine Judy 1.0.5 (official tarball, sha256 `d2704089…`), compiled
+**static into the extension with the identical pinned CFLAGS**, verified
+unpatched at the instruction level (0 `popcnt`, 12 `bswap`, against arm C's 89
+and 985). S-vs-C therefore varies *only* the source patches.
+
+| key type | delivered (B→C) | our patches alone (S→C) | share attributable to our patches |
+| --- | ---: | ---: | ---: |
+| integer / bitset | **-17.7%** (n=33) | **-16.5%** (n=32) | **96.5%** |
+| string | **-22.2%** (n=57) | **-11.4%** (n=49) | **39.8%** |
+
+Share is the per-cell median of `ln(S→C) / ln(B→C)` over matched cells. The
+residual — shared-library linkage, Debian's hardening flags, and Debian's own
+patch 04 — is inferred, not measured directly.
+
+**The honest headline is therefore split by key type:**
+
+- **Integer and bitset paths: the gain is genuinely ours.** 96.5% of the -17.7%
+  survives when linkage and flags are held constant. The largest cells are
+  integer API operations — `equals` -28.3%, `fromArray` -25.7%, `putAll` -25.4%,
+  `intersect` -25.0% — consistent with O1 (hardware popcount) and O3 (word-access
+  node metadata) acting on every `JudyL` branch descend.
+- **String paths: users get the full -22.2%, but only about 40% of it is our
+  source changes.** O4's string-layer work is real and measurable (-11.4%), but
+  the majority of the string uplift comes from bundling the library into the
+  extension rather than from the patches.
+
+Why the linkage effect is *not* uniform across key types — offered as a
+hypothesis, not a measurement, since the bench host has no PMU: `JudySL` and
+`JudyHS` are layered on top of `JudyL`, so a single string operation performs
+several `JudyL` calls. In arm B each of those crosses the PLT into a shared
+object; in arms S and C it is a direct call inside the extension's own binary.
+Per-call overhead therefore scales with how many cross-library calls an
+operation makes, and string operations make several times more of them than
+integer operations do. This is falsifiable: a `-fno-plt` or `-Bsymbolic` build
+of the shared arm should close most of the string gap and little of the integer
+one. That test has not been run.
+
+The prediction, the falsifier, and the scoring of this decomposition were
+**pre-registered before the attribution arm was measured** — see
+[`research/three-arm-benchmark/PREREGISTRATION.md`](research/three-arm-benchmark/PREREGISTRATION.md).
+Both of the competing predictions recorded there turned out partly wrong, which
+is the point of writing them down first.
+
+### The control that makes the above believable
+
+Two builds of **identical source**, independently linked, rotated so no round
+ever compares a binary against itself, run through the same suite:
+
+| control | result |
+| --- | --- |
+| C-vs-C rebuild control, 94 cells | **0 faster, 0 slower, 94 null** |
+| PHP-array-only rows, same run | **-0.07% [-0.19, +0.01]** over 43 rows |
+| PHP-array-only rows, phase 1 | **+0.00% [-0.12, +0.17]** over 43 rows |
+| per-build spread, phase 1 faster cells | 0.07% - 2.15% |
+
+Every cell of the rebuild control is null. That is the apparatus demonstrating
+it does not manufacture wins: whatever page and cache layout differ between two
+separately linked binaries of the same code, it does not reach the claim floor.
+A cell whose per-build spread exceeded its own delta would have been demoted to
+null automatically; none in the reported set were.
+
+### Confidence tiers, and what is NOT measured
+
+| platform | toolchain | timing | memory | tier |
+| --- | --- | --- | --- | --- |
+| Linux x86-64, honeycomb | gcc 14.2.0, PHP 8.4.24, Debian 13 | measured | measured | **claim-grade** |
+| macOS arm64 | Apple clang 21, PHP 8.5.8, Homebrew | **not measured** | measured | **directional only** |
+| Alpine / musl x86-64 | gcc, PHP 8.4 | not measured | not measured | **not measured** |
+| Linux x86-64, out-of-cache (>=6M) | gcc 14.2.0 | not measured | measured (8M rows above) | **not measured** |
+| Windows | MSVC | not measured | not measured | **not measured** |
+
+- **macOS arm64 is directional, not claim-grade, and the hole is narrowed rather
+  than closed.** No timing was taken: the host failed the hygiene gate (load 4.22
+  on 8 cores against a threshold of 4, with browser processes above 50% CPU) and
+  was under memory pressure with active compression, which can depress RSS
+  readings. The memory ratios it produced track the Linux ones closely
+  (`bitset` 30.2x vs 22.7x, `int_to_mixed` 0.79x vs 0.79x, `string_to_int` 3.09x
+  vs 3.32x) and its B/C ratios are ~1.00, but they are reported as directional.
+  **Apple clang / arm64 remains this project's acknowledged measurement gap.**
+- **Out-of-cache timing is not measured.** The intended 6M run aborted: arm B
+  terminated with SIGSEGV in the `core.int` group. That is under separate
+  investigation and is deliberately **not** reported as a php-judy-versus-system
+  robustness claim — a single uncharacterized crash is not a result. The 8M rows
+  in the memory table are unaffected, since those run in their own child
+  processes.
+- **Alpine / musl is not measured.** It matters — musl's allocator is not
+  glibc's and Judy is allocation-heavy — and Alpine ships **pristine** 1.0.5, so
+  its B-vs-C would also include P1. Deferred for host scheduling reasons only.
+- **Windows is CI-artifact territory**; no rigorous number is offered.
+
+### Reproducing this
+
+```sh
+# Build BOTH arms from ONE tree with ONE toolchain, changing only --with-judy.
+phpize && ./configure --with-judy=/usr    && make && cp modules/judy.so judy-system.so
+make clean && phpize --clean
+phpize && ./configure --with-judy=bundled && make && cp modules/judy.so judy-bundled.so
+
+php scripts/bench-threearm.php \
+  --system-so judy-system.so --bundled-so judy-bundled.so \
+  --rounds 7 --size 300000 --assert-same-source \
+  --system-provenance "$(. /etc/os-release; echo "$PRETTY_NAME") $(dpkg-query -W -f='${Version}' libjudy-dev 2>/dev/null)" \
+  --out bench-threearm.json
+```
+
+Pass `--system-so` / `--bundled-so` more than once to rotate independent builds.
+Passing two *bundled* builds turns the run into the C-vs-C rebuild control.
+`--skip-timing` runs only the memory matrix, which is what makes a contended
+host still useful. Raw JSON and console output for every run quoted above are
+committed under `research/three-arm-benchmark/results/`.
+
+**Before trusting a re-run**: take the host exclusively, pin the workload, and
+read the `hygiene` block in the JSON. A run that self-marks `contaminated`
+asserts nothing, and — as the co-tenancy note above explains — a flat PHP-array
+control is not by itself evidence that the host was quiet.
+
+---
+
 ## Running the Benchmarks
 
 ### **Quick Benchmarks**

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1772,12 +1772,25 @@ null automatically; none in the reported set were.
   (`bitset` 30.2x vs 22.7x, `int_to_mixed` 0.79x vs 0.79x, `string_to_int` 3.09x
   vs 3.32x) and its B/C ratios are ~1.00, but they are reported as directional.
   **Apple clang / arm64 remains this project's acknowledged measurement gap.**
-- **Out-of-cache timing is not measured.** The intended 6M run aborted: arm B
-  terminated with SIGSEGV in the `core.int` group. That is under separate
-  investigation and is deliberately **not** reported as a php-judy-versus-system
-  robustness claim — a single uncharacterized crash is not a result. The 8M rows
-  in the memory table are unaffected, since those run in their own child
-  processes.
+- **Out-of-cache timing is not measured, and the reason is a memory-safety
+  signal that is still open.** The intended 6M run aborted when arm B terminated
+  with SIGSEGV in the `core.int` group. Triage so far:
+
+  | check | result |
+  | --- | --- |
+  | macOS arm64, plain 6M `INT_TO_INT` insert loop, both arms | clean, no fault, identical `memoryUsage()` |
+  | linux/amd64, `judy-bench.php --group core.int --size 3000000`, arm **B** | `zend_mm_heap corrupted` |
+  | linux/amd64, same cell, arm **C** (bundled) | `zend_mm_heap corrupted` |
+
+  **Both arms corrupt the heap**, so this is explicitly **not** a
+  bundled-versus-system robustness claim, and nothing in this section should be
+  read as one. A simple large insert loop is clean, so it is specific to what the
+  `core.int` group does at scale. Whether the fault lies in the extension, in the
+  benchmark script, or in libJudy below both is **not yet established**, and it is
+  being tracked as its own correctness investigation rather than resolved here —
+  a memory-safety bug is not a benchmark footnote. The 8M rows in the memory
+  table are unaffected: those run in their own child processes and complete
+  cleanly.
 - **Alpine / musl is not measured.** It matters — musl's allocator is not
   glibc's and Judy is allocation-heavy — and Alpine ships **pristine** 1.0.5, so
   its B-vs-C would also include P1. Deferred for host scheduling reasons only.

--- a/package.xml
+++ b/package.xml
@@ -408,6 +408,7 @@
          <file name="API.md" role="doc" />
          <file name="scripts/api-metadata.php" role="doc" />
          <file name="scripts/bench-compare.php" role="doc" />
+         <file name="scripts/bench-threearm.php" role="doc" />
          <file name="scripts/generate-api-docs.php" role="doc" />
          <file name="scripts/judy_debug_common.py" role="doc" />
          <file name="scripts/judy_gdb.py" role="doc" />

--- a/research/three-arm-benchmark/PREREGISTRATION.md
+++ b/research/three-arm-benchmark/PREREGISTRATION.md
@@ -96,4 +96,64 @@ as "the vendoring speedup" without this decomposition printed beside it.
 
 ## Result
 
-*(To be filled in after `run5-attribution.json` exists. Prediction above is frozen.)*
+Measured 2026-08-19, `run5-attribution.json`, exclusive pinned host, hygiene
+clean (`failed=false`, `foreign_tenant=false`), php-only control
+`-0.08% [-0.21, +0.05]` over 43 rows, 81 FASTER / 0 SLOWER / 13 null. Arm S
+verified unpatched at the instruction level (popcnt=0, bswap=12) against arm C
+(popcnt=89, bswap=985).
+
+| family | S-vs-C (patches only) | B-vs-C (full delivered) | patch share of the gain |
+| --- | --- | --- | --- |
+| int/bitset-keyed | **-16.54%** (n=32) | -17.66% (n=33) | **96.5%** |
+| string-keyed | **-11.36%** (n=49) | -22.16% (n=57) | **39.8%** |
+
+Patch share is the per-cell median of `ln(S-vs-C ratio) / ln(B-vs-C ratio)` over
+matched cells. B-vs-S is not measured directly; it is the residual, and is
+described as such.
+
+### Scoring — this was a split decision, and both predictions lost something
+
+**On integer paths I was right and the coordinator was wrong.** Our source
+patches explain **96.5%** of the delivered integer-path gain. Linkage and
+hardening flags contribute roughly one percentage point of the -17.66%. The
+prediction that S-vs-C would be "small, plausibly single-digit" is falsified for
+this family: -16.54% is neither small nor single-digit, and the largest S-vs-C
+cells are exactly the integer API operations (`api.equals.int_to_int` -28.3%,
+`api.fromArray.int_to_int` -25.7%, `api.putAll.int_to_int` -25.4%).
+
+**On string paths the coordinator's concern was justified and my prediction
+failed.** I predicted S-vs-C would carry more than half the effect in BOTH
+families. It carries only **39.8%** on strings — the majority of the string
+uplift is NOT our source patches. My string threshold (">=10%") was met at
+-11.36%, so O4 and the JudyL-layer effect are real and measurable, but they are
+not the main story there. Had this been published as "vendoring made string
+operations 22% faster because of our patches", it would have been wrong by
+roughly a factor of two.
+
+**Both of us were wrong about the shape of the linkage effect.** I predicted it
+would be "under 10% and roughly key-type-agnostic"; the coordinator implicitly
+predicted the same uniformity. It is strongly key-type-**specific**: about one
+point on integer paths versus roughly eleven on string paths.
+
+The most plausible mechanism for that asymmetry — offered as a hypothesis, not a
+measurement, since the host has no PMU — is call frequency. `JudySL` and
+`JudyHS` are layered *on top of* `JudyL`: one string operation performs several
+`JudyL` calls, each an exported-symbol call that in arm B crosses the PLT into a
+shared object, whereas in arms S and C it is a direct call inside the
+extension's own binary. PLT and hardening overhead therefore scale with the
+number of cross-library calls per PHP-level operation, and string operations
+make several times more of them than integer operations do. This predicts the
+observed asymmetry and is falsifiable: a `-fno-plt` or `-Bsymbolic` build of the
+shared arm should close most of the string gap and little of the integer one.
+
+### Consequence for BENCHMARK.md
+
+The headline is split by key type rather than stated once:
+
+- **Integer/bitset paths**: the gain is genuinely ours (96.5% attributable to
+  the vendored patches).
+- **String paths**: the delivered gain is real and users get all of it, but only
+  about 40% is attributable to our source changes; the rest comes from bundling
+  the library into the extension instead of linking a distro shared object.
+
+Both numbers are published, with the decomposition beside them.

--- a/research/three-arm-benchmark/PREREGISTRATION.md
+++ b/research/three-arm-benchmark/PREREGISTRATION.md
@@ -1,0 +1,99 @@
+# Pre-registration — B-vs-C decomposition (three-arm benchmark)
+
+**Status**: frozen point-in-time record, written BEFORE the attribution arm was
+measured. One-per-gate. Do not edit the prediction after the fact; record the
+outcome in the "Result" section at the bottom instead.
+
+**Written**: 2026-08-19, after phase 1 (cache-resident + memory) and phase 2
+(C-vs-C control) completed and were read, and after phases 3 and 4 **failed**
+(`PHASE3 rc=1`, `PHASE4 rc=2`) producing no attribution JSON. No pristine-static
+(arm S) result had been produced or observed at the time of writing. Verifiable
+by the git commit timestamp of this file relative to the commit adding
+`run5-attribution.json`.
+
+## What is being decomposed
+
+Phase 1 measured, claim-grade on an exclusive pinned host (Linux x86-64,
+gcc 14.2.0, PHP 8.4.24, control `+0.00% [-0.12, +0.17]` over 43 rows):
+
+| family | n | median B-vs-C | range |
+| --- | --- | --- | --- |
+| int/bitset-keyed | 33 | **-17.66%** | -30.54 .. -5.07 |
+| string-keyed | 57 | **-22.16%** | -45.38 .. -3.65 |
+
+90 cells FASTER, 0 SLOWER, 4 null.
+
+B-vs-C bundles five differences at once. Arm **S** (pristine Judy-1.0.5, sha256
+`d2704089…` verified identical to the official tarball, compiled static into the
+extension with the *identical* pinned vendor CFLAGS, verified POPCNT=0 /
+BSWAP=12) splits them:
+
+- **S vs C** = our source patches ONLY (P1-P7, O1, O3, O4), linkage and flags held constant.
+- **B vs S** = shared-library linkage + Debian hardening flags + Debian patch 04.
+
+## The coordinator's prediction (recorded verbatim in substance)
+
+S-vs-C will be **small — plausibly single-digit and concentrated in int-keyed
+cells** — while B-vs-S carries the bulk of the -17.7%/-22.2%. Rationale: O1 has
+zero popcount duty cycle on string corpora and O3 measured <=1.2% on
+string-shaped keys, so our source optimizations predict roughly null on string
+paths; a uniform uplift that is flat-or-larger where the optimizations cannot
+act is the fingerprint of a build/linkage effect (the same signature the
+adversarial panel used to demolish the GHA "corroboration", FINDINGS §11.10).
+
+## My prediction — I expect this to be substantially WRONG, and here is why
+
+I agree completely with the *discipline* (decompose before publishing) and with
+the *risk* (a key-type-agnostic uplift is the classic linkage fingerprint). I do
+**not** agree with the specific quantitative prediction, and I am recording my
+disagreement now so that it is falsifiable rather than retrofitted.
+
+I predict **S-vs-C will be large and will carry most of the string gains**, for
+two reasons the "null on strings" argument does not cover:
+
+1. **O4 is itself a string-layer optimization, and the biggest phase-1 cells are
+   exactly its targets.** O4a deletes a full `strlen` pass per `JudySLNext` —
+   i.e. per element of an ordered string walk. O4d deletes an entire
+   `JUDYHASHSTR` pass plus two JudyL descents per `JudyHSDel`. The largest
+   phase-1 movers are `core.string_to_int.free` (-43.7%),
+   `core.string_to_*.iter` (-32 .. -36%) and `api.range.size.string_to_int`
+   (-45.4%). These are algorithmic removals of O(len) work per operation, not
+   micro-optimizations, and they act *only* on string paths.
+
+2. **O1/O3 are not actually inert on this benchmark's string keys.** JudySL and
+   JudyHS are built *on top of* JudyL arrays keyed by word-sized chunks of the
+   string, so every string lookup performs several JudyL descents — and JudyL
+   descends are precisely what O3 (`JU_JPDCDPOP0` word access, every branch
+   descend) and O1 (popcount on bitmap leaves) accelerate. The C-level gate
+   measured "null on strings" against the **`urand16` high-entropy** corpus,
+   where the underlying JudyL arrays are sparse and hit linear leaves.
+   `judy-bench.php` uses **low-entropy structured keys** (`key:0`, `key:1`, …),
+   whose chunked words are dense and clustered — a materially higher popcount
+   and branch duty cycle. Transferring a null result from `urand16` to these
+   keys is a corpus-shape extrapolation, not a measurement.
+
+**Quantitative pre-registration** (medians, cache-resident, 300k, core.int + core.str):
+
+- S-vs-C int/bitset-keyed median: **at least 8% faster** (I expect ~10-18%).
+- S-vs-C string-keyed median: **at least 10% faster** (I expect ~15-22%).
+- B-vs-S median, either family: **under 10%**, and roughly key-type-agnostic.
+- S-vs-C will account for **more than half** the phase-1 B-vs-C effect
+  (in log-ratio terms) in BOTH families.
+
+**What would falsify me / confirm the coordinator**: B-vs-S carrying more than
+half the effect in both families, or S-vs-C string median inside the ~3% floor.
+If that happens, the coordinator is right, the headline must be reattributed to
+linkage, and my reasoning above is wrong — most likely because the PLT and
+hardening overhead per Judy call is far larger than I estimate.
+
+**What would falsify the coordinator**: S-vs-C carrying the majority in both
+families, in which case the string gains are genuinely ours (O4 plus O1/O3
+acting through the JudyL layer beneath JudySL/JudyHS) and the "null on strings"
+expectation was a corpus-shape artifact of `urand16`.
+
+**Either way**: the unattributed -17.7% / -22.2% will NOT appear in BENCHMARK.md
+as "the vendoring speedup" without this decomposition printed beside it.
+
+## Result
+
+*(To be filled in after `run5-attribution.json` exists. Prediction above is frozen.)*

--- a/research/three-arm-benchmark/results/heap-corruption-triage.txt
+++ b/research/three-arm-benchmark/results/heap-corruption-triage.txt
@@ -1,0 +1,20 @@
+# Heap-corruption triage (surfaced by, not caused by, the three-arm benchmark)
+
+Both arms, both sizes. NOT a bundled-vs-system difference.
+
+## linux/amd64 (Docker), judy-bench.php --group core.int --iterations 1
+arm=B n=3000000  rc=0        PHP array                     156.09         91.70         75.39         30.00       64.0 MB zend_mm_heap corrupted 
+arm=B n=6000000  rc=0        PHP array                     430.23        187.85        141.98         58.76      128.0 MB zend_mm_heap corrupted 
+arm=C n=3000000  rc=0        PHP array                     151.92         90.83         77.12         29.12       64.0 MB zend_mm_heap corrupted 
+arm=C n=6000000  rc=0        PHP array                     367.46        195.77        140.10         73.84      128.0 MB zend_mm_heap corrupted 
+
+## macOS arm64, minimal 6M INT_TO_INT insert loop (control: clean)
+  n=1000000 arm=B rc=0 count=1000000 mem=8323832
+  n=1000000 arm=C rc=0 count=1000000 mem=8323832
+  n=6000000 arm=B rc=0 count=6000000 mem=49885112
+  n=6000000 arm=C rc=0 count=6000000 mem=49885112
+  n=6000000 arm=B rc=0 (memory_limit=2G) count=6000000 mem=49885112
+  n=6000000 arm=C rc=0 (memory_limit=2G) count=6000000 mem=49885112
+
+## honeycomb native x86-64
+  arm=B n=6000000 judy-bench core.int -> SIGSEGV (status 139)

--- a/research/three-arm-benchmark/results/mac-memory.json
+++ b/research/three-arm-benchmark/results/mac-memory.json
@@ -1,0 +1,924 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "macos-arm64-appleclang21-php8.5-MEMORY-ONLY",
+        "date": "2026-08-19T02:09:26+00:00",
+        "php_version": "8.5.8",
+        "platform": "Darwin arm64",
+        "uname": "Darwin NicolasMBP.local 25.4.0 Darwin Kernel Version 25.4.0: Thu Mar 19 19:32:36 PDT 2026; root:xnu-12377.101.15~1/RELEASE_ARM64_T8103 arm64",
+        "judy_version": "2.5.2",
+        "system_so": [
+            "/private/tmp/claude-501/-Users-nicolas-Documents-git-orieg-php-judy--claude-worktrees-quizzical-grothendieck-3fa8aa/06f561e1-3f48-402b-9b8d-e74604df5c75/scratchpad/mac/builds/judy-B-.so"
+        ],
+        "bundled_so": [
+            "/private/tmp/claude-501/-Users-nicolas-Documents-git-orieg-php-judy--claude-worktrees-quizzical-grothendieck-3fa8aa/06f561e1-3f48-402b-9b8d-e74604df5c75/scratchpad/mac/builds/judy-C-.so"
+        ],
+        "system_so_sha256": [
+            "87dff601b0da0f1988f19daa7d3913ca5038e01b698d0c9196de591c72eb62a3"
+        ],
+        "bundled_so_sha256": [
+            "1f57bc069035e7c94d29ca890bc6399cfdde6baec00ef31c0205e938a2a92f91"
+        ],
+        "system_provenance": "Homebrew judy 1.0.5 (bottle) \u2014 PRISTINE upstream tarball, formula carries no patch stanza",
+        "bundled_provenance": "bundled libjudy/ (vendored Judy-1.0.5 + P1-P7, O1, O3, O4)",
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 300000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            100000,
+            1000000,
+            8000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "cache-resident",
+        "claim_floor_pct": 3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 0,
+        "memory_children": 144,
+        "wall_seconds": 44.5
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T02:08:42+00:00",
+                "load1": 4.22,
+                "cpus": 8,
+                "threshold": 4,
+                "over": true,
+                "heavy": [
+                    {
+                        "cpu_pct": 156.4,
+                        "rss_kb": 14720,
+                        "cmd": "bfs"
+                    },
+                    {
+                        "cpu_pct": 71.1,
+                        "rss_kb": 370000,
+                        "cmd": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+                    },
+                    {
+                        "cpu_pct": 65.1,
+                        "rss_kb": 150480,
+                        "cmd": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)"
+                    },
+                    {
+                        "cpu_pct": 44.8,
+                        "rss_kb": 37040,
+                        "cmd": "/System/Library/PrivateFrameworks/XprotectFramework.framework/Versions/A/XPCServices/XprotectService.xpc/Contents/MacOS/XprotectService"
+                    },
+                    {
+                        "cpu_pct": 18.1,
+                        "rss_kb": 298384,
+                        "cmd": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)"
+                    }
+                ]
+            },
+            {
+                "phase": "after-memory",
+                "at": "2026-08-19T02:09:26+00:00",
+                "load1": 4.11,
+                "cpus": 8,
+                "threshold": 4,
+                "over": true,
+                "heavy": [
+                    {
+                        "cpu_pct": 74.3,
+                        "rss_kb": 308096,
+                        "cmd": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)"
+                    },
+                    {
+                        "cpu_pct": 41.2,
+                        "rss_kb": 171536,
+                        "cmd": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)"
+                    },
+                    {
+                        "cpu_pct": 36.7,
+                        "rss_kb": 377360,
+                        "cmd": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+                    },
+                    {
+                        "cpu_pct": 11.8,
+                        "rss_kb": 205168,
+                        "cmd": "agy"
+                    },
+                    {
+                        "cpu_pct": 8.4,
+                        "rss_kb": 189344,
+                        "cmd": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)"
+                    }
+                ]
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T02:09:26+00:00",
+                "load1": 4.11,
+                "cpus": 8,
+                "threshold": 4,
+                "over": true,
+                "heavy": [
+                    {
+                        "cpu_pct": 53.3,
+                        "rss_kb": 309456,
+                        "cmd": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)"
+                    },
+                    {
+                        "cpu_pct": 49.2,
+                        "rss_kb": 172112,
+                        "cmd": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)"
+                    },
+                    {
+                        "cpu_pct": 43.5,
+                        "rss_kb": 381536,
+                        "cmd": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+                    },
+                    {
+                        "cpu_pct": 10.6,
+                        "rss_kb": 205168,
+                        "cmd": "agy"
+                    },
+                    {
+                        "cpu_pct": 10.2,
+                        "rss_kb": 189344,
+                        "cmd": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)"
+                    }
+                ]
+            }
+        ],
+        "failed": true,
+        "contaminated": true
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 1,
+            "delta_pct": 0,
+            "ci_delta_pct": [
+                0,
+                0
+            ],
+            "measured_spread_pct": 0,
+            "row_count": 0,
+            "rows": []
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 0,
+        "slower": 0,
+        "null": 0
+    },
+    "a_counts": {
+        "php-judy": 0,
+        "php-array": 0,
+        "parity": 0
+    },
+    "bundled_vs_system": [],
+    "array_vs_bundled": [],
+    "judy_vs_phploop": [],
+    "memory": [
+        {
+            "workload": "int_to_int",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 30015488,
+                    "peak_rss_ci": [
+                        29999104,
+                        30195712
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 2113616,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 3129344,
+                    "bytes_per_element": 31.29
+                },
+                "B": {
+                    "peak_rss_bytes": 28033024,
+                    "peak_rss_ci": [
+                        28033024,
+                        28098560
+                    ],
+                    "index_bytes": 841464,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 966656,
+                    "bytes_per_element": 9.67
+                },
+                "C": {
+                    "peak_rss_bytes": 28164096,
+                    "peak_rss_ci": [
+                        28000256,
+                        28180480
+                    ],
+                    "index_bytes": 841464,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 1146880,
+                    "bytes_per_element": 11.47
+                }
+            },
+            "array_over_bundled": 2.729,
+            "system_over_bundled": 0.843
+        },
+        {
+            "workload": "int_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 44548096,
+                    "peak_rss_ci": [
+                        44400640,
+                        44548096
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 16793680,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 17661952,
+                    "bytes_per_element": 17.66
+                },
+                "B": {
+                    "peak_rss_bytes": 35651584,
+                    "peak_rss_ci": [
+                        35553280,
+                        35667968
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 8585216,
+                    "bytes_per_element": 8.59
+                },
+                "C": {
+                    "peak_rss_bytes": 35635200,
+                    "peak_rss_ci": [
+                        35602432,
+                        35651584
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 8617984,
+                    "bytes_per_element": 8.62
+                }
+            },
+            "array_over_bundled": 2.049,
+            "system_over_bundled": 0.996
+        },
+        {
+            "workload": "int_to_int",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 156516352,
+                    "peak_rss_ci": [
+                        156467200,
+                        156516352
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 134234192,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 129630208,
+                    "bytes_per_element": 16.2
+                },
+                "B": {
+                    "peak_rss_bytes": 94060544,
+                    "peak_rss_ci": [
+                        93995008,
+                        94191616
+                    ],
+                    "index_bytes": 66512056,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 66994176,
+                    "bytes_per_element": 8.37
+                },
+                "C": {
+                    "peak_rss_bytes": 94093312,
+                    "peak_rss_ci": [
+                        94060544,
+                        94109696
+                    ],
+                    "index_bytes": 66512056,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 67076096,
+                    "bytes_per_element": 8.38
+                }
+            },
+            "array_over_bundled": 1.933,
+            "system_over_bundled": 0.999
+        },
+        {
+            "workload": "int_sparse",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 34095104,
+                    "peak_rss_ci": [
+                        34078720,
+                        34242560
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 5242960,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 7208960,
+                    "bytes_per_element": 72.09
+                },
+                "B": {
+                    "peak_rss_bytes": 28622848,
+                    "peak_rss_ci": [
+                        28622848,
+                        28639232
+                    ],
+                    "index_bytes": 1261504,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 1556480,
+                    "bytes_per_element": 15.56
+                },
+                "C": {
+                    "peak_rss_bytes": 28557312,
+                    "peak_rss_ci": [
+                        28557312,
+                        28688384
+                    ],
+                    "index_bytes": 1261504,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 1540096,
+                    "bytes_per_element": 15.4
+                }
+            },
+            "array_over_bundled": 4.681,
+            "system_over_bundled": 1.011
+        },
+        {
+            "workload": "int_sparse",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 69926912,
+                    "peak_rss_ci": [
+                        69894144,
+                        69976064
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43040768,
+                    "bytes_per_element": 43.04
+                },
+                "B": {
+                    "peak_rss_bytes": 40419328,
+                    "peak_rss_ci": [
+                        40386560,
+                        40435712
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13352960,
+                    "bytes_per_element": 13.35
+                },
+                "C": {
+                    "peak_rss_bytes": 40370176,
+                    "peak_rss_ci": [
+                        40337408,
+                        40435712
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13352960,
+                    "bytes_per_element": 13.35
+                }
+            },
+            "array_over_bundled": 3.223,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "int_sparse",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 352632832,
+                    "peak_rss_ci": [
+                        352550912,
+                        352649216
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 335544400,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 325746688,
+                    "bytes_per_element": 40.72
+                },
+                "B": {
+                    "peak_rss_bytes": 132235264,
+                    "peak_rss_ci": [
+                        132202496,
+                        132251648
+                    ],
+                    "index_bytes": 100116064,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 105168896,
+                    "bytes_per_element": 13.15
+                },
+                "C": {
+                    "peak_rss_bytes": 132202496,
+                    "peak_rss_ci": [
+                        132202496,
+                        132333568
+                    ],
+                    "index_bytes": 100116064,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 105185280,
+                    "bytes_per_element": 13.15
+                }
+            },
+            "array_over_bundled": 3.097,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "int_to_mixed",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 30490624,
+                    "peak_rss_ci": [
+                        30474240,
+                        30507008
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 3713456,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 3604480,
+                    "bytes_per_element": 36.04
+                },
+                "B": {
+                    "peak_rss_bytes": 30998528,
+                    "peak_rss_ci": [
+                        30932992,
+                        31064064
+                    ],
+                    "index_bytes": 841464,
+                    "php_heap_bytes": 3200000,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 3932160,
+                    "bytes_per_element": 39.32
+                },
+                "C": {
+                    "peak_rss_bytes": 31014912,
+                    "peak_rss_ci": [
+                        30834688,
+                        31014912
+                    ],
+                    "index_bytes": 841464,
+                    "php_heap_bytes": 3200000,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 3997696,
+                    "bytes_per_element": 39.98
+                }
+            },
+            "array_over_bundled": 0.902,
+            "system_over_bundled": 0.984
+        },
+        {
+            "workload": "int_to_mixed",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 58736640,
+                    "peak_rss_ci": [
+                        58687488,
+                        58785792
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 32793520,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 31850496,
+                    "bytes_per_element": 31.85
+                },
+                "B": {
+                    "peak_rss_bytes": 67534848,
+                    "peak_rss_ci": [
+                        67469312,
+                        67567616
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 32000000,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 40468480,
+                    "bytes_per_element": 40.47
+                },
+                "C": {
+                    "peak_rss_bytes": 67469312,
+                    "peak_rss_ci": [
+                        67469312,
+                        67502080
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 32000000,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 40452096,
+                    "bytes_per_element": 40.45
+                }
+            },
+            "array_over_bundled": 0.787,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "int_to_mixed",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 282935296,
+                    "peak_rss_ci": [
+                        282902528,
+                        282984448
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 262234032,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 256049152,
+                    "bytes_per_element": 32.01
+                },
+                "B": {
+                    "peak_rss_bytes": 350224384,
+                    "peak_rss_ci": [
+                        350208000,
+                        350273536
+                    ],
+                    "index_bytes": 66512056,
+                    "php_heap_bytes": 256000000,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 323158016,
+                    "bytes_per_element": 40.39
+                },
+                "C": {
+                    "peak_rss_bytes": 350322688,
+                    "peak_rss_ci": [
+                        350257152,
+                        350371840
+                    ],
+                    "index_bytes": 66512056,
+                    "php_heap_bytes": 256000000,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 323305472,
+                    "bytes_per_element": 40.41
+                }
+            },
+            "array_over_bundled": 0.792,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "string_to_int",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 34897920,
+                    "peak_rss_ci": [
+                        34897920,
+                        35012608
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 9234960,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 8011776,
+                    "bytes_per_element": 80.12
+                },
+                "B": {
+                    "peak_rss_bytes": 29442048,
+                    "peak_rss_ci": [
+                        29409280,
+                        29474816
+                    ],
+                    "index_bytes": 1788890,
+                    "php_heap_bytes": 65696,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 2375680,
+                    "bytes_per_element": 23.76
+                },
+                "C": {
+                    "peak_rss_bytes": 29376512,
+                    "peak_rss_ci": [
+                        29360128,
+                        29425664
+                    ],
+                    "index_bytes": 1788890,
+                    "php_heap_bytes": 65696,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 2359296,
+                    "bytes_per_element": 23.59
+                }
+            },
+            "array_over_bundled": 3.396,
+            "system_over_bundled": 1.007
+        },
+        {
+            "workload": "string_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 107298816,
+                    "peak_rss_ci": [
+                        107216896,
+                        107364352
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 81935120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 80412672,
+                    "bytes_per_element": 80.41
+                },
+                "B": {
+                    "peak_rss_bytes": 48922624,
+                    "peak_rss_ci": [
+                        48742400,
+                        48988160
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21856256,
+                    "bytes_per_element": 21.86
+                },
+                "C": {
+                    "peak_rss_bytes": 50593792,
+                    "peak_rss_ci": [
+                        50495488,
+                        50659328
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 23576576,
+                    "bytes_per_element": 23.58
+                }
+            },
+            "array_over_bundled": 3.411,
+            "system_over_bundled": 0.927
+        },
+        {
+            "workload": "string_to_int",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 671645696,
+                    "peak_rss_ci": [
+                        671629312,
+                        671678464
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 655536400,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 644759552,
+                    "bytes_per_element": 80.59
+                },
+                "B": {
+                    "peak_rss_bytes": 235487232,
+                    "peak_rss_ci": [
+                        235470848,
+                        235601920
+                    ],
+                    "index_bytes": 158888890,
+                    "php_heap_bytes": 65696,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 208420864,
+                    "bytes_per_element": 26.05
+                },
+                "C": {
+                    "peak_rss_bytes": 235405312,
+                    "peak_rss_ci": [
+                        235274240,
+                        235405312
+                    ],
+                    "index_bytes": 158888890,
+                    "php_heap_bytes": 65696,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 208388096,
+                    "bytes_per_element": 26.05
+                }
+            },
+            "array_over_bundled": 3.094,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "bitset",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 34144256,
+                    "peak_rss_ci": [
+                        34111488,
+                        34177024
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 5242960,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 7258112,
+                    "bytes_per_element": 72.58
+                },
+                "B": {
+                    "peak_rss_bytes": 27394048,
+                    "peak_rss_ci": [
+                        27377664,
+                        27410432
+                    ],
+                    "index_bytes": 140784,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 327680,
+                    "bytes_per_element": 3.28
+                },
+                "C": {
+                    "peak_rss_bytes": 27361280,
+                    "peak_rss_ci": [
+                        27262976,
+                        27426816
+                    ],
+                    "index_bytes": 140784,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 344064,
+                    "bytes_per_element": 3.44
+                }
+            },
+            "array_over_bundled": 21.095,
+            "system_over_bundled": 0.952
+        },
+        {
+            "workload": "bitset",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 69894144,
+                    "peak_rss_ci": [
+                        69779456,
+                        69926912
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43008000,
+                    "bytes_per_element": 43.01
+                },
+                "B": {
+                    "peak_rss_bytes": 28622848,
+                    "peak_rss_ci": [
+                        28573696,
+                        28639232
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1556480,
+                    "bytes_per_element": 1.56
+                },
+                "C": {
+                    "peak_rss_bytes": 28524544,
+                    "peak_rss_ci": [
+                        28442624,
+                        28606464
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1507328,
+                    "bytes_per_element": 1.51
+                }
+            },
+            "array_over_bundled": 28.533,
+            "system_over_bundled": 1.033
+        },
+        {
+            "workload": "bitset",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 352665600,
+                    "peak_rss_ci": [
+                        352600064,
+                        352681984
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 335544400,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 325779456,
+                    "bytes_per_element": 40.72
+                },
+                "B": {
+                    "peak_rss_bytes": 37863424,
+                    "peak_rss_ci": [
+                        37748736,
+                        37879808
+                    ],
+                    "index_bytes": 10526704,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 10797056,
+                    "bytes_per_element": 1.35
+                },
+                "C": {
+                    "peak_rss_bytes": 37797888,
+                    "peak_rss_ci": [
+                        37748736,
+                        37814272
+                    ],
+                    "index_bytes": 10526704,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 10780672,
+                    "bytes_per_element": 1.35
+                }
+            },
+            "array_over_bundled": 30.219,
+            "system_over_bundled": 1.002
+        }
+    ],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "/var/folders/ht/8ys5k1fx16d978vsb3m0snrc0000gn/T/judy-bench-threearm-60398/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "/var/folders/ht/8ys5k1fx16d978vsb3m0snrc0000gn/T/judy-bench-threearm-60398/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/mac-memory.txt
+++ b/research/three-arm-benchmark/results/mac-memory.txt
@@ -1,0 +1,75 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /private/tmp/claude-501/-Users-nicolas-Documents-git-orieg-php-judy--claude-worktrees-quizzical-grothendieck-3fa8aa/06f561e1-3f48-402b-9b8d-e74604df5c75/scratchpad/mac/builds/judy-B-.so
+  C  php-judy + bundled libJudy : /private/tmp/claude-501/-Users-nicolas-Documents-git-orieg-php-judy--claude-worktrees-quizzical-grothendieck-3fa8aa/06f561e1-3f48-402b-9b8d-e74604df5c75/scratchpad/mac/builds/judy-C-.so
+  memory int_to_int     n=100000    A=3.0 MB     B=944.0 KB   C=1.1 MB      A/C=2.73x
+  memory int_to_int     n=1000000   A=16.8 MB    B=8.2 MB     C=8.2 MB      A/C=2.05x
+  memory int_to_int     n=8000000   A=123.6 MB   B=63.9 MB    C=64.0 MB     A/C=1.93x
+  memory int_sparse     n=100000    A=6.9 MB     B=1.5 MB     C=1.5 MB      A/C=4.68x
+  memory int_sparse     n=1000000   A=41.0 MB    B=12.7 MB    C=12.7 MB     A/C=3.22x
+  memory int_sparse     n=8000000   A=310.7 MB   B=100.3 MB   C=100.3 MB    A/C=3.10x
+  memory int_to_mixed   n=100000    A=3.4 MB     B=3.8 MB     C=3.8 MB      A/C=0.90x
+  memory int_to_mixed   n=1000000   A=30.4 MB    B=38.6 MB    C=38.6 MB     A/C=0.79x
+  memory int_to_mixed   n=8000000   A=244.2 MB   B=308.2 MB   C=308.3 MB    A/C=0.79x
+  memory string_to_int  n=100000    A=7.6 MB     B=2.3 MB     C=2.2 MB      A/C=3.40x
+  memory string_to_int  n=1000000   A=76.7 MB    B=20.8 MB    C=22.5 MB     A/C=3.41x
+  memory string_to_int  n=8000000   A=614.9 MB   B=198.8 MB   C=198.7 MB    A/C=3.09x
+  memory bitset         n=100000    A=6.9 MB     B=320.0 KB   C=336.0 KB    A/C=21.09x
+  memory bitset         n=1000000   A=41.0 MB    B=1.5 MB     C=1.4 MB      A/C=28.53x
+  memory bitset         n=8000000   A=310.7 MB   B=10.3 MB    C=10.3 MB     A/C=30.22x
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — macos-arm64-appleclang21-php8.5-MEMORY-ONLY
+------------------------------------------------------------------------------------------------
+  PHP 8.5.8, Darwin arm64
+  arm B system libJudy : Homebrew judy 1.0.5 (bottle) — PRISTINE upstream tarball, formula carries no patch stanza
+  arm C bundled libJudy: bundled libjudy/ (vendored Judy-1.0.5 + P1-P7, O1, O3, O4)
+  size 300000 (cache-resident), 7 rounds, 3 iterations, floor 3.0%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=4.22   cpus=8 threshold=4.0 *** OVER THRESHOLD ***
+      heavy: 156.4% bfs
+      heavy:  71.1% /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+      heavy:  65.1% /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)
+      heavy:  44.8% /System/Library/PrivateFrameworks/XprotectFramework.framework/Versions/A/XPCServices/XprotectService.xpc/Contents/MacOS/XprotectService
+      heavy:  18.1% /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)
+    after-memory   load1=4.11   cpus=8 threshold=4.0 *** OVER THRESHOLD ***
+      heavy:  74.3% /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)
+      heavy:  41.2% /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)
+      heavy:  36.7% /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+      heavy:  11.8% agy
+      heavy:   8.4% /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)
+    end            load1=4.11   cpus=8 threshold=4.0 *** OVER THRESHOLD ***
+      heavy:  53.3% /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)
+      heavy:  49.2% /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)
+      heavy:  43.5% /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+      heavy:  10.6% agy
+      heavy:  10.2% /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/151.0.7922.138/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)
+
+  control (PHP-only rows, touch no libJudy): +0.00% [+0.00, +0.00] over 0 rows
+  measured control scatter: 0.00%  (assumed floor 3.0%)
+  *** RUN FLAGGED CONTAMINATED — all verdicts suppressed to null ***
+
+------------------------------------------------------------------------------------------------
+  MEMORY — peak RSS over per-arm empty-process floor (the headline axis)
+------------------------------------------------------------------------------------------------
+  workload                n      A array     B system    C bundled       A/C       B/C
+  int_to_int         100000       3.0 MB     944.0 KB       1.1 MB     2.73x     0.84x
+  int_to_int        1000000      16.8 MB       8.2 MB       8.2 MB     2.05x     1.00x
+  int_to_int        8000000     123.6 MB      63.9 MB      64.0 MB     1.93x     1.00x
+  int_sparse         100000       6.9 MB       1.5 MB       1.5 MB     4.68x     1.01x
+  int_sparse        1000000      41.0 MB      12.7 MB      12.7 MB     3.22x     1.00x
+  int_sparse        8000000     310.7 MB     100.3 MB     100.3 MB     3.10x     1.00x
+  int_to_mixed       100000       3.4 MB       3.8 MB       3.8 MB     0.90x     0.98x
+  int_to_mixed      1000000      30.4 MB      38.6 MB      38.6 MB     0.79x     1.00x
+  int_to_mixed      8000000     244.2 MB     308.2 MB     308.3 MB     0.79x     1.00x
+  string_to_int      100000       7.6 MB       2.3 MB       2.2 MB     3.40x     1.01x
+  string_to_int     1000000      76.7 MB      20.8 MB      22.5 MB     3.41x     0.93x
+  string_to_int     8000000     614.9 MB     198.8 MB     198.7 MB     3.09x     1.00x
+  bitset             100000       6.9 MB     320.0 KB     336.0 KB    21.09x     0.95x
+  bitset            1000000      41.0 MB       1.5 MB       1.4 MB    28.53x     1.03x
+  bitset            8000000     310.7 MB      10.3 MB      10.3 MB    30.22x     1.00x
+  A/C above 1.00 means the PHP array uses that many times more memory than php-judy.
+
+Wrote /private/tmp/claude-501/-Users-nicolas-Documents-git-orieg-php-judy--claude-worktrees-quizzical-grothendieck-3fa8aa/06f561e1-3f48-402b-9b8d-e74604df5c75/scratchpad/mac/results/mac-memory.json

--- a/research/three-arm-benchmark/results/run1-cache-300k.json
+++ b/research/three-arm-benchmark/results/run1-cache-300k.json
@@ -1,0 +1,8654 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "linux-x86_64-gcc14.2-php8.4-cacheresident",
+        "date": "2026-08-19T02:28:48+00:00",
+        "php_version": "8.4.24",
+        "platform": "Linux x86_64",
+        "uname": "Linux 9d84886938ba 6.8.0-136-generic #136~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  3 16:29:11 UTC  x86_64",
+        "judy_version": "2.5.2",
+        "system_so": [
+            "/work/builds/judy-B-1.so",
+            "/work/builds/judy-B-2.so",
+            "/work/builds/judy-B-3.so"
+        ],
+        "bundled_so": [
+            "/work/builds/judy-C-1.so",
+            "/work/builds/judy-C-2.so",
+            "/work/builds/judy-C-3.so"
+        ],
+        "system_so_sha256": [
+            "ab5562073c68a7da4b740a6928bab49dfef313a80e817cc631a0aacbf1631cdd",
+            "5ac8e6196bbd697c2eb656bcea088e7e74e22f098fa90519c13cb43d47568750",
+            "0bd4ff9846f7d60abe40635a89c2a93100b4625f4915d58d3c1e29188a7be8cc"
+        ],
+        "bundled_so_sha256": [
+            "354dc68ce9ed49662f5fcb51c033683b0e63073db69384178903d520617726b0",
+            "1cb7ca0eda6ae78552276e8b211a08474902df7d58e08eb1c4a50d404570bb2b",
+            "cfce55bc85a2126e779d7d23e9ad1cdb0e1cdf4002d064f5587a3fe31e8f43f1"
+        ],
+        "system_provenance": "Debian 13 trixie, libjudy-dev 1.0.5-5.1 SHARED lib; Baskins jp_1Index fix APPLIED (debian patch 04); dpkg hardening CFLAGS",
+        "bundled_provenance": "bundled libjudy/ static into the extension (P1-P7, O1 popcount, O3 bswap, O4 string-layer); vendor CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt",
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 300000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            100000,
+            1000000,
+            8000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "cache-resident",
+        "claim_floor_pct": 3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 70,
+        "memory_children": 144,
+        "wall_seconds": 221.4
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T02:25:06+00:00",
+                "load1": 1.58,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T02:28:26+00:00",
+                "load1": 1.02,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-memory",
+                "at": "2026-08-19T02:28:48+00:00",
+                "load1": 1.02,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T02:28:48+00:00",
+                "load1": 1.02,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "note": "load average alone is necessary but not sufficient: a co-resident memory-bound benchmark contends for LLC and memory bandwidth at low load, and a PHP-array control does not detect it"
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 1,
+            "delta_pct": 0,
+            "ci_delta_pct": [
+                -0.12,
+                0.17
+            ],
+            "measured_spread_pct": 3.43,
+            "row_count": 43,
+            "eligibility": "genuine PHP-array rows only (TAM_ARM_A_ROWS); Judy-touching .php rows are excluded because they carry real signal",
+            "rows": {
+                "core.bitset.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00104,
+                    "delta_pct": 0.1,
+                    "ci_delta_pct": [
+                        -0.7,
+                        1.33
+                    ],
+                    "n": 7,
+                    "b_ms": 2.991,
+                    "c_ms": 2.9974
+                },
+                "core.bitset.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99823,
+                    "delta_pct": -0.18,
+                    "ci_delta_pct": [
+                        -1.14,
+                        0.09
+                    ],
+                    "n": 7,
+                    "b_ms": 1.079,
+                    "c_ms": 1.0703
+                },
+                "core.bitset.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00372,
+                    "delta_pct": 0.37,
+                    "ci_delta_pct": [
+                        -0.61,
+                        3.72
+                    ],
+                    "n": 7,
+                    "b_ms": 0.913,
+                    "c_ms": 0.9163
+                },
+                "core.int_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99532,
+                    "delta_pct": -0.47,
+                    "ci_delta_pct": [
+                        -0.89,
+                        0.81
+                    ],
+                    "n": 7,
+                    "b_ms": 3.0707,
+                    "c_ms": 3.0725
+                },
+                "core.int_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99925,
+                    "delta_pct": -0.07,
+                    "ci_delta_pct": [
+                        -1.88,
+                        0.66
+                    ],
+                    "n": 7,
+                    "b_ms": 1.0688,
+                    "c_ms": 1.0696
+                },
+                "core.int_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99912,
+                    "delta_pct": -0.09,
+                    "ci_delta_pct": [
+                        -0.12,
+                        -0.01
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9133,
+                    "c_ms": 0.9127
+                },
+                "core.int_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00172,
+                    "delta_pct": 0.17,
+                    "ci_delta_pct": [
+                        -0.02,
+                        0.8
+                    ],
+                    "n": 7,
+                    "b_ms": 4.0066,
+                    "c_ms": 4.0302
+                },
+                "core.int_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99948,
+                    "delta_pct": -0.05,
+                    "ci_delta_pct": [
+                        -0.63,
+                        1.45
+                    ],
+                    "n": 7,
+                    "b_ms": 1.5462,
+                    "c_ms": 1.5417
+                },
+                "core.int_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99936,
+                    "delta_pct": -0.06,
+                    "ci_delta_pct": [
+                        -0.67,
+                        0.18
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9365,
+                    "c_ms": 0.9347
+                },
+                "core.int_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98956,
+                    "delta_pct": -1.04,
+                    "ci_delta_pct": [
+                        -2.11,
+                        0.07
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6207,
+                    "c_ms": 1.6147
+                },
+                "core.int_to_packed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9999,
+                    "delta_pct": -0.01,
+                    "ci_delta_pct": [
+                        -0.38,
+                        0.09
+                    ],
+                    "n": 7,
+                    "b_ms": 4.9389,
+                    "c_ms": 4.9376
+                },
+                "core.int_to_packed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1,
+                    "delta_pct": 0,
+                    "ci_delta_pct": [
+                        -1.83,
+                        0.35
+                    ],
+                    "n": 7,
+                    "b_ms": 1.5778,
+                    "c_ms": 1.5571
+                },
+                "core.int_to_packed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01249,
+                    "delta_pct": 1.25,
+                    "ci_delta_pct": [
+                        -0.41,
+                        2.92
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9388,
+                    "c_ms": 0.9434
+                },
+                "core.int_to_packed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99791,
+                    "delta_pct": -0.21,
+                    "ci_delta_pct": [
+                        -1.22,
+                        1.08
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6196,
+                    "c_ms": 1.6236
+                },
+                "core.string_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99884,
+                    "delta_pct": -0.12,
+                    "ci_delta_pct": [
+                        -0.78,
+                        0.15
+                    ],
+                    "n": 7,
+                    "b_ms": 11.6272,
+                    "c_ms": 11.6137
+                },
+                "core.string_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01492,
+                    "delta_pct": 1.49,
+                    "ci_delta_pct": [
+                        -0.01,
+                        3.97
+                    ],
+                    "n": 7,
+                    "b_ms": 2.1277,
+                    "c_ms": 2.2212
+                },
+                "core.string_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99294,
+                    "delta_pct": -0.71,
+                    "ci_delta_pct": [
+                        -3.27,
+                        0.58
+                    ],
+                    "n": 7,
+                    "b_ms": 1.4107,
+                    "c_ms": 1.377
+                },
+                "core.string_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98602,
+                    "delta_pct": -1.4,
+                    "ci_delta_pct": [
+                        -2.28,
+                        0.43
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9152,
+                    "c_ms": 0.8961
+                },
+                "core.string_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99834,
+                    "delta_pct": -0.17,
+                    "ci_delta_pct": [
+                        -0.46,
+                        0.25
+                    ],
+                    "n": 7,
+                    "b_ms": 12.7203,
+                    "c_ms": 12.697
+                },
+                "core.string_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00171,
+                    "delta_pct": 0.17,
+                    "ci_delta_pct": [
+                        -0.24,
+                        3.53
+                    ],
+                    "n": 7,
+                    "b_ms": 2.5108,
+                    "c_ms": 2.5519
+                },
+                "core.string_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00948,
+                    "delta_pct": 0.95,
+                    "ci_delta_pct": [
+                        0.09,
+                        1.59
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6139,
+                    "c_ms": 1.6263
+                },
+                "core.string_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00923,
+                    "delta_pct": 0.92,
+                    "ci_delta_pct": [
+                        -0.25,
+                        1.18
+                    ],
+                    "n": 7,
+                    "b_ms": 2.6016,
+                    "c_ms": 2.6153
+                },
+                "core.string_to_int_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00383,
+                    "delta_pct": 0.38,
+                    "ci_delta_pct": [
+                        -0.34,
+                        2.15
+                    ],
+                    "n": 7,
+                    "b_ms": 11.3715,
+                    "c_ms": 11.4135
+                },
+                "core.string_to_int_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98083,
+                    "delta_pct": -1.92,
+                    "ci_delta_pct": [
+                        -4.16,
+                        3.48
+                    ],
+                    "n": 7,
+                    "b_ms": 2.2274,
+                    "c_ms": 2.1776
+                },
+                "core.string_to_int_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98366,
+                    "delta_pct": -1.63,
+                    "ci_delta_pct": [
+                        -2.3,
+                        2.3
+                    ],
+                    "n": 7,
+                    "b_ms": 1.4031,
+                    "c_ms": 1.3968
+                },
+                "core.string_to_int_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9777,
+                    "delta_pct": -2.23,
+                    "ci_delta_pct": [
+                        -4.46,
+                        2.05
+                    ],
+                    "n": 7,
+                    "b_ms": 0.8923,
+                    "c_ms": 0.8724
+                },
+                "core.string_to_mixed_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.0017,
+                    "delta_pct": 0.17,
+                    "ci_delta_pct": [
+                        -0.5,
+                        0.57
+                    ],
+                    "n": 7,
+                    "b_ms": 12.2757,
+                    "c_ms": 12.3002
+                },
+                "core.string_to_mixed_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9986,
+                    "delta_pct": -0.14,
+                    "ci_delta_pct": [
+                        -1.76,
+                        2.17
+                    ],
+                    "n": 7,
+                    "b_ms": 2.5195,
+                    "c_ms": 2.5281
+                },
+                "core.string_to_mixed_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01113,
+                    "delta_pct": 1.11,
+                    "ci_delta_pct": [
+                        -0.39,
+                        3.17
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6033,
+                    "c_ms": 1.6168
+                },
+                "core.string_to_mixed_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00449,
+                    "delta_pct": 0.45,
+                    "ci_delta_pct": [
+                        -0.38,
+                        1.36
+                    ],
+                    "n": 7,
+                    "b_ms": 2.6055,
+                    "c_ms": 2.6066
+                },
+                "core.string_to_int_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00085,
+                    "delta_pct": 0.09,
+                    "ci_delta_pct": [
+                        0.04,
+                        0.42
+                    ],
+                    "n": 7,
+                    "b_ms": 11.3661,
+                    "c_ms": 11.3785
+                },
+                "core.string_to_int_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.03427,
+                    "delta_pct": 3.43,
+                    "ci_delta_pct": [
+                        -4.3,
+                        4.66
+                    ],
+                    "n": 7,
+                    "b_ms": 2.1771,
+                    "c_ms": 2.2093
+                },
+                "core.string_to_int_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9975,
+                    "delta_pct": -0.25,
+                    "ci_delta_pct": [
+                        -3.14,
+                        3.64
+                    ],
+                    "n": 7,
+                    "b_ms": 1.4022,
+                    "c_ms": 1.4039
+                },
+                "core.string_to_int_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98532,
+                    "delta_pct": -1.47,
+                    "ci_delta_pct": [
+                        -2.56,
+                        1.14
+                    ],
+                    "n": 7,
+                    "b_ms": 0.8994,
+                    "c_ms": 0.8854
+                },
+                "core.string_to_mixed_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00006,
+                    "delta_pct": 0.01,
+                    "ci_delta_pct": [
+                        -0.32,
+                        0.62
+                    ],
+                    "n": 7,
+                    "b_ms": 12.2804,
+                    "c_ms": 12.3009
+                },
+                "core.string_to_mixed_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00852,
+                    "delta_pct": 0.85,
+                    "ci_delta_pct": [
+                        -0.63,
+                        1.84
+                    ],
+                    "n": 7,
+                    "b_ms": 2.4985,
+                    "c_ms": 2.5143
+                },
+                "core.string_to_mixed_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99661,
+                    "delta_pct": -0.34,
+                    "ci_delta_pct": [
+                        -0.65,
+                        1.74
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6148,
+                    "c_ms": 1.6266
+                },
+                "core.string_to_mixed_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99715,
+                    "delta_pct": -0.28,
+                    "ci_delta_pct": [
+                        -1.15,
+                        0.7
+                    ],
+                    "n": 7,
+                    "b_ms": 2.6115,
+                    "c_ms": 2.6046
+                },
+                "api.increment.int_to_int": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01048,
+                    "delta_pct": 1.05,
+                    "ci_delta_pct": [
+                        0.05,
+                        2.14
+                    ],
+                    "n": 7,
+                    "b_ms": 2.8901,
+                    "c_ms": 2.9107
+                },
+                "api.setop.union.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00427,
+                    "delta_pct": 0.43,
+                    "ci_delta_pct": [
+                        -1.93,
+                        2.25
+                    ],
+                    "n": 7,
+                    "b_ms": 2.3308,
+                    "c_ms": 2.341
+                },
+                "api.setop.intersect.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00207,
+                    "delta_pct": 0.21,
+                    "ci_delta_pct": [
+                        -0.14,
+                        0.29
+                    ],
+                    "n": 7,
+                    "b_ms": 4.593,
+                    "c_ms": 4.5982
+                },
+                "api.setop.diff.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00327,
+                    "delta_pct": 0.33,
+                    "ci_delta_pct": [
+                        0.03,
+                        0.38
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6517,
+                    "c_ms": 1.6562
+                },
+                "api.setop.xor.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00352,
+                    "delta_pct": 0.35,
+                    "ci_delta_pct": [
+                        -0.59,
+                        0.41
+                    ],
+                    "n": 7,
+                    "b_ms": 7.5942,
+                    "c_ms": 7.6159
+                }
+            }
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 90,
+        "slower": 0,
+        "null": 4
+    },
+    "a_counts": {
+        "php-judy": 1,
+        "php-array": 42,
+        "parity": 0
+    },
+    "bundled_vs_system": {
+        "core.bitset.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90184,
+            "delta_pct": -9.82,
+            "ci_delta_pct": [
+                -9.96,
+                -9.73
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.73,
+                "B2/C2": -9.83,
+                "B3/C3": -9.93
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 5.6676,
+            "bundled_ms": 5.1044,
+            "raw_delta_pct": -9.82,
+            "spread_pct": [
+                0.7,
+                0.7
+            ],
+            "system_runs_ms": [
+                5.6688,
+                5.6692,
+                5.6716,
+                5.6676,
+                5.6673,
+                5.6326,
+                5.6372
+            ],
+            "bundled_runs_ms": [
+                5.1044,
+                5.1127,
+                5.1016,
+                5.1164,
+                5.1094,
+                5.0801,
+                5.0928
+            ],
+            "paired_ratios": [
+                0.90044,
+                0.90184,
+                0.8995,
+                0.90275,
+                0.90156,
+                0.90191,
+                0.90343
+            ]
+        },
+        "core.bitset.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9319,
+            "delta_pct": -6.81,
+            "ci_delta_pct": [
+                -8.19,
+                -6.56
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.91,
+                "B2/C2": -5.9,
+                "B3/C3": -7.49
+            },
+            "build_spread_pct": 1.59,
+            "builds": 3,
+            "system_ms": 3.6801,
+            "bundled_ms": 3.4142,
+            "raw_delta_pct": -6.81,
+            "spread_pct": [
+                4,
+                2.5
+            ],
+            "system_runs_ms": [
+                3.7176,
+                3.5924,
+                3.7392,
+                3.6117,
+                3.6801,
+                3.6602,
+                3.7123
+            ],
+            "bundled_runs_ms": [
+                3.4607,
+                3.4133,
+                3.4301,
+                3.3748,
+                3.4295,
+                3.4142,
+                3.4082
+            ],
+            "paired_ratios": [
+                0.9309,
+                0.95014,
+                0.91734,
+                0.93441,
+                0.9319,
+                0.93279,
+                0.91808
+            ]
+        },
+        "core.bitset.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91094,
+            "delta_pct": -8.91,
+            "ci_delta_pct": [
+                -11.7,
+                -8.68
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.39,
+                "B2/C2": -10.27,
+                "B3/C3": -8.79
+            },
+            "build_spread_pct": 2.6,
+            "builds": 3,
+            "system_ms": 5.8947,
+            "bundled_ms": 5.3211,
+            "raw_delta_pct": -8.91,
+            "spread_pct": [
+                2.6,
+                6
+            ],
+            "system_runs_ms": [
+                5.9262,
+                5.8947,
+                5.8413,
+                5.9957,
+                5.8463,
+                5.9362,
+                5.8663
+            ],
+            "bundled_runs_ms": [
+                5.2515,
+                5.3738,
+                5.3211,
+                5.2211,
+                5.162,
+                5.4209,
+                5.4792
+            ],
+            "paired_ratios": [
+                0.88615,
+                0.91163,
+                0.91094,
+                0.87081,
+                0.88295,
+                0.91319,
+                0.93401
+            ]
+        },
+        "core.int_to_int.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77642,
+            "delta_pct": -22.36,
+            "ci_delta_pct": [
+                -23.08,
+                -21.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.95,
+                "B2/C2": -22.33,
+                "B3/C3": -22.83
+            },
+            "build_spread_pct": 0.62,
+            "builds": 3,
+            "system_ms": 9.1358,
+            "bundled_ms": 7.0996,
+            "raw_delta_pct": -22.36,
+            "spread_pct": [
+                5.5,
+                2.8
+            ],
+            "system_runs_ms": [
+                9.1283,
+                9.1358,
+                9.5601,
+                9.2496,
+                9.1319,
+                9.0561,
+                9.1537
+            ],
+            "bundled_runs_ms": [
+                7.1333,
+                7.0985,
+                7.0996,
+                7.115,
+                7.0902,
+                7.2516,
+                7.0533
+            ],
+            "paired_ratios": [
+                0.78145,
+                0.777,
+                0.74263,
+                0.76922,
+                0.77642,
+                0.80074,
+                0.77054
+            ]
+        },
+        "core.int_to_int.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85977,
+            "delta_pct": -14.02,
+            "ci_delta_pct": [
+                -16.84,
+                -12.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.95,
+                "B2/C2": -12.85,
+                "B3/C3": -15.91
+            },
+            "build_spread_pct": 3.06,
+            "builds": 3,
+            "system_ms": 3.9711,
+            "bundled_ms": 3.4355,
+            "raw_delta_pct": -14.02,
+            "spread_pct": [
+                4.8,
+                5.2
+            ],
+            "system_runs_ms": [
+                3.975,
+                3.9393,
+                4.131,
+                3.9501,
+                3.9693,
+                4.0511,
+                3.9711
+            ],
+            "bundled_runs_ms": [
+                3.4203,
+                3.4796,
+                3.4355,
+                3.4524,
+                3.4127,
+                3.4438,
+                3.2994
+            ],
+            "paired_ratios": [
+                0.86045,
+                0.8833,
+                0.83164,
+                0.874,
+                0.85977,
+                0.85009,
+                0.83085
+            ]
+        },
+        "core.int_to_int.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.95214,
+            "delta_pct": -4.79,
+            "ci_delta_pct": [
+                -7.04,
+                -2.81
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.21,
+                "B2/C2": -3.5,
+                "B3/C3": -5.22
+            },
+            "build_spread_pct": 2.71,
+            "builds": 3,
+            "system_ms": 6.3414,
+            "bundled_ms": 6.0375,
+            "raw_delta_pct": -4.79,
+            "spread_pct": [
+                4.4,
+                2.4
+            ],
+            "system_runs_ms": [
+                6.4158,
+                6.232,
+                6.4032,
+                6.3414,
+                6.179,
+                6.2136,
+                6.4592
+            ],
+            "bundled_runs_ms": [
+                5.964,
+                5.938,
+                5.9138,
+                6.0379,
+                6.0375,
+                6.0392,
+                6.0579
+            ],
+            "paired_ratios": [
+                0.92958,
+                0.95282,
+                0.92357,
+                0.95214,
+                0.9771,
+                0.97193,
+                0.93787
+            ]
+        },
+        "core.int_to_mixed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84843,
+            "delta_pct": -15.16,
+            "ci_delta_pct": [
+                -16.45,
+                -15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.95,
+                "B2/C2": -15.08,
+                "B3/C3": -15.71
+            },
+            "build_spread_pct": 0.87,
+            "builds": 3,
+            "system_ms": 11.8867,
+            "bundled_ms": 10.0509,
+            "raw_delta_pct": -15.16,
+            "spread_pct": [
+                2.9,
+                1.9
+            ],
+            "system_runs_ms": [
+                11.8653,
+                11.8154,
+                12.1654,
+                11.9748,
+                11.8246,
+                11.8867,
+                11.917
+            ],
+            "bundled_runs_ms": [
+                10.0848,
+                10.0245,
+                10.0737,
+                10.0046,
+                10.0509,
+                10.1945,
+                10.0165
+            ],
+            "paired_ratios": [
+                0.84994,
+                0.84843,
+                0.82806,
+                0.83547,
+                0.85,
+                0.85764,
+                0.84052
+            ]
+        },
+        "core.int_to_mixed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76723,
+            "delta_pct": -23.28,
+            "ci_delta_pct": [
+                -23.42,
+                -22.13
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.91,
+                "B2/C2": -22.77,
+                "B3/C3": -23.42
+            },
+            "build_spread_pct": 0.65,
+            "builds": 3,
+            "system_ms": 4.7526,
+            "bundled_ms": 3.688,
+            "raw_delta_pct": -23.28,
+            "spread_pct": [
+                1.8,
+                4.1
+            ],
+            "system_runs_ms": [
+                4.7411,
+                4.8156,
+                4.7526,
+                4.7946,
+                4.7426,
+                4.7295,
+                4.7617
+            ],
+            "bundled_runs_ms": [
+                3.6375,
+                3.688,
+                3.6421,
+                3.696,
+                3.693,
+                3.6194,
+                3.7701
+            ],
+            "paired_ratios": [
+                0.76723,
+                0.76584,
+                0.76634,
+                0.77087,
+                0.77869,
+                0.76528,
+                0.79176
+            ]
+        },
+        "core.int_to_mixed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93497,
+            "delta_pct": -6.5,
+            "ci_delta_pct": [
+                -7.03,
+                -6.13
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.03,
+                "B2/C2": -6.42,
+                "B3/C3": -6.02
+            },
+            "build_spread_pct": 1.01,
+            "builds": 3,
+            "system_ms": 6.1723,
+            "bundled_ms": 5.7474,
+            "raw_delta_pct": -6.5,
+            "spread_pct": [
+                1.5,
+                2.3
+            ],
+            "system_runs_ms": [
+                6.1778,
+                6.1723,
+                6.096,
+                6.1911,
+                6.1352,
+                6.1285,
+                6.174
+            ],
+            "bundled_runs_ms": [
+                5.6481,
+                5.7806,
+                5.7354,
+                5.7557,
+                5.7362,
+                5.753,
+                5.7474
+            ],
+            "paired_ratios": [
+                0.91426,
+                0.93654,
+                0.94085,
+                0.92967,
+                0.93497,
+                0.93873,
+                0.9309
+            ]
+        },
+        "core.int_to_mixed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90065,
+            "delta_pct": -9.94,
+            "ci_delta_pct": [
+                -10.77,
+                -8.72
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.94,
+                "B2/C2": -10.56,
+                "B3/C3": -7.87
+            },
+            "build_spread_pct": 2.69,
+            "builds": 3,
+            "system_ms": 4.8339,
+            "bundled_ms": 4.3497,
+            "raw_delta_pct": -9.94,
+            "spread_pct": [
+                3.2,
+                4.6
+            ],
+            "system_runs_ms": [
+                4.8749,
+                4.9288,
+                4.7742,
+                4.793,
+                4.8339,
+                4.8207,
+                4.8364
+            ],
+            "bundled_runs_ms": [
+                4.3497,
+                4.3172,
+                4.5174,
+                4.3168,
+                4.4125,
+                4.3211,
+                4.4077
+            ],
+            "paired_ratios": [
+                0.89226,
+                0.87591,
+                0.94621,
+                0.90065,
+                0.91282,
+                0.89636,
+                0.91136
+            ]
+        },
+        "core.int_to_packed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9005,
+            "delta_pct": -9.95,
+            "ci_delta_pct": [
+                -10.14,
+                -9.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.14,
+                "B2/C2": -9.89,
+                "B3/C3": -9.19
+            },
+            "build_spread_pct": 0.95,
+            "builds": 3,
+            "system_ms": 15.2995,
+            "bundled_ms": 13.778,
+            "raw_delta_pct": -9.95,
+            "spread_pct": [
+                1.4,
+                0.6
+            ],
+            "system_runs_ms": [
+                15.3703,
+                15.2995,
+                15.2456,
+                15.4138,
+                15.2561,
+                15.2034,
+                15.3004
+            ],
+            "bundled_runs_ms": [
+                13.8122,
+                13.775,
+                13.8487,
+                13.7744,
+                13.7592,
+                13.8029,
+                13.778
+            ],
+            "paired_ratios": [
+                0.89863,
+                0.90036,
+                0.90837,
+                0.89364,
+                0.90188,
+                0.90788,
+                0.9005
+            ]
+        },
+        "core.int_to_packed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94931,
+            "delta_pct": -5.07,
+            "ci_delta_pct": [
+                -5.43,
+                -4.78
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.15,
+                "B2/C2": -4.93,
+                "B3/C3": -5.12
+            },
+            "build_spread_pct": 0.22,
+            "builds": 3,
+            "system_ms": 10.4147,
+            "bundled_ms": 9.8729,
+            "raw_delta_pct": -5.07,
+            "spread_pct": [
+                1,
+                0.7
+            ],
+            "system_runs_ms": [
+                10.4558,
+                10.4147,
+                10.4597,
+                10.4091,
+                10.3596,
+                10.3958,
+                10.4216
+            ],
+            "bundled_runs_ms": [
+                9.9285,
+                9.8868,
+                9.871,
+                9.8729,
+                9.8642,
+                9.9169,
+                9.8558
+            ],
+            "paired_ratios": [
+                0.94957,
+                0.94931,
+                0.94372,
+                0.94849,
+                0.95218,
+                0.95393,
+                0.94571
+            ]
+        },
+        "core.int_to_packed.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.97435,
+            "delta_pct": -2.57,
+            "ci_delta_pct": [
+                -3.65,
+                -2.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.52,
+                "B2/C2": -2.45,
+                "B3/C3": -3.94
+            },
+            "build_spread_pct": 1.49,
+            "builds": 3,
+            "system_ms": 12.6706,
+            "bundled_ms": 12.3149,
+            "raw_delta_pct": -2.57,
+            "spread_pct": [
+                1.5,
+                1.5
+            ],
+            "system_runs_ms": [
+                12.6706,
+                12.6616,
+                12.8018,
+                12.7034,
+                12.6087,
+                12.7023,
+                12.6439
+            ],
+            "bundled_runs_ms": [
+                12.3516,
+                12.3368,
+                12.2,
+                12.2394,
+                12.3149,
+                12.2973,
+                12.3899
+            ],
+            "paired_ratios": [
+                0.97482,
+                0.97435,
+                0.95299,
+                0.96347,
+                0.9767,
+                0.96812,
+                0.97991
+            ]
+        },
+        "core.int_to_packed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86309,
+            "delta_pct": -13.69,
+            "ci_delta_pct": [
+                -14.18,
+                -13.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.24,
+                "B2/C2": -13.96,
+                "B3/C3": -13.66
+            },
+            "build_spread_pct": 0.72,
+            "builds": 3,
+            "system_ms": 3.0453,
+            "bundled_ms": 2.6127,
+            "raw_delta_pct": -13.69,
+            "spread_pct": [
+                2.5,
+                1.6
+            ],
+            "system_runs_ms": [
+                2.9903,
+                3.0582,
+                3.0453,
+                2.9827,
+                3.0482,
+                3.0025,
+                3.0553
+            ],
+            "bundled_runs_ms": [
+                2.5944,
+                2.6246,
+                2.6127,
+                2.6112,
+                2.6296,
+                2.6085,
+                2.637
+            ],
+            "paired_ratios": [
+                0.86761,
+                0.85822,
+                0.85795,
+                0.87545,
+                0.86267,
+                0.86878,
+                0.86309
+            ]
+        },
+        "core.string_to_int.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74914,
+            "delta_pct": -25.09,
+            "ci_delta_pct": [
+                -25.1,
+                -24.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.1,
+                "B2/C2": -24.95,
+                "B3/C3": -24.84
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 34.7702,
+            "bundled_ms": 26.1135,
+            "raw_delta_pct": -25.09,
+            "spread_pct": [
+                1.3,
+                0.9
+            ],
+            "system_runs_ms": [
+                34.7326,
+                34.7993,
+                34.7421,
+                34.8661,
+                34.7536,
+                34.7702,
+                35.1928
+            ],
+            "bundled_runs_ms": [
+                26.0151,
+                26.0848,
+                26.2048,
+                26.1197,
+                26.1135,
+                26.0415,
+                26.2556
+            ],
+            "paired_ratios": [
+                0.74901,
+                0.74958,
+                0.75427,
+                0.74914,
+                0.75139,
+                0.74896,
+                0.74605
+            ]
+        },
+        "core.string_to_int.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.66749,
+            "delta_pct": -33.25,
+            "ci_delta_pct": [
+                -33.33,
+                -33.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -33.2,
+                "B2/C2": -32.81,
+                "B3/C3": -33.54
+            },
+            "build_spread_pct": 0.73,
+            "builds": 3,
+            "system_ms": 14.5979,
+            "bundled_ms": 9.7477,
+            "raw_delta_pct": -33.25,
+            "spread_pct": [
+                0.4,
+                1.9
+            ],
+            "system_runs_ms": [
+                14.6336,
+                14.6035,
+                14.5944,
+                14.5902,
+                14.577,
+                14.5997,
+                14.5979
+            ],
+            "bundled_runs_ms": [
+                9.7759,
+                9.7477,
+                9.6689,
+                9.7346,
+                9.8582,
+                9.7329,
+                9.7587
+            ],
+            "paired_ratios": [
+                0.66804,
+                0.66749,
+                0.66251,
+                0.6672,
+                0.67628,
+                0.66665,
+                0.6685
+            ]
+        },
+        "core.string_to_int.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.63978,
+            "delta_pct": -36.02,
+            "ci_delta_pct": [
+                -36.21,
+                -35.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -35.79,
+                "B2/C2": -36.11,
+                "B3/C3": -35.83
+            },
+            "build_spread_pct": 0.32,
+            "builds": 3,
+            "system_ms": 21.6452,
+            "bundled_ms": 13.834,
+            "raw_delta_pct": -36.02,
+            "spread_pct": [
+                0.6,
+                1.8
+            ],
+            "system_runs_ms": [
+                21.5903,
+                21.6232,
+                21.6945,
+                21.7046,
+                21.5742,
+                21.6452,
+                21.7054
+            ],
+            "bundled_runs_ms": [
+                13.8089,
+                13.834,
+                14.0133,
+                14.0076,
+                13.7628,
+                13.7988,
+                13.9368
+            ],
+            "paired_ratios": [
+                0.63959,
+                0.63978,
+                0.64594,
+                0.64537,
+                0.63793,
+                0.6375,
+                0.64209
+            ]
+        },
+        "core.string_to_int.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.56354,
+            "delta_pct": -43.65,
+            "ci_delta_pct": [
+                -43.96,
+                -43.26
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -43.96,
+                "B2/C2": -43.27,
+                "B3/C3": -43.55
+            },
+            "build_spread_pct": 0.69,
+            "builds": 3,
+            "system_ms": 8.116,
+            "bundled_ms": 4.5871,
+            "raw_delta_pct": -43.65,
+            "spread_pct": [
+                1.1,
+                1.4
+            ],
+            "system_runs_ms": [
+                8.116,
+                8.0956,
+                8.0994,
+                8.1705,
+                8.1249,
+                8.0805,
+                8.1443
+            ],
+            "bundled_runs_ms": [
+                4.5481,
+                4.5923,
+                4.5458,
+                4.6044,
+                4.6098,
+                4.5871,
+                4.5567
+            ],
+            "paired_ratios": [
+                0.56039,
+                0.56726,
+                0.56125,
+                0.56354,
+                0.56737,
+                0.56768,
+                0.5595
+            ]
+        },
+        "core.string_to_mixed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.70151,
+            "delta_pct": -29.85,
+            "ci_delta_pct": [
+                -30.12,
+                -29.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -30.12,
+                "B2/C2": -29.55,
+                "B3/C3": -29.61
+            },
+            "build_spread_pct": 0.57,
+            "builds": 3,
+            "system_ms": 41.4905,
+            "bundled_ms": 29.0912,
+            "raw_delta_pct": -29.85,
+            "spread_pct": [
+                0.9,
+                1.3
+            ],
+            "system_runs_ms": [
+                41.4595,
+                41.4694,
+                41.5173,
+                41.5067,
+                41.4905,
+                41.4395,
+                41.8039
+            ],
+            "bundled_runs_ms": [
+                28.9728,
+                29.0912,
+                29.0756,
+                29.2655,
+                29.3554,
+                29.3172,
+                29.0485
+            ],
+            "paired_ratios": [
+                0.69882,
+                0.70151,
+                0.70032,
+                0.70508,
+                0.70752,
+                0.70747,
+                0.69488
+            ]
+        },
+        "core.string_to_mixed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.64906,
+            "delta_pct": -35.09,
+            "ci_delta_pct": [
+                -35.34,
+                -35.06
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -35.06,
+                "B2/C2": -35.45,
+                "B3/C3": -35.17
+            },
+            "build_spread_pct": 0.39,
+            "builds": 3,
+            "system_ms": 15.2987,
+            "bundled_ms": 9.927,
+            "raw_delta_pct": -35.09,
+            "spread_pct": [
+                0.7,
+                1.4
+            ],
+            "system_runs_ms": [
+                15.2611,
+                15.3673,
+                15.3692,
+                15.3062,
+                15.2987,
+                15.282,
+                15.2857
+            ],
+            "bundled_runs_ms": [
+                9.996,
+                9.8613,
+                9.9536,
+                9.8969,
+                9.9338,
+                9.9189,
+                9.927
+            ],
+            "paired_ratios": [
+                0.655,
+                0.64171,
+                0.64763,
+                0.64659,
+                0.64932,
+                0.64906,
+                0.64943
+            ]
+        },
+        "core.string_to_mixed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.6512,
+            "delta_pct": -34.88,
+            "ci_delta_pct": [
+                -35.58,
+                -34.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -34.87,
+                "B2/C2": -35.25,
+                "B3/C3": -35.14
+            },
+            "build_spread_pct": 0.38,
+            "builds": 3,
+            "system_ms": 21.8208,
+            "bundled_ms": 14.1897,
+            "raw_delta_pct": -34.88,
+            "spread_pct": [
+                0.8,
+                1.8
+            ],
+            "system_runs_ms": [
+                21.8317,
+                21.9215,
+                21.8208,
+                21.778,
+                21.7843,
+                21.8,
+                21.9425
+            ],
+            "bundled_runs_ms": [
+                14.0646,
+                14.1093,
+                14.0964,
+                14.3196,
+                14.1897,
+                14.1961,
+                14.292
+            ],
+            "paired_ratios": [
+                0.64423,
+                0.64363,
+                0.64601,
+                0.65753,
+                0.65137,
+                0.6512,
+                0.65134
+            ]
+        },
+        "core.string_to_mixed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.59177,
+            "delta_pct": -40.82,
+            "ci_delta_pct": [
+                -40.91,
+                -40.71
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -40.76,
+                "B2/C2": -40.87,
+                "B3/C3": -40.81
+            },
+            "build_spread_pct": 0.11,
+            "builds": 3,
+            "system_ms": 25.1824,
+            "bundled_ms": 14.9023,
+            "raw_delta_pct": -40.82,
+            "spread_pct": [
+                0.4,
+                0.7
+            ],
+            "system_runs_ms": [
+                25.2049,
+                25.1824,
+                25.1806,
+                25.1347,
+                25.2423,
+                25.2025,
+                25.1462
+            ],
+            "bundled_runs_ms": [
+                14.8635,
+                14.9023,
+                14.9304,
+                14.9703,
+                14.9154,
+                14.892,
+                14.8959
+            ],
+            "paired_ratios": [
+                0.58971,
+                0.59177,
+                0.59293,
+                0.5956,
+                0.59089,
+                0.59089,
+                0.59237
+            ]
+        },
+        "core.string_to_int_hash.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83426,
+            "delta_pct": -16.57,
+            "ci_delta_pct": [
+                -16.61,
+                -16.4
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.57,
+                "B2/C2": -15.61,
+                "B3/C3": -16.6
+            },
+            "build_spread_pct": 0.99,
+            "builds": 3,
+            "system_ms": 57.3184,
+            "bundled_ms": 47.8434,
+            "raw_delta_pct": -16.57,
+            "spread_pct": [
+                0.4,
+                2
+            ],
+            "system_runs_ms": [
+                57.2861,
+                57.1628,
+                57.3719,
+                57.2396,
+                57.3184,
+                57.3821,
+                57.3328
+            ],
+            "bundled_runs_ms": [
+                47.7607,
+                48.6969,
+                47.8434,
+                47.7955,
+                47.9165,
+                47.8647,
+                47.8306
+            ],
+            "paired_ratios": [
+                0.83372,
+                0.8519,
+                0.83392,
+                0.83501,
+                0.83597,
+                0.83414,
+                0.83426
+            ]
+        },
+        "core.string_to_int_hash.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88235,
+            "delta_pct": -11.76,
+            "ci_delta_pct": [
+                -12.48,
+                -11.63
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.15,
+                "B2/C2": -10.47,
+                "B3/C3": -11.64
+            },
+            "build_spread_pct": 1.68,
+            "builds": 3,
+            "system_ms": 9.1458,
+            "bundled_ms": 8.071,
+            "raw_delta_pct": -11.76,
+            "spread_pct": [
+                0.9,
+                4.2
+            ],
+            "system_runs_ms": [
+                9.1475,
+                9.1429,
+                9.1344,
+                9.1458,
+                9.1729,
+                9.1359,
+                9.2197
+            ],
+            "bundled_runs_ms": [
+                8.0713,
+                8.3697,
+                8.071,
+                8.0345,
+                8.0282,
+                8.0733,
+                8.0651
+            ],
+            "paired_ratios": [
+                0.88235,
+                0.91543,
+                0.88358,
+                0.87849,
+                0.87521,
+                0.88369,
+                0.87477
+            ]
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.67239,
+            "delta_pct": -32.76,
+            "ci_delta_pct": [
+                -33.46,
+                -32.67
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -33.14,
+                "B2/C2": -33.11,
+                "B3/C3": -30.99
+            },
+            "build_spread_pct": 2.15,
+            "builds": 3,
+            "system_ms": 27.9524,
+            "bundled_ms": 18.69,
+            "raw_delta_pct": -32.76,
+            "spread_pct": [
+                1.6,
+                5.7
+            ],
+            "system_runs_ms": [
+                27.9621,
+                27.7586,
+                27.7963,
+                28.0223,
+                27.9524,
+                27.7562,
+                28.203
+            ],
+            "bundled_runs_ms": [
+                18.6067,
+                18.6899,
+                18.69,
+                18.7363,
+                18.5766,
+                19.6453,
+                18.9741
+            ],
+            "paired_ratios": [
+                0.66543,
+                0.6733,
+                0.67239,
+                0.66862,
+                0.66458,
+                0.70778,
+                0.67277
+            ]
+        },
+        "core.string_to_int_hash.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.681,
+            "delta_pct": -31.9,
+            "ci_delta_pct": [
+                -32.03,
+                -31.47
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -32.03,
+                "B2/C2": -31.73,
+                "B3/C3": -30.26
+            },
+            "build_spread_pct": 1.77,
+            "builds": 3,
+            "system_ms": 14.4173,
+            "bundled_ms": 9.8516,
+            "raw_delta_pct": -31.9,
+            "spread_pct": [
+                5.3,
+                5.3
+            ],
+            "system_runs_ms": [
+                14.4073,
+                14.4152,
+                14.4663,
+                14.3678,
+                15.0001,
+                14.4173,
+                15.1263
+            ],
+            "bundled_runs_ms": [
+                9.792,
+                9.8789,
+                9.8516,
+                9.7995,
+                10.2003,
+                10.2915,
+                9.7695
+            ],
+            "paired_ratios": [
+                0.67966,
+                0.68531,
+                0.681,
+                0.68205,
+                0.68002,
+                0.71383,
+                0.64586
+            ]
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76115,
+            "delta_pct": -23.89,
+            "ci_delta_pct": [
+                -24.6,
+                -23.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.89,
+                "B2/C2": -23.84,
+                "B3/C3": -24.51
+            },
+            "build_spread_pct": 0.67,
+            "builds": 3,
+            "system_ms": 77.363,
+            "bundled_ms": 58.7768,
+            "raw_delta_pct": -23.89,
+            "spread_pct": [
+                1.5,
+                0.4
+            ],
+            "system_runs_ms": [
+                77.8583,
+                77.363,
+                78.3343,
+                77.1976,
+                77.3092,
+                77.3983,
+                77.2215
+            ],
+            "bundled_runs_ms": [
+                58.7054,
+                58.937,
+                58.8216,
+                58.7701,
+                58.8659,
+                58.7352,
+                58.7768
+            ],
+            "paired_ratios": [
+                0.754,
+                0.76182,
+                0.7509,
+                0.76129,
+                0.76143,
+                0.75887,
+                0.76115
+            ]
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87606,
+            "delta_pct": -12.39,
+            "ci_delta_pct": [
+                -13.06,
+                -12.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.06,
+                "B2/C2": -12.41,
+                "B3/C3": -12.29
+            },
+            "build_spread_pct": 0.77,
+            "builds": 3,
+            "system_ms": 9.4616,
+            "bundled_ms": 8.2861,
+            "raw_delta_pct": -12.39,
+            "spread_pct": [
+                0.6,
+                0.8
+            ],
+            "system_runs_ms": [
+                9.4902,
+                9.4485,
+                9.4672,
+                9.4946,
+                9.4616,
+                9.4374,
+                9.4502
+            ],
+            "bundled_runs_ms": [
+                8.2237,
+                8.2896,
+                8.2938,
+                8.2545,
+                8.2732,
+                8.2875,
+                8.2861
+            ],
+            "paired_ratios": [
+                0.86655,
+                0.87735,
+                0.87606,
+                0.86939,
+                0.8744,
+                0.87816,
+                0.87682
+            ]
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.66996,
+            "delta_pct": -33,
+            "ci_delta_pct": [
+                -33.25,
+                -32.75
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -33,
+                "B2/C2": -33.26,
+                "B3/C3": -32.7
+            },
+            "build_spread_pct": 0.56,
+            "builds": 3,
+            "system_ms": 29.5434,
+            "bundled_ms": 19.8194,
+            "raw_delta_pct": -33,
+            "spread_pct": [
+                0.9,
+                0.7
+            ],
+            "system_runs_ms": [
+                29.5458,
+                29.5,
+                29.5135,
+                29.5434,
+                29.7186,
+                29.4443,
+                29.6916
+            ],
+            "bundled_runs_ms": [
+                19.871,
+                19.7311,
+                19.8352,
+                19.793,
+                19.7886,
+                19.8455,
+                19.8194
+            ],
+            "paired_ratios": [
+                0.67255,
+                0.66885,
+                0.67207,
+                0.66996,
+                0.66587,
+                0.674,
+                0.66751
+            ]
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.66802,
+            "delta_pct": -33.2,
+            "ci_delta_pct": [
+                -33.28,
+                -33.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -33.22,
+                "B2/C2": -33.1,
+                "B3/C3": -33.24
+            },
+            "build_spread_pct": 0.14,
+            "builds": 3,
+            "system_ms": 40.8448,
+            "bundled_ms": 27.281,
+            "raw_delta_pct": -33.2,
+            "spread_pct": [
+                0.6,
+                0.9
+            ],
+            "system_runs_ms": [
+                40.6996,
+                40.8386,
+                40.8448,
+                40.7808,
+                40.8894,
+                40.9271,
+                40.9169
+            ],
+            "bundled_runs_ms": [
+                27.1797,
+                27.281,
+                27.3165,
+                27.208,
+                27.3933,
+                27.2756,
+                27.4251
+            ],
+            "paired_ratios": [
+                0.66781,
+                0.66802,
+                0.66879,
+                0.66718,
+                0.66994,
+                0.66644,
+                0.67026
+            ]
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84411,
+            "delta_pct": -15.59,
+            "ci_delta_pct": [
+                -15.73,
+                -14.79
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.51,
+                "B2/C2": -15.36,
+                "B3/C3": -15.7
+            },
+            "build_spread_pct": 0.34,
+            "builds": 3,
+            "system_ms": 56.6127,
+            "bundled_ms": 47.7778,
+            "raw_delta_pct": -15.59,
+            "spread_pct": [
+                0.5,
+                3
+            ],
+            "system_runs_ms": [
+                56.5429,
+                56.4757,
+                56.6436,
+                56.6017,
+                56.6184,
+                56.7573,
+                56.6127
+            ],
+            "bundled_runs_ms": [
+                47.7755,
+                48.1225,
+                47.7331,
+                47.7778,
+                47.5971,
+                47.867,
+                49.0151
+            ],
+            "paired_ratios": [
+                0.84494,
+                0.85209,
+                0.84269,
+                0.84411,
+                0.84066,
+                0.84336,
+                0.8658
+            ]
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8795,
+            "delta_pct": -12.05,
+            "ci_delta_pct": [
+                -12.21,
+                -11.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.05,
+                "B2/C2": -12.57,
+                "B3/C3": -11.41
+            },
+            "build_spread_pct": 1.16,
+            "builds": 3,
+            "system_ms": 8.8456,
+            "bundled_ms": 7.7693,
+            "raw_delta_pct": -12.05,
+            "spread_pct": [
+                0.9,
+                1.4
+            ],
+            "system_runs_ms": [
+                8.8207,
+                8.8321,
+                8.8572,
+                8.85,
+                8.9026,
+                8.8456,
+                8.8292
+            ],
+            "bundled_runs_ms": [
+                7.7578,
+                7.7663,
+                7.8512,
+                7.7693,
+                7.7388,
+                7.8315,
+                7.7812
+            ],
+            "paired_ratios": [
+                0.8795,
+                0.87933,
+                0.88642,
+                0.87789,
+                0.86927,
+                0.88536,
+                0.8813
+            ]
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.67703,
+            "delta_pct": -32.3,
+            "ci_delta_pct": [
+                -32.62,
+                -32.03
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -32.03,
+                "B2/C2": -32.54,
+                "B3/C3": -32.61
+            },
+            "build_spread_pct": 0.58,
+            "builds": 3,
+            "system_ms": 27.2887,
+            "bundled_ms": 18.4646,
+            "raw_delta_pct": -32.3,
+            "spread_pct": [
+                0.4,
+                2.9
+            ],
+            "system_runs_ms": [
+                27.2617,
+                27.2731,
+                27.2887,
+                27.2294,
+                27.2964,
+                27.3389,
+                27.3492
+            ],
+            "bundled_runs_ms": [
+                18.4726,
+                18.4646,
+                18.3905,
+                18.5073,
+                18.3489,
+                18.4221,
+                18.8773
+            ],
+            "paired_ratios": [
+                0.6776,
+                0.67703,
+                0.67392,
+                0.67968,
+                0.67221,
+                0.67384,
+                0.69023
+            ]
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68131,
+            "delta_pct": -31.87,
+            "ci_delta_pct": [
+                -32.31,
+                -31.37
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -31.74,
+                "B2/C2": -31.84,
+                "B3/C3": -32.2
+            },
+            "build_spread_pct": 0.46,
+            "builds": 3,
+            "system_ms": 14.3777,
+            "bundled_ms": 9.8354,
+            "raw_delta_pct": -31.87,
+            "spread_pct": [
+                1.3,
+                6.8
+            ],
+            "system_runs_ms": [
+                14.3412,
+                14.3704,
+                14.5115,
+                14.3588,
+                14.5308,
+                14.4853,
+                14.3777
+            ],
+            "bundled_runs_ms": [
+                9.7887,
+                9.8621,
+                9.7897,
+                9.7539,
+                9.8354,
+                9.869,
+                10.4262
+            ],
+            "paired_ratios": [
+                0.68256,
+                0.68628,
+                0.67462,
+                0.6793,
+                0.67687,
+                0.68131,
+                0.72516
+            ]
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7691,
+            "delta_pct": -23.09,
+            "ci_delta_pct": [
+                -23.27,
+                -22.14
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.22,
+                "B2/C2": -22.33,
+                "B3/C3": -22.95
+            },
+            "build_spread_pct": 0.89,
+            "builds": 3,
+            "system_ms": 77.5208,
+            "bundled_ms": 59.7229,
+            "raw_delta_pct": -23.09,
+            "spread_pct": [
+                1,
+                1.6
+            ],
+            "system_runs_ms": [
+                77.5574,
+                77.0872,
+                77.8556,
+                77.5208,
+                77.6533,
+                77.1898,
+                77.3337
+            ],
+            "bundled_runs_ms": [
+                59.5084,
+                60.4593,
+                59.6442,
+                59.5197,
+                59.7229,
+                59.8226,
+                60.2117
+            ],
+            "paired_ratios": [
+                0.76728,
+                0.7843,
+                0.76609,
+                0.76779,
+                0.7691,
+                0.77501,
+                0.7786
+            ]
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88638,
+            "delta_pct": -11.36,
+            "ci_delta_pct": [
+                -11.42,
+                -10.91
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.91,
+                "B2/C2": -11.46,
+                "B3/C3": -11.23
+            },
+            "build_spread_pct": 0.55,
+            "builds": 3,
+            "system_ms": 9.1462,
+            "bundled_ms": 8.1165,
+            "raw_delta_pct": -11.36,
+            "spread_pct": [
+                0.5,
+                0.6
+            ],
+            "system_runs_ms": [
+                9.1145,
+                9.1569,
+                9.1593,
+                9.1403,
+                9.1462,
+                9.1494,
+                9.1104
+            ],
+            "bundled_runs_ms": [
+                8.12,
+                8.0986,
+                8.1165,
+                8.0961,
+                8.107,
+                8.1366,
+                8.1413
+            ],
+            "paired_ratios": [
+                0.89089,
+                0.88443,
+                0.88615,
+                0.88576,
+                0.88638,
+                0.8893,
+                0.89363
+            ]
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68005,
+            "delta_pct": -31.99,
+            "ci_delta_pct": [
+                -32.28,
+                -31.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -31.6,
+                "B2/C2": -32.33,
+                "B3/C3": -31.82
+            },
+            "build_spread_pct": 0.73,
+            "builds": 3,
+            "system_ms": 29.5544,
+            "bundled_ms": 20.0936,
+            "raw_delta_pct": -31.99,
+            "spread_pct": [
+                1.6,
+                2.9
+            ],
+            "system_runs_ms": [
+                29.5472,
+                29.489,
+                29.9306,
+                29.5668,
+                29.7514,
+                29.4669,
+                29.5544
+            ],
+            "bundled_runs_ms": [
+                20.0936,
+                20.0251,
+                20.5466,
+                20.3052,
+                20.0594,
+                19.9552,
+                20.2164
+            ],
+            "paired_ratios": [
+                0.68005,
+                0.67907,
+                0.68647,
+                0.68676,
+                0.67423,
+                0.67721,
+                0.68404
+            ]
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.67778,
+            "delta_pct": -32.22,
+            "ci_delta_pct": [
+                -32.61,
+                -32.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -32.18,
+                "B2/C2": -32.34,
+                "B3/C3": -33.1
+            },
+            "build_spread_pct": 0.92,
+            "builds": 3,
+            "system_ms": 40.9635,
+            "bundled_ms": 27.717,
+            "raw_delta_pct": -32.22,
+            "spread_pct": [
+                3.9,
+                1.7
+            ],
+            "system_runs_ms": [
+                40.7597,
+                41.0051,
+                42.3635,
+                40.8812,
+                40.9635,
+                40.9929,
+                40.87
+            ],
+            "bundled_runs_ms": [
+                27.6262,
+                27.633,
+                28.09,
+                27.7488,
+                27.8231,
+                27.6649,
+                27.717
+            ],
+            "paired_ratios": [
+                0.67778,
+                0.67389,
+                0.66307,
+                0.67877,
+                0.67922,
+                0.67487,
+                0.67817
+            ]
+        },
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74599,
+            "delta_pct": -25.4,
+            "ci_delta_pct": [
+                -25.81,
+                -25.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.4,
+                "B2/C2": -25.43,
+                "B3/C3": -25
+            },
+            "build_spread_pct": 0.43,
+            "builds": 3,
+            "system_ms": 8.3107,
+            "bundled_ms": 6.2028,
+            "raw_delta_pct": -25.4,
+            "spread_pct": [
+                1.2,
+                1.2
+            ],
+            "system_runs_ms": [
+                8.3018,
+                8.2646,
+                8.294,
+                8.3196,
+                8.3649,
+                8.3107,
+                8.3615
+            ],
+            "bundled_runs_ms": [
+                6.1997,
+                6.1947,
+                6.2639,
+                6.2063,
+                6.2063,
+                6.1897,
+                6.2028
+            ],
+            "paired_ratios": [
+                0.74679,
+                0.74955,
+                0.75523,
+                0.74599,
+                0.74195,
+                0.74479,
+                0.74183
+            ]
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74739,
+            "delta_pct": -25.26,
+            "ci_delta_pct": [
+                -25.75,
+                -24.92
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.26,
+                "B2/C2": -25.46,
+                "B3/C3": -25.25
+            },
+            "build_spread_pct": 0.21,
+            "builds": 3,
+            "system_ms": 8.2777,
+            "bundled_ms": 6.2049,
+            "raw_delta_pct": -25.26,
+            "spread_pct": [
+                1.6,
+                1.6
+            ],
+            "system_runs_ms": [
+                8.2445,
+                8.2777,
+                8.2642,
+                8.3064,
+                8.3731,
+                8.2579,
+                8.3413
+            ],
+            "bundled_runs_ms": [
+                6.2452,
+                6.1944,
+                6.2049,
+                6.2081,
+                6.2171,
+                6.1452,
+                6.185
+            ],
+            "paired_ratios": [
+                0.7575,
+                0.74832,
+                0.75082,
+                0.74739,
+                0.74251,
+                0.74416,
+                0.74149
+            ]
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90838,
+            "delta_pct": -9.16,
+            "ci_delta_pct": [
+                -9.41,
+                -8.68
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.16,
+                "B2/C2": -9.52,
+                "B3/C3": -8.61
+            },
+            "build_spread_pct": 0.91,
+            "builds": 3,
+            "system_ms": 15.1346,
+            "bundled_ms": 13.7695,
+            "raw_delta_pct": -9.16,
+            "spread_pct": [
+                1.2,
+                0.7
+            ],
+            "system_runs_ms": [
+                15.1346,
+                15.1359,
+                15.092,
+                15.099,
+                15.2783,
+                15.1041,
+                15.1683
+            ],
+            "bundled_runs_ms": [
+                13.7479,
+                13.7118,
+                13.7819,
+                13.7344,
+                13.8063,
+                13.8139,
+                13.7695
+            ],
+            "paired_ratios": [
+                0.90838,
+                0.90591,
+                0.91319,
+                0.90962,
+                0.90365,
+                0.91458,
+                0.90778
+            ]
+        },
+        "api.increment.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79015,
+            "delta_pct": -20.98,
+            "ci_delta_pct": [
+                -21.35,
+                -18.67
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.98,
+                "B2/C2": -18.94,
+                "B3/C3": -21.37
+            },
+            "build_spread_pct": 2.43,
+            "builds": 3,
+            "system_ms": 8.9506,
+            "bundled_ms": 7.191,
+            "raw_delta_pct": -20.98,
+            "spread_pct": [
+                3,
+                3.5
+            ],
+            "system_runs_ms": [
+                8.9075,
+                8.9346,
+                9.0989,
+                8.9506,
+                8.9119,
+                9.1795,
+                9.069
+            ],
+            "bundled_runs_ms": [
+                7.0312,
+                7.191,
+                7.1565,
+                7.2797,
+                7.2744,
+                7.2159,
+                7.1659
+            ],
+            "paired_ratios": [
+                0.78936,
+                0.80485,
+                0.78652,
+                0.81332,
+                0.81626,
+                0.78609,
+                0.79015
+            ]
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90366,
+            "delta_pct": -9.63,
+            "ci_delta_pct": [
+                -10.04,
+                -9.13
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.91,
+                "B2/C2": -9.38,
+                "B3/C3": -9.71
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 4.83,
+            "bundled_ms": 4.3613,
+            "raw_delta_pct": -9.63,
+            "spread_pct": [
+                1.3,
+                1
+            ],
+            "system_runs_ms": [
+                4.8479,
+                4.8051,
+                4.789,
+                4.849,
+                4.8121,
+                4.8505,
+                4.83
+            ],
+            "bundled_runs_ms": [
+                4.3613,
+                4.3666,
+                4.3571,
+                4.3683,
+                4.3485,
+                4.3462,
+                4.3879
+            ],
+            "paired_ratios": [
+                0.89963,
+                0.90874,
+                0.90981,
+                0.90087,
+                0.90366,
+                0.89603,
+                0.90847
+            ]
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90781,
+            "delta_pct": -9.22,
+            "ci_delta_pct": [
+                -9.43,
+                -8.98
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.03,
+                "B2/C2": -8.72,
+                "B3/C3": -9.4
+            },
+            "build_spread_pct": 0.68,
+            "builds": 3,
+            "system_ms": 4.8649,
+            "bundled_ms": 4.42,
+            "raw_delta_pct": -9.22,
+            "spread_pct": [
+                1.6,
+                1.7
+            ],
+            "system_runs_ms": [
+                4.8561,
+                4.8649,
+                4.8524,
+                4.8556,
+                4.8685,
+                4.8906,
+                4.9286
+            ],
+            "bundled_runs_ms": [
+                4.42,
+                4.4164,
+                4.3947,
+                4.4171,
+                4.4684,
+                4.432,
+                4.4281
+            ],
+            "paired_ratios": [
+                0.9102,
+                0.90781,
+                0.90568,
+                0.90969,
+                0.91782,
+                0.90623,
+                0.89845
+            ]
+        },
+        "api.range.size.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.54621,
+            "delta_pct": -45.38,
+            "ci_delta_pct": [
+                -45.5,
+                -45.28
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -45.4,
+                "B2/C2": -45.31,
+                "B3/C3": -45.33
+            },
+            "build_spread_pct": 0.09,
+            "builds": 3,
+            "system_ms": 1.8271,
+            "bundled_ms": 0.9964,
+            "raw_delta_pct": -45.38,
+            "spread_pct": [
+                0.5,
+                0.8
+            ],
+            "system_runs_ms": [
+                1.828,
+                1.8312,
+                1.8271,
+                1.822,
+                1.8227,
+                1.8257,
+                1.8293
+            ],
+            "bundled_runs_ms": [
+                0.998,
+                1.0021,
+                1.0019,
+                0.9952,
+                0.9964,
+                0.995,
+                0.9944
+            ],
+            "paired_ratios": [
+                0.54595,
+                0.54724,
+                0.54836,
+                0.54621,
+                0.54666,
+                0.545,
+                0.5436
+            ]
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.82336,
+            "delta_pct": -17.66,
+            "ci_delta_pct": [
+                -17.68,
+                -17.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -17.68,
+                "B2/C2": -17.6,
+                "B3/C3": -17.56
+            },
+            "build_spread_pct": 0.12,
+            "builds": 3,
+            "system_ms": 2.7873,
+            "bundled_ms": 2.2963,
+            "raw_delta_pct": -17.66,
+            "spread_pct": [
+                1.3,
+                0.6
+            ],
+            "system_runs_ms": [
+                2.7539,
+                2.7843,
+                2.7899,
+                2.7873,
+                2.7893,
+                2.7673,
+                2.7887
+            ],
+            "bundled_runs_ms": [
+                2.2967,
+                2.2963,
+                2.2967,
+                2.2825,
+                2.2966,
+                2.2846,
+                2.2956
+            ],
+            "paired_ratios": [
+                0.83398,
+                0.82473,
+                0.82322,
+                0.81889,
+                0.82336,
+                0.82557,
+                0.82318
+            ]
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76596,
+            "delta_pct": -23.4,
+            "ci_delta_pct": [
+                -23.8,
+                -23.17
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.53,
+                "B2/C2": -23.02,
+                "B3/C3": -23.6
+            },
+            "build_spread_pct": 0.58,
+            "builds": 3,
+            "system_ms": 15.3249,
+            "bundled_ms": 11.746,
+            "raw_delta_pct": -23.4,
+            "spread_pct": [
+                3.6,
+                0.8
+            ],
+            "system_runs_ms": [
+                15.3176,
+                15.371,
+                15.3073,
+                15.8107,
+                15.2586,
+                15.3972,
+                15.3249
+            ],
+            "bundled_runs_ms": [
+                11.746,
+                11.8101,
+                11.7248,
+                11.788,
+                11.7675,
+                11.7325,
+                11.7197
+            ],
+            "paired_ratios": [
+                0.76683,
+                0.76834,
+                0.76596,
+                0.74557,
+                0.7712,
+                0.76199,
+                0.76475
+            ]
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69465,
+            "delta_pct": -30.54,
+            "ci_delta_pct": [
+                -30.84,
+                -29.24
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -30.48,
+                "B2/C2": -30.04,
+                "B3/C3": -31.17
+            },
+            "build_spread_pct": 1.13,
+            "builds": 3,
+            "system_ms": 4.7036,
+            "bundled_ms": 3.2589,
+            "raw_delta_pct": -30.54,
+            "spread_pct": [
+                0.6,
+                6.3
+            ],
+            "system_runs_ms": [
+                4.6862,
+                4.7123,
+                4.6818,
+                4.6978,
+                4.7112,
+                4.7036,
+                4.7095
+            ],
+            "bundled_runs_ms": [
+                3.2509,
+                3.2589,
+                3.2522,
+                3.2661,
+                3.3336,
+                3.2076,
+                3.4132
+            ],
+            "paired_ratios": [
+                0.69372,
+                0.69157,
+                0.69465,
+                0.69524,
+                0.70759,
+                0.68195,
+                0.72475
+            ]
+        },
+        "api.setop.union.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76374,
+            "delta_pct": -23.63,
+            "ci_delta_pct": [
+                -24.12,
+                -23.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.63,
+                "B2/C2": -23.52,
+                "B3/C3": -23.77
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 11.8961,
+            "bundled_ms": 9.0855,
+            "raw_delta_pct": -23.63,
+            "spread_pct": [
+                1.1,
+                1.6
+            ],
+            "system_runs_ms": [
+                11.9683,
+                11.8647,
+                11.8326,
+                11.8961,
+                11.968,
+                11.8739,
+                11.9216
+            ],
+            "bundled_runs_ms": [
+                9.0388,
+                9.1119,
+                9.0602,
+                9.0855,
+                9.1153,
+                9.0103,
+                9.1527
+            ],
+            "paired_ratios": [
+                0.75523,
+                0.76798,
+                0.7657,
+                0.76374,
+                0.76164,
+                0.75883,
+                0.76774
+            ]
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75695,
+            "delta_pct": -24.3,
+            "ci_delta_pct": [
+                -24.34,
+                -24.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.32,
+                "B2/C2": -24.01,
+                "B3/C3": -24.23
+            },
+            "build_spread_pct": 0.31,
+            "builds": 3,
+            "system_ms": 5.7269,
+            "bundled_ms": 4.3359,
+            "raw_delta_pct": -24.3,
+            "spread_pct": [
+                1.1,
+                1.2
+            ],
+            "system_runs_ms": [
+                5.7345,
+                5.709,
+                5.7743,
+                5.7569,
+                5.7223,
+                5.7261,
+                5.7269
+            ],
+            "bundled_runs_ms": [
+                4.348,
+                4.3551,
+                4.3814,
+                4.3359,
+                4.3315,
+                4.3325,
+                4.3341
+            ],
+            "paired_ratios": [
+                0.75822,
+                0.76285,
+                0.75878,
+                0.75317,
+                0.75695,
+                0.75662,
+                0.7568
+            ]
+        },
+        "api.setop.diff.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79576,
+            "delta_pct": -20.42,
+            "ci_delta_pct": [
+                -20.85,
+                -20.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.42,
+                "B2/C2": -20.36,
+                "B3/C3": -20.78
+            },
+            "build_spread_pct": 0.42,
+            "builds": 3,
+            "system_ms": 5.4263,
+            "bundled_ms": 4.325,
+            "raw_delta_pct": -20.42,
+            "spread_pct": [
+                1.2,
+                2.6
+            ],
+            "system_runs_ms": [
+                5.4263,
+                5.4173,
+                5.4263,
+                5.4183,
+                5.4497,
+                5.4807,
+                5.4319
+            ],
+            "bundled_runs_ms": [
+                4.4026,
+                4.3298,
+                4.3295,
+                4.2884,
+                4.325,
+                4.3107,
+                4.3225
+            ],
+            "paired_ratios": [
+                0.81134,
+                0.79925,
+                0.79787,
+                0.79147,
+                0.79362,
+                0.78652,
+                0.79576
+            ]
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76935,
+            "delta_pct": -23.06,
+            "ci_delta_pct": [
+                -23.41,
+                -22.79
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.41,
+                "B2/C2": -23.19,
+                "B3/C3": -22.82
+            },
+            "build_spread_pct": 0.59,
+            "builds": 3,
+            "system_ms": 11.1656,
+            "bundled_ms": 8.5903,
+            "raw_delta_pct": -23.06,
+            "spread_pct": [
+                1.2,
+                1
+            ],
+            "system_runs_ms": [
+                11.1487,
+                11.1656,
+                11.1107,
+                11.246,
+                11.2299,
+                11.1749,
+                11.1417
+            ],
+            "bundled_runs_ms": [
+                8.5383,
+                8.5903,
+                8.5787,
+                8.5513,
+                8.6114,
+                8.6219,
+                8.6041
+            ],
+            "paired_ratios": [
+                0.76586,
+                0.76935,
+                0.77211,
+                0.76039,
+                0.76683,
+                0.77154,
+                0.77224
+            ]
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7479,
+            "delta_pct": -25.21,
+            "ci_delta_pct": [
+                -25.66,
+                -25.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.62,
+                "B2/C2": -25.36,
+                "B3/C3": -25.06
+            },
+            "build_spread_pct": 0.56,
+            "builds": 3,
+            "system_ms": 17.0866,
+            "bundled_ms": 12.7775,
+            "raw_delta_pct": -25.21,
+            "spread_pct": [
+                0.4,
+                0.8
+            ],
+            "system_runs_ms": [
+                17.0846,
+                17.0809,
+                17.0866,
+                17.1116,
+                17.1413,
+                17.0662,
+                17.0974
+            ],
+            "bundled_runs_ms": [
+                12.7775,
+                12.7994,
+                12.7796,
+                12.7173,
+                12.743,
+                12.8141,
+                12.7162
+            ],
+            "paired_ratios": [
+                0.7479,
+                0.74934,
+                0.74793,
+                0.7432,
+                0.74341,
+                0.75085,
+                0.74375
+            ]
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74491,
+            "delta_pct": -25.51,
+            "ci_delta_pct": [
+                -26.36,
+                -25.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.45,
+                "B2/C2": -25.1,
+                "B3/C3": -26.34
+            },
+            "build_spread_pct": 1.24,
+            "builds": 3,
+            "system_ms": 7.0776,
+            "bundled_ms": 5.271,
+            "raw_delta_pct": -25.51,
+            "spread_pct": [
+                1.3,
+                4
+            ],
+            "system_runs_ms": [
+                7.0579,
+                7.116,
+                7.1002,
+                7.0776,
+                7.0332,
+                7.0449,
+                7.1257
+            ],
+            "bundled_runs_ms": [
+                5.2885,
+                5.3585,
+                5.271,
+                5.2121,
+                5.2391,
+                5.1489,
+                5.3123
+            ],
+            "paired_ratios": [
+                0.7493,
+                0.75302,
+                0.74237,
+                0.73642,
+                0.74491,
+                0.73087,
+                0.74551
+            ]
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77314,
+            "delta_pct": -22.69,
+            "ci_delta_pct": [
+                -23.32,
+                -22.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.7,
+                "B2/C2": -23.1,
+                "B3/C3": -22.54
+            },
+            "build_spread_pct": 0.56,
+            "builds": 3,
+            "system_ms": 6.7366,
+            "bundled_ms": 5.2279,
+            "raw_delta_pct": -22.69,
+            "spread_pct": [
+                1,
+                3.4
+            ],
+            "system_runs_ms": [
+                6.719,
+                6.7484,
+                6.7666,
+                6.7366,
+                6.7331,
+                6.7368,
+                6.6965
+            ],
+            "bundled_runs_ms": [
+                5.1519,
+                5.2537,
+                5.2315,
+                5.2913,
+                5.1132,
+                5.2279,
+                5.1764
+            ],
+            "paired_ratios": [
+                0.76677,
+                0.77851,
+                0.77314,
+                0.78546,
+                0.75941,
+                0.77602,
+                0.773
+            ]
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75872,
+            "delta_pct": -24.13,
+            "ci_delta_pct": [
+                -24.56,
+                -23.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.93,
+                "B2/C2": -23.87,
+                "B3/C3": -24.2
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 13.7227,
+            "bundled_ms": 10.4117,
+            "raw_delta_pct": -24.13,
+            "spread_pct": [
+                0.4,
+                2.2
+            ],
+            "system_runs_ms": [
+                13.6941,
+                13.7521,
+                13.7227,
+                13.7556,
+                13.7154,
+                13.7073,
+                13.7359
+            ],
+            "bundled_runs_ms": [
+                10.5384,
+                10.5686,
+                10.4117,
+                10.464,
+                10.3423,
+                10.3796,
+                10.3625
+            ],
+            "paired_ratios": [
+                0.76956,
+                0.76851,
+                0.75872,
+                0.76071,
+                0.75406,
+                0.75723,
+                0.75441
+            ]
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77968,
+            "delta_pct": -22.03,
+            "ci_delta_pct": [
+                -22.63,
+                -21.82
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.03,
+                "B2/C2": -21.06,
+                "B3/C3": -22.38
+            },
+            "build_spread_pct": 1.32,
+            "builds": 3,
+            "system_ms": 108.917,
+            "bundled_ms": 84.9712,
+            "raw_delta_pct": -22.03,
+            "spread_pct": [
+                1.5,
+                2.5
+            ],
+            "system_runs_ms": [
+                108.9617,
+                108.908,
+                108.6849,
+                108.764,
+                108.917,
+                110.2725,
+                109.9002
+            ],
+            "bundled_runs_ms": [
+                84.9553,
+                87.0513,
+                84.9688,
+                84.9877,
+                84.8923,
+                84.9712,
+                85.0301
+            ],
+            "paired_ratios": [
+                0.77968,
+                0.79931,
+                0.78179,
+                0.7814,
+                0.77942,
+                0.77056,
+                0.7737
+            ]
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76337,
+            "delta_pct": -23.66,
+            "ci_delta_pct": [
+                -23.79,
+                -23.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.47,
+                "B2/C2": -23.8,
+                "B3/C3": -23.77
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 47.1755,
+            "bundled_ms": 36.088,
+            "raw_delta_pct": -23.66,
+            "spread_pct": [
+                0.7,
+                0.7
+            ],
+            "system_runs_ms": [
+                47.1655,
+                47.1583,
+                47.1755,
+                47.1246,
+                47.4714,
+                47.2563,
+                47.2747
+            ],
+            "bundled_runs_ms": [
+                36.0974,
+                36.1037,
+                35.9505,
+                36.1855,
+                36.001,
+                36.0391,
+                36.088
+            ],
+            "paired_ratios": [
+                0.76533,
+                0.76559,
+                0.76206,
+                0.76787,
+                0.75837,
+                0.76263,
+                0.76337
+            ]
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.731,
+            "delta_pct": -26.9,
+            "ci_delta_pct": [
+                -26.94,
+                -26.76
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.9,
+                "B2/C2": -26.83,
+                "B3/C3": -26.84
+            },
+            "build_spread_pct": 0.07,
+            "builds": 3,
+            "system_ms": 44.4856,
+            "bundled_ms": 32.5652,
+            "raw_delta_pct": -26.9,
+            "spread_pct": [
+                0.5,
+                0.5
+            ],
+            "system_runs_ms": [
+                44.452,
+                44.487,
+                44.655,
+                44.4921,
+                44.4856,
+                44.4759,
+                44.4483
+            ],
+            "bundled_runs_ms": [
+                32.4945,
+                32.4716,
+                32.632,
+                32.5652,
+                32.6301,
+                32.573,
+                32.4734
+            ],
+            "paired_ratios": [
+                0.731,
+                0.72991,
+                0.73076,
+                0.73193,
+                0.7335,
+                0.73237,
+                0.73059
+            ]
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79092,
+            "delta_pct": -20.91,
+            "ci_delta_pct": [
+                -22.36,
+                -20.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.91,
+                "B2/C2": -21.23,
+                "B3/C3": -20.99
+            },
+            "build_spread_pct": 0.32,
+            "builds": 3,
+            "system_ms": 18.7209,
+            "bundled_ms": 14.8839,
+            "raw_delta_pct": -20.91,
+            "spread_pct": [
+                4.5,
+                2.8
+            ],
+            "system_runs_ms": [
+                18.7006,
+                18.7236,
+                18.7012,
+                18.6948,
+                18.7209,
+                19.2747,
+                19.5298
+            ],
+            "bundled_runs_ms": [
+                14.7907,
+                14.8785,
+                15.032,
+                14.9136,
+                14.6169,
+                14.9647,
+                14.8839
+            ],
+            "paired_ratios": [
+                0.79092,
+                0.79464,
+                0.8038,
+                0.79774,
+                0.78078,
+                0.77639,
+                0.76211
+            ]
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7693,
+            "delta_pct": -23.07,
+            "ci_delta_pct": [
+                -25,
+                -22.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.41,
+                "B2/C2": -23.66,
+                "B3/C3": -22.78
+            },
+            "build_spread_pct": 1.63,
+            "builds": 3,
+            "system_ms": 87.9217,
+            "bundled_ms": 67.8054,
+            "raw_delta_pct": -23.07,
+            "spread_pct": [
+                3.5,
+                1.3
+            ],
+            "system_runs_ms": [
+                90.5109,
+                90.2915,
+                87.9217,
+                87.7419,
+                87.4287,
+                87.4823,
+                90.2676
+            ],
+            "bundled_runs_ms": [
+                67.6829,
+                67.7194,
+                67.6382,
+                68.5112,
+                67.9123,
+                67.8054,
+                68.2345
+            ],
+            "paired_ratios": [
+                0.74779,
+                0.75001,
+                0.7693,
+                0.78083,
+                0.77677,
+                0.77508,
+                0.75591
+            ]
+        },
+        "adv.forEach.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9431,
+            "delta_pct": -5.69,
+            "ci_delta_pct": [
+                -5.87,
+                -3.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.12,
+                "B2/C2": -4.65,
+                "B3/C3": -5.82
+            },
+            "build_spread_pct": 1.17,
+            "builds": 3,
+            "system_ms": 10.0591,
+            "bundled_ms": 9.5724,
+            "raw_delta_pct": -5.69,
+            "spread_pct": [
+                3.2,
+                3.6
+            ],
+            "system_runs_ms": [
+                10.0889,
+                10,
+                10.0591,
+                9.9445,
+                10.123,
+                10.2688,
+                10.0284
+            ],
+            "bundled_runs_ms": [
+                9.5724,
+                9.431,
+                9.469,
+                9.6221,
+                9.7581,
+                9.6755,
+                9.4104
+            ],
+            "paired_ratios": [
+                0.94881,
+                0.9431,
+                0.94134,
+                0.96758,
+                0.96395,
+                0.94222,
+                0.93838
+            ]
+        },
+        "adv.forEach.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.71199,
+            "delta_pct": -28.8,
+            "ci_delta_pct": [
+                -28.9,
+                -28.11
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -28.86,
+                "B2/C2": -28.52,
+                "B3/C3": -28.51
+            },
+            "build_spread_pct": 0.35,
+            "builds": 3,
+            "system_ms": 23.6267,
+            "bundled_ms": 16.9128,
+            "raw_delta_pct": -28.8,
+            "spread_pct": [
+                1.1,
+                1.1
+            ],
+            "system_runs_ms": [
+                23.6928,
+                23.6196,
+                23.7866,
+                23.522,
+                23.6029,
+                23.6267,
+                23.6855
+            ],
+            "bundled_runs_ms": [
+                16.8544,
+                16.817,
+                16.9128,
+                16.9703,
+                16.9397,
+                16.9841,
+                16.7958
+            ],
+            "paired_ratios": [
+                0.71137,
+                0.71199,
+                0.71102,
+                0.72147,
+                0.7177,
+                0.71885,
+                0.70912
+            ]
+        },
+        "adv.filter.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93362,
+            "delta_pct": -6.64,
+            "ci_delta_pct": [
+                -7.27,
+                -6.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.46,
+                "B2/C2": -6.96,
+                "B3/C3": -6.74
+            },
+            "build_spread_pct": 0.5,
+            "builds": 3,
+            "system_ms": 14.9596,
+            "bundled_ms": 13.9724,
+            "raw_delta_pct": -6.64,
+            "spread_pct": [
+                0.8,
+                1.3
+            ],
+            "system_runs_ms": [
+                14.9591,
+                14.9596,
+                14.9659,
+                14.9087,
+                14.9963,
+                14.8852,
+                15.0037
+            ],
+            "bundled_runs_ms": [
+                13.9921,
+                13.8466,
+                13.9724,
+                14.0284,
+                14.0246,
+                13.8681,
+                13.9133
+            ],
+            "paired_ratios": [
+                0.93536,
+                0.9256,
+                0.93362,
+                0.94095,
+                0.9352,
+                0.93167,
+                0.92732
+            ]
+        },
+        "adv.filter.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.82021,
+            "delta_pct": -17.98,
+            "ci_delta_pct": [
+                -18.22,
+                -17.39
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -17.87,
+                "B2/C2": -18.18,
+                "B3/C3": -16.33
+            },
+            "build_spread_pct": 1.85,
+            "builds": 3,
+            "system_ms": 44.835,
+            "bundled_ms": 36.8099,
+            "raw_delta_pct": -17.98,
+            "spread_pct": [
+                0.6,
+                4.4
+            ],
+            "system_runs_ms": [
+                44.8986,
+                44.8138,
+                44.835,
+                44.8791,
+                44.9618,
+                44.7284,
+                44.6763
+            ],
+            "bundled_runs_ms": [
+                36.8764,
+                36.6417,
+                38.2501,
+                36.7019,
+                36.8099,
+                36.6868,
+                36.9068
+            ],
+            "paired_ratios": [
+                0.82133,
+                0.81764,
+                0.85313,
+                0.81779,
+                0.81869,
+                0.82021,
+                0.82609
+            ]
+        },
+        "adv.map.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91224,
+            "delta_pct": -8.78,
+            "ci_delta_pct": [
+                -9.12,
+                -8.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.79,
+                "B2/C2": -11.27,
+                "B3/C3": -8.07
+            },
+            "build_spread_pct": 3.2,
+            "builds": 3,
+            "system_ms": 16.0543,
+            "bundled_ms": 14.6626,
+            "raw_delta_pct": -8.78,
+            "spread_pct": [
+                6.6,
+                0.7
+            ],
+            "system_runs_ms": [
+                16.0543,
+                16.1144,
+                15.9824,
+                16.0552,
+                17.0034,
+                15.9877,
+                15.9383
+            ],
+            "bundled_runs_ms": [
+                14.6428,
+                14.7002,
+                14.6925,
+                14.591,
+                14.6626,
+                14.6983,
+                14.6065
+            ],
+            "paired_ratios": [
+                0.91208,
+                0.91224,
+                0.91929,
+                0.9088,
+                0.86233,
+                0.91935,
+                0.91644
+            ]
+        },
+        "adv.map.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.81809,
+            "delta_pct": -18.19,
+            "ci_delta_pct": [
+                -18.42,
+                -17.78
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -17.82,
+                "B2/C2": -19.44,
+                "B3/C3": -18.04
+            },
+            "build_spread_pct": 1.62,
+            "builds": 3,
+            "system_ms": 61.0674,
+            "bundled_ms": 50.0246,
+            "raw_delta_pct": -18.19,
+            "spread_pct": [
+                3.1,
+                0.4
+            ],
+            "system_runs_ms": [
+                60.9053,
+                61.2208,
+                60.8413,
+                61.0674,
+                62.7395,
+                61.3198,
+                60.902
+            ],
+            "bundled_runs_ms": [
+                50.0515,
+                49.9423,
+                50.0246,
+                49.9589,
+                49.9033,
+                50.0935,
+                50.0853
+            ],
+            "paired_ratios": [
+                0.82179,
+                0.81577,
+                0.82221,
+                0.81809,
+                0.7954,
+                0.81692,
+                0.82239
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79984,
+            "delta_pct": -20.02,
+            "ci_delta_pct": [
+                -20.18,
+                -19.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.18,
+                "B2/C2": -19.94,
+                "B3/C3": -19.82
+            },
+            "build_spread_pct": 0.36,
+            "builds": 3,
+            "system_ms": 27.7679,
+            "bundled_ms": 22.2209,
+            "raw_delta_pct": -20.02,
+            "spread_pct": [
+                0.6,
+                0.5
+            ],
+            "system_runs_ms": [
+                27.9035,
+                27.7679,
+                27.8581,
+                27.7635,
+                27.7626,
+                27.7341,
+                27.808
+            ],
+            "bundled_runs_ms": [
+                22.2209,
+                22.21,
+                22.3048,
+                22.187,
+                22.25,
+                22.2673,
+                22.1963
+            ],
+            "paired_ratios": [
+                0.79635,
+                0.79984,
+                0.80066,
+                0.79914,
+                0.80144,
+                0.80289,
+                0.7982
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68494,
+            "delta_pct": -31.51,
+            "ci_delta_pct": [
+                -31.64,
+                -30.95
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -31.51,
+                "B2/C2": -31.77,
+                "B3/C3": -31.06
+            },
+            "build_spread_pct": 0.71,
+            "builds": 3,
+            "system_ms": 19.1397,
+            "bundled_ms": 13.18,
+            "raw_delta_pct": -31.51,
+            "spread_pct": [
+                1.3,
+                0.9
+            ],
+            "system_runs_ms": [
+                19.1264,
+                19.3207,
+                19.1007,
+                19.1397,
+                19.3573,
+                19.1157,
+                19.1591
+            ],
+            "bundled_runs_ms": [
+                13.2073,
+                13.2085,
+                13.12,
+                13.1085,
+                13.18,
+                13.2269,
+                13.1228
+            ],
+            "paired_ratios": [
+                0.69053,
+                0.68365,
+                0.68689,
+                0.68489,
+                0.68088,
+                0.69194,
+                0.68494
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8579,
+            "delta_pct": -14.21,
+            "ci_delta_pct": [
+                -14.53,
+                -13.82
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.19,
+                "B2/C2": -14.79,
+                "B3/C3": -14.01
+            },
+            "build_spread_pct": 0.78,
+            "builds": 3,
+            "system_ms": 68.9249,
+            "bundled_ms": 59.2357,
+            "raw_delta_pct": -14.21,
+            "spread_pct": [
+                1.7,
+                1.1
+            ],
+            "system_runs_ms": [
+                68.5449,
+                69.5795,
+                68.5643,
+                68.9386,
+                69.7245,
+                68.9249,
+                68.8977
+            ],
+            "bundled_runs_ms": [
+                59.4366,
+                59.4708,
+                58.8214,
+                59.0821,
+                59.2357,
+                59.4005,
+                59.1214
+            ],
+            "paired_ratios": [
+                0.86712,
+                0.85472,
+                0.8579,
+                0.85702,
+                0.84957,
+                0.86181,
+                0.8581
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78063,
+            "delta_pct": -21.94,
+            "ci_delta_pct": [
+                -21.96,
+                -21.66
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.96,
+                "B2/C2": -21.94,
+                "B3/C3": -21.76
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 26.3098,
+            "bundled_ms": 20.5382,
+            "raw_delta_pct": -21.94,
+            "spread_pct": [
+                0.5,
+                0.9
+            ],
+            "system_runs_ms": [
+                26.3184,
+                26.2173,
+                26.2292,
+                26.2871,
+                26.3098,
+                26.3396,
+                26.3373
+            ],
+            "bundled_runs_ms": [
+                20.5326,
+                20.4651,
+                20.5481,
+                20.5155,
+                20.5382,
+                20.5838,
+                20.6442
+            ],
+            "paired_ratios": [
+                0.78016,
+                0.7806,
+                0.78341,
+                0.78044,
+                0.78063,
+                0.78148,
+                0.78384
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.65103,
+            "delta_pct": -34.9,
+            "ci_delta_pct": [
+                -35.05,
+                -34.68
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -34.68,
+                "B2/C2": -34.94,
+                "B3/C3": -34.94
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 16.1794,
+            "bundled_ms": 10.5318,
+            "raw_delta_pct": -34.9,
+            "spread_pct": [
+                0.8,
+                0.6
+            ],
+            "system_runs_ms": [
+                16.2725,
+                16.1662,
+                16.1511,
+                16.1702,
+                16.2179,
+                16.2146,
+                16.1794
+            ],
+            "bundled_runs_ms": [
+                10.5076,
+                10.5111,
+                10.5253,
+                10.5641,
+                10.5583,
+                10.5318,
+                10.5685
+            ],
+            "paired_ratios": [
+                0.64573,
+                0.65019,
+                0.65168,
+                0.65331,
+                0.65103,
+                0.64953,
+                0.65321
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83293,
+            "delta_pct": -16.71,
+            "ci_delta_pct": [
+                -16.88,
+                -16.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.67,
+                "B2/C2": -16.65,
+                "B3/C3": -16.85
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 61.577,
+            "bundled_ms": 51.2228,
+            "raw_delta_pct": -16.71,
+            "spread_pct": [
+                0.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                61.8294,
+                61.6626,
+                61.577,
+                61.5137,
+                61.642,
+                61.5598,
+                61.4316
+            ],
+            "bundled_runs_ms": [
+                51.1753,
+                51.3608,
+                51.2228,
+                51.4932,
+                51.4083,
+                51.1655,
+                51.1934
+            ],
+            "paired_ratios": [
+                0.82769,
+                0.83293,
+                0.83185,
+                0.8371,
+                0.83398,
+                0.83115,
+                0.83334
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84536,
+            "delta_pct": -15.46,
+            "ci_delta_pct": [
+                -15.58,
+                -15.18
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.49,
+                "B2/C2": -15.52,
+                "B3/C3": -15.19
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 34.5983,
+            "bundled_ms": 29.2955,
+            "raw_delta_pct": -15.46,
+            "spread_pct": [
+                0.9,
+                0.7
+            ],
+            "system_runs_ms": [
+                34.5908,
+                34.5718,
+                34.5506,
+                34.8569,
+                34.6546,
+                34.6256,
+                34.5983
+            ],
+            "bundled_runs_ms": [
+                29.2315,
+                29.1847,
+                29.3062,
+                29.2184,
+                29.2955,
+                29.3612,
+                29.3832
+            ],
+            "paired_ratios": [
+                0.84507,
+                0.84418,
+                0.84821,
+                0.83824,
+                0.84536,
+                0.84796,
+                0.84927
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77837,
+            "delta_pct": -22.16,
+            "ci_delta_pct": [
+                -22.3,
+                -21.79
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.16,
+                "B2/C2": -22.35,
+                "B3/C3": -21.92
+            },
+            "build_spread_pct": 0.43,
+            "builds": 3,
+            "system_ms": 22.9525,
+            "bundled_ms": 17.8626,
+            "raw_delta_pct": -22.16,
+            "spread_pct": [
+                0.6,
+                1.2
+            ],
+            "system_runs_ms": [
+                22.8503,
+                22.9525,
+                22.8733,
+                22.9778,
+                22.9887,
+                22.918,
+                22.9561
+            ],
+            "bundled_runs_ms": [
+                17.7854,
+                17.8088,
+                17.8275,
+                17.8852,
+                17.8626,
+                17.9249,
+                17.998
+            ],
+            "paired_ratios": [
+                0.77834,
+                0.7759,
+                0.7794,
+                0.77837,
+                0.77702,
+                0.78213,
+                0.78402
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92105,
+            "delta_pct": -7.9,
+            "ci_delta_pct": [
+                -8.09,
+                -7.68
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.68,
+                "B2/C2": -8.09,
+                "B3/C3": -7.94
+            },
+            "build_spread_pct": 0.41,
+            "builds": 3,
+            "system_ms": 66.2023,
+            "bundled_ms": 61.0211,
+            "raw_delta_pct": -7.9,
+            "spread_pct": [
+                0.7,
+                0.7
+            ],
+            "system_runs_ms": [
+                66.059,
+                66.3907,
+                66.2023,
+                65.9204,
+                66.3367,
+                66.1881,
+                66.3504
+            ],
+            "bundled_runs_ms": [
+                60.8435,
+                61.0211,
+                60.8317,
+                61.2122,
+                60.9741,
+                61.0495,
+                61.2525
+            ],
+            "paired_ratios": [
+                0.92105,
+                0.91912,
+                0.91888,
+                0.92858,
+                0.91916,
+                0.92236,
+                0.92317
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95531,
+            "delta_pct": -4.47,
+            "ci_delta_pct": [
+                -4.71,
+                -4.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.47,
+                "B2/C2": -4.8,
+                "B3/C3": -4.3
+            },
+            "build_spread_pct": 0.5,
+            "builds": 3,
+            "system_ms": 16.8319,
+            "bundled_ms": 16.0668,
+            "raw_delta_pct": -4.47,
+            "spread_pct": [
+                1,
+                0.6
+            ],
+            "system_runs_ms": [
+                16.8082,
+                16.8868,
+                16.8319,
+                16.7892,
+                16.8549,
+                16.7839,
+                16.9514
+            ],
+            "bundled_runs_ms": [
+                16.057,
+                16.0603,
+                16.1024,
+                16.143,
+                16.0616,
+                16.0668,
+                16.1532
+            ],
+            "paired_ratios": [
+                0.95531,
+                0.95106,
+                0.95666,
+                0.96151,
+                0.95293,
+                0.95727,
+                0.95291
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89401,
+            "delta_pct": -10.6,
+            "ci_delta_pct": [
+                -10.99,
+                -10.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.94,
+                "B2/C2": -10.76,
+                "B3/C3": -10.09
+            },
+            "build_spread_pct": 0.85,
+            "builds": 3,
+            "system_ms": 21.1581,
+            "bundled_ms": 18.9188,
+            "raw_delta_pct": -10.6,
+            "spread_pct": [
+                0.7,
+                1.1
+            ],
+            "system_runs_ms": [
+                21.2159,
+                21.1706,
+                21.1326,
+                21.1013,
+                21.1581,
+                21.127,
+                21.2427
+            ],
+            "bundled_runs_ms": [
+                18.8378,
+                18.8439,
+                18.952,
+                18.8648,
+                18.9317,
+                19.0435,
+                18.9188
+            ],
+            "paired_ratios": [
+                0.88791,
+                0.8901,
+                0.89681,
+                0.89401,
+                0.89477,
+                0.90138,
+                0.8906
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93591,
+            "delta_pct": -6.41,
+            "ci_delta_pct": [
+                -7.02,
+                -6.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.02,
+                "B2/C2": -6.26,
+                "B3/C3": -6.05
+            },
+            "build_spread_pct": 0.97,
+            "builds": 3,
+            "system_ms": 125.5511,
+            "bundled_ms": 117.3326,
+            "raw_delta_pct": -6.41,
+            "spread_pct": [
+                0.7,
+                1.4
+            ],
+            "system_runs_ms": [
+                126.2237,
+                125.3677,
+                125.5511,
+                125.6838,
+                125.5307,
+                125.8768,
+                125.3147
+            ],
+            "bundled_runs_ms": [
+                117.3183,
+                117.3326,
+                117.6969,
+                116.8607,
+                117.8691,
+                118.5267,
+                117.121
+            ],
+            "paired_ratios": [
+                0.92945,
+                0.93591,
+                0.93744,
+                0.9298,
+                0.93897,
+                0.94161,
+                0.93462
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95424,
+            "delta_pct": -4.58,
+            "ci_delta_pct": [
+                -4.79,
+                -4.5
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.58,
+                "B2/C2": -4.6,
+                "B3/C3": -4.6
+            },
+            "build_spread_pct": 0.02,
+            "builds": 3,
+            "system_ms": 16.8335,
+            "bundled_ms": 16.0755,
+            "raw_delta_pct": -4.58,
+            "spread_pct": [
+                0.8,
+                1
+            ],
+            "system_runs_ms": [
+                16.8671,
+                16.9349,
+                16.8335,
+                16.8035,
+                16.8332,
+                16.8225,
+                16.8807
+            ],
+            "bundled_runs_ms": [
+                15.9856,
+                16.1397,
+                16.0278,
+                16.0469,
+                16.0755,
+                16.0801,
+                16.1082
+            ],
+            "paired_ratios": [
+                0.94774,
+                0.95304,
+                0.95214,
+                0.95497,
+                0.95499,
+                0.95587,
+                0.95424
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88431,
+            "delta_pct": -11.57,
+            "ci_delta_pct": [
+                -11.75,
+                -11.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.75,
+                "B2/C2": -11.55,
+                "B3/C3": -11.44
+            },
+            "build_spread_pct": 0.31,
+            "builds": 3,
+            "system_ms": 21.4844,
+            "bundled_ms": 18.9658,
+            "raw_delta_pct": -11.57,
+            "spread_pct": [
+                0.5,
+                0.5
+            ],
+            "system_runs_ms": [
+                21.4844,
+                21.4845,
+                21.4694,
+                21.3937,
+                21.5029,
+                21.4023,
+                21.4995
+            ],
+            "bundled_runs_ms": [
+                18.9596,
+                18.9623,
+                18.9857,
+                18.9658,
+                19.0594,
+                18.9835,
+                18.958
+            ],
+            "paired_ratios": [
+                0.88248,
+                0.8826,
+                0.88431,
+                0.88651,
+                0.88636,
+                0.88698,
+                0.88179
+            ]
+        },
+        "adv.optiter.ratio.increment.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92814,
+            "delta_pct": -7.19,
+            "ci_delta_pct": [
+                -7.39,
+                -7.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.17,
+                "B2/C2": -7.29,
+                "B3/C3": -7.16
+            },
+            "build_spread_pct": 0.13,
+            "builds": 3,
+            "system_ms": 127.3619,
+            "bundled_ms": 118.1896,
+            "raw_delta_pct": -7.19,
+            "spread_pct": [
+                0.7,
+                0.9
+            ],
+            "system_runs_ms": [
+                127.3747,
+                126.8651,
+                127.5402,
+                127.3172,
+                127.741,
+                127.2246,
+                127.3619
+            ],
+            "bundled_runs_ms": [
+                118.6044,
+                117.4886,
+                118.4551,
+                118.1896,
+                118.5615,
+                118.0562,
+                117.6918
+            ],
+            "paired_ratios": [
+                0.93115,
+                0.92609,
+                0.92877,
+                0.92831,
+                0.92814,
+                0.92794,
+                0.92407
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89,
+            "delta_pct": -11,
+            "ci_delta_pct": [
+                -11.55,
+                -10.88
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11,
+                "B2/C2": -10.47,
+                "B3/C3": -11.62
+            },
+            "build_spread_pct": 1.15,
+            "builds": 3,
+            "system_ms": 34.2671,
+            "bundled_ms": 30.4597,
+            "raw_delta_pct": -11,
+            "spread_pct": [
+                0.7,
+                1.5
+            ],
+            "system_runs_ms": [
+                34.2609,
+                34.2671,
+                34.3972,
+                34.3815,
+                34.1783,
+                34.4069,
+                34.2438
+            ],
+            "bundled_runs_ms": [
+                30.4923,
+                30.8216,
+                30.3796,
+                30.4168,
+                30.4597,
+                30.4317,
+                30.4848
+            ],
+            "paired_ratios": [
+                0.89,
+                0.89945,
+                0.8832,
+                0.88469,
+                0.8912,
+                0.88447,
+                0.89023
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.67496,
+            "delta_pct": -32.5,
+            "ci_delta_pct": [
+                -32.63,
+                -32.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -32.5,
+                "B2/C2": -32.49,
+                "B3/C3": -32.36
+            },
+            "build_spread_pct": 0.14,
+            "builds": 3,
+            "system_ms": 21.0932,
+            "bundled_ms": 14.2404,
+            "raw_delta_pct": -32.5,
+            "spread_pct": [
+                0.7,
+                0.6
+            ],
+            "system_runs_ms": [
+                21.0604,
+                21.048,
+                21.0605,
+                21.0932,
+                21.1366,
+                21.1925,
+                21.0967
+            ],
+            "bundled_runs_ms": [
+                14.2732,
+                14.2396,
+                14.3257,
+                14.2353,
+                14.2404,
+                14.2544,
+                14.2394
+            ],
+            "paired_ratios": [
+                0.67773,
+                0.67653,
+                0.68022,
+                0.67488,
+                0.67373,
+                0.67262,
+                0.67496
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76048,
+            "delta_pct": -23.95,
+            "ci_delta_pct": [
+                -24.4,
+                -23.72
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.85,
+                "B2/C2": -24.59,
+                "B3/C3": -23.47
+            },
+            "build_spread_pct": 1.12,
+            "builds": 3,
+            "system_ms": 61.4705,
+            "bundled_ms": 46.8008,
+            "raw_delta_pct": -23.95,
+            "spread_pct": [
+                1,
+                2
+            ],
+            "system_runs_ms": [
+                61.4705,
+                61.4233,
+                61.2272,
+                61.3505,
+                61.8423,
+                61.5936,
+                61.6073
+            ],
+            "bundled_runs_ms": [
+                46.8092,
+                46.2001,
+                47.1557,
+                46.8008,
+                46.7516,
+                46.8405,
+                46.7098
+            ],
+            "paired_ratios": [
+                0.76149,
+                0.75216,
+                0.77018,
+                0.76284,
+                0.75598,
+                0.76048,
+                0.75819
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86427,
+            "delta_pct": -13.57,
+            "ci_delta_pct": [
+                -13.67,
+                -13.45
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.53,
+                "B2/C2": -13.56,
+                "B3/C3": -13.58
+            },
+            "build_spread_pct": 0.05,
+            "builds": 3,
+            "system_ms": 33.8625,
+            "bundled_ms": 29.2817,
+            "raw_delta_pct": -13.57,
+            "spread_pct": [
+                0.4,
+                0.5
+            ],
+            "system_runs_ms": [
+                33.8625,
+                33.8358,
+                33.7911,
+                33.9384,
+                33.927,
+                33.8681,
+                33.8193
+            ],
+            "bundled_runs_ms": [
+                29.2817,
+                29.2862,
+                29.1984,
+                29.1528,
+                29.2901,
+                29.2712,
+                29.2863
+            ],
+            "paired_ratios": [
+                0.86472,
+                0.86554,
+                0.86409,
+                0.85899,
+                0.86333,
+                0.86427,
+                0.86596
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68984,
+            "delta_pct": -31.02,
+            "ci_delta_pct": [
+                -31.16,
+                -30.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -30.49,
+                "B2/C2": -31.21,
+                "B3/C3": -31.06
+            },
+            "build_spread_pct": 0.72,
+            "builds": 3,
+            "system_ms": 18.1012,
+            "bundled_ms": 12.4801,
+            "raw_delta_pct": -31.02,
+            "spread_pct": [
+                0.5,
+                1
+            ],
+            "system_runs_ms": [
+                18.0615,
+                18.1208,
+                18.1012,
+                18.0505,
+                18.1118,
+                18.1337,
+                18.0587
+            ],
+            "bundled_runs_ms": [
+                12.4596,
+                12.4801,
+                12.4617,
+                12.5474,
+                12.4448,
+                12.5188,
+                12.5665
+            ],
+            "paired_ratios": [
+                0.68984,
+                0.68872,
+                0.68845,
+                0.69513,
+                0.68711,
+                0.69036,
+                0.69587
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79776,
+            "delta_pct": -20.22,
+            "ci_delta_pct": [
+                -20.41,
+                -19.64
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -19.64,
+                "B2/C2": -20.42,
+                "B3/C3": -20.22
+            },
+            "build_spread_pct": 0.78,
+            "builds": 3,
+            "system_ms": 53.3977,
+            "bundled_ms": 42.6792,
+            "raw_delta_pct": -20.22,
+            "spread_pct": [
+                0.7,
+                1.3
+            ],
+            "system_runs_ms": [
+                53.3378,
+                53.5551,
+                53.568,
+                53.1859,
+                53.3844,
+                53.5421,
+                53.3977
+            ],
+            "bundled_runs_ms": [
+                42.5507,
+                42.6143,
+                42.6792,
+                43.0401,
+                42.488,
+                42.7683,
+                42.9092
+            ],
+            "paired_ratios": [
+                0.79776,
+                0.79571,
+                0.79673,
+                0.80924,
+                0.79589,
+                0.79878,
+                0.80358
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88986,
+            "delta_pct": -11.01,
+            "ci_delta_pct": [
+                -11.23,
+                -10.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.01,
+                "B2/C2": -10.85,
+                "B3/C3": -10.97
+            },
+            "build_spread_pct": 0.16,
+            "builds": 3,
+            "system_ms": 44.3259,
+            "bundled_ms": 39.5098,
+            "raw_delta_pct": -11.01,
+            "spread_pct": [
+                0.7,
+                0.9
+            ],
+            "system_runs_ms": [
+                44.2728,
+                44.4402,
+                44.3016,
+                44.5755,
+                44.3259,
+                44.302,
+                44.3517
+            ],
+            "bundled_runs_ms": [
+                39.3964,
+                39.5098,
+                39.3262,
+                39.4692,
+                39.6256,
+                39.5619,
+                39.6872
+            ],
+            "paired_ratios": [
+                0.88986,
+                0.88906,
+                0.88769,
+                0.88545,
+                0.89396,
+                0.893,
+                0.89483
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78303,
+            "delta_pct": -21.7,
+            "ci_delta_pct": [
+                -22.01,
+                -21.56
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.66,
+                "B2/C2": -21.84,
+                "B3/C3": -21.86
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 27.655,
+            "bundled_ms": 21.6258,
+            "raw_delta_pct": -21.7,
+            "spread_pct": [
+                0.5,
+                0.8
+            ],
+            "system_runs_ms": [
+                27.5506,
+                27.655,
+                27.6815,
+                27.6181,
+                27.5879,
+                27.6716,
+                27.7009
+            ],
+            "bundled_runs_ms": [
+                21.612,
+                21.5325,
+                21.6708,
+                21.6258,
+                21.6465,
+                21.5823,
+                21.6998
+            ],
+            "paired_ratios": [
+                0.78445,
+                0.77861,
+                0.78286,
+                0.78303,
+                0.78464,
+                0.77994,
+                0.78336
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87771,
+            "delta_pct": -12.23,
+            "ci_delta_pct": [
+                -12.46,
+                -11.81
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.85,
+                "B2/C2": -12.33,
+                "B3/C3": -12.23
+            },
+            "build_spread_pct": 0.48,
+            "builds": 3,
+            "system_ms": 62.2387,
+            "bundled_ms": 54.6771,
+            "raw_delta_pct": -12.23,
+            "spread_pct": [
+                0.8,
+                1.1
+            ],
+            "system_runs_ms": [
+                62.2292,
+                62.2297,
+                62.4841,
+                61.958,
+                62.2387,
+                62.4612,
+                62.4572
+            ],
+            "bundled_runs_ms": [
+                54.8578,
+                54.4991,
+                55.1052,
+                54.7916,
+                54.6276,
+                54.5534,
+                54.6771
+            ],
+            "paired_ratios": [
+                0.88154,
+                0.87577,
+                0.88191,
+                0.88433,
+                0.87771,
+                0.8734,
+                0.87543
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.97529,
+            "delta_pct": -2.47,
+            "ci_delta_pct": [
+                -2.58,
+                -1.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.52,
+                "B2/C2": -2.6,
+                "B3/C3": -1.71
+            },
+            "build_spread_pct": 0.89,
+            "builds": 3,
+            "system_ms": 24.8451,
+            "bundled_ms": 24.291,
+            "raw_delta_pct": -2.47,
+            "spread_pct": [
+                0.9,
+                1.6
+            ],
+            "system_runs_ms": [
+                24.8058,
+                24.8451,
+                24.8502,
+                24.9177,
+                24.8566,
+                24.6835,
+                24.8253
+            ],
+            "bundled_runs_ms": [
+                24.1664,
+                24.2313,
+                24.3232,
+                24.291,
+                24.1775,
+                24.3612,
+                24.5672
+            ],
+            "paired_ratios": [
+                0.97422,
+                0.97529,
+                0.97879,
+                0.97485,
+                0.97268,
+                0.98694,
+                0.9896
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.96351,
+            "delta_pct": -3.65,
+            "ci_delta_pct": [
+                -3.89,
+                -3.28
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.59,
+                "B2/C2": -3.9,
+                "B3/C3": -3.55
+            },
+            "build_spread_pct": 0.35,
+            "builds": 3,
+            "system_ms": 27.3169,
+            "bundled_ms": 26.2998,
+            "raw_delta_pct": -3.65,
+            "spread_pct": [
+                0.8,
+                3.6
+            ],
+            "system_runs_ms": [
+                27.3244,
+                27.4114,
+                27.1923,
+                27.2834,
+                27.3169,
+                27.3175,
+                27.3066
+            ],
+            "bundled_runs_ms": [
+                26.344,
+                26.3366,
+                26.2998,
+                26.2877,
+                26.2553,
+                26.2758,
+                27.2109
+            ],
+            "paired_ratios": [
+                0.96412,
+                0.96079,
+                0.96718,
+                0.96351,
+                0.96114,
+                0.96187,
+                0.9965
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.98814,
+            "delta_pct": -1.19,
+            "ci_delta_pct": [
+                -1.49,
+                -1.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.04,
+                "B2/C2": -1.34,
+                "B3/C3": -1.86
+            },
+            "build_spread_pct": 0.82,
+            "builds": 3,
+            "system_ms": 109.9949,
+            "bundled_ms": 108.5939,
+            "raw_delta_pct": -1.19,
+            "spread_pct": [
+                1.1,
+                2.7
+            ],
+            "system_runs_ms": [
+                110.1533,
+                110.3291,
+                109.4248,
+                109.4941,
+                109.898,
+                110.6709,
+                109.9949
+            ],
+            "bundled_runs_ms": [
+                109.0108,
+                108.6885,
+                108.1265,
+                108.2199,
+                108.5939,
+                107.8593,
+                110.7611
+            ],
+            "paired_ratios": [
+                0.98963,
+                0.98513,
+                0.98814,
+                0.98836,
+                0.98813,
+                0.97459,
+                1.00697
+            ]
+        }
+    },
+    "array_vs_bundled": {
+        "core.bitset.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.70294,
+            "delta_pct": 70.29,
+            "ci_delta_pct": [
+                69.66,
+                70.87
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.9974,
+                2.9922,
+                3.007,
+                3.0025,
+                2.9722,
+                3.0309,
+                2.9919
+            ],
+            "judy_runs_ms": [
+                5.1044,
+                5.1127,
+                5.1016,
+                5.1164,
+                5.1094,
+                5.0801,
+                5.0928
+            ],
+            "array_ms": 2.9974,
+            "judy_ms": 5.1044,
+            "judy_over_array": 1.703,
+            "winner": "php-array"
+        },
+        "core.bitset.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.19412,
+            "delta_pct": 219.41,
+            "ci_delta_pct": [
+                217.57,
+                220.42
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.0793,
+                1.0684,
+                1.0801,
+                1.0725,
+                1.0703,
+                1.0689,
+                1.0683
+            ],
+            "judy_runs_ms": [
+                3.4607,
+                3.4133,
+                3.4301,
+                3.3748,
+                3.4295,
+                3.4142,
+                3.4082
+            ],
+            "array_ms": 1.0703,
+            "judy_ms": 3.4142,
+            "judy_over_array": 3.19,
+            "winner": "php-array"
+        },
+        "core.bitset.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.7318,
+            "delta_pct": 473.18,
+            "ci_delta_pct": [
+                465.68,
+                488.39
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9201,
+                0.9133,
+                0.9125,
+                0.9109,
+                0.947,
+                0.9163,
+                0.9686
+            ],
+            "judy_runs_ms": [
+                5.2515,
+                5.3738,
+                5.3211,
+                5.2211,
+                5.162,
+                5.4209,
+                5.4792
+            ],
+            "array_ms": 0.9163,
+            "judy_ms": 5.3211,
+            "judy_over_array": 5.807,
+            "winner": "php-array"
+        },
+        "core.int_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.31518,
+            "delta_pct": 131.52,
+            "ci_delta_pct": [
+                129.17,
+                133.39
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                3.2229,
+                3.0427,
+                3.0419,
+                3.0732,
+                3.0632,
+                3.0725,
+                3.0777
+            ],
+            "judy_runs_ms": [
+                7.1333,
+                7.0985,
+                7.0996,
+                7.115,
+                7.0902,
+                7.2516,
+                7.0533
+            ],
+            "array_ms": 3.0725,
+            "judy_ms": 7.0996,
+            "judy_over_array": 2.311,
+            "winner": "php-array"
+        },
+        "core.int_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.19953,
+            "delta_pct": 219.95,
+            "ci_delta_pct": [
+                219.6,
+                221.65
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.069,
+                1.0696,
+                1.0681,
+                1.0793,
+                1.0678,
+                1.0751,
+                1.0699
+            ],
+            "judy_runs_ms": [
+                3.4203,
+                3.4796,
+                3.4355,
+                3.4524,
+                3.4127,
+                3.4438,
+                3.2994
+            ],
+            "array_ms": 1.0696,
+            "judy_ms": 3.4355,
+            "judy_over_array": 3.212,
+            "winner": "php-array"
+        },
+        "core.int_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.53661,
+            "delta_pct": 553.66,
+            "ci_delta_pct": [
+                550.81,
+                561.47
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9124,
+                0.9124,
+                0.9127,
+                0.9128,
+                0.9131,
+                0.9246,
+                0.9122
+            ],
+            "judy_runs_ms": [
+                5.964,
+                5.938,
+                5.9138,
+                6.0379,
+                6.0375,
+                6.0392,
+                6.0579
+            ],
+            "array_ms": 0.9127,
+            "judy_ms": 6.0375,
+            "judy_over_array": 6.615,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.49495,
+            "delta_pct": 149.49,
+            "ci_delta_pct": [
+                149.02,
+                150.22
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.0304,
+                4.0255,
+                4.0385,
+                4.0302,
+                4.0285,
+                4.0422,
+                4.0113
+            ],
+            "judy_runs_ms": [
+                10.0848,
+                10.0245,
+                10.0737,
+                10.0046,
+                10.0509,
+                10.1945,
+                10.0165
+            ],
+            "array_ms": 4.0302,
+            "judy_ms": 10.0509,
+            "judy_over_array": 2.494,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.36953,
+            "delta_pct": 136.95,
+            "ci_delta_pct": [
+                135.58,
+                140.04
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.5981,
+                1.5364,
+                1.5417,
+                1.5598,
+                1.5315,
+                1.5364,
+                1.5746
+            ],
+            "judy_runs_ms": [
+                3.6375,
+                3.688,
+                3.6421,
+                3.696,
+                3.693,
+                3.6194,
+                3.7701
+            ],
+            "array_ms": 1.5417,
+            "judy_ms": 3.688,
+            "judy_over_array": 2.392,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.14892,
+            "delta_pct": 514.89,
+            "ci_delta_pct": [
+                502.98,
+                518.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9367,
+                0.9331,
+                0.9708,
+                0.9324,
+                0.9273,
+                0.9378,
+                0.9347
+            ],
+            "judy_runs_ms": [
+                5.6481,
+                5.7806,
+                5.7354,
+                5.7557,
+                5.7362,
+                5.753,
+                5.7474
+            ],
+            "array_ms": 0.9347,
+            "judy_ms": 5.7474,
+            "judy_over_array": 6.149,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.71505,
+            "delta_pct": 171.5,
+            "ci_delta_pct": [
+                166.44,
+                172.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.5736,
+                1.5901,
+                1.7142,
+                1.6021,
+                1.6206,
+                1.6218,
+                1.6147
+            ],
+            "judy_runs_ms": [
+                4.3497,
+                4.3172,
+                4.5174,
+                4.3168,
+                4.4125,
+                4.3211,
+                4.4077
+            ],
+            "array_ms": 1.6147,
+            "judy_ms": 4.3497,
+            "judy_over_array": 2.694,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.7897,
+            "delta_pct": 178.97,
+            "ci_delta_pct": [
+                177.94,
+                181.19
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.9003,
+                4.8989,
+                4.9826,
+                4.9376,
+                4.9391,
+                4.9285,
+                4.9637
+            ],
+            "judy_runs_ms": [
+                13.8122,
+                13.775,
+                13.8487,
+                13.7744,
+                13.7592,
+                13.8029,
+                13.778
+            ],
+            "array_ms": 4.9376,
+            "judy_ms": 13.778,
+            "judy_over_array": 2.79,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.34379,
+            "delta_pct": 534.38,
+            "ci_delta_pct": [
+                533.77,
+                537.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.5571,
+                1.5585,
+                1.5489,
+                1.5578,
+                1.6534,
+                1.5442,
+                1.5544
+            ],
+            "judy_runs_ms": [
+                9.9285,
+                9.8868,
+                9.871,
+                9.8729,
+                9.8642,
+                9.9169,
+                9.8558
+            ],
+            "array_ms": 1.5571,
+            "judy_ms": 9.8729,
+            "judy_over_array": 6.341,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.04952,
+            "delta_pct": 1204.95,
+            "ci_delta_pct": [
+                1133.06,
+                1211.87
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9434,
+                0.9404,
+                0.9349,
+                0.9488,
+                0.9326,
+                0.9973,
+                1.0336
+            ],
+            "judy_runs_ms": [
+                12.3516,
+                12.3368,
+                12.2,
+                12.2394,
+                12.3149,
+                12.2973,
+                12.3899
+            ],
+            "array_ms": 0.9434,
+            "judy_ms": 12.3149,
+            "judy_over_array": 13.054,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.61355,
+            "delta_pct": 61.35,
+            "ci_delta_pct": [
+                60.66,
+                63.73
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.5894,
+                1.601,
+                1.6254,
+                1.6386,
+                1.6297,
+                1.6236,
+                1.6106
+            ],
+            "judy_runs_ms": [
+                2.5944,
+                2.6246,
+                2.6127,
+                2.6112,
+                2.6296,
+                2.6085,
+                2.637
+            ],
+            "array_ms": 1.6236,
+            "judy_ms": 2.6127,
+            "judy_over_array": 1.609,
+            "winner": "php-array"
+        },
+        "core.string_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.25091,
+            "delta_pct": 125.09,
+            "ci_delta_pct": [
+                124.85,
+                126.26
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.5576,
+                11.6372,
+                11.65,
+                11.504,
+                11.6137,
+                11.5093,
+                11.6253
+            ],
+            "judy_runs_ms": [
+                26.0151,
+                26.0848,
+                26.2048,
+                26.1197,
+                26.1135,
+                26.0415,
+                26.2556
+            ],
+            "array_ms": 11.6137,
+            "judy_ms": 26.1135,
+            "judy_over_array": 2.249,
+            "winner": "php-array"
+        },
+        "core.string_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.38182,
+            "delta_pct": 338.18,
+            "ci_delta_pct": [
+                314.19,
+                361.03
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.2773,
+                2.3678,
+                2.3344,
+                2.1635,
+                2.0953,
+                2.2212,
+                2.1167
+            ],
+            "judy_runs_ms": [
+                9.7759,
+                9.7477,
+                9.6689,
+                9.7346,
+                9.8582,
+                9.7329,
+                9.7587
+            ],
+            "array_ms": 2.2212,
+            "judy_ms": 9.7477,
+            "judy_over_array": 4.388,
+            "winner": "php-array"
+        },
+        "core.string_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.10371,
+            "delta_pct": 910.37,
+            "ci_delta_pct": [
+                885.36,
+                918.79
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.4014,
+                1.3692,
+                1.4185,
+                1.3657,
+                1.3509,
+                1.4175,
+                1.377
+            ],
+            "judy_runs_ms": [
+                13.8089,
+                13.834,
+                14.0133,
+                14.0076,
+                13.7628,
+                13.7988,
+                13.9368
+            ],
+            "array_ms": 1.377,
+            "judy_ms": 13.834,
+            "judy_over_array": 10.046,
+            "winner": "php-array"
+        },
+        "core.string_to_int.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.08212,
+            "delta_pct": 408.21,
+            "ci_delta_pct": [
+                406.92,
+                412.78
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.8957,
+                0.8961,
+                0.8865,
+                0.906,
+                0.8906,
+                0.9049,
+                0.9015
+            ],
+            "judy_runs_ms": [
+                4.5481,
+                4.5923,
+                4.5458,
+                4.6044,
+                4.6098,
+                4.5871,
+                4.5567
+            ],
+            "array_ms": 0.8961,
+            "judy_ms": 4.5871,
+            "judy_over_array": 5.119,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.29306,
+            "delta_pct": 129.31,
+            "ci_delta_pct": [
+                129.12,
+                130.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.635,
+                12.697,
+                12.6865,
+                12.6322,
+                12.7423,
+                12.7677,
+                12.7475
+            ],
+            "judy_runs_ms": [
+                28.9728,
+                29.0912,
+                29.0756,
+                29.2655,
+                29.3554,
+                29.3172,
+                29.0485
+            ],
+            "array_ms": 12.697,
+            "judy_ms": 29.0912,
+            "judy_over_array": 2.291,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.87172,
+            "delta_pct": 287.17,
+            "ci_delta_pct": [
+                285.17,
+                296.18
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5024,
+                2.5519,
+                2.5151,
+                2.5562,
+                2.7053,
+                2.5752,
+                2.5057
+            ],
+            "judy_runs_ms": [
+                9.996,
+                9.8613,
+                9.9536,
+                9.8969,
+                9.9338,
+                9.9189,
+                9.927
+            ],
+            "array_ms": 2.5519,
+            "judy_ms": 9.927,
+            "judy_over_array": 3.89,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 8.72302,
+            "delta_pct": 772.3,
+            "ci_delta_pct": [
+                762.28,
+                779.94
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6311,
+                1.6407,
+                1.616,
+                1.6262,
+                1.6263,
+                1.6292,
+                1.6242
+            ],
+            "judy_runs_ms": [
+                14.0646,
+                14.1093,
+                14.0964,
+                14.3196,
+                14.1897,
+                14.1961,
+                14.292
+            ],
+            "array_ms": 1.6263,
+            "judy_ms": 14.1897,
+            "judy_over_array": 8.725,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.70887,
+            "delta_pct": 470.89,
+            "ci_delta_pct": [
+                463.59,
+                476.85
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5806,
+                2.5745,
+                2.6153,
+                2.5952,
+                2.6465,
+                2.6364,
+                2.6728
+            ],
+            "judy_runs_ms": [
+                14.8635,
+                14.9023,
+                14.9304,
+                14.9703,
+                14.9154,
+                14.892,
+                14.8959
+            ],
+            "array_ms": 2.6153,
+            "judy_ms": 14.9023,
+            "judy_over_array": 5.698,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.19054,
+            "delta_pct": 319.05,
+            "ci_delta_pct": [
+                313.47,
+                321.52
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.3089,
+                11.7777,
+                11.417,
+                11.4135,
+                11.3676,
+                11.6164,
+                11.3679
+            ],
+            "judy_runs_ms": [
+                47.7607,
+                48.6969,
+                47.8434,
+                47.7955,
+                47.9165,
+                47.8647,
+                47.8306
+            ],
+            "array_ms": 11.4135,
+            "judy_ms": 47.8434,
+            "judy_over_array": 4.192,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.71772,
+            "delta_pct": 271.77,
+            "ci_delta_pct": [
+                260.58,
+                279.13
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.1529,
+                2.2513,
+                2.1776,
+                2.1192,
+                2.2707,
+                2.239,
+                2.0978
+            ],
+            "judy_runs_ms": [
+                8.0713,
+                8.3697,
+                8.071,
+                8.0345,
+                8.0282,
+                8.0733,
+                8.0651
+            ],
+            "array_ms": 2.1776,
+            "judy_ms": 8.071,
+            "judy_over_array": 3.706,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.43113,
+            "delta_pct": 1243.11,
+            "ci_delta_pct": [
+                1210.38,
+                1254.89
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.3733,
+                1.4263,
+                1.3968,
+                1.4303,
+                1.3831,
+                1.3506,
+                1.4012
+            ],
+            "judy_runs_ms": [
+                18.6067,
+                18.6899,
+                18.69,
+                18.7363,
+                18.5766,
+                19.6453,
+                18.9741
+            ],
+            "array_ms": 1.3968,
+            "judy_ms": 18.69,
+            "judy_over_array": 13.381,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 11.35927,
+            "delta_pct": 1035.93,
+            "ci_delta_pct": [
+                1017.43,
+                1046.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.8763,
+                0.8876,
+                0.8666,
+                0.8546,
+                0.867,
+                0.906,
+                0.8724
+            ],
+            "judy_runs_ms": [
+                9.792,
+                9.8789,
+                9.8516,
+                9.7995,
+                10.2003,
+                10.2915,
+                9.7695
+            ],
+            "array_ms": 0.8724,
+            "judy_ms": 9.8516,
+            "judy_over_array": 11.293,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.78512,
+            "delta_pct": 378.51,
+            "ci_delta_pct": [
+                377.64,
+                379.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.1767,
+                12.3002,
+                12.2926,
+                12.3034,
+                12.2982,
+                12.3457,
+                12.3057
+            ],
+            "judy_runs_ms": [
+                58.7054,
+                58.937,
+                58.8216,
+                58.7701,
+                58.8659,
+                58.7352,
+                58.7768
+            ],
+            "array_ms": 12.3002,
+            "judy_ms": 58.7768,
+            "judy_over_array": 4.779,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.27898,
+            "delta_pct": 227.9,
+            "ci_delta_pct": [
+                222.84,
+                232.11
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.6119,
+                2.5281,
+                2.4752,
+                2.5568,
+                2.5554,
+                2.5023,
+                2.495
+            ],
+            "judy_runs_ms": [
+                8.2237,
+                8.2896,
+                8.2938,
+                8.2545,
+                8.2732,
+                8.2875,
+                8.2861
+            ],
+            "array_ms": 2.5281,
+            "judy_ms": 8.2861,
+            "judy_over_array": 3.278,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.23936,
+            "delta_pct": 1123.94,
+            "ci_delta_pct": [
+                1115.41,
+                1139.95
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.639,
+                1.6043,
+                1.5993,
+                1.6285,
+                1.6168,
+                1.6229,
+                1.5984
+            ],
+            "judy_runs_ms": [
+                19.871,
+                19.7311,
+                19.8352,
+                19.793,
+                19.7886,
+                19.8455,
+                19.8194
+            ],
+            "array_ms": 1.6168,
+            "judy_ms": 19.8194,
+            "judy_over_array": 12.258,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.51048,
+            "delta_pct": 951.05,
+            "ci_delta_pct": [
+                941.69,
+                952.14
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5834,
+                2.5956,
+                2.5759,
+                2.6262,
+                2.6184,
+                2.6184,
+                2.6066
+            ],
+            "judy_runs_ms": [
+                27.1797,
+                27.281,
+                27.3165,
+                27.208,
+                27.3933,
+                27.2756,
+                27.4251
+            ],
+            "array_ms": 2.6066,
+            "judy_ms": 27.281,
+            "judy_over_array": 10.466,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.19895,
+            "delta_pct": 319.9,
+            "ci_delta_pct": [
+                319.57,
+                321.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.3297,
+                11.372,
+                11.374,
+                11.3785,
+                11.4084,
+                11.394,
+                11.6822
+            ],
+            "judy_runs_ms": [
+                47.7755,
+                48.1225,
+                47.7331,
+                47.7778,
+                47.5971,
+                47.867,
+                49.0151
+            ],
+            "array_ms": 11.3785,
+            "judy_ms": 47.7778,
+            "judy_over_array": 4.199,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.52202,
+            "delta_pct": 252.2,
+            "ci_delta_pct": [
+                247.52,
+                259.84
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.2323,
+                2.2517,
+                2.0838,
+                2.2251,
+                2.1506,
+                2.2063,
+                2.2093
+            ],
+            "judy_runs_ms": [
+                7.7578,
+                7.7663,
+                7.8512,
+                7.7693,
+                7.7388,
+                7.8315,
+                7.7812
+            ],
+            "array_ms": 2.2093,
+            "judy_ms": 7.7693,
+            "judy_over_array": 3.517,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.12209,
+            "delta_pct": 1212.21,
+            "ci_delta_pct": [
+                1205.48,
+                1219.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.415,
+                1.399,
+                1.3987,
+                1.4208,
+                1.3904,
+                1.4039,
+                1.446
+            ],
+            "judy_runs_ms": [
+                18.4726,
+                18.4646,
+                18.3905,
+                18.5073,
+                18.3489,
+                18.4221,
+                18.8773
+            ],
+            "array_ms": 1.4039,
+            "judy_ms": 18.4646,
+            "judy_over_array": 13.152,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 11.09943,
+            "delta_pct": 1009.94,
+            "ci_delta_pct": [
+                992.75,
+                1022.73
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.8854,
+                0.8784,
+                0.882,
+                0.8926,
+                0.8742,
+                0.8862,
+                1.0616
+            ],
+            "judy_runs_ms": [
+                9.7887,
+                9.8621,
+                9.7897,
+                9.7539,
+                9.8354,
+                9.869,
+                10.4262
+            ],
+            "array_ms": 0.8854,
+            "judy_ms": 9.8354,
+            "judy_over_array": 11.108,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.86299,
+            "delta_pct": 386.3,
+            "ci_delta_pct": [
+                384.12,
+                388.93
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.1916,
+                12.32,
+                12.2887,
+                12.3009,
+                12.2811,
+                12.3571,
+                12.315
+            ],
+            "judy_runs_ms": [
+                59.5084,
+                60.4593,
+                59.6442,
+                59.5197,
+                59.7229,
+                59.8226,
+                60.2117
+            ],
+            "array_ms": 12.3009,
+            "judy_ms": 59.7229,
+            "judy_over_array": 4.855,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.22002,
+            "delta_pct": 222,
+            "ci_delta_pct": [
+                221.38,
+                223.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5084,
+                2.4862,
+                2.5839,
+                2.5143,
+                2.5058,
+                2.5285,
+                2.5332
+            ],
+            "judy_runs_ms": [
+                8.12,
+                8.0986,
+                8.1165,
+                8.0961,
+                8.107,
+                8.1366,
+                8.1413
+            ],
+            "array_ms": 2.5143,
+            "judy_ms": 8.1165,
+            "judy_over_array": 3.228,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.40943,
+            "delta_pct": 1140.94,
+            "ci_delta_pct": [
+                1129.79,
+                1159.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6339,
+                1.6137,
+                1.6311,
+                1.6063,
+                1.6266,
+                1.6269,
+                1.6154
+            ],
+            "judy_runs_ms": [
+                20.0936,
+                20.0251,
+                20.5466,
+                20.3052,
+                20.0594,
+                19.9552,
+                20.2164
+            ],
+            "array_ms": 1.6266,
+            "judy_ms": 20.0936,
+            "judy_over_array": 12.353,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.62685,
+            "delta_pct": 962.69,
+            "ci_delta_pct": [
+                957.98,
+                973.3
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.6046,
+                2.6003,
+                2.6016,
+                2.6228,
+                2.5923,
+                2.624,
+                2.6073
+            ],
+            "judy_runs_ms": [
+                27.6262,
+                27.633,
+                28.09,
+                27.7488,
+                27.8231,
+                27.6649,
+                27.717
+            ],
+            "array_ms": 2.6046,
+            "judy_ms": 27.717,
+            "judy_over_array": 10.642,
+            "winner": "php-array"
+        },
+        "api.increment.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.45182,
+            "delta_pct": 145.18,
+            "ci_delta_pct": [
+                143.08,
+                147.91
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.8993,
+                2.8916,
+                2.9217,
+                2.9691,
+                2.9926,
+                2.9107,
+                2.8989
+            ],
+            "judy_runs_ms": [
+                7.0312,
+                7.191,
+                7.1565,
+                7.2797,
+                7.2744,
+                7.2159,
+                7.1659
+            ],
+            "array_ms": 2.9107,
+            "judy_ms": 7.191,
+            "judy_over_array": 2.471,
+            "winner": "php-array"
+        },
+        "api.setop.union.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.87117,
+            "delta_pct": 287.12,
+            "ci_delta_pct": [
+                282.77,
+                292.6
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.3349,
+                2.3123,
+                2.341,
+                2.3142,
+                2.4645,
+                2.354,
+                2.3619
+            ],
+            "judy_runs_ms": [
+                9.0388,
+                9.1119,
+                9.0602,
+                9.0855,
+                9.1153,
+                9.0103,
+                9.1527
+            ],
+            "array_ms": 2.341,
+            "judy_ms": 9.0855,
+            "judy_over_array": 3.881,
+            "winner": "php-array"
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94476,
+            "delta_pct": -5.52,
+            "ci_delta_pct": [
+                -5.87,
+                -5.31
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.6292,
+                4.5731,
+                4.6269,
+                4.5982,
+                4.5818,
+                4.6025,
+                4.5875
+            ],
+            "judy_runs_ms": [
+                4.348,
+                4.3551,
+                4.3814,
+                4.3359,
+                4.3315,
+                4.3325,
+                4.3341
+            ],
+            "array_ms": 4.5982,
+            "judy_ms": 4.3359,
+            "judy_over_array": 0.943,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.6108,
+            "delta_pct": 161.08,
+            "ci_delta_pct": [
+                157.7,
+                161.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6535,
+                1.6562,
+                1.6916,
+                1.6641,
+                1.6526,
+                1.6511,
+                1.6576
+            ],
+            "judy_runs_ms": [
+                4.4026,
+                4.3298,
+                4.3295,
+                4.2884,
+                4.325,
+                4.3107,
+                4.3225
+            ],
+            "array_ms": 1.6562,
+            "judy_ms": 4.325,
+            "judy_over_array": 2.611,
+            "winner": "php-array"
+        },
+        "api.setop.xor.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.12708,
+            "delta_pct": 12.71,
+            "ci_delta_pct": [
+                12.2,
+                13.53
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                7.6159,
+                7.6217,
+                7.6461,
+                7.6094,
+                7.5616,
+                7.627,
+                7.5784
+            ],
+            "judy_runs_ms": [
+                8.5383,
+                8.5903,
+                8.5787,
+                8.5513,
+                8.6114,
+                8.6219,
+                8.6041
+            ],
+            "array_ms": 7.6159,
+            "judy_ms": 8.5903,
+            "judy_over_array": 1.128,
+            "winner": "php-array"
+        }
+    },
+    "judy_vs_phploop": {
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68386,
+            "delta_pct": -31.61,
+            "ci_delta_pct": [
+                -31.71,
+                -31.44
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                9.0657,
+                9.064,
+                9.0768,
+                9.0552,
+                9.1689,
+                9.064,
+                9.047
+            ],
+            "judy_runs_ms": [
+                6.1997,
+                6.1947,
+                6.2639,
+                6.2063,
+                6.2063,
+                6.1897,
+                6.2028
+            ],
+            "array_ms": 9.064,
+            "judy_ms": 6.2028,
+            "judy_over_array": 0.684,
+            "winner": "php-judy"
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.6836,
+            "delta_pct": -31.64,
+            "ci_delta_pct": [
+                -32.19,
+                -31.44
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                9.0657,
+                9.064,
+                9.0768,
+                9.0552,
+                9.1689,
+                9.064,
+                9.047
+            ],
+            "judy_runs_ms": [
+                6.2452,
+                6.1944,
+                6.2049,
+                6.2081,
+                6.2171,
+                6.1452,
+                6.185
+            ],
+            "array_ms": 9.064,
+            "judy_ms": 6.2049,
+            "judy_over_array": 0.685,
+            "winner": "php-judy"
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75576,
+            "delta_pct": -24.42,
+            "ci_delta_pct": [
+                -25.55,
+                -24.21
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.8474,
+                18.1532,
+                18.2329,
+                18.1729,
+                18.5452,
+                18.2256,
+                18.1328
+            ],
+            "judy_runs_ms": [
+                13.7479,
+                13.7118,
+                13.7819,
+                13.7344,
+                13.8063,
+                13.8139,
+                13.7695
+            ],
+            "array_ms": 18.2256,
+            "judy_ms": 13.7695,
+            "judy_over_array": 0.756,
+            "winner": "php-judy"
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.51973,
+            "delta_pct": -48.03,
+            "ci_delta_pct": [
+                -49.97,
+                -47.2
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.5706,
+                0.5661,
+                0.5953,
+                0.564,
+                0.5876,
+                0.5852,
+                0.5678
+            ],
+            "judy_runs_ms": [
+                0.291,
+                0.2985,
+                0.2978,
+                0.2978,
+                0.2906,
+                0.337,
+                0.2951
+            ],
+            "array_ms": 0.5706,
+            "judy_ms": 0.2978,
+            "judy_over_array": 0.522,
+            "winner": "php-judy"
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.5356,
+            "delta_pct": -46.44,
+            "ci_delta_pct": [
+                -46.51,
+                -46.42
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                8.1737,
+                8.1517,
+                8.1399,
+                8.1523,
+                8.119,
+                8.1248,
+                8.174
+            ],
+            "judy_runs_ms": [
+                4.3613,
+                4.3666,
+                4.3571,
+                4.3683,
+                4.3485,
+                4.3462,
+                4.3879
+            ],
+            "array_ms": 8.1517,
+            "judy_ms": 4.3613,
+            "judy_over_array": 0.535,
+            "winner": "php-judy"
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.54549,
+            "delta_pct": -45.45,
+            "ci_delta_pct": [
+                -45.54,
+                -45.34
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                8.0119,
+                8.0816,
+                8.0699,
+                8.0975,
+                8.1754,
+                8.1793,
+                8.1312
+            ],
+            "judy_runs_ms": [
+                4.42,
+                4.4164,
+                4.3947,
+                4.4171,
+                4.4684,
+                4.432,
+                4.4281
+            ],
+            "array_ms": 8.0975,
+            "judy_ms": 4.42,
+            "judy_over_array": 0.546,
+            "winner": "php-judy"
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.04405,
+            "delta_pct": -95.59,
+            "ci_delta_pct": [
+                -95.61,
+                -95.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                7.0823,
+                7.1254,
+                7.023,
+                7.0972,
+                7.0795,
+                7.0197,
+                7.0939
+            ],
+            "judy_runs_ms": [
+                0.312,
+                0.3126,
+                0.3122,
+                0.312,
+                0.3119,
+                0.3117,
+                0.3117
+            ],
+            "array_ms": 7.0823,
+            "judy_ms": 0.312,
+            "judy_over_array": 0.044,
+            "winner": "php-judy"
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.39977,
+            "delta_pct": -60.02,
+            "ci_delta_pct": [
+                -60.34,
+                -59.99
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.745,
+                5.7437,
+                5.769,
+                5.7551,
+                5.6853,
+                5.8013,
+                5.7381
+            ],
+            "judy_runs_ms": [
+                2.2967,
+                2.2963,
+                2.2967,
+                2.2825,
+                2.2966,
+                2.2846,
+                2.2956
+            ],
+            "array_ms": 5.745,
+            "judy_ms": 2.2963,
+            "judy_over_array": 0.4,
+            "winner": "php-judy"
+        },
+        "api.populationCount.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 2.0e-5,
+            "delta_pct": -100,
+            "ci_delta_pct": [
+                -100,
+                -100
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.8609,
+                5.8079,
+                5.9674,
+                5.8488,
+                5.765,
+                5.873,
+                6.0294
+            ],
+            "judy_runs_ms": [
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001
+            ],
+            "array_ms": 5.8609,
+            "judy_ms": 0.0001,
+            "judy_over_array": 0,
+            "winner": "php-judy"
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69033,
+            "delta_pct": -30.97,
+            "ci_delta_pct": [
+                -30.99,
+                -30.66
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                17.015,
+                17.006,
+                17.0105,
+                17.001,
+                17.0456,
+                17.0021,
+                16.9776
+            ],
+            "judy_runs_ms": [
+                11.746,
+                11.8101,
+                11.7248,
+                11.788,
+                11.7675,
+                11.7325,
+                11.7197
+            ],
+            "array_ms": 17.006,
+            "judy_ms": 11.746,
+            "judy_over_array": 0.691,
+            "winner": "php-judy"
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.23799,
+            "delta_pct": -76.2,
+            "ci_delta_pct": [
+                -76.76,
+                -75.55
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                13.9861,
+                13.329,
+                13.6653,
+                13.7797,
+                13.789,
+                13.8204,
+                13.4873
+            ],
+            "judy_runs_ms": [
+                3.2509,
+                3.2589,
+                3.2522,
+                3.2661,
+                3.3336,
+                3.2076,
+                3.4132
+            ],
+            "array_ms": 13.7797,
+            "judy_ms": 3.2589,
+            "judy_over_array": 0.237,
+            "winner": "php-judy"
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.50501,
+            "delta_pct": -49.5,
+            "ci_delta_pct": [
+                -49.74,
+                -49.35
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                25.3015,
+                25.2199,
+                25.2819,
+                25.3038,
+                25.3696,
+                25.2974,
+                25.233
+            ],
+            "judy_runs_ms": [
+                12.7775,
+                12.7994,
+                12.7796,
+                12.7173,
+                12.743,
+                12.8141,
+                12.7162
+            ],
+            "array_ms": 25.2974,
+            "judy_ms": 12.7775,
+            "judy_over_array": 0.505,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42395,
+            "delta_pct": -57.6,
+            "ci_delta_pct": [
+                -58.09,
+                -57.51
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.4652,
+                12.3846,
+                12.462,
+                12.4368,
+                12.3578,
+                12.3872,
+                12.5022
+            ],
+            "judy_runs_ms": [
+                5.2885,
+                5.3585,
+                5.271,
+                5.2121,
+                5.2391,
+                5.1489,
+                5.3123
+            ],
+            "array_ms": 12.4368,
+            "judy_ms": 5.271,
+            "judy_over_array": 0.424,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41035,
+            "delta_pct": -58.97,
+            "ci_delta_pct": [
+                -59.82,
+                -58.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.8205,
+                12.8031,
+                12.7484,
+                12.7686,
+                12.728,
+                12.6094,
+                12.7182
+            ],
+            "judy_runs_ms": [
+                5.1519,
+                5.2537,
+                5.2315,
+                5.2913,
+                5.1132,
+                5.2279,
+                5.1764
+            ],
+            "array_ms": 12.7484,
+            "judy_ms": 5.2279,
+            "judy_over_array": 0.41,
+            "winner": "php-judy"
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.40675,
+            "delta_pct": -59.32,
+            "ci_delta_pct": [
+                -59.42,
+                -58.91
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                25.6889,
+                25.5802,
+                25.6638,
+                25.4636,
+                25.4881,
+                25.5475,
+                25.4761
+            ],
+            "judy_runs_ms": [
+                10.5384,
+                10.5686,
+                10.4117,
+                10.464,
+                10.3423,
+                10.3796,
+                10.3625
+            ],
+            "array_ms": 25.5475,
+            "judy_ms": 10.4117,
+            "judy_over_array": 0.408,
+            "winner": "php-judy"
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91244,
+            "delta_pct": -8.76,
+            "ci_delta_pct": [
+                -8.86,
+                -8.5
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                93.2947,
+                93.3643,
+                92.8667,
+                93.2434,
+                93.1466,
+                93.1255,
+                93.1389
+            ],
+            "judy_runs_ms": [
+                84.9553,
+                87.0513,
+                84.9688,
+                84.9877,
+                84.8923,
+                84.9712,
+                85.0301
+            ],
+            "array_ms": 93.1466,
+            "judy_ms": 84.9712,
+            "judy_over_array": 0.912,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87054,
+            "delta_pct": -12.95,
+            "ci_delta_pct": [
+                -13.12,
+                -12.77
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                41.4654,
+                41.5619,
+                41.3795,
+                41.4752,
+                41.3395,
+                41.44,
+                41.3693
+            ],
+            "judy_runs_ms": [
+                36.0974,
+                36.1037,
+                35.9505,
+                36.1855,
+                36.001,
+                36.0391,
+                36.088
+            ],
+            "array_ms": 41.44,
+            "judy_ms": 36.088,
+            "judy_over_array": 0.871,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83771,
+            "delta_pct": -16.23,
+            "ci_delta_pct": [
+                -16.51,
+                -16.05
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                38.9207,
+                38.9432,
+                38.8151,
+                38.8094,
+                38.8666,
+                38.8834,
+                38.8904
+            ],
+            "judy_runs_ms": [
+                32.4945,
+                32.4716,
+                32.632,
+                32.5652,
+                32.6301,
+                32.573,
+                32.4734
+            ],
+            "array_ms": 38.8834,
+            "judy_ms": 32.5652,
+            "judy_over_array": 0.838,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77078,
+            "delta_pct": -22.92,
+            "ci_delta_pct": [
+                -23.8,
+                -22.61
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                19.4109,
+                19.3647,
+                19.4478,
+                19.3486,
+                19.3226,
+                19.3365,
+                19.2301
+            ],
+            "judy_runs_ms": [
+                14.7907,
+                14.8785,
+                15.032,
+                14.9136,
+                14.6169,
+                14.9647,
+                14.8839
+            ],
+            "array_ms": 19.3486,
+            "judy_ms": 14.8839,
+            "judy_over_array": 0.769,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92473,
+            "delta_pct": -7.53,
+            "ci_delta_pct": [
+                -7.75,
+                -7.49
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                73.1655,
+                73.2319,
+                73.1375,
+                75.583,
+                73.352,
+                73.503,
+                73.8034
+            ],
+            "judy_runs_ms": [
+                67.6829,
+                67.7194,
+                67.6382,
+                68.5112,
+                67.9123,
+                67.8054,
+                68.2345
+            ],
+            "array_ms": 73.352,
+            "judy_ms": 67.8054,
+            "judy_over_array": 0.924,
+            "winner": "php-judy"
+        },
+        "adv.forEach.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.5168,
+            "delta_pct": 51.68,
+            "ci_delta_pct": [
+                46.05,
+                53.28
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                6.3353,
+                6.4574,
+                6.2397,
+                6.3437,
+                6.3664,
+                6.2882,
+                6.4936
+            ],
+            "judy_runs_ms": [
+                9.5724,
+                9.431,
+                9.469,
+                9.6221,
+                9.7581,
+                9.6755,
+                9.4104
+            ],
+            "array_ms": 6.3437,
+            "judy_ms": 9.5724,
+            "judy_over_array": 1.509,
+            "winner": "php-array"
+        },
+        "adv.forEach.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.17049,
+            "delta_pct": 17.05,
+            "ci_delta_pct": [
+                16.17,
+                18.42
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                14.3267,
+                14.4764,
+                14.6423,
+                14.3302,
+                14.2529,
+                14.5796,
+                14.3494
+            ],
+            "judy_runs_ms": [
+                16.8544,
+                16.817,
+                16.9128,
+                16.9703,
+                16.9397,
+                16.9841,
+                16.7958
+            ],
+            "array_ms": 14.3494,
+            "judy_ms": 16.9128,
+            "judy_over_array": 1.179,
+            "winner": "php-array"
+        },
+        "adv.filter.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.23534,
+            "delta_pct": 23.53,
+            "ci_delta_pct": [
+                21.94,
+                24.05
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.3081,
+                11.4668,
+                11.3774,
+                11.2955,
+                11.3053,
+                11.3727,
+                11.2627
+            ],
+            "judy_runs_ms": [
+                13.9921,
+                13.8466,
+                13.9724,
+                14.0284,
+                14.0246,
+                13.8681,
+                13.9133
+            ],
+            "array_ms": 11.3081,
+            "judy_ms": 13.9724,
+            "judy_over_array": 1.236,
+            "winner": "php-array"
+        },
+        "adv.filter.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.0713,
+            "delta_pct": 7.13,
+            "ci_delta_pct": [
+                6.63,
+                7.19
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                34.4018,
+                34.5362,
+                34.9364,
+                34.2591,
+                34.3929,
+                34.4068,
+                34.4395
+            ],
+            "judy_runs_ms": [
+                36.8764,
+                36.6417,
+                38.2501,
+                36.7019,
+                36.8099,
+                36.6868,
+                36.9068
+            ],
+            "array_ms": 34.4068,
+            "judy_ms": 36.8099,
+            "judy_over_array": 1.07,
+            "winner": "php-array"
+        },
+        "adv.map.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.08614,
+            "delta_pct": 8.61,
+            "ci_delta_pct": [
+                8.56,
+                9.03
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                13.4438,
+                13.5343,
+                13.4758,
+                13.5366,
+                13.4395,
+                13.5359,
+                13.4549
+            ],
+            "judy_runs_ms": [
+                14.6428,
+                14.7002,
+                14.6925,
+                14.591,
+                14.6626,
+                14.6983,
+                14.6065
+            ],
+            "array_ms": 13.4758,
+            "judy_ms": 14.6626,
+            "judy_over_array": 1.088,
+            "winner": "php-array"
+        },
+        "adv.map.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.02104,
+            "delta_pct": 2.1,
+            "ci_delta_pct": [
+                2,
+                2.2
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                49.0202,
+                49.0809,
+                48.9295,
+                48.9784,
+                48.8964,
+                49.0534,
+                49.0054
+            ],
+            "judy_runs_ms": [
+                50.0515,
+                49.9423,
+                50.0246,
+                49.9589,
+                49.9033,
+                50.0935,
+                50.0853
+            ],
+            "array_ms": 49.0054,
+            "judy_ms": 50.0246,
+            "judy_over_array": 1.021,
+            "winner": "parity"
+        }
+    },
+    "memory": [
+        {
+            "workload": "int_to_int",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 27131904,
+                    "peak_rss_ci": [
+                        27131904,
+                        27525120
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 2101328,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 2949120,
+                    "bytes_per_element": 29.49
+                },
+                "B": {
+                    "peak_rss_bytes": 25362432,
+                    "peak_rss_ci": [
+                        25362432,
+                        25559040
+                    ],
+                    "index_bytes": 841464,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 983040,
+                    "bytes_per_element": 9.83
+                },
+                "C": {
+                    "peak_rss_bytes": 25559040,
+                    "peak_rss_ci": [
+                        25362432,
+                        25559040
+                    ],
+                    "index_bytes": 841464,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 1179648,
+                    "bytes_per_element": 11.8
+                }
+            },
+            "array_over_bundled": 2.5,
+            "system_over_bundled": 0.833
+        },
+        {
+            "workload": "int_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 42557440,
+                    "peak_rss_ci": [
+                        42557440,
+                        42561536
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 16781392,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 18374656,
+                    "bytes_per_element": 18.37
+                },
+                "B": {
+                    "peak_rss_bytes": 33226752,
+                    "peak_rss_ci": [
+                        33226752,
+                        33226752
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 8847360,
+                    "bytes_per_element": 8.85
+                },
+                "C": {
+                    "peak_rss_bytes": 33030144,
+                    "peak_rss_ci": [
+                        33030144,
+                        33226752
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 8650752,
+                    "bytes_per_element": 8.65
+                }
+            },
+            "array_over_bundled": 2.124,
+            "system_over_bundled": 1.023
+        },
+        {
+            "workload": "int_to_int",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 160129024,
+                    "peak_rss_ci": [
+                        160124928,
+                        160129024
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 134221904,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 135946240,
+                    "bytes_per_element": 16.99
+                },
+                "B": {
+                    "peak_rss_bytes": 93585408,
+                    "peak_rss_ci": [
+                        93585408,
+                        93782016
+                    ],
+                    "index_bytes": 66512056,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 69206016,
+                    "bytes_per_element": 8.65
+                },
+                "C": {
+                    "peak_rss_bytes": 93782016,
+                    "peak_rss_ci": [
+                        93782016,
+                        93782016
+                    ],
+                    "index_bytes": 66512056,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 69402624,
+                    "bytes_per_element": 8.68
+                }
+            },
+            "array_over_bundled": 1.959,
+            "system_over_bundled": 0.997
+        },
+        {
+            "workload": "int_sparse",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 31457280,
+                    "peak_rss_ci": [
+                        31260672,
+                        31457280
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 5242960,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 7274496,
+                    "bytes_per_element": 72.74
+                },
+                "B": {
+                    "peak_rss_bytes": 25755648,
+                    "peak_rss_ci": [
+                        25755648,
+                        25952256
+                    ],
+                    "index_bytes": 1261504,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 1376256,
+                    "bytes_per_element": 13.76
+                },
+                "C": {
+                    "peak_rss_bytes": 25755648,
+                    "peak_rss_ci": [
+                        25755648,
+                        25952256
+                    ],
+                    "index_bytes": 1261504,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 1376256,
+                    "bytes_per_element": 13.76
+                }
+            },
+            "array_over_bundled": 5.286,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "int_sparse",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 67272704,
+                    "peak_rss_ci": [
+                        67076096,
+                        67272704
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43089920,
+                    "bytes_per_element": 43.09
+                },
+                "B": {
+                    "peak_rss_bytes": 37552128,
+                    "peak_rss_ci": [
+                        37355520,
+                        37552128
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13172736,
+                    "bytes_per_element": 13.17
+                },
+                "C": {
+                    "peak_rss_bytes": 37748736,
+                    "peak_rss_ci": [
+                        37748736,
+                        37748736
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13369344,
+                    "bytes_per_element": 13.37
+                }
+            },
+            "array_over_bundled": 3.223,
+            "system_over_bundled": 0.985
+        },
+        {
+            "workload": "int_sparse",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 349859840,
+                    "peak_rss_ci": [
+                        349716480,
+                        349863936
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 335544400,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 325677056,
+                    "bytes_per_element": 40.71
+                },
+                "B": {
+                    "peak_rss_bytes": 128581632,
+                    "peak_rss_ci": [
+                        128581632,
+                        128778240
+                    ],
+                    "index_bytes": 100116064,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 104202240,
+                    "bytes_per_element": 13.03
+                },
+                "C": {
+                    "peak_rss_bytes": 128778240,
+                    "peak_rss_ci": [
+                        128778240,
+                        128778240
+                    ],
+                    "index_bytes": 100116064,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 104398848,
+                    "bytes_per_element": 13.05
+                }
+            },
+            "array_over_bundled": 3.12,
+            "system_over_bundled": 0.998
+        },
+        {
+            "workload": "int_to_mixed",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 27918336,
+                    "peak_rss_ci": [
+                        27918336,
+                        27918336
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 3701168,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 3735552,
+                    "bytes_per_element": 37.36
+                },
+                "B": {
+                    "peak_rss_bytes": 28311552,
+                    "peak_rss_ci": [
+                        28311552,
+                        28311552
+                    ],
+                    "index_bytes": 841464,
+                    "php_heap_bytes": 3200000,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 3932160,
+                    "bytes_per_element": 39.32
+                },
+                "C": {
+                    "peak_rss_bytes": 28311552,
+                    "peak_rss_ci": [
+                        28311552,
+                        28508160
+                    ],
+                    "index_bytes": 841464,
+                    "php_heap_bytes": 3200000,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 3932160,
+                    "bytes_per_element": 39.32
+                }
+            },
+            "array_over_bundled": 0.95,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "int_to_mixed",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 56008704,
+                    "peak_rss_ci": [
+                        55820288,
+                        56012800
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 32781232,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 31825920,
+                    "bytes_per_element": 31.83
+                },
+                "B": {
+                    "peak_rss_bytes": 64880640,
+                    "peak_rss_ci": [
+                        64880640,
+                        65077248
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 32000000,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 40501248,
+                    "bytes_per_element": 40.5
+                },
+                "C": {
+                    "peak_rss_bytes": 65077248,
+                    "peak_rss_ci": [
+                        64880640,
+                        65077248
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 32000000,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 40697856,
+                    "bytes_per_element": 40.7
+                }
+            },
+            "array_over_bundled": 0.782,
+            "system_over_bundled": 0.995
+        },
+        {
+            "workload": "int_to_mixed",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 280326144,
+                    "peak_rss_ci": [
+                        280129536,
+                        280330240
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 262221744,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 256143360,
+                    "bytes_per_element": 32.02
+                },
+                "B": {
+                    "peak_rss_bytes": 349962240,
+                    "peak_rss_ci": [
+                        349765632,
+                        349962240
+                    ],
+                    "index_bytes": 66512056,
+                    "php_heap_bytes": 256000000,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 325582848,
+                    "bytes_per_element": 40.7
+                },
+                "C": {
+                    "peak_rss_bytes": 349962240,
+                    "peak_rss_ci": [
+                        349962240,
+                        349962240
+                    ],
+                    "index_bytes": 66512056,
+                    "php_heap_bytes": 256000000,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 325582848,
+                    "bytes_per_element": 40.7
+                }
+            },
+            "array_over_bundled": 0.787,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "string_to_int",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 32247808,
+                    "peak_rss_ci": [
+                        32247808,
+                        32247808
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 9234960,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 8065024,
+                    "bytes_per_element": 80.65
+                },
+                "B": {
+                    "peak_rss_bytes": 26738688,
+                    "peak_rss_ci": [
+                        26542080,
+                        26738688
+                    ],
+                    "index_bytes": 1788890,
+                    "php_heap_bytes": 65696,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 2359296,
+                    "bytes_per_element": 23.59
+                },
+                "C": {
+                    "peak_rss_bytes": 26738688,
+                    "peak_rss_ci": [
+                        26738688,
+                        26738688
+                    ],
+                    "index_bytes": 1788890,
+                    "php_heap_bytes": 65696,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 2359296,
+                    "bytes_per_element": 23.59
+                }
+            },
+            "array_over_bundled": 3.418,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "string_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 104587264,
+                    "peak_rss_ci": [
+                        104386560,
+                        104591360
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 81935120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 80404480,
+                    "bytes_per_element": 80.4
+                },
+                "B": {
+                    "peak_rss_bytes": 45809664,
+                    "peak_rss_ci": [
+                        45809664,
+                        46006272
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21430272,
+                    "bytes_per_element": 21.43
+                },
+                "C": {
+                    "peak_rss_bytes": 45809664,
+                    "peak_rss_ci": [
+                        45809664,
+                        46006272
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21430272,
+                    "bytes_per_element": 21.43
+                }
+            },
+            "array_over_bundled": 3.752,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "string_to_int",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 668925952,
+                    "peak_rss_ci": [
+                        668729344,
+                        668925952
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 655536400,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 644743168,
+                    "bytes_per_element": 80.59
+                },
+                "B": {
+                    "peak_rss_bytes": 218824704,
+                    "peak_rss_ci": [
+                        218824704,
+                        219021312
+                    ],
+                    "index_bytes": 158888890,
+                    "php_heap_bytes": 65696,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 194445312,
+                    "bytes_per_element": 24.31
+                },
+                "C": {
+                    "peak_rss_bytes": 218824704,
+                    "peak_rss_ci": [
+                        218824704,
+                        219021312
+                    ],
+                    "index_bytes": 158888890,
+                    "php_heap_bytes": 65696,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 194445312,
+                    "bytes_per_element": 24.31
+                }
+            },
+            "array_over_bundled": 3.316,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "bitset",
+            "n": 100000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 31457280,
+                    "peak_rss_ci": [
+                        31457280,
+                        31653888
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 5242960,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 7274496,
+                    "bytes_per_element": 72.74
+                },
+                "B": {
+                    "peak_rss_bytes": 24576000,
+                    "peak_rss_ci": [
+                        24576000,
+                        24772608
+                    ],
+                    "index_bytes": 140784,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 196608,
+                    "bytes_per_element": 1.97
+                },
+                "C": {
+                    "peak_rss_bytes": 24772608,
+                    "peak_rss_ci": [
+                        24772608,
+                        24772608
+                    ],
+                    "index_bytes": 140784,
+                    "php_heap_bytes": 160,
+                    "count": 100000,
+                    "runs": 3,
+                    "over_floor_bytes": 393216,
+                    "bytes_per_element": 3.93
+                }
+            },
+            "array_over_bundled": 18.5,
+            "system_over_bundled": 0.5
+        },
+        {
+            "workload": "bitset",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 67276800,
+                    "peak_rss_ci": [
+                        67272704,
+                        67469312
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43094016,
+                    "bytes_per_element": 43.09
+                },
+                "B": {
+                    "peak_rss_bytes": 26345472,
+                    "peak_rss_ci": [
+                        26148864,
+                        26345472
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1966080,
+                    "bytes_per_element": 1.97
+                },
+                "C": {
+                    "peak_rss_bytes": 26345472,
+                    "peak_rss_ci": [
+                        26345472,
+                        26345472
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1966080,
+                    "bytes_per_element": 1.97
+                }
+            },
+            "array_over_bundled": 21.919,
+            "system_over_bundled": 1
+        },
+        {
+            "workload": "bitset",
+            "n": 8000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 349863936,
+                    "peak_rss_ci": [
+                        349667328,
+                        349863936
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 335544400,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 325681152,
+                    "bytes_per_element": 40.71
+                },
+                "B": {
+                    "peak_rss_bytes": 38535168,
+                    "peak_rss_ci": [
+                        38535168,
+                        38731776
+                    ],
+                    "index_bytes": 10526704,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 14155776,
+                    "bytes_per_element": 1.77
+                },
+                "C": {
+                    "peak_rss_bytes": 38731776,
+                    "peak_rss_ci": [
+                        38731776,
+                        38928384
+                    ],
+                    "index_bytes": 10526704,
+                    "php_heap_bytes": 160,
+                    "count": 8000000,
+                    "runs": 3,
+                    "over_floor_bytes": 14352384,
+                    "bytes_per_element": 1.79
+                }
+            },
+            "array_over_bundled": 22.692,
+            "system_over_bundled": 0.986
+        }
+    ],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-B-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-9/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-B-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-9/B2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-B-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-9/B3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-9/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-9/C2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-9/C3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/run1-cache-300k.txt
+++ b/research/three-arm-benchmark/results/run1-cache-300k.txt
@@ -1,0 +1,218 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /work/builds/judy-B-1.so, /work/builds/judy-B-2.so, /work/builds/judy-B-3.so
+  C  php-judy + bundled libJudy : /work/builds/judy-C-1.so, /work/builds/judy-C-2.so, /work/builds/judy-C-3.so
+  timing core.int     round 1/7  timing core.int     round 2/7  timing core.int     round 3/7  timing core.int     round 4/7  timing core.int     round 5/7  timing core.int     round 6/7  timing core.int     round 7/7  timing core.int     done          
+  timing core.str     round 1/7  timing core.str     round 2/7  timing core.str     round 3/7  timing core.str     round 4/7  timing core.str     round 5/7  timing core.str     round 6/7  timing core.str     round 7/7  timing core.str     done          
+  timing api.batch    round 1/7  timing api.batch    round 2/7  timing api.batch    round 3/7  timing api.batch    round 4/7  timing api.batch    round 5/7  timing api.batch    round 6/7  timing api.batch    round 7/7  timing api.batch    done          
+  timing api.setops   round 1/7  timing api.setops   round 2/7  timing api.setops   round 3/7  timing api.setops   round 4/7  timing api.setops   round 5/7  timing api.setops   round 6/7  timing api.setops   round 7/7  timing api.setops   done          
+  timing adv.iter     round 1/7  timing adv.iter     round 2/7  timing adv.iter     round 3/7  timing adv.iter     round 4/7  timing adv.iter     round 5/7  timing adv.iter     round 6/7  timing adv.iter     round 7/7  timing adv.iter     done          
+  memory int_to_int     n=100000    A=2.8 MB     B=960.0 KB   C=1.1 MB      A/C=2.50x
+  memory int_to_int     n=1000000   A=17.5 MB    B=8.4 MB     C=8.2 MB      A/C=2.12x
+  memory int_to_int     n=8000000   A=129.6 MB   B=66.0 MB    C=66.2 MB     A/C=1.96x
+  memory int_sparse     n=100000    A=6.9 MB     B=1.3 MB     C=1.3 MB      A/C=5.29x
+  memory int_sparse     n=1000000   A=41.1 MB    B=12.6 MB    C=12.8 MB     A/C=3.22x
+  memory int_sparse     n=8000000   A=310.6 MB   B=99.4 MB    C=99.6 MB     A/C=3.12x
+  memory int_to_mixed   n=100000    A=3.6 MB     B=3.8 MB     C=3.8 MB      A/C=0.95x
+  memory int_to_mixed   n=1000000   A=30.4 MB    B=38.6 MB    C=38.8 MB     A/C=0.78x
+  memory int_to_mixed   n=8000000   A=244.3 MB   B=310.5 MB   C=310.5 MB    A/C=0.79x
+  memory string_to_int  n=100000    A=7.7 MB     B=2.2 MB     C=2.2 MB      A/C=3.42x
+  memory string_to_int  n=1000000   A=76.7 MB    B=20.4 MB    C=20.4 MB     A/C=3.75x
+  memory string_to_int  n=8000000   A=614.9 MB   B=185.4 MB   C=185.4 MB    A/C=3.32x
+  memory bitset         n=100000    A=6.9 MB     B=192.0 KB   C=384.0 KB    A/C=18.50x
+  memory bitset         n=1000000   A=41.1 MB    B=1.9 MB     C=1.9 MB      A/C=21.92x
+  memory bitset         n=8000000   A=310.6 MB   B=13.5 MB    C=13.7 MB     A/C=22.69x
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — linux-x86_64-gcc14.2-php8.4-cacheresident
+------------------------------------------------------------------------------------------------
+  PHP 8.4.24, Linux x86_64
+  arm B system libJudy : Debian 13 trixie, libjudy-dev 1.0.5-5.1 SHARED lib; Baskins jp_1Index fix APPLIED (debian patch 04); dpkg hardening CFLAGS
+  arm C bundled libJudy: bundled libjudy/ static into the extension (P1-P7, O1 popcount, O3 bswap, O4 string-layer); vendor CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt
+  size 300000 (cache-resident), 7 rounds, 3 iterations, floor 3.0%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=1.58   cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-timing   load1=1.02   cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-memory   load1=1.02   cpus=24   threshold=12.0  foreign=  0.0% ok
+    end            load1=1.02   cpus=24   threshold=12.0  foreign=  0.0% ok
+
+  control (PHP-only rows, touch no libJudy): +0.00% [-0.12, +0.17] over 43 rows
+  measured control scatter: 3.43%  (assumed floor 3.0%)
+
+------------------------------------------------------------------------------------------------
+  MEMORY — peak RSS over per-arm empty-process floor (the headline axis)
+------------------------------------------------------------------------------------------------
+  workload                n      A array     B system    C bundled       A/C       B/C
+  int_to_int         100000       2.8 MB     960.0 KB       1.1 MB     2.50x     0.83x
+  int_to_int        1000000      17.5 MB       8.4 MB       8.2 MB     2.12x     1.02x
+  int_to_int        8000000     129.6 MB      66.0 MB      66.2 MB     1.96x     1.00x
+  int_sparse         100000       6.9 MB       1.3 MB       1.3 MB     5.29x     1.00x
+  int_sparse        1000000      41.1 MB      12.6 MB      12.8 MB     3.22x     0.98x
+  int_sparse        8000000     310.6 MB      99.4 MB      99.6 MB     3.12x     1.00x
+  int_to_mixed       100000       3.6 MB       3.8 MB       3.8 MB     0.95x     1.00x
+  int_to_mixed      1000000      30.4 MB      38.6 MB      38.8 MB     0.78x     0.99x
+  int_to_mixed      8000000     244.3 MB     310.5 MB     310.5 MB     0.79x     1.00x
+  string_to_int      100000       7.7 MB       2.2 MB       2.2 MB     3.42x     1.00x
+  string_to_int     1000000      76.7 MB      20.4 MB      20.4 MB     3.75x     1.00x
+  string_to_int     8000000     614.9 MB     185.4 MB     185.4 MB     3.32x     1.00x
+  bitset             100000       6.9 MB     192.0 KB     384.0 KB    18.50x     0.50x
+  bitset            1000000      41.1 MB       1.9 MB       1.9 MB    21.92x     1.00x
+  bitset            8000000     310.6 MB      13.5 MB      13.7 MB    22.69x     0.99x
+  A/C above 1.00 means the PHP array uses that many times more memory than php-judy.
+
+------------------------------------------------------------------------------------------------
+  B vs C — bundled libJudy against system libJudy (this project's contribution)
+  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears
+  the 3.0% floor assert anything; everything else is null.
+------------------------------------------------------------------------------------------------
+  benchmark                                     system   bundled    delta CI                 verdict
+  api.range.size.string_to_int                    1.83      1.00  -45.38% [-45.50,-45.28] FASTER
+  core.string_to_int.free                         8.12      4.59  -43.65% [-43.96,-43.26] FASTER
+  core.string_to_mixed.free                      25.18     14.90  -40.82% [-40.91,-40.71] FASTER
+  core.string_to_int.iter                        21.65     13.83  -36.02% [-36.21,-35.46] FASTER
+  core.string_to_mixed.read                      15.30      9.93  -35.09% [-35.34,-35.06] FASTER
+  adv.optiter.values.string_to_int_hash.optimized     16.18     10.53  -34.90% [-35.05,-34.68] FASTER
+  core.string_to_mixed.iter                      21.82     14.19  -34.88% [-35.58,-34.86] FASTER
+  core.string_to_int.read                        14.60      9.75  -33.25% [-33.33,-33.15] FASTER
+  core.string_to_mixed_hash.free                 40.84     27.28  -33.20% [-33.28,-33.01] FASTER
+  core.string_to_mixed_hash.iter                 29.54     19.82  -33.00% [-33.25,-32.75] FASTER
+  core.string_to_int_hash.iter                   27.95     18.69  -32.76% [-33.46,-32.67] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.optimized     21.09     14.24  -32.50% [-32.63,-32.23] FASTER
+  core.string_to_int_adaptive.iter               27.29     18.46  -32.30% [-32.62,-32.03] FASTER
+  core.string_to_mixed_adaptive.free             40.96     27.72  -32.22% [-32.61,-32.12] FASTER
+  core.string_to_mixed_adaptive.iter             29.55     20.09  -31.99% [-32.28,-31.35] FASTER
+  core.string_to_int_hash.free                   14.42      9.85  -31.90% [-32.03,-31.47] FASTER
+  core.string_to_int_adaptive.free               14.38      9.84  -31.87% [-32.31,-31.37] FASTER
+  adv.optiter.foreach.string_to_int_hash.optimized     19.14     13.18  -31.51% [-31.64,-30.95] FASTER
+  adv.optiter.values.string_to_int_adaptive.optimized     18.10     12.48  -31.02% [-31.16,-30.49] FASTER
+  api.equals.int_to_int                           4.70      3.26  -30.54% [-30.84,-29.24] FASTER
+  core.string_to_mixed.write                     41.49     29.09  -29.85% [-30.12,-29.25] FASTER
+  adv.forEach.string_to_int                      23.63     16.91  -28.80% [-28.90,-28.11] FASTER
+  api.setop.diff.string_to_int                   44.49     32.57  -26.90% [-26.94,-26.76] FASTER
+  api.setop.intersect.int_to_int                  7.08      5.27  -25.51% [-26.36,-25.07] FASTER
+  api.putAll.int_to_int                           8.31      6.20  -25.40% [-25.81,-25.05] FASTER
+  api.fromArray.int_to_int                        8.28      6.20  -25.26% [-25.75,-24.92] FASTER
+  api.setop.union.int_to_int                     17.09     12.78  -25.21% [-25.66,-25.07] FASTER
+  core.string_to_int.write                       34.77     26.11  -25.09% [-25.10,-24.86] FASTER
+  api.setop.intersect.bitset                      5.73      4.34  -24.30% [-24.34,-24.12] FASTER
+  api.setop.xor.int_to_int                       13.72     10.41  -24.13% [-24.56,-23.15] FASTER
+  adv.optiter.ratio.foreach.string_to_int_adaptive     61.47     46.80  -23.95% [-24.40,-23.72] FASTER
+  core.string_to_mixed_hash.write                77.36     58.78  -23.89% [-24.60,-23.86] FASTER
+  api.setop.intersect.string_to_int              47.18     36.09  -23.66% [-23.79,-23.44] FASTER
+  api.setop.union.bitset                         11.90      9.09  -23.63% [-24.12,-23.23] FASTER
+  api.deleteRange.int_to_int                     15.32     11.75  -23.40% [-23.80,-23.17] FASTER
+  core.int_to_mixed.read                          4.75      3.69  -23.28% [-23.42,-22.13] FASTER
+  core.string_to_mixed_adaptive.write            77.52     59.72  -23.09% [-23.27,-22.14] FASTER
+  api.mergeWith.string_to_int                    87.92     67.81  -23.07% [-25.00,-22.32] FASTER
+  api.setop.xor.bitset                           11.17      8.59  -23.06% [-23.41,-22.79] FASTER
+  api.setop.diff.int_to_int                       6.74      5.23  -22.69% [-23.32,-22.15] FASTER
+  core.int_to_int.write                           9.14      7.10  -22.36% [-23.08,-21.86] FASTER
+  adv.optiter.toArray.string_to_int_hash.optimized     22.95     17.86  -22.16% [-22.30,-21.79] FASTER
+  api.setop.union.string_to_int                 108.92     84.97  -22.03% [-22.63,-21.82] FASTER
+  adv.optiter.values.string_to_int_hash.default     26.31     20.54  -21.94% [-21.96,-21.66] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.optimized     27.66     21.63  -21.70% [-22.01,-21.56] FASTER
+  api.increment.int_to_int                        8.95      7.19  -20.98% [-21.35,-18.67] FASTER
+  api.mergeWith.int_to_int                       18.72     14.88  -20.91% [-22.36,-20.23] FASTER
+  api.setop.diff.bitset                           5.43      4.33  -20.42% [-20.85,-20.07] FASTER
+  adv.optiter.ratio.values.string_to_int_adaptive     53.40     42.68  -20.22% [-20.41,-19.64] FASTER
+  adv.optiter.foreach.string_to_int_hash.default     27.77     22.22  -20.02% [-20.18,-19.86] FASTER
+  adv.map.string_to_int                          61.07     50.02  -18.19% [-18.42,-17.78] FASTER
+  adv.filter.string_to_int                       44.84     36.81  -17.98% [-18.22,-17.39] FASTER
+  api.sumValues.int_to_int                        2.79      2.30  -17.66% [-17.68,-17.44] FASTER
+  adv.optiter.ratio.values.string_to_int_hash     61.58     51.22  -16.71% [-16.88,-16.60] FASTER
+  core.string_to_int_hash.write                  57.32     47.84  -16.57% [-16.61,-16.40] FASTER
+  core.string_to_int_adaptive.write              56.61     47.78  -15.59% [-15.73,-14.79] FASTER
+  adv.optiter.toArray.string_to_int_hash.default     34.60     29.30  -15.46% [-15.58,-15.18] FASTER
+  core.int_to_mixed.write                        11.89     10.05  -15.16% [-16.45,-15.00] FASTER
+  adv.optiter.ratio.foreach.string_to_int_hash     68.92     59.24  -14.21% [-14.53,-13.82] FASTER
+  core.int_to_int.read                            3.97      3.44  -14.02% [-16.84,-12.60] FASTER
+  core.int_to_packed.free                         3.05      2.61  -13.69% [-14.18,-13.12] FASTER
+  adv.optiter.values.string_to_int_adaptive.default     33.86     29.28  -13.57% [-13.67,-13.45] FASTER
+  core.string_to_mixed_hash.read                  9.46      8.29  -12.39% [-13.06,-12.27] FASTER
+  adv.optiter.ratio.toArray.string_to_int_adaptive     62.24     54.68  -12.23% [-12.46,-11.81] FASTER
+  core.string_to_int_adaptive.read                8.85      7.77  -12.05% [-12.21,-11.46] FASTER
+  core.string_to_int_hash.read                    9.15      8.07  -11.76% [-12.48,-11.63] FASTER
+  adv.optiter.increment.string_to_int_hash.optimized     21.48     18.97  -11.57% [-11.75,-11.35] FASTER
+  core.string_to_mixed_adaptive.read              9.15      8.12  -11.36% [-11.42,-10.91] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.default     44.33     39.51  -11.01% [-11.23,-10.60] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.default     34.27     30.46  -11.00% [-11.55,-10.88] FASTER
+  adv.optiter.overwrite.string_to_int_hash.optimized     21.16     18.92  -10.60% [-10.99,-10.32] FASTER
+  core.int_to_packed.write                       15.30     13.78   -9.95% [-10.14, -9.21] FASTER
+  core.int_to_mixed.free                          4.83      4.35   -9.94% [-10.77, -8.72] FASTER
+  core.bitset.write                               5.67      5.10   -9.82% [ -9.96, -9.73] FASTER
+  api.keys.int_to_int                             4.83      4.36   -9.63% [-10.04, -9.13] FASTER
+  api.values.int_to_int                           4.86      4.42   -9.22% [ -9.43, -8.98] FASTER
+  api.toArray.int_to_int                         15.13     13.77   -9.16% [ -9.41, -8.68] FASTER
+  core.bitset.iter                                5.89      5.32   -8.91% [-11.70, -8.68] FASTER
+  adv.map.int_to_int                             16.05     14.66   -8.78% [ -9.12, -8.07] FASTER
+  adv.optiter.ratio.toArray.string_to_int_hash     66.20     61.02   -7.90% [ -8.09, -7.68] FASTER
+  adv.optiter.ratio.increment.string_to_int_hash    127.36    118.19   -7.19% [ -7.39, -7.12] FASTER
+  core.bitset.read                                3.68      3.41   -6.81% [ -8.19, -6.56] FASTER
+  adv.filter.int_to_int                          14.96     13.97   -6.64% [ -7.27, -6.46] FASTER
+  core.int_to_mixed.iter                          6.17      5.75   -6.50% [ -7.03, -6.13] FASTER
+  adv.optiter.ratio.overwrite.string_to_int_hash    125.55    117.33   -6.41% [ -7.02, -6.10] FASTER
+  adv.forEach.int_to_int                         10.06      9.57   -5.69% [ -5.87, -3.60] FASTER
+  core.int_to_packed.read                        10.41      9.87   -5.07% [ -5.43, -4.78] FASTER
+  core.int_to_int.iter                            6.34      6.04   -4.79% [ -7.04, -2.81] null
+  adv.optiter.increment.string_to_int_hash.default     16.83     16.08   -4.58% [ -4.79, -4.50] FASTER
+  adv.optiter.overwrite.string_to_int_hash.default     16.83     16.07   -4.47% [ -4.71, -4.27] FASTER
+  adv.optiter.overwrite.string_to_int_adaptive.optimized     27.32     26.30   -3.65% [ -3.89, -3.28] FASTER
+  core.int_to_packed.iter                        12.67     12.31   -2.57% [ -3.65, -2.33] null
+  adv.optiter.overwrite.string_to_int_adaptive.default     24.85     24.29   -2.47% [ -2.58, -1.31] null
+  adv.optiter.ratio.overwrite.string_to_int_adaptive    109.99    108.59   -1.19% [ -1.49, -1.04] null
+  totals: 90 faster, 0 slower, 4 null
+
+------------------------------------------------------------------------------------------------
+  A vs C — PHP native array against php-judy (bundled)
+  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means
+  the PHP array is FASTER — publish these, they are the honest half of the story.
+------------------------------------------------------------------------------------------------
+  benchmark                                   array ms   judy ms  judy/arr winner
+  api.setop.intersect.bitset                      4.60      4.34     0.94x php-judy
+  api.setop.xor.bitset                            7.62      8.59     1.13x php-array
+  core.int_to_packed.free                         1.62      2.61     1.61x php-array
+  core.bitset.write                               3.00      5.10     1.70x php-array
+  core.string_to_int.write                       11.61     26.11     2.25x php-array
+  core.string_to_mixed.write                     12.70     29.09     2.29x php-array
+  core.int_to_int.write                           3.07      7.10     2.31x php-array
+  core.int_to_mixed.read                          1.54      3.69     2.39x php-array
+  api.increment.int_to_int                        2.91      7.19     2.47x php-array
+  core.int_to_mixed.write                         4.03     10.05     2.49x php-array
+  api.setop.diff.bitset                           1.66      4.33     2.61x php-array
+  core.int_to_mixed.free                          1.61      4.35     2.69x php-array
+  core.int_to_packed.write                        4.94     13.78     2.79x php-array
+  core.bitset.read                                1.07      3.41     3.19x php-array
+  core.int_to_int.read                            1.07      3.44     3.21x php-array
+  core.string_to_mixed_adaptive.read              2.51      8.12     3.23x php-array
+  core.string_to_mixed_hash.read                  2.53      8.29     3.28x php-array
+  core.string_to_int_adaptive.read                2.21      7.77     3.52x php-array
+  core.string_to_int_hash.read                    2.18      8.07     3.71x php-array
+  api.setop.union.bitset                          2.34      9.09     3.88x php-array
+  core.string_to_mixed.read                       2.55      9.93     3.89x php-array
+  core.string_to_int_hash.write                  11.41     47.84     4.19x php-array
+  core.string_to_int_adaptive.write              11.38     47.78     4.20x php-array
+  core.string_to_int.read                         2.22      9.75     4.39x php-array
+  core.string_to_mixed_hash.write                12.30     58.78     4.78x php-array
+  core.string_to_mixed_adaptive.write            12.30     59.72     4.86x php-array
+  core.string_to_int.free                         0.90      4.59     5.12x php-array
+  core.string_to_mixed.free                       2.62     14.90     5.70x php-array
+  core.bitset.iter                                0.92      5.32     5.81x php-array
+  core.int_to_mixed.iter                          0.93      5.75     6.15x php-array
+  core.int_to_packed.read                         1.56      9.87     6.34x php-array
+  core.int_to_int.iter                            0.91      6.04     6.62x php-array
+  core.string_to_mixed.iter                       1.63     14.19     8.72x php-array
+  core.string_to_int.iter                         1.38     13.83    10.05x php-array
+  core.string_to_mixed_hash.free                  2.61     27.28    10.47x php-array
+  core.string_to_mixed_adaptive.free              2.60     27.72    10.64x php-array
+  core.string_to_int_adaptive.free                0.89      9.84    11.11x php-array
+  core.string_to_int_hash.free                    0.87      9.85    11.29x php-array
+  core.string_to_mixed_hash.iter                  1.62     19.82    12.26x php-array
+  core.string_to_mixed_adaptive.iter              1.63     20.09    12.35x php-array
+  core.int_to_packed.iter                         0.94     12.31    13.05x php-array
+  core.string_to_int_adaptive.iter                1.40     18.46    13.15x php-array
+  core.string_to_int_hash.iter                    1.40     18.69    13.38x php-array
+  totals: php-judy wins 1, PHP array wins 42, parity 0
+
+Wrote /work/results2/run1-cache-300k.json

--- a/research/three-arm-benchmark/results/run2-dram-6m.txt
+++ b/research/three-arm-benchmark/results/run2-dram-6m.txt
@@ -1,0 +1,7 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /work/builds/judy-B-1.so, /work/builds/judy-B-2.so, /work/builds/judy-B-3.so
+  C  php-judy + bundled libJudy : /work/builds/judy-C-1.so, /work/builds/judy-C-2.so, /work/builds/judy-C-3.so
+arm B1: group core.int failed (status 139)
+Segmentation fault (core dumped)
+

--- a/research/three-arm-benchmark/results/run3-cc-control.json
+++ b/research/three-arm-benchmark/results/run3-cc-control.json
@@ -1,0 +1,7936 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "linux-x86_64-gcc14.2-php8.4-CvsC-rebuild-control",
+        "date": "2026-08-19T02:31:48+00:00",
+        "php_version": "8.4.24",
+        "platform": "Linux x86_64",
+        "uname": "Linux 9d84886938ba 6.8.0-136-generic #136~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  3 16:29:11 UTC  x86_64",
+        "judy_version": "2.5.2",
+        "system_so": [
+            "/work/builds/judy-C-1.so",
+            "/work/builds/judy-C-2.so",
+            "/work/builds/judy-C-3.so"
+        ],
+        "bundled_so": [
+            "/work/builds/judy-C-2.so",
+            "/work/builds/judy-C-3.so",
+            "/work/builds/judy-C-1.so"
+        ],
+        "system_so_sha256": [
+            "354dc68ce9ed49662f5fcb51c033683b0e63073db69384178903d520617726b0",
+            "1cb7ca0eda6ae78552276e8b211a08474902df7d58e08eb1c4a50d404570bb2b",
+            "cfce55bc85a2126e779d7d23e9ad1cdb0e1cdf4002d064f5587a3fe31e8f43f1"
+        ],
+        "bundled_so_sha256": [
+            "1cb7ca0eda6ae78552276e8b211a08474902df7d58e08eb1c4a50d404570bb2b",
+            "cfce55bc85a2126e779d7d23e9ad1cdb0e1cdf4002d064f5587a3fe31e8f43f1",
+            "354dc68ce9ed49662f5fcb51c033683b0e63073db69384178903d520617726b0"
+        ],
+        "system_provenance": "CONTROL bundled C1/C2/C3",
+        "bundled_provenance": "CONTROL bundled C2/C3/C1 (offset: no round self-compares)",
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 300000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            100000,
+            1000000,
+            8000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "cache-resident",
+        "claim_floor_pct": 3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 70,
+        "memory_children": 0,
+        "wall_seconds": 179.6
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T02:28:48+00:00",
+                "load1": 1.02,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T02:31:48+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T02:31:48+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "note": "load average alone is necessary but not sufficient: a co-resident memory-bound benchmark contends for LLC and memory bandwidth at low load, and a PHP-array control does not detect it"
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 0.99931,
+            "delta_pct": -0.07,
+            "ci_delta_pct": [
+                -0.19,
+                0.01
+            ],
+            "measured_spread_pct": 5.12,
+            "row_count": 43,
+            "eligibility": "genuine PHP-array rows only (TAM_ARM_A_ROWS); Judy-touching .php rows are excluded because they carry real signal",
+            "rows": {
+                "core.bitset.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99463,
+                    "delta_pct": -0.54,
+                    "ci_delta_pct": [
+                        -0.75,
+                        1.81
+                    ],
+                    "n": 7,
+                    "b_ms": 2.9996,
+                    "c_ms": 3
+                },
+                "core.bitset.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00262,
+                    "delta_pct": 0.26,
+                    "ci_delta_pct": [
+                        -0.03,
+                        1.14
+                    ],
+                    "n": 7,
+                    "b_ms": 1.0701,
+                    "c_ms": 1.0722
+                },
+                "core.bitset.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99989,
+                    "delta_pct": -0.01,
+                    "ci_delta_pct": [
+                        -0.13,
+                        0.03
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9131,
+                    "c_ms": 0.9129
+                },
+                "core.int_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00573,
+                    "delta_pct": 0.57,
+                    "ci_delta_pct": [
+                        -0.19,
+                        0.97
+                    ],
+                    "n": 7,
+                    "b_ms": 3.0886,
+                    "c_ms": 3.1033
+                },
+                "core.int_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99935,
+                    "delta_pct": -0.07,
+                    "ci_delta_pct": [
+                        -0.28,
+                        0.64
+                    ],
+                    "n": 7,
+                    "b_ms": 1.0707,
+                    "c_ms": 1.0687
+                },
+                "core.int_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00022,
+                    "delta_pct": 0.02,
+                    "ci_delta_pct": [
+                        0.01,
+                        0.85
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9129,
+                    "c_ms": 0.9133
+                },
+                "core.int_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00007,
+                    "delta_pct": 0.01,
+                    "ci_delta_pct": [
+                        -0.49,
+                        0.7
+                    ],
+                    "n": 7,
+                    "b_ms": 4.0096,
+                    "c_ms": 4.0107
+                },
+                "core.int_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00097,
+                    "delta_pct": 0.1,
+                    "ci_delta_pct": [
+                        -0.9,
+                        1.54
+                    ],
+                    "n": 7,
+                    "b_ms": 1.5664,
+                    "c_ms": 1.5632
+                },
+                "core.int_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99872,
+                    "delta_pct": -0.13,
+                    "ci_delta_pct": [
+                        -0.37,
+                        2.47
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9363,
+                    "c_ms": 0.9379
+                },
+                "core.int_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00217,
+                    "delta_pct": 0.22,
+                    "ci_delta_pct": [
+                        -0.29,
+                        0.81
+                    ],
+                    "n": 7,
+                    "b_ms": 1.616,
+                    "c_ms": 1.6241
+                },
+                "core.int_to_packed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00364,
+                    "delta_pct": 0.36,
+                    "ci_delta_pct": [
+                        -0.08,
+                        2.71
+                    ],
+                    "n": 7,
+                    "b_ms": 4.9273,
+                    "c_ms": 4.94
+                },
+                "core.int_to_packed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00572,
+                    "delta_pct": 0.57,
+                    "ci_delta_pct": [
+                        -3.43,
+                        1.96
+                    ],
+                    "n": 7,
+                    "b_ms": 1.5589,
+                    "c_ms": 1.5639
+                },
+                "core.int_to_packed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00397,
+                    "delta_pct": 0.4,
+                    "ci_delta_pct": [
+                        -0.95,
+                        1.64
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9389,
+                    "c_ms": 0.9366
+                },
+                "core.int_to_packed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9916,
+                    "delta_pct": -0.84,
+                    "ci_delta_pct": [
+                        -2.37,
+                        3.09
+                    ],
+                    "n": 7,
+                    "b_ms": 1.645,
+                    "c_ms": 1.6413
+                },
+                "core.string_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9992,
+                    "delta_pct": -0.08,
+                    "ci_delta_pct": [
+                        -0.15,
+                        0.48
+                    ],
+                    "n": 7,
+                    "b_ms": 11.6928,
+                    "c_ms": 11.7467
+                },
+                "core.string_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.0374,
+                    "delta_pct": 3.74,
+                    "ci_delta_pct": [
+                        1.78,
+                        4.67
+                    ],
+                    "n": 7,
+                    "b_ms": 2.1707,
+                    "c_ms": 2.2213
+                },
+                "core.string_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00466,
+                    "delta_pct": 0.47,
+                    "ci_delta_pct": [
+                        -2.55,
+                        7.76
+                    ],
+                    "n": 7,
+                    "b_ms": 1.4059,
+                    "c_ms": 1.4175
+                },
+                "core.string_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99703,
+                    "delta_pct": -0.3,
+                    "ci_delta_pct": [
+                        -0.43,
+                        0.52
+                    ],
+                    "n": 7,
+                    "b_ms": 0.933,
+                    "c_ms": 0.929
+                },
+                "core.string_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99841,
+                    "delta_pct": -0.16,
+                    "ci_delta_pct": [
+                        -0.34,
+                        0.01
+                    ],
+                    "n": 7,
+                    "b_ms": 12.8405,
+                    "c_ms": 12.8178
+                },
+                "core.string_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98444,
+                    "delta_pct": -1.56,
+                    "ci_delta_pct": [
+                        -2.29,
+                        1.99
+                    ],
+                    "n": 7,
+                    "b_ms": 2.5442,
+                    "c_ms": 2.5066
+                },
+                "core.string_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99614,
+                    "delta_pct": -0.39,
+                    "ci_delta_pct": [
+                        -1.48,
+                        2.03
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6309,
+                    "c_ms": 1.6402
+                },
+                "core.string_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9994,
+                    "delta_pct": -0.06,
+                    "ci_delta_pct": [
+                        -0.91,
+                        0.24
+                    ],
+                    "n": 7,
+                    "b_ms": 2.6823,
+                    "c_ms": 2.6807
+                },
+                "core.string_to_int_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00074,
+                    "delta_pct": 0.07,
+                    "ci_delta_pct": [
+                        -0.05,
+                        0.79
+                    ],
+                    "n": 7,
+                    "b_ms": 11.4448,
+                    "c_ms": 11.4608
+                },
+                "core.string_to_int_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.0512,
+                    "delta_pct": 5.12,
+                    "ci_delta_pct": [
+                        2.76,
+                        7.03
+                    ],
+                    "n": 7,
+                    "b_ms": 2.143,
+                    "c_ms": 2.24
+                },
+                "core.string_to_int_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99398,
+                    "delta_pct": -0.6,
+                    "ci_delta_pct": [
+                        -1.46,
+                        1.24
+                    ],
+                    "n": 7,
+                    "b_ms": 1.4216,
+                    "c_ms": 1.4258
+                },
+                "core.string_to_int_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99869,
+                    "delta_pct": -0.13,
+                    "ci_delta_pct": [
+                        -2.12,
+                        -0.07
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9136,
+                    "c_ms": 0.9064
+                },
+                "core.string_to_mixed_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00005,
+                    "delta_pct": 0,
+                    "ci_delta_pct": [
+                        -1.25,
+                        0.23
+                    ],
+                    "n": 7,
+                    "b_ms": 12.3836,
+                    "c_ms": 12.3834
+                },
+                "core.string_to_mixed_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99518,
+                    "delta_pct": -0.48,
+                    "ci_delta_pct": [
+                        -1.14,
+                        1.73
+                    ],
+                    "n": 7,
+                    "b_ms": 2.5372,
+                    "c_ms": 2.5415
+                },
+                "core.string_to_mixed_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99223,
+                    "delta_pct": -0.78,
+                    "ci_delta_pct": [
+                        -1.34,
+                        0.23
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6286,
+                    "c_ms": 1.6207
+                },
+                "core.string_to_mixed_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00674,
+                    "delta_pct": 0.67,
+                    "ci_delta_pct": [
+                        -0.36,
+                        1.13
+                    ],
+                    "n": 7,
+                    "b_ms": 2.6494,
+                    "c_ms": 2.6577
+                },
+                "core.string_to_int_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99882,
+                    "delta_pct": -0.12,
+                    "ci_delta_pct": [
+                        -0.19,
+                        -0
+                    ],
+                    "n": 7,
+                    "b_ms": 11.4452,
+                    "c_ms": 11.4517
+                },
+                "core.string_to_int_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.03934,
+                    "delta_pct": 3.93,
+                    "ci_delta_pct": [
+                        -3.1,
+                        10.2
+                    ],
+                    "n": 7,
+                    "b_ms": 2.1738,
+                    "c_ms": 2.2007
+                },
+                "core.string_to_int_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99028,
+                    "delta_pct": -0.97,
+                    "ci_delta_pct": [
+                        -3.54,
+                        0.11
+                    ],
+                    "n": 7,
+                    "b_ms": 1.4038,
+                    "c_ms": 1.3858
+                },
+                "core.string_to_int_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.97812,
+                    "delta_pct": -2.19,
+                    "ci_delta_pct": [
+                        -2.66,
+                        -0.72
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9241,
+                    "c_ms": 0.9114
+                },
+                "core.string_to_mixed_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99774,
+                    "delta_pct": -0.23,
+                    "ci_delta_pct": [
+                        -0.41,
+                        -0.02
+                    ],
+                    "n": 7,
+                    "b_ms": 12.3851,
+                    "c_ms": 12.3608
+                },
+                "core.string_to_mixed_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99996,
+                    "delta_pct": -0,
+                    "ci_delta_pct": [
+                        -1.21,
+                        2.84
+                    ],
+                    "n": 7,
+                    "b_ms": 2.5457,
+                    "c_ms": 2.5382
+                },
+                "core.string_to_mixed_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9981,
+                    "delta_pct": -0.19,
+                    "ci_delta_pct": [
+                        -0.44,
+                        0.54
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6239,
+                    "c_ms": 1.6298
+                },
+                "core.string_to_mixed_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99573,
+                    "delta_pct": -0.43,
+                    "ci_delta_pct": [
+                        -0.87,
+                        0.02
+                    ],
+                    "n": 7,
+                    "b_ms": 2.6579,
+                    "c_ms": 2.6498
+                },
+                "api.increment.int_to_int": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98612,
+                    "delta_pct": -1.39,
+                    "ci_delta_pct": [
+                        -2.45,
+                        -0.83
+                    ],
+                    "n": 7,
+                    "b_ms": 2.9158,
+                    "c_ms": 2.8906
+                },
+                "api.setop.union.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99931,
+                    "delta_pct": -0.07,
+                    "ci_delta_pct": [
+                        -3.12,
+                        1.26
+                    ],
+                    "n": 7,
+                    "b_ms": 2.3451,
+                    "c_ms": 2.343
+                },
+                "api.setop.intersect.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99815,
+                    "delta_pct": -0.19,
+                    "ci_delta_pct": [
+                        -1.15,
+                        0.67
+                    ],
+                    "n": 7,
+                    "b_ms": 4.583,
+                    "c_ms": 4.5818
+                },
+                "api.setop.diff.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00012,
+                    "delta_pct": 0.01,
+                    "ci_delta_pct": [
+                        -0.3,
+                        0.29
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6578,
+                    "c_ms": 1.6535
+                },
+                "api.setop.xor.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99707,
+                    "delta_pct": -0.29,
+                    "ci_delta_pct": [
+                        -0.39,
+                        1.32
+                    ],
+                    "n": 7,
+                    "b_ms": 7.6119,
+                    "c_ms": 7.6286
+                }
+            }
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 0,
+        "slower": 0,
+        "null": 94
+    },
+    "a_counts": {
+        "php-judy": 1,
+        "php-array": 42,
+        "parity": 0
+    },
+    "bundled_vs_system": {
+        "core.bitset.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00123,
+            "delta_pct": 0.12,
+            "ci_delta_pct": [
+                -0.25,
+                0.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.15,
+                "B2/C2": 0.11,
+                "B3/C3": 0
+            },
+            "build_spread_pct": 0.15,
+            "builds": 3,
+            "system_ms": 5.1274,
+            "bundled_ms": 5.1183,
+            "raw_delta_pct": 0.05,
+            "spread_pct": [
+                1,
+                0.7
+            ],
+            "system_runs_ms": [
+                5.1059,
+                5.1295,
+                5.1107,
+                5.1128,
+                5.1274,
+                5.1277,
+                5.1596
+            ],
+            "bundled_runs_ms": [
+                5.1102,
+                5.1133,
+                5.1135,
+                5.1252,
+                5.1482,
+                5.1183,
+                5.1279
+            ],
+            "paired_ratios": [
+                1.00084,
+                0.99684,
+                1.00055,
+                1.00243,
+                1.00406,
+                0.99817,
+                0.99386
+            ]
+        },
+        "core.bitset.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.01535,
+            "delta_pct": 1.54,
+            "ci_delta_pct": [
+                -0.2,
+                2.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 2.33,
+                "B2/C2": 1.2,
+                "B3/C3": 0.76
+            },
+            "build_spread_pct": 1.57,
+            "builds": 3,
+            "system_ms": 3.3987,
+            "bundled_ms": 3.4451,
+            "raw_delta_pct": 1.47,
+            "spread_pct": [
+                4.2,
+                2.1
+            ],
+            "system_runs_ms": [
+                3.3267,
+                3.36,
+                3.4108,
+                3.469,
+                3.3987,
+                3.4439,
+                3.3792
+            ],
+            "bundled_runs_ms": [
+                3.4587,
+                3.4451,
+                3.4608,
+                3.3907,
+                3.3895,
+                3.4411,
+                3.4556
+            ],
+            "paired_ratios": [
+                1.03968,
+                1.02533,
+                1.01466,
+                0.97743,
+                0.99729,
+                0.99919,
+                1.02261
+            ]
+        },
+        "core.bitset.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.98658,
+            "delta_pct": -1.34,
+            "ci_delta_pct": [
+                -1.61,
+                2.02
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.47,
+                "B2/C2": 1.01,
+                "B3/C3": -0.03
+            },
+            "build_spread_pct": 2.48,
+            "builds": 3,
+            "system_ms": 5.396,
+            "bundled_ms": 5.3386,
+            "raw_delta_pct": -1.41,
+            "spread_pct": [
+                3.8,
+                3.4
+            ],
+            "system_runs_ms": [
+                5.4014,
+                5.3714,
+                5.4298,
+                5.3031,
+                5.2799,
+                5.396,
+                5.4852
+            ],
+            "bundled_runs_ms": [
+                5.3182,
+                5.2957,
+                5.3386,
+                5.4066,
+                5.4537,
+                5.4756,
+                5.2981
+            ],
+            "paired_ratios": [
+                0.9846,
+                0.98591,
+                0.9832,
+                1.01952,
+                1.03292,
+                1.01475,
+                0.96589
+            ]
+        },
+        "core.int_to_int.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99846,
+            "delta_pct": -0.15,
+            "ci_delta_pct": [
+                -0.37,
+                0.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.15,
+                "B2/C2": 0.21,
+                "B3/C3": -0.31
+            },
+            "build_spread_pct": 0.52,
+            "builds": 3,
+            "system_ms": 7.1226,
+            "bundled_ms": 7.1154,
+            "raw_delta_pct": -0.22,
+            "spread_pct": [
+                3.4,
+                0.4
+            ],
+            "system_runs_ms": [
+                7.0791,
+                7.1226,
+                7.1231,
+                7.1155,
+                7.0887,
+                7.1547,
+                7.3183
+            ],
+            "bundled_runs_ms": [
+                7.1072,
+                7.1154,
+                7.1,
+                7.0997,
+                7.1166,
+                7.1233,
+                7.1249
+            ],
+            "paired_ratios": [
+                1.00397,
+                0.99899,
+                0.99676,
+                0.99778,
+                1.00394,
+                0.99561,
+                0.97357
+            ]
+        },
+        "core.int_to_int.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00337,
+            "delta_pct": 0.34,
+            "ci_delta_pct": [
+                -1.91,
+                3.52
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.75,
+                "B2/C2": 3.77,
+                "B3/C3": 0.26
+            },
+            "build_spread_pct": 5.52,
+            "builds": 3,
+            "system_ms": 3.3641,
+            "bundled_ms": 3.3866,
+            "raw_delta_pct": 0.27,
+            "spread_pct": [
+                7.1,
+                4.6
+            ],
+            "system_runs_ms": [
+                3.3951,
+                3.2175,
+                3.3427,
+                3.4548,
+                3.3037,
+                3.4053,
+                3.3641
+            ],
+            "bundled_runs_ms": [
+                3.4042,
+                3.4445,
+                3.4581,
+                3.3866,
+                3.3147,
+                3.3008,
+                3.303
+            ],
+            "paired_ratios": [
+                1.00268,
+                1.07055,
+                1.03452,
+                0.98026,
+                1.00333,
+                0.96931,
+                0.98184
+            ]
+        },
+        "core.int_to_int.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00479,
+            "delta_pct": 0.48,
+            "ci_delta_pct": [
+                -0.24,
+                0.96
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.53,
+                "B2/C2": 0.4,
+                "B3/C3": 0.29
+            },
+            "build_spread_pct": 0.24,
+            "builds": 3,
+            "system_ms": 5.9887,
+            "bundled_ms": 6.0167,
+            "raw_delta_pct": 0.41,
+            "spread_pct": [
+                1.8,
+                2.2
+            ],
+            "system_runs_ms": [
+                6.0253,
+                5.9529,
+                6.0147,
+                5.936,
+                5.9787,
+                6.0442,
+                5.9887
+            ],
+            "bundled_runs_ms": [
+                6.0068,
+                5.9338,
+                6.0167,
+                5.9632,
+                6.0377,
+                6.069,
+                6.042
+            ],
+            "paired_ratios": [
+                0.99693,
+                0.99679,
+                1.00033,
+                1.00458,
+                1.00987,
+                1.0041,
+                1.0089
+            ]
+        },
+        "core.int_to_mixed.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99721,
+            "delta_pct": -0.28,
+            "ci_delta_pct": [
+                -1.32,
+                0.2
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.28,
+                "B2/C2": -0.61,
+                "B3/C3": -0.66
+            },
+            "build_spread_pct": 0.38,
+            "builds": 3,
+            "system_ms": 10.0522,
+            "bundled_ms": 10.0191,
+            "raw_delta_pct": -0.35,
+            "spread_pct": [
+                1.1,
+                1.5
+            ],
+            "system_runs_ms": [
+                10.074,
+                10.038,
+                10.0522,
+                10.0009,
+                10.056,
+                10.1128,
+                10.0041
+            ],
+            "bundled_runs_ms": [
+                10.0371,
+                10.0414,
+                10.065,
+                10.0191,
+                9.9164,
+                9.9517,
+                9.9694
+            ],
+            "paired_ratios": [
+                0.99634,
+                1.00034,
+                1.00127,
+                1.00182,
+                0.98612,
+                0.98407,
+                0.99653
+            ]
+        },
+        "core.int_to_mixed.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.01357,
+            "delta_pct": 1.36,
+            "ci_delta_pct": [
+                -0.17,
+                1.9
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.17,
+                "B2/C2": 0.83,
+                "B3/C3": 1.75
+            },
+            "build_spread_pct": 1.92,
+            "builds": 3,
+            "system_ms": 3.7129,
+            "bundled_ms": 3.7136,
+            "raw_delta_pct": 1.29,
+            "spread_pct": [
+                4.6,
+                3.2
+            ],
+            "system_runs_ms": [
+                3.8161,
+                3.6488,
+                3.6445,
+                3.6785,
+                3.7129,
+                3.7668,
+                3.7224
+            ],
+            "bundled_runs_ms": [
+                3.6947,
+                3.7126,
+                3.7202,
+                3.7458,
+                3.7047,
+                3.8153,
+                3.7136
+            ],
+            "paired_ratios": [
+                0.96819,
+                1.01749,
+                1.02077,
+                1.0183,
+                0.99779,
+                1.01288,
+                0.99764
+            ]
+        },
+        "core.int_to_mixed.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99861,
+            "delta_pct": -0.14,
+            "ci_delta_pct": [
+                -0.6,
+                2.18
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.6,
+                "B2/C2": 0.86,
+                "B3/C3": 1.02
+            },
+            "build_spread_pct": 1.62,
+            "builds": 3,
+            "system_ms": 5.7332,
+            "bundled_ms": 5.7248,
+            "raw_delta_pct": -0.21,
+            "spread_pct": [
+                1.2,
+                2.1
+            ],
+            "system_runs_ms": [
+                5.7343,
+                5.6777,
+                5.747,
+                5.6919,
+                5.7436,
+                5.686,
+                5.7332
+            ],
+            "bundled_runs_ms": [
+                5.6842,
+                5.7989,
+                5.7351,
+                5.7248,
+                5.7123,
+                5.8057,
+                5.695
+            ],
+            "paired_ratios": [
+                0.99126,
+                1.02135,
+                0.99793,
+                1.00578,
+                0.99455,
+                1.02105,
+                0.99334
+            ]
+        },
+        "core.int_to_mixed.free": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00221,
+            "delta_pct": 0.22,
+            "ci_delta_pct": [
+                -1,
+                0.97
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.38,
+                "B2/C2": 0.38,
+                "B3/C3": -0.4
+            },
+            "build_spread_pct": 0.78,
+            "builds": 3,
+            "system_ms": 4.3278,
+            "bundled_ms": 4.3155,
+            "raw_delta_pct": 0.15,
+            "spread_pct": [
+                1.8,
+                2.2
+            ],
+            "system_runs_ms": [
+                4.3323,
+                4.2706,
+                4.3322,
+                4.3477,
+                4.3278,
+                4.3245,
+                4.3056
+            ],
+            "bundled_runs_ms": [
+                4.3459,
+                4.3091,
+                4.2848,
+                4.3013,
+                4.3155,
+                4.3311,
+                4.3799
+            ],
+            "paired_ratios": [
+                1.00314,
+                1.00902,
+                0.98906,
+                0.98933,
+                0.99716,
+                1.00153,
+                1.01726
+            ]
+        },
+        "core.int_to_packed.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00043,
+            "delta_pct": 0.04,
+            "ci_delta_pct": [
+                -0.43,
+                0.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.32,
+                "B2/C2": -0.54,
+                "B3/C3": -0.19
+            },
+            "build_spread_pct": 0.86,
+            "builds": 3,
+            "system_ms": 13.802,
+            "bundled_ms": 13.7714,
+            "raw_delta_pct": -0.03,
+            "spread_pct": [
+                0.6,
+                6.4
+            ],
+            "system_runs_ms": [
+                13.7734,
+                13.802,
+                13.8325,
+                13.7634,
+                13.7968,
+                13.8028,
+                13.8437
+            ],
+            "bundled_runs_ms": [
+                13.7714,
+                13.7339,
+                13.7643,
+                13.7978,
+                13.6979,
+                13.7993,
+                14.5833
+            ],
+            "paired_ratios": [
+                0.99985,
+                0.99507,
+                0.99507,
+                1.0025,
+                0.99283,
+                0.99975,
+                1.05343
+            ]
+        },
+        "core.int_to_packed.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00151,
+            "delta_pct": 0.15,
+            "ci_delta_pct": [
+                -0.64,
+                1.26
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.27,
+                "B2/C2": -0.45,
+                "B3/C3": 0.71
+            },
+            "build_spread_pct": 1.16,
+            "builds": 3,
+            "system_ms": 9.8975,
+            "bundled_ms": 9.9176,
+            "raw_delta_pct": 0.08,
+            "spread_pct": [
+                1.5,
+                7.3
+            ],
+            "system_runs_ms": [
+                9.9769,
+                9.9604,
+                9.832,
+                9.8975,
+                9.9729,
+                9.8806,
+                9.8621
+            ],
+            "bundled_runs_ms": [
+                9.9063,
+                9.8838,
+                9.9491,
+                9.9176,
+                9.9467,
+                9.8887,
+                10.6086
+            ],
+            "paired_ratios": [
+                0.99292,
+                0.99231,
+                1.01191,
+                1.00203,
+                0.99737,
+                1.00082,
+                1.07569
+            ]
+        },
+        "core.int_to_packed.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00226,
+            "delta_pct": 0.23,
+            "ci_delta_pct": [
+                -0.31,
+                2.92
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 2.92,
+                "B2/C2": 0.15,
+                "B3/C3": -0.33
+            },
+            "build_spread_pct": 3.25,
+            "builds": 3,
+            "system_ms": 12.3305,
+            "bundled_ms": 12.3844,
+            "raw_delta_pct": 0.16,
+            "spread_pct": [
+                0.9,
+                6.3
+            ],
+            "system_runs_ms": [
+                12.3066,
+                12.2903,
+                12.3986,
+                12.3172,
+                12.3663,
+                12.3617,
+                12.3305
+            ],
+            "bundled_runs_ms": [
+                12.6576,
+                12.2908,
+                12.2773,
+                12.2707,
+                12.3857,
+                12.3844,
+                13.053
+            ],
+            "paired_ratios": [
+                1.02852,
+                1.00004,
+                0.99022,
+                0.99622,
+                1.00157,
+                1.00184,
+                1.05859
+            ]
+        },
+        "core.int_to_packed.free": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00462,
+            "delta_pct": 0.46,
+            "ci_delta_pct": [
+                -0.68,
+                1.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 1.12,
+                "B2/C2": -1.27,
+                "B3/C3": 0.45
+            },
+            "build_spread_pct": 2.39,
+            "builds": 3,
+            "system_ms": 2.5936,
+            "bundled_ms": 2.6034,
+            "raw_delta_pct": 0.39,
+            "spread_pct": [
+                1.2,
+                3.2
+            ],
+            "system_runs_ms": [
+                2.6232,
+                2.6197,
+                2.5936,
+                2.5911,
+                2.6181,
+                2.5934,
+                2.5932
+            ],
+            "bundled_runs_ms": [
+                2.6508,
+                2.6,
+                2.5895,
+                2.6259,
+                2.5676,
+                2.6174,
+                2.6034
+            ],
+            "paired_ratios": [
+                1.01052,
+                0.99248,
+                0.99842,
+                1.01343,
+                0.98071,
+                1.00925,
+                1.00393
+            ]
+        },
+        "core.string_to_int.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00371,
+            "delta_pct": 0.37,
+            "ci_delta_pct": [
+                -0.08,
+                0.51
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.37,
+                "B2/C2": 0.21,
+                "B3/C3": 0.22
+            },
+            "build_spread_pct": 0.16,
+            "builds": 3,
+            "system_ms": 26.1503,
+            "bundled_ms": 26.1222,
+            "raw_delta_pct": 0.3,
+            "spread_pct": [
+                1.3,
+                2.6
+            ],
+            "system_runs_ms": [
+                26.3284,
+                26.0386,
+                26.1544,
+                26.2204,
+                26.1503,
+                26.044,
+                25.9762
+            ],
+            "bundled_runs_ms": [
+                26.1222,
+                26.1217,
+                26.1155,
+                26.7308,
+                26.14,
+                26.1592,
+                26.0546
+            ],
+            "paired_ratios": [
+                0.99217,
+                1.00319,
+                0.99851,
+                1.01947,
+                0.99961,
+                1.00442,
+                1.00302
+            ]
+        },
+        "core.string_to_int.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99989,
+            "delta_pct": -0.01,
+            "ci_delta_pct": [
+                -0.28,
+                0.9
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.28,
+                "B2/C2": 0.09,
+                "B3/C3": 0.44
+            },
+            "build_spread_pct": 0.72,
+            "builds": 3,
+            "system_ms": 9.7478,
+            "bundled_ms": 9.8152,
+            "raw_delta_pct": -0.08,
+            "spread_pct": [
+                1.3,
+                2.6
+            ],
+            "system_runs_ms": [
+                9.7904,
+                9.7398,
+                9.7369,
+                9.7104,
+                9.8357,
+                9.8272,
+                9.7478
+            ],
+            "bundled_runs_ms": [
+                9.7458,
+                9.7635,
+                9.8174,
+                9.9733,
+                9.8152,
+                9.8194,
+                9.7134
+            ],
+            "paired_ratios": [
+                0.99544,
+                1.00243,
+                1.00827,
+                1.02707,
+                0.99792,
+                0.99921,
+                0.99647
+            ]
+        },
+        "core.string_to_int.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00098,
+            "delta_pct": 0.1,
+            "ci_delta_pct": [
+                0.03,
+                1.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.03,
+                "B2/C2": 0.31,
+                "B3/C3": 0.63
+            },
+            "build_spread_pct": 0.6,
+            "builds": 3,
+            "system_ms": 13.8795,
+            "bundled_ms": 13.853,
+            "raw_delta_pct": 0.03,
+            "spread_pct": [
+                1,
+                2.9
+            ],
+            "system_runs_ms": [
+                13.8795,
+                13.8996,
+                13.9093,
+                13.9273,
+                13.8534,
+                13.7913,
+                13.8585
+            ],
+            "bundled_runs_ms": [
+                13.7794,
+                13.9716,
+                14.0603,
+                14.1865,
+                13.8491,
+                13.7953,
+                13.853
+            ],
+            "paired_ratios": [
+                0.99279,
+                1.00518,
+                1.01086,
+                1.01861,
+                0.99969,
+                1.00029,
+                0.9996
+            ]
+        },
+        "core.string_to_int.free": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00723,
+            "delta_pct": 0.72,
+            "ci_delta_pct": [
+                -0.12,
+                0.93
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.12,
+                "B2/C2": 0.92,
+                "B3/C3": 0.37
+            },
+            "build_spread_pct": 1.04,
+            "builds": 3,
+            "system_ms": 4.56,
+            "bundled_ms": 4.5802,
+            "raw_delta_pct": 0.65,
+            "spread_pct": [
+                2.2,
+                1.5
+            ],
+            "system_runs_ms": [
+                4.5681,
+                4.5414,
+                4.5688,
+                4.627,
+                4.5268,
+                4.5585,
+                4.56
+            ],
+            "bundled_runs_ms": [
+                4.5597,
+                4.5802,
+                4.5669,
+                4.5997,
+                4.5656,
+                4.5883,
+                4.628
+            ],
+            "paired_ratios": [
+                0.99816,
+                1.00854,
+                0.99958,
+                0.9941,
+                1.00857,
+                1.00654,
+                1.01491
+            ]
+        },
+        "core.string_to_mixed.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00135,
+            "delta_pct": 0.14,
+            "ci_delta_pct": [
+                -0.3,
+                1.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.79,
+                "B2/C2": -0.23,
+                "B3/C3": 1.13
+            },
+            "build_spread_pct": 1.36,
+            "builds": 3,
+            "system_ms": 29.1288,
+            "bundled_ms": 29.1909,
+            "raw_delta_pct": 0.07,
+            "spread_pct": [
+                0.9,
+                2.3
+            ],
+            "system_runs_ms": [
+                29.0265,
+                29.201,
+                29.0818,
+                29.1288,
+                29.299,
+                29.25,
+                29.0678
+            ],
+            "bundled_runs_ms": [
+                29.3425,
+                29.134,
+                29.8145,
+                29.1482,
+                29.1909,
+                29.1315,
+                29.2777
+            ],
+            "paired_ratios": [
+                1.01089,
+                0.99771,
+                1.02519,
+                1.00067,
+                0.99631,
+                0.99595,
+                1.00722
+            ]
+        },
+        "core.string_to_mixed.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00702,
+            "delta_pct": 0.7,
+            "ci_delta_pct": [
+                -0.16,
+                2.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.16,
+                "B2/C2": 0.73,
+                "B3/C3": 1.2
+            },
+            "build_spread_pct": 1.36,
+            "builds": 3,
+            "system_ms": 9.9311,
+            "bundled_ms": 9.9921,
+            "raw_delta_pct": 0.63,
+            "spread_pct": [
+                0.9,
+                3.3
+            ],
+            "system_runs_ms": [
+                9.9389,
+                9.9235,
+                9.8941,
+                9.9868,
+                9.9311,
+                9.9566,
+                9.9183
+            ],
+            "bundled_runs_ms": [
+                9.9061,
+                9.9921,
+                10.1408,
+                10.2237,
+                9.994,
+                9.9341,
+                9.8957
+            ],
+            "paired_ratios": [
+                0.9967,
+                1.00691,
+                1.02493,
+                1.02372,
+                1.00633,
+                0.99774,
+                0.99772
+            ]
+        },
+        "core.string_to_mixed.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99962,
+            "delta_pct": -0.04,
+            "ci_delta_pct": [
+                -0.44,
+                0.06
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.02,
+                "B2/C2": -0.4,
+                "B3/C3": -0.2
+            },
+            "build_spread_pct": 0.42,
+            "builds": 3,
+            "system_ms": 14.1614,
+            "bundled_ms": 14.1493,
+            "raw_delta_pct": -0.11,
+            "spread_pct": [
+                1.1,
+                2.3
+            ],
+            "system_runs_ms": [
+                14.2319,
+                14.2114,
+                14.1271,
+                14.0987,
+                14.2217,
+                14.1614,
+                14.0811
+            ],
+            "bundled_runs_ms": [
+                14.2254,
+                14.1506,
+                14.1252,
+                14.3941,
+                14.1493,
+                14.0877,
+                14.0661
+            ],
+            "paired_ratios": [
+                0.99954,
+                0.99572,
+                0.99987,
+                1.02095,
+                0.99491,
+                0.9948,
+                0.99893
+            ]
+        },
+        "core.string_to_mixed.free": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00049,
+            "delta_pct": 0.05,
+            "ci_delta_pct": [
+                -0.11,
+                0.78
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.05,
+                "B2/C2": -0.03,
+                "B3/C3": 0.41
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 14.9052,
+            "bundled_ms": 14.9386,
+            "raw_delta_pct": -0.02,
+            "spread_pct": [
+                0.7,
+                2.9
+            ],
+            "system_runs_ms": [
+                14.8586,
+                14.8436,
+                14.9052,
+                14.8514,
+                14.9446,
+                14.9405,
+                14.9415
+            ],
+            "bundled_runs_ms": [
+                14.7741,
+                14.8165,
+                15.0108,
+                15.2036,
+                14.9429,
+                14.9361,
+                14.9386
+            ],
+            "paired_ratios": [
+                0.99431,
+                0.99817,
+                1.00708,
+                1.02371,
+                0.99989,
+                0.99971,
+                0.99981
+            ]
+        },
+        "core.string_to_int_hash.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00154,
+            "delta_pct": 0.15,
+            "ci_delta_pct": [
+                0.01,
+                0.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.34,
+                "B2/C2": 0.05,
+                "B3/C3": 1.5
+            },
+            "build_spread_pct": 1.45,
+            "builds": 3,
+            "system_ms": 47.7219,
+            "bundled_ms": 47.7799,
+            "raw_delta_pct": 0.09,
+            "spread_pct": [
+                0.4,
+                2.8
+            ],
+            "system_runs_ms": [
+                47.6578,
+                47.7219,
+                47.6344,
+                47.7129,
+                47.7521,
+                47.739,
+                47.8055
+            ],
+            "bundled_runs_ms": [
+                47.8196,
+                47.6963,
+                48.9595,
+                47.8412,
+                47.756,
+                47.7799,
+                47.6093
+            ],
+            "paired_ratios": [
+                1.0034,
+                0.99946,
+                1.02782,
+                1.00269,
+                1.00008,
+                1.00086,
+                0.9959
+            ]
+        },
+        "core.string_to_int_hash.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00468,
+            "delta_pct": 0.47,
+            "ci_delta_pct": [
+                -0.16,
+                2.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.47,
+                "B2/C2": 1.23,
+                "B3/C3": 2.67
+            },
+            "build_spread_pct": 2.2,
+            "builds": 3,
+            "system_ms": 8.0405,
+            "bundled_ms": 8.0726,
+            "raw_delta_pct": 0.4,
+            "spread_pct": [
+                1,
+                5.3
+            ],
+            "system_runs_ms": [
+                8.0405,
+                8.0197,
+                8.0186,
+                8.0264,
+                8.0585,
+                8.0714,
+                8.1006
+            ],
+            "bundled_runs_ms": [
+                8.0726,
+                8.0225,
+                8.4539,
+                8.1708,
+                8.2425,
+                8.0527,
+                8.0357
+            ],
+            "paired_ratios": [
+                1.00399,
+                1.00035,
+                1.05429,
+                1.01799,
+                1.02283,
+                0.99768,
+                0.99199
+            ]
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99916,
+            "delta_pct": -0.08,
+            "ci_delta_pct": [
+                -0.59,
+                0.62
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.62,
+                "B2/C2": -0.68,
+                "B3/C3": 0.07
+            },
+            "build_spread_pct": 1.3,
+            "builds": 3,
+            "system_ms": 18.6362,
+            "bundled_ms": 18.6077,
+            "raw_delta_pct": -0.15,
+            "spread_pct": [
+                1.3,
+                0.7
+            ],
+            "system_runs_ms": [
+                18.7187,
+                18.8353,
+                18.6362,
+                18.6095,
+                18.6223,
+                18.6579,
+                18.5978
+            ],
+            "bundled_runs_ms": [
+                18.5964,
+                18.5949,
+                18.6077,
+                18.7139,
+                18.5814,
+                18.6852,
+                18.7011
+            ],
+            "paired_ratios": [
+                0.99347,
+                0.98724,
+                0.99847,
+                1.00561,
+                0.9978,
+                1.00146,
+                1.00555
+            ]
+        },
+        "core.string_to_int_hash.free": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99761,
+            "delta_pct": -0.24,
+            "ci_delta_pct": [
+                -0.32,
+                0.89
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.48,
+                "B2/C2": -0.28,
+                "B3/C3": -0.12
+            },
+            "build_spread_pct": 0.76,
+            "builds": 3,
+            "system_ms": 9.8055,
+            "bundled_ms": 9.8155,
+            "raw_delta_pct": -0.31,
+            "spread_pct": [
+                1.7,
+                1.4
+            ],
+            "system_runs_ms": [
+                9.8245,
+                9.8055,
+                9.7899,
+                9.7918,
+                9.8533,
+                9.9128,
+                9.7472
+            ],
+            "bundled_runs_ms": [
+                9.7915,
+                9.7754,
+                9.8698,
+                9.832,
+                9.8155,
+                9.7947,
+                9.9172
+            ],
+            "paired_ratios": [
+                0.99664,
+                0.99693,
+                1.00816,
+                1.00411,
+                0.99616,
+                0.98809,
+                1.01744
+            ]
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99778,
+            "delta_pct": -0.22,
+            "ci_delta_pct": [
+                -0.4,
+                0.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.17,
+                "B2/C2": 0.02,
+                "B3/C3": -2.01
+            },
+            "build_spread_pct": 2.03,
+            "builds": 3,
+            "system_ms": 58.9825,
+            "bundled_ms": 58.8113,
+            "raw_delta_pct": -0.29,
+            "spread_pct": [
+                4.6,
+                0.5
+            ],
+            "system_runs_ms": [
+                58.9825,
+                58.9699,
+                59.0319,
+                59.0275,
+                58.6373,
+                61.2643,
+                58.5514
+            ],
+            "bundled_runs_ms": [
+                58.8113,
+                58.6998,
+                58.7561,
+                58.8844,
+                58.8546,
+                58.9994,
+                58.7714
+            ],
+            "paired_ratios": [
+                0.9971,
+                0.99542,
+                0.99533,
+                0.99758,
+                1.00371,
+                0.96303,
+                1.00376
+            ]
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00046,
+            "delta_pct": 0.05,
+            "ci_delta_pct": [
+                -0.45,
+                0.58
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.58,
+                "B2/C2": 0.02,
+                "B3/C3": -0.59
+            },
+            "build_spread_pct": 1.17,
+            "builds": 3,
+            "system_ms": 8.2972,
+            "bundled_ms": 8.2988,
+            "raw_delta_pct": -0.02,
+            "spread_pct": [
+                1.1,
+                1.1
+            ],
+            "system_runs_ms": [
+                8.2597,
+                8.2972,
+                8.3422,
+                8.3204,
+                8.287,
+                8.3473,
+                8.274
+            ],
+            "bundled_runs_ms": [
+                8.3016,
+                8.2953,
+                8.2988,
+                8.3269,
+                8.2812,
+                8.2816,
+                8.3727
+            ],
+            "paired_ratios": [
+                1.00507,
+                0.99977,
+                0.9948,
+                1.00078,
+                0.9993,
+                0.99213,
+                1.01193
+            ]
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00217,
+            "delta_pct": 0.22,
+            "ci_delta_pct": [
+                0.09,
+                0.53
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.53,
+                "B2/C2": -0.33,
+                "B3/C3": 0.11
+            },
+            "build_spread_pct": 0.86,
+            "builds": 3,
+            "system_ms": 19.8035,
+            "bundled_ms": 19.7953,
+            "raw_delta_pct": 0.15,
+            "spread_pct": [
+                1.2,
+                1
+            ],
+            "system_runs_ms": [
+                19.6684,
+                19.8269,
+                19.7735,
+                19.8649,
+                19.9069,
+                19.7699,
+                19.8035
+            ],
+            "bundled_runs_ms": [
+                19.7953,
+                19.8564,
+                19.7772,
+                19.9147,
+                19.7203,
+                19.7842,
+                19.8953
+            ],
+            "paired_ratios": [
+                1.00645,
+                1.00149,
+                1.00019,
+                1.00251,
+                0.99063,
+                1.00072,
+                1.00464
+            ]
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00228,
+            "delta_pct": 0.23,
+            "ci_delta_pct": [
+                -0.22,
+                1.61
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 1.61,
+                "B2/C2": -0.27,
+                "B3/C3": 0.27
+            },
+            "build_spread_pct": 1.88,
+            "builds": 3,
+            "system_ms": 27.2438,
+            "bundled_ms": 27.2872,
+            "raw_delta_pct": 0.16,
+            "spread_pct": [
+                0.8,
+                4
+            ],
+            "system_runs_ms": [
+                27.2052,
+                27.2829,
+                27.2022,
+                27.2519,
+                27.3964,
+                27.171,
+                27.2438
+            ],
+            "bundled_runs_ms": [
+                27.6238,
+                27.1793,
+                27.2703,
+                28.2612,
+                27.3173,
+                27.2114,
+                27.2872
+            ],
+            "paired_ratios": [
+                1.01539,
+                0.9962,
+                1.0025,
+                1.03704,
+                0.99711,
+                1.00149,
+                1.00159
+            ]
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00542,
+            "delta_pct": 0.54,
+            "ci_delta_pct": [
+                -0.07,
+                0.7
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.07,
+                "B2/C2": 0.62,
+                "B3/C3": 0.55
+            },
+            "build_spread_pct": 0.69,
+            "builds": 3,
+            "system_ms": 47.7019,
+            "bundled_ms": 47.8494,
+            "raw_delta_pct": 0.47,
+            "spread_pct": [
+                0.7,
+                1.7
+            ],
+            "system_runs_ms": [
+                47.8016,
+                47.5516,
+                47.6199,
+                47.7843,
+                47.4847,
+                47.8291,
+                47.7019
+            ],
+            "bundled_runs_ms": [
+                48.4329,
+                47.8494,
+                47.8614,
+                47.7202,
+                47.7094,
+                48.0472,
+                47.5988
+            ],
+            "paired_ratios": [
+                1.01321,
+                1.00626,
+                1.00507,
+                0.99866,
+                1.00473,
+                1.00456,
+                0.99784
+            ]
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00035,
+            "delta_pct": 0.04,
+            "ci_delta_pct": [
+                -0.28,
+                0.55
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.55,
+                "B2/C2": -0.12,
+                "B3/C3": -0.02
+            },
+            "build_spread_pct": 0.67,
+            "builds": 3,
+            "system_ms": 7.7817,
+            "bundled_ms": 7.782,
+            "raw_delta_pct": -0.03,
+            "spread_pct": [
+                0.6,
+                2.1
+            ],
+            "system_runs_ms": [
+                7.7448,
+                7.7878,
+                7.7911,
+                7.7817,
+                7.7693,
+                7.7697,
+                7.7818
+            ],
+            "bundled_runs_ms": [
+                7.782,
+                7.7852,
+                7.7642,
+                7.9052,
+                7.7421,
+                7.7826,
+                7.7385
+            ],
+            "paired_ratios": [
+                1.0048,
+                0.99967,
+                0.99655,
+                1.01587,
+                0.9965,
+                1.00166,
+                0.99444
+            ]
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99989,
+            "delta_pct": -0.01,
+            "ci_delta_pct": [
+                -0.79,
+                0.56
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.38,
+                "B2/C2": -0.7,
+                "B3/C3": 0.26
+            },
+            "build_spread_pct": 0.96,
+            "builds": 3,
+            "system_ms": 18.4389,
+            "bundled_ms": 18.4204,
+            "raw_delta_pct": -0.08,
+            "spread_pct": [
+                2,
+                1.1
+            ],
+            "system_runs_ms": [
+                18.4879,
+                18.752,
+                18.4351,
+                18.4477,
+                18.4047,
+                18.4389,
+                18.3895
+            ],
+            "bundled_runs_ms": [
+                18.3288,
+                18.3693,
+                18.4204,
+                18.3658,
+                18.4994,
+                18.5243,
+                18.479
+            ],
+            "paired_ratios": [
+                0.99139,
+                0.97959,
+                0.9992,
+                0.99556,
+                1.00515,
+                1.00463,
+                1.00487
+            ]
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00014,
+            "delta_pct": 0.01,
+            "ci_delta_pct": [
+                -0.42,
+                1.17
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.41,
+                "B2/C2": 1.02,
+                "B3/C3": 0.58
+            },
+            "build_spread_pct": 1.43,
+            "builds": 3,
+            "system_ms": 9.8144,
+            "bundled_ms": 9.8379,
+            "raw_delta_pct": -0.05,
+            "spread_pct": [
+                1.2,
+                2.2
+            ],
+            "system_runs_ms": [
+                9.8863,
+                9.7877,
+                9.8176,
+                9.8029,
+                9.8144,
+                9.8305,
+                9.7659
+            ],
+            "bundled_runs_ms": [
+                9.8379,
+                9.8669,
+                9.9703,
+                9.7561,
+                9.9224,
+                9.7782,
+                9.7606
+            ],
+            "paired_ratios": [
+                0.9951,
+                1.00809,
+                1.01555,
+                0.99523,
+                1.011,
+                0.99468,
+                0.99946
+            ]
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00237,
+            "delta_pct": 0.24,
+            "ci_delta_pct": [
+                0.11,
+                0.73
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.24,
+                "B2/C2": 0.29,
+                "B3/C3": 0.24
+            },
+            "build_spread_pct": 0.05,
+            "builds": 3,
+            "system_ms": 59.6468,
+            "bundled_ms": 59.746,
+            "raw_delta_pct": 0.17,
+            "spread_pct": [
+                0.9,
+                0.6
+            ],
+            "system_runs_ms": [
+                59.7209,
+                59.5314,
+                59.9286,
+                59.7849,
+                59.6439,
+                59.4009,
+                59.6468
+            ],
+            "bundled_runs_ms": [
+                59.746,
+                59.719,
+                59.7365,
+                59.8853,
+                59.7177,
+                59.7955,
+                60.0553
+            ],
+            "paired_ratios": [
+                1.00042,
+                1.00315,
+                0.99679,
+                1.00168,
+                1.00124,
+                1.00664,
+                1.00685
+            ]
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00112,
+            "delta_pct": 0.11,
+            "ci_delta_pct": [
+                -0.16,
+                0.3
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.16,
+                "B2/C2": 0.28,
+                "B3/C3": 0.39
+            },
+            "build_spread_pct": 0.55,
+            "builds": 3,
+            "system_ms": 8.0937,
+            "bundled_ms": 8.0972,
+            "raw_delta_pct": 0.04,
+            "spread_pct": [
+                0.7,
+                0.9
+            ],
+            "system_runs_ms": [
+                8.0824,
+                8.0711,
+                8.0904,
+                8.0968,
+                8.1155,
+                8.0937,
+                8.1305
+            ],
+            "bundled_runs_ms": [
+                8.0643,
+                8.0894,
+                8.1389,
+                8.0972,
+                8.1315,
+                8.0972,
+                8.1071
+            ],
+            "paired_ratios": [
+                0.99776,
+                1.00227,
+                1.00599,
+                1.00005,
+                1.00197,
+                1.00043,
+                0.99712
+            ]
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00099,
+            "delta_pct": 0.1,
+            "ci_delta_pct": [
+                -0.19,
+                0.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.35,
+                "B2/C2": -0.05,
+                "B3/C3": -0.41
+            },
+            "build_spread_pct": 0.76,
+            "builds": 3,
+            "system_ms": 20.0533,
+            "bundled_ms": 20.0131,
+            "raw_delta_pct": 0.03,
+            "spread_pct": [
+                1.2,
+                1.1
+            ],
+            "system_runs_ms": [
+                19.9945,
+                19.9345,
+                20.1813,
+                20.0369,
+                20.0648,
+                20.0533,
+                20.1094
+            ],
+            "bundled_runs_ms": [
+                19.9695,
+                19.9406,
+                19.9689,
+                20.129,
+                20.0131,
+                20.0729,
+                20.1669
+            ],
+            "paired_ratios": [
+                0.99875,
+                1.00031,
+                0.98948,
+                1.0046,
+                0.99742,
+                1.00098,
+                1.00286
+            ]
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99868,
+            "delta_pct": -0.13,
+            "ci_delta_pct": [
+                -0.99,
+                0.03
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.99,
+                "B2/C2": -0.09,
+                "B3/C3": 0.14
+            },
+            "build_spread_pct": 1.13,
+            "builds": 3,
+            "system_ms": 27.779,
+            "bundled_ms": 27.735,
+            "raw_delta_pct": -0.2,
+            "spread_pct": [
+                2.1,
+                0.5
+            ],
+            "system_runs_ms": [
+                28.2054,
+                27.7544,
+                27.8261,
+                27.779,
+                27.7712,
+                27.6128,
+                27.9556
+            ],
+            "bundled_runs_ms": [
+                27.7882,
+                27.7439,
+                27.7702,
+                27.735,
+                27.6949,
+                27.7072,
+                27.6602
+            ],
+            "paired_ratios": [
+                0.98521,
+                0.99962,
+                0.99799,
+                0.99842,
+                0.99725,
+                1.00342,
+                0.98943
+            ]
+        },
+        "api.putAll.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00193,
+            "delta_pct": 0.19,
+            "ci_delta_pct": [
+                -0.41,
+                0.95
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.19,
+                "B2/C2": 0.72,
+                "B3/C3": -3.46
+            },
+            "build_spread_pct": 4.18,
+            "builds": 3,
+            "system_ms": 6.2098,
+            "bundled_ms": 6.2175,
+            "raw_delta_pct": 0.12,
+            "spread_pct": [
+                8.2,
+                2.2
+            ],
+            "system_runs_ms": [
+                6.216,
+                6.1788,
+                6.2393,
+                6.1853,
+                6.2096,
+                6.6905,
+                6.2098
+            ],
+            "bundled_runs_ms": [
+                6.1978,
+                6.2893,
+                6.294,
+                6.2236,
+                6.1796,
+                6.1601,
+                6.2175
+            ],
+            "paired_ratios": [
+                0.99707,
+                1.01788,
+                1.00877,
+                1.00619,
+                0.99517,
+                0.92072,
+                1.00124
+            ]
+        },
+        "api.fromArray.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99522,
+            "delta_pct": -0.48,
+            "ci_delta_pct": [
+                -1.27,
+                0.11
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.27,
+                "B2/C2": -0.21,
+                "B3/C3": -0.28
+            },
+            "build_spread_pct": 1.06,
+            "builds": 3,
+            "system_ms": 6.2343,
+            "bundled_ms": 6.1975,
+            "raw_delta_pct": -0.55,
+            "spread_pct": [
+                1.7,
+                1.3
+            ],
+            "system_runs_ms": [
+                6.1837,
+                6.2343,
+                6.2457,
+                6.2437,
+                6.1845,
+                6.209,
+                6.2892
+            ],
+            "bundled_runs_ms": [
+                6.2114,
+                6.1975,
+                6.2369,
+                6.1579,
+                6.187,
+                6.1751,
+                6.2052
+            ],
+            "paired_ratios": [
+                1.00448,
+                0.9941,
+                0.99859,
+                0.98626,
+                1.0004,
+                0.99454,
+                0.98664
+            ]
+        },
+        "api.toArray.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00292,
+            "delta_pct": 0.29,
+            "ci_delta_pct": [
+                -0.34,
+                0.66
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.66,
+                "B2/C2": -0.47,
+                "B3/C3": 0.08
+            },
+            "build_spread_pct": 1.13,
+            "builds": 3,
+            "system_ms": 13.8351,
+            "bundled_ms": 13.8481,
+            "raw_delta_pct": 0.22,
+            "spread_pct": [
+                1,
+                1.2
+            ],
+            "system_runs_ms": [
+                13.7983,
+                13.9099,
+                13.8274,
+                13.8814,
+                13.8915,
+                13.8351,
+                13.776
+            ],
+            "bundled_runs_ms": [
+                13.8481,
+                13.8166,
+                13.801,
+                13.9707,
+                13.8353,
+                13.866,
+                13.8581
+            ],
+            "paired_ratios": [
+                1.00361,
+                0.99329,
+                0.99809,
+                1.00643,
+                0.99595,
+                1.00223,
+                1.00596
+            ]
+        },
+        "api.increment.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00087,
+            "delta_pct": 0.09,
+            "ci_delta_pct": [
+                -2.8,
+                1.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.8,
+                "B2/C2": 0.4,
+                "B3/C3": 1.38
+            },
+            "build_spread_pct": 4.18,
+            "builds": 3,
+            "system_ms": 7.1947,
+            "bundled_ms": 7.175,
+            "raw_delta_pct": 0.02,
+            "spread_pct": [
+                7,
+                4.5
+            ],
+            "system_runs_ms": [
+                7.1947,
+                7.0648,
+                7.1451,
+                7.5694,
+                7.0946,
+                7.2072,
+                7.2188
+            ],
+            "bundled_runs_ms": [
+                7.2845,
+                7.1369,
+                7.3316,
+                7.175,
+                7.0694,
+                7.2085,
+                7.0117
+            ],
+            "paired_ratios": [
+                1.01248,
+                1.01021,
+                1.0261,
+                0.9479,
+                0.99645,
+                1.00018,
+                0.97131
+            ]
+        },
+        "api.keys.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00025,
+            "delta_pct": 0.03,
+            "ci_delta_pct": [
+                -0.44,
+                0.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.09,
+                "B2/C2": -0.16,
+                "B3/C3": -0.09
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 4.3794,
+            "bundled_ms": 4.3744,
+            "raw_delta_pct": -0.04,
+            "spread_pct": [
+                3.3,
+                0.3
+            ],
+            "system_runs_ms": [
+                4.3565,
+                4.3929,
+                4.3737,
+                4.4998,
+                4.3763,
+                4.3919,
+                4.3794
+            ],
+            "bundled_runs_ms": [
+                4.3712,
+                4.3751,
+                4.3826,
+                4.3735,
+                4.3744,
+                4.3694,
+                4.3805
+            ],
+            "paired_ratios": [
+                1.00337,
+                0.99595,
+                1.00203,
+                0.97193,
+                0.99957,
+                0.99488,
+                1.00025
+            ]
+        },
+        "api.values.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00015,
+            "delta_pct": 0.01,
+            "ci_delta_pct": [
+                -0.71,
+                1.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.15,
+                "B2/C2": 0.23,
+                "B3/C3": -0
+            },
+            "build_spread_pct": 0.23,
+            "builds": 3,
+            "system_ms": 4.4436,
+            "bundled_ms": 4.445,
+            "raw_delta_pct": -0.05,
+            "spread_pct": [
+                6.5,
+                2
+            ],
+            "system_runs_ms": [
+                4.404,
+                4.4392,
+                4.4406,
+                4.6912,
+                4.4436,
+                4.4474,
+                4.4488
+            ],
+            "bundled_runs_ms": [
+                4.4501,
+                4.4046,
+                4.4369,
+                4.4183,
+                4.4927,
+                4.445,
+                4.4526
+            ],
+            "paired_ratios": [
+                1.01047,
+                0.99221,
+                0.99917,
+                0.94183,
+                1.01105,
+                0.99946,
+                1.00085
+            ]
+        },
+        "api.range.size.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99948,
+            "delta_pct": -0.05,
+            "ci_delta_pct": [
+                -0.58,
+                0.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.1,
+                "B2/C2": -0.2,
+                "B3/C3": 0.34
+            },
+            "build_spread_pct": 0.54,
+            "builds": 3,
+            "system_ms": 0.9961,
+            "bundled_ms": 0.9973,
+            "raw_delta_pct": -0.12,
+            "spread_pct": [
+                3.1,
+                0.6
+            ],
+            "system_runs_ms": [
+                0.9943,
+                0.9961,
+                0.9948,
+                1.0239,
+                1.0023,
+                0.9934,
+                1.0001
+            ],
+            "bundled_runs_ms": [
+                0.9996,
+                0.9973,
+                0.9936,
+                0.9946,
+                0.9958,
+                1,
+                0.9984
+            ],
+            "paired_ratios": [
+                1.00533,
+                1.0012,
+                0.99879,
+                0.97138,
+                0.99351,
+                1.00664,
+                0.9983
+            ]
+        },
+        "api.sumValues.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.9921,
+            "delta_pct": -0.79,
+            "ci_delta_pct": [
+                -4.04,
+                4.22
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.41,
+                "B2/C2": 3.59,
+                "B3/C3": -2.05
+            },
+            "build_spread_pct": 5.64,
+            "builds": 3,
+            "system_ms": 2.2961,
+            "bundled_ms": 2.2766,
+            "raw_delta_pct": -0.86,
+            "spread_pct": [
+                9.6,
+                4.2
+            ],
+            "system_runs_ms": [
+                2.2066,
+                2.1287,
+                2.2993,
+                2.3481,
+                2.2963,
+                2.296,
+                2.2961
+            ],
+            "bundled_runs_ms": [
+                2.2981,
+                2.2966,
+                2.2964,
+                2.2271,
+                2.2766,
+                2.2017,
+                2.2621
+            ],
+            "paired_ratios": [
+                1.04147,
+                1.07887,
+                0.99874,
+                0.94847,
+                0.99142,
+                0.95893,
+                0.98519
+            ]
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00087,
+            "delta_pct": 0.09,
+            "ci_delta_pct": [
+                -0.34,
+                0.84
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.09,
+                "B2/C2": 0.79,
+                "B3/C3": 0.37
+            },
+            "build_spread_pct": 0.7,
+            "builds": 3,
+            "system_ms": 11.7584,
+            "bundled_ms": 11.769,
+            "raw_delta_pct": 0.02,
+            "spread_pct": [
+                1.6,
+                2
+            ],
+            "system_runs_ms": [
+                11.7584,
+                11.7496,
+                11.7829,
+                11.9241,
+                11.7749,
+                11.7541,
+                11.735
+            ],
+            "bundled_runs_ms": [
+                11.769,
+                11.9673,
+                11.8742,
+                11.8564,
+                11.7272,
+                11.7348,
+                11.7372
+            ],
+            "paired_ratios": [
+                1.0009,
+                1.01853,
+                1.00775,
+                0.99432,
+                0.99595,
+                0.99836,
+                1.00019
+            ]
+        },
+        "api.equals.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00529,
+            "delta_pct": 0.53,
+            "ci_delta_pct": [
+                -1.26,
+                1.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.9,
+                "B2/C2": 1.89,
+                "B3/C3": -3.07
+            },
+            "build_spread_pct": 4.96,
+            "builds": 3,
+            "system_ms": 3.2818,
+            "bundled_ms": 3.3096,
+            "raw_delta_pct": 0.46,
+            "spread_pct": [
+                7.1,
+                5.8
+            ],
+            "system_runs_ms": [
+                3.3502,
+                3.197,
+                3.4287,
+                3.3784,
+                3.2304,
+                3.2763,
+                3.2818
+            ],
+            "bundled_runs_ms": [
+                3.3656,
+                3.2347,
+                3.1731,
+                3.3335,
+                3.3096,
+                3.3148,
+                3.2499
+            ],
+            "paired_ratios": [
+                1.0046,
+                1.01179,
+                0.92545,
+                0.98671,
+                1.02452,
+                1.01175,
+                0.99028
+            ]
+        },
+        "api.setop.union.bitset": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.0073,
+            "delta_pct": 0.73,
+            "ci_delta_pct": [
+                -1.43,
+                0.94
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.73,
+                "B2/C2": -0.06,
+                "B3/C3": -0.5
+            },
+            "build_spread_pct": 1.23,
+            "builds": 3,
+            "system_ms": 9.035,
+            "bundled_ms": 9.0698,
+            "raw_delta_pct": 0.66,
+            "spread_pct": [
+                2.2,
+                2.5
+            ],
+            "system_runs_ms": [
+                9.0638,
+                9.097,
+                9.1408,
+                9.0102,
+                9.035,
+                8.9947,
+                8.9417
+            ],
+            "bundled_runs_ms": [
+                8.9278,
+                8.9992,
+                8.9568,
+                9.0698,
+                9.1086,
+                9.0728,
+                9.154
+            ],
+            "paired_ratios": [
+                0.985,
+                0.98925,
+                0.97987,
+                1.00661,
+                1.00815,
+                1.00868,
+                1.02374
+            ]
+        },
+        "api.setop.intersect.bitset": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99451,
+            "delta_pct": -0.55,
+            "ci_delta_pct": [
+                -1.09,
+                0.06
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.09,
+                "B2/C2": -0.21,
+                "B3/C3": 0.04
+            },
+            "build_spread_pct": 1.13,
+            "builds": 3,
+            "system_ms": 4.3494,
+            "bundled_ms": 4.3228,
+            "raw_delta_pct": -0.62,
+            "spread_pct": [
+                3.3,
+                1.1
+            ],
+            "system_runs_ms": [
+                4.3307,
+                4.3494,
+                4.3732,
+                4.3625,
+                4.3231,
+                4.315,
+                4.4595
+            ],
+            "bundled_runs_ms": [
+                4.2987,
+                4.3257,
+                4.3462,
+                4.3121,
+                4.3228,
+                4.3393,
+                4.3208
+            ],
+            "paired_ratios": [
+                0.99261,
+                0.99455,
+                0.99383,
+                0.98845,
+                0.99993,
+                1.00563,
+                0.9689
+            ]
+        },
+        "api.setop.diff.bitset": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.01308,
+            "delta_pct": 1.31,
+            "ci_delta_pct": [
+                0.75,
+                1.61
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 1.61,
+                "B2/C2": 0.87,
+                "B3/C3": 1.07
+            },
+            "build_spread_pct": 0.74,
+            "builds": 3,
+            "system_ms": 4.3008,
+            "bundled_ms": 4.3662,
+            "raw_delta_pct": 1.24,
+            "spread_pct": [
+                1.2,
+                1.6
+            ],
+            "system_runs_ms": [
+                4.3092,
+                4.2883,
+                4.316,
+                4.2868,
+                4.2945,
+                4.3398,
+                4.3008
+            ],
+            "bundled_runs_ms": [
+                4.3427,
+                4.3039,
+                4.3733,
+                4.3662,
+                4.3477,
+                4.3694,
+                4.367
+            ],
+            "paired_ratios": [
+                1.00777,
+                1.00364,
+                1.01328,
+                1.01852,
+                1.01239,
+                1.00682,
+                1.01539
+            ]
+        },
+        "api.setop.xor.bitset": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99927,
+            "delta_pct": -0.07,
+            "ci_delta_pct": [
+                -0.17,
+                0.54
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.17,
+                "B2/C2": -0.07,
+                "B3/C3": -0.7
+            },
+            "build_spread_pct": 0.87,
+            "builds": 3,
+            "system_ms": 8.558,
+            "bundled_ms": 8.5699,
+            "raw_delta_pct": -0.14,
+            "spread_pct": [
+                2.8,
+                0.8
+            ],
+            "system_runs_ms": [
+                8.5395,
+                8.553,
+                8.7787,
+                8.558,
+                8.5977,
+                8.5368,
+                8.5835
+            ],
+            "bundled_runs_ms": [
+                8.5478,
+                8.5406,
+                8.5699,
+                8.5984,
+                8.5855,
+                8.6083,
+                8.5627
+            ],
+            "paired_ratios": [
+                1.00097,
+                0.99855,
+                0.97622,
+                1.00472,
+                0.99858,
+                1.00838,
+                0.99758
+            ]
+        },
+        "api.setop.union.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00247,
+            "delta_pct": 0.25,
+            "ci_delta_pct": [
+                -0.98,
+                3.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.04,
+                "B2/C2": -0.19,
+                "B3/C3": 14.64
+            },
+            "build_spread_pct": 14.83,
+            "builds": 3,
+            "system_ms": 12.7513,
+            "bundled_ms": 12.7974,
+            "raw_delta_pct": 0.18,
+            "spread_pct": [
+                1.4,
+                29.2
+            ],
+            "system_runs_ms": [
+                12.8289,
+                12.8168,
+                12.812,
+                12.6537,
+                12.6929,
+                12.7066,
+                12.7513
+            ],
+            "bundled_runs_ms": [
+                12.6951,
+                12.6442,
+                12.8349,
+                13.0289,
+                12.7974,
+                16.3835,
+                12.7473
+            ],
+            "paired_ratios": [
+                0.98957,
+                0.98653,
+                1.00179,
+                1.02965,
+                1.00823,
+                1.28937,
+                0.99969
+            ]
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00869,
+            "delta_pct": 0.87,
+            "ci_delta_pct": [
+                0.1,
+                2.03
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.1,
+                "B2/C2": 0.72,
+                "B3/C3": 1.45
+            },
+            "build_spread_pct": 1.35,
+            "builds": 3,
+            "system_ms": 5.2463,
+            "bundled_ms": 5.2818,
+            "raw_delta_pct": 0.8,
+            "spread_pct": [
+                1.6,
+                5
+            ],
+            "system_runs_ms": [
+                5.2232,
+                5.23,
+                5.2399,
+                5.2826,
+                5.2463,
+                5.2672,
+                5.3067
+            ],
+            "bundled_runs_ms": [
+                5.2248,
+                5.2443,
+                5.2818,
+                5.4889,
+                5.2999,
+                5.3707,
+                5.2687
+            ],
+            "paired_ratios": [
+                1.00031,
+                1.00273,
+                1.008,
+                1.03905,
+                1.01022,
+                1.01965,
+                0.99284
+            ]
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.0042,
+            "delta_pct": 0.42,
+            "ci_delta_pct": [
+                -0.42,
+                1.99
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.42,
+                "B2/C2": 0.08,
+                "B3/C3": 0.19
+            },
+            "build_spread_pct": 0.34,
+            "builds": 3,
+            "system_ms": 5.2125,
+            "bundled_ms": 5.2103,
+            "raw_delta_pct": 0.35,
+            "spread_pct": [
+                2.9,
+                8.7
+            ],
+            "system_runs_ms": [
+                5.127,
+                5.2125,
+                5.112,
+                5.2626,
+                5.1923,
+                5.2504,
+                5.2408
+            ],
+            "bundled_runs_ms": [
+                5.145,
+                5.2378,
+                5.2103,
+                5.5967,
+                5.1687,
+                5.1617,
+                5.2151
+            ],
+            "paired_ratios": [
+                1.00351,
+                1.00485,
+                1.01923,
+                1.06349,
+                0.99545,
+                0.98311,
+                0.9951
+            ]
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00336,
+            "delta_pct": 0.34,
+            "ci_delta_pct": [
+                -0.76,
+                1.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.34,
+                "B2/C2": -0.1,
+                "B3/C3": 0.13
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 10.5198,
+            "bundled_ms": 10.5184,
+            "raw_delta_pct": 0.27,
+            "spread_pct": [
+                1,
+                3.9
+            ],
+            "system_runs_ms": [
+                10.4828,
+                10.5656,
+                10.5007,
+                10.5198,
+                10.5854,
+                10.5623,
+                10.4904
+            ],
+            "bundled_runs_ms": [
+                10.477,
+                10.6173,
+                10.6415,
+                10.8456,
+                10.4978,
+                10.4335,
+                10.5184
+            ],
+            "paired_ratios": [
+                0.99945,
+                1.00489,
+                1.01341,
+                1.03097,
+                0.99172,
+                0.98781,
+                1.00267
+            ]
+        },
+        "api.setop.union.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00026,
+            "delta_pct": 0.03,
+            "ci_delta_pct": [
+                -0.16,
+                0.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.11,
+                "B2/C2": -0.31,
+                "B3/C3": 0.13
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 84.9876,
+            "bundled_ms": 85.0684,
+            "raw_delta_pct": -0.04,
+            "spread_pct": [
+                2.7,
+                2.2
+            ],
+            "system_runs_ms": [
+                85.124,
+                87.1808,
+                84.9876,
+                84.9726,
+                85.0259,
+                84.8523,
+                84.9505
+            ],
+            "bundled_runs_ms": [
+                85.1631,
+                86.7113,
+                84.8711,
+                86.3258,
+                84.8353,
+                85.0684,
+                84.914
+            ],
+            "paired_ratios": [
+                1.00046,
+                0.99461,
+                0.99863,
+                1.01593,
+                0.99776,
+                1.00255,
+                0.99957
+            ]
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.0014,
+            "delta_pct": 0.14,
+            "ci_delta_pct": [
+                -0.02,
+                0.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.23,
+                "B2/C2": -0.02,
+                "B3/C3": 0.43
+            },
+            "build_spread_pct": 0.45,
+            "builds": 3,
+            "system_ms": 35.9665,
+            "bundled_ms": 35.9869,
+            "raw_delta_pct": 0.07,
+            "spread_pct": [
+                0.6,
+                1
+            ],
+            "system_runs_ms": [
+                35.8773,
+                35.9613,
+                35.9665,
+                35.9413,
+                36.029,
+                35.9754,
+                36.0787
+            ],
+            "bundled_runs_ms": [
+                35.893,
+                35.9869,
+                36.2632,
+                35.9986,
+                35.9419,
+                35.942,
+                36.1455
+            ],
+            "paired_ratios": [
+                1.00044,
+                1.00071,
+                1.00825,
+                1.00159,
+                0.99758,
+                0.99907,
+                1.00185
+            ]
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99816,
+            "delta_pct": -0.18,
+            "ci_delta_pct": [
+                -0.4,
+                0.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.04,
+                "B2/C2": -0.49,
+                "B3/C3": 0.03
+            },
+            "build_spread_pct": 0.52,
+            "builds": 3,
+            "system_ms": 32.5508,
+            "bundled_ms": 32.4909,
+            "raw_delta_pct": -0.25,
+            "spread_pct": [
+                0.8,
+                1
+            ],
+            "system_runs_ms": [
+                32.5508,
+                32.6951,
+                32.6925,
+                32.4462,
+                32.6505,
+                32.5324,
+                32.5417
+            ],
+            "bundled_runs_ms": [
+                32.4688,
+                32.5414,
+                32.7528,
+                32.4909,
+                32.4366,
+                32.4478,
+                32.5055
+            ],
+            "paired_ratios": [
+                0.99748,
+                0.9953,
+                1.00184,
+                1.00138,
+                0.99345,
+                0.9974,
+                0.99889
+            ]
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00248,
+            "delta_pct": 0.25,
+            "ci_delta_pct": [
+                -0.14,
+                1.02
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 1.02,
+                "B2/C2": -0.09,
+                "B3/C3": 0.45
+            },
+            "build_spread_pct": 1.11,
+            "builds": 3,
+            "system_ms": 14.8179,
+            "bundled_ms": 14.8463,
+            "raw_delta_pct": 0.18,
+            "spread_pct": [
+                1.2,
+                1.7
+            ],
+            "system_runs_ms": [
+                14.7503,
+                14.8773,
+                14.8179,
+                14.9243,
+                14.7617,
+                14.7822,
+                14.8409
+            ],
+            "bundled_runs_ms": [
+                14.8909,
+                14.8463,
+                14.9045,
+                14.8065,
+                14.7455,
+                14.8087,
+                14.9984
+            ],
+            "paired_ratios": [
+                1.00953,
+                0.99792,
+                1.00584,
+                0.99211,
+                0.9989,
+                1.00179,
+                1.01061
+            ]
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99569,
+            "delta_pct": -0.43,
+            "ci_delta_pct": [
+                -2.87,
+                0.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.43,
+                "B2/C2": -1.18,
+                "B3/C3": -0.18
+            },
+            "build_spread_pct": 1,
+            "builds": 3,
+            "system_ms": 67.8558,
+            "bundled_ms": 67.7424,
+            "raw_delta_pct": -0.5,
+            "spread_pct": [
+                3.4,
+                0.9
+            ],
+            "system_runs_ms": [
+                67.6065,
+                69.9171,
+                68.0664,
+                67.6834,
+                67.6431,
+                67.8558,
+                69.843
+            ],
+            "bundled_runs_ms": [
+                67.7424,
+                67.8634,
+                67.6761,
+                67.3453,
+                67.9445,
+                67.911,
+                67.6347
+            ],
+            "paired_ratios": [
+                1.00201,
+                0.97063,
+                0.99427,
+                0.995,
+                1.00446,
+                1.00081,
+                0.96838
+            ]
+        },
+        "adv.forEach.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.98878,
+            "delta_pct": -1.12,
+            "ci_delta_pct": [
+                -1.58,
+                0.43
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.14,
+                "B2/C2": -0.37,
+                "B3/C3": 0.1
+            },
+            "build_spread_pct": 1.24,
+            "builds": 3,
+            "system_ms": 9.6622,
+            "bundled_ms": 9.6321,
+            "raw_delta_pct": -1.19,
+            "spread_pct": [
+                3.1,
+                1.6
+            ],
+            "system_runs_ms": [
+                9.4993,
+                9.6347,
+                9.5002,
+                9.6622,
+                9.8014,
+                9.7932,
+                9.7456
+            ],
+            "bundled_runs_ms": [
+                9.5332,
+                9.6657,
+                9.6627,
+                9.5453,
+                9.6848,
+                9.6321,
+                9.5276
+            ],
+            "paired_ratios": [
+                1.00357,
+                1.00322,
+                1.0171,
+                0.9879,
+                0.9881,
+                0.98355,
+                0.97763
+            ]
+        },
+        "adv.forEach.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99906,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.62,
+                1.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.09,
+                "B2/C2": 1.15,
+                "B3/C3": -0.73
+            },
+            "build_spread_pct": 1.88,
+            "builds": 3,
+            "system_ms": 16.9185,
+            "bundled_ms": 16.9077,
+            "raw_delta_pct": -0.16,
+            "spread_pct": [
+                2,
+                1.3
+            ],
+            "system_runs_ms": [
+                16.8686,
+                16.7025,
+                17.0366,
+                16.8919,
+                16.9185,
+                16.981,
+                16.9763
+            ],
+            "bundled_runs_ms": [
+                16.934,
+                16.9077,
+                16.8836,
+                16.8645,
+                17.0773,
+                16.8638,
+                16.9424
+            ],
+            "paired_ratios": [
+                1.00388,
+                1.01229,
+                0.99102,
+                0.99838,
+                1.00939,
+                0.9931,
+                0.998
+            ]
+        },
+        "adv.filter.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99879,
+            "delta_pct": -0.12,
+            "ci_delta_pct": [
+                -0.22,
+                0.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.22,
+                "B2/C2": 0.06,
+                "B3/C3": 0.51
+            },
+            "build_spread_pct": 0.73,
+            "builds": 3,
+            "system_ms": 13.936,
+            "bundled_ms": 13.9579,
+            "raw_delta_pct": -0.19,
+            "spread_pct": [
+                1.4,
+                0.7
+            ],
+            "system_runs_ms": [
+                13.9283,
+                14.0009,
+                13.9408,
+                13.936,
+                13.9346,
+                13.8126,
+                13.9985
+            ],
+            "bundled_runs_ms": [
+                13.9435,
+                13.9604,
+                13.9144,
+                13.8699,
+                13.9716,
+                13.9602,
+                13.9579
+            ],
+            "paired_ratios": [
+                1.00109,
+                0.99711,
+                0.99811,
+                0.99526,
+                1.00266,
+                1.01069,
+                0.9971
+            ]
+        },
+        "adv.filter.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99971,
+            "delta_pct": -0.03,
+            "ci_delta_pct": [
+                -0.29,
+                0.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.2,
+                "B2/C2": -0.11,
+                "B3/C3": 0.14
+            },
+            "build_spread_pct": 0.34,
+            "builds": 3,
+            "system_ms": 36.7895,
+            "bundled_ms": 36.7693,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                0.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                36.7688,
+                36.8981,
+                36.8667,
+                36.7895,
+                36.7618,
+                36.6826,
+                36.907
+            ],
+            "bundled_runs_ms": [
+                36.9227,
+                36.7672,
+                36.8306,
+                36.6926,
+                36.7632,
+                36.7693,
+                36.7744
+            ],
+            "paired_ratios": [
+                1.00419,
+                0.99645,
+                0.99902,
+                0.99737,
+                1.00004,
+                1.00236,
+                0.99641
+            ]
+        },
+        "adv.map.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00226,
+            "delta_pct": 0.23,
+            "ci_delta_pct": [
+                -0.63,
+                0.77
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.38,
+                "B2/C2": -0.27,
+                "B3/C3": 1.1
+            },
+            "build_spread_pct": 1.37,
+            "builds": 3,
+            "system_ms": 14.6423,
+            "bundled_ms": 14.6742,
+            "raw_delta_pct": 0.16,
+            "spread_pct": [
+                1.4,
+                2.1
+            ],
+            "system_runs_ms": [
+                14.7549,
+                14.637,
+                14.6543,
+                14.6986,
+                14.6423,
+                14.5433,
+                14.5868
+            ],
+            "bundled_runs_ms": [
+                14.6512,
+                14.5149,
+                14.6742,
+                14.7437,
+                14.6653,
+                14.8238,
+                14.6886
+            ],
+            "paired_ratios": [
+                0.99297,
+                0.99166,
+                1.00136,
+                1.00307,
+                1.00157,
+                1.01929,
+                1.00698
+            ]
+        },
+        "adv.map.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99859,
+            "delta_pct": -0.14,
+            "ci_delta_pct": [
+                -0.23,
+                0.45
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.23,
+                "B2/C2": -0.04,
+                "B3/C3": 0.34
+            },
+            "build_spread_pct": 0.57,
+            "builds": 3,
+            "system_ms": 50.1132,
+            "bundled_ms": 49.9932,
+            "raw_delta_pct": -0.21,
+            "spread_pct": [
+                0.8,
+                0.8
+            ],
+            "system_runs_ms": [
+                50.1442,
+                50.1535,
+                49.7526,
+                50.1341,
+                50.0606,
+                49.9504,
+                50.1132
+            ],
+            "bundled_runs_ms": [
+                49.9932,
+                49.8591,
+                49.9642,
+                49.9856,
+                50.2496,
+                50.0041,
+                50.0084
+            ],
+            "paired_ratios": [
+                0.99699,
+                0.99413,
+                1.00425,
+                0.99704,
+                1.00378,
+                1.00108,
+                0.99791
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00123,
+            "delta_pct": 0.12,
+            "ci_delta_pct": [
+                -0.16,
+                0.26
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.12,
+                "B2/C2": 0.01,
+                "B3/C3": 0.15
+            },
+            "build_spread_pct": 0.14,
+            "builds": 3,
+            "system_ms": 22.2686,
+            "bundled_ms": 22.2628,
+            "raw_delta_pct": 0.05,
+            "spread_pct": [
+                0.5,
+                0.7
+            ],
+            "system_runs_ms": [
+                22.2468,
+                22.3282,
+                22.236,
+                22.2923,
+                22.2068,
+                22.2686,
+                22.3102
+            ],
+            "bundled_runs_ms": [
+                22.2588,
+                22.2783,
+                22.2788,
+                22.2328,
+                22.2308,
+                22.2628,
+                22.3792
+            ],
+            "paired_ratios": [
+                1.00054,
+                0.99777,
+                1.00192,
+                0.99733,
+                1.00108,
+                0.99974,
+                1.00309
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99915,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.33,
+                0.64
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.33,
+                "B2/C2": -0.01,
+                "B3/C3": 0.24
+            },
+            "build_spread_pct": 0.57,
+            "builds": 3,
+            "system_ms": 13.1506,
+            "bundled_ms": 13.1494,
+            "raw_delta_pct": -0.15,
+            "spread_pct": [
+                1.8,
+                2.6
+            ],
+            "system_runs_ms": [
+                13.0619,
+                13.1506,
+                13.1483,
+                13.1984,
+                13.207,
+                13.1088,
+                13.2995
+            ],
+            "bundled_runs_ms": [
+                13.3895,
+                13.1494,
+                13.2229,
+                13.1459,
+                13.1867,
+                13.0799,
+                13.0539
+            ],
+            "paired_ratios": [
+                1.02508,
+                0.99991,
+                1.00567,
+                0.99602,
+                0.99846,
+                0.9978,
+                0.98153
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99937,
+            "delta_pct": -0.06,
+            "ci_delta_pct": [
+                -0.19,
+                0.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.06,
+                "B2/C2": 0.05,
+                "B3/C3": 0.16
+            },
+            "build_spread_pct": 0.22,
+            "builds": 3,
+            "system_ms": 59.131,
+            "bundled_ms": 59.1286,
+            "raw_delta_pct": -0.13,
+            "spread_pct": [
+                1.5,
+                3.1
+            ],
+            "system_runs_ms": [
+                58.7137,
+                58.8968,
+                59.131,
+                59.2064,
+                59.4729,
+                58.8665,
+                59.612
+            ],
+            "bundled_runs_ms": [
+                60.1535,
+                59.0234,
+                59.3517,
+                59.1286,
+                59.3174,
+                58.7521,
+                58.3304
+            ],
+            "paired_ratios": [
+                1.02452,
+                1.00215,
+                1.00373,
+                0.99869,
+                0.99739,
+                0.99806,
+                0.9785
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99837,
+            "delta_pct": -0.16,
+            "ci_delta_pct": [
+                -0.52,
+                -0
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.37,
+                "B2/C2": -0.31,
+                "B3/C3": 0.01
+            },
+            "build_spread_pct": 0.38,
+            "builds": 3,
+            "system_ms": 20.6318,
+            "bundled_ms": 20.5968,
+            "raw_delta_pct": -0.23,
+            "spread_pct": [
+                1.7,
+                0.5
+            ],
+            "system_runs_ms": [
+                20.9034,
+                20.6318,
+                20.5827,
+                20.5604,
+                20.7202,
+                20.5475,
+                20.7157
+            ],
+            "bundled_runs_ms": [
+                20.6052,
+                20.5968,
+                20.5686,
+                20.5128,
+                20.5986,
+                20.5374,
+                20.6252
+            ],
+            "paired_ratios": [
+                0.98573,
+                0.9983,
+                0.99931,
+                0.99768,
+                0.99413,
+                0.99951,
+                0.99563
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99982,
+            "delta_pct": -0.02,
+            "ci_delta_pct": [
+                -0.48,
+                0.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.48,
+                "B2/C2": 0.41,
+                "B3/C3": 0.1
+            },
+            "build_spread_pct": 0.89,
+            "builds": 3,
+            "system_ms": 10.5442,
+            "bundled_ms": 10.5434,
+            "raw_delta_pct": -0.09,
+            "spread_pct": [
+                0.9,
+                1.1
+            ],
+            "system_runs_ms": [
+                10.5845,
+                10.5593,
+                10.5289,
+                10.5442,
+                10.5252,
+                10.534,
+                10.62
+            ],
+            "bundled_runs_ms": [
+                10.5434,
+                10.5556,
+                10.5436,
+                10.4866,
+                10.6001,
+                10.5249,
+                10.5348
+            ],
+            "paired_ratios": [
+                0.99612,
+                0.99965,
+                1.0014,
+                0.99454,
+                1.00712,
+                0.99914,
+                0.99198
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00203,
+            "delta_pct": 0.2,
+            "ci_delta_pct": [
+                -0.25,
+                1.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.25,
+                "B2/C2": 0.79,
+                "B3/C3": 0.15
+            },
+            "build_spread_pct": 1.04,
+            "builds": 3,
+            "system_ms": 51.1797,
+            "bundled_ms": 51.2474,
+            "raw_delta_pct": 0.13,
+            "spread_pct": [
+                1.3,
+                0.7
+            ],
+            "system_runs_ms": [
+                50.6351,
+                51.1797,
+                51.1542,
+                51.2839,
+                50.797,
+                51.2668,
+                51.2654
+            ],
+            "bundled_runs_ms": [
+                51.1686,
+                51.2486,
+                51.2604,
+                51.1224,
+                51.4603,
+                51.2474,
+                51.0773
+            ],
+            "paired_ratios": [
+                1.01054,
+                1.00135,
+                1.00208,
+                0.99685,
+                1.01306,
+                0.99962,
+                0.99633
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00152,
+            "delta_pct": 0.15,
+            "ci_delta_pct": [
+                -0.48,
+                0.59
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.48,
+                "B2/C2": 0.1,
+                "B3/C3": 0.67
+            },
+            "build_spread_pct": 1.15,
+            "builds": 3,
+            "system_ms": 29.3474,
+            "bundled_ms": 29.3278,
+            "raw_delta_pct": 0.08,
+            "spread_pct": [
+                9.2,
+                0.8
+            ],
+            "system_runs_ms": [
+                31.8485,
+                29.3668,
+                29.1761,
+                29.1368,
+                29.3474,
+                29.1424,
+                29.4618
+            ],
+            "bundled_runs_ms": [
+                29.3614,
+                29.3278,
+                29.3746,
+                29.1612,
+                29.4052,
+                29.2931,
+                29.3016
+            ],
+            "paired_ratios": [
+                0.92191,
+                0.99867,
+                1.0068,
+                1.00084,
+                1.00197,
+                1.00517,
+                0.99456
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99666,
+            "delta_pct": -0.33,
+            "ci_delta_pct": [
+                -0.64,
+                0.24
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.64,
+                "B2/C2": -0.04,
+                "B3/C3": 0.32
+            },
+            "build_spread_pct": 0.96,
+            "builds": 3,
+            "system_ms": 17.8864,
+            "bundled_ms": 17.9179,
+            "raw_delta_pct": -0.4,
+            "spread_pct": [
+                3.7,
+                1.4
+            ],
+            "system_runs_ms": [
+                18.4999,
+                17.9618,
+                17.8519,
+                17.835,
+                17.8864,
+                17.8542,
+                18.0544
+            ],
+            "bundled_runs_ms": [
+                18.0077,
+                17.8895,
+                17.923,
+                17.7625,
+                17.9179,
+                17.8712,
+                17.9266
+            ],
+            "paired_ratios": [
+                0.97339,
+                0.99597,
+                1.00398,
+                0.99593,
+                1.00176,
+                1.00095,
+                0.99292
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99799,
+            "delta_pct": -0.2,
+            "ci_delta_pct": [
+                -0.35,
+                0.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.1,
+                "B2/C2": -0.08,
+                "B3/C3": -0.28
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 61.1868,
+            "bundled_ms": 61.0083,
+            "raw_delta_pct": -0.27,
+            "spread_pct": [
+                5.2,
+                0.7
+            ],
+            "system_runs_ms": [
+                58.0872,
+                61.1636,
+                61.1868,
+                61.2112,
+                60.9471,
+                61.2654,
+                61.2806
+            ],
+            "bundled_runs_ms": [
+                61.331,
+                60.9986,
+                61.0152,
+                60.9114,
+                60.9346,
+                61.0083,
+                61.1795
+            ],
+            "paired_ratios": [
+                1.05584,
+                0.9973,
+                0.9972,
+                0.9951,
+                0.99979,
+                0.9958,
+                0.99835
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99765,
+            "delta_pct": -0.23,
+            "ci_delta_pct": [
+                -1.69,
+                -0.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.69,
+                "B2/C2": -0.51,
+                "B3/C3": -0.19
+            },
+            "build_spread_pct": 1.5,
+            "builds": 3,
+            "system_ms": 16.1407,
+            "bundled_ms": 16.09,
+            "raw_delta_pct": -0.3,
+            "spread_pct": [
+                2.4,
+                1
+            ],
+            "system_runs_ms": [
+                16.5028,
+                16.2337,
+                16.1246,
+                16.1407,
+                16.1163,
+                16.1232,
+                16.4992
+            ],
+            "bundled_runs_ms": [
+                16.2129,
+                16.0679,
+                16.09,
+                16.1195,
+                16.0943,
+                16.0743,
+                16.0573
+            ],
+            "paired_ratios": [
+                0.98243,
+                0.98979,
+                0.99785,
+                0.99869,
+                0.99863,
+                0.99697,
+                0.97322
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99973,
+            "delta_pct": -0.03,
+            "ci_delta_pct": [
+                -4.8,
+                0.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.8,
+                "B2/C2": 0.06,
+                "B3/C3": -0.09
+            },
+            "build_spread_pct": 4.86,
+            "builds": 3,
+            "system_ms": 18.9169,
+            "bundled_ms": 18.8989,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                11.9,
+                0.4
+            ],
+            "system_runs_ms": [
+                19.8248,
+                18.9123,
+                18.9342,
+                18.9169,
+                18.8856,
+                18.9105,
+                21.1282
+            ],
+            "bundled_runs_ms": [
+                18.8597,
+                18.902,
+                18.8704,
+                18.8989,
+                18.8941,
+                18.9158,
+                18.9323
+            ],
+            "paired_ratios": [
+                0.95132,
+                0.99946,
+                0.99663,
+                0.99905,
+                1.00045,
+                1.00028,
+                0.89607
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00105,
+            "delta_pct": 0.11,
+            "ci_delta_pct": [
+                -3.1,
+                0.4
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.1,
+                "B2/C2": 0.65,
+                "B3/C3": 0.17
+            },
+            "build_spread_pct": 3.75,
+            "builds": 3,
+            "system_ms": 117.2871,
+            "bundled_ms": 117.3959,
+            "raw_delta_pct": 0.04,
+            "spread_pct": [
+                9.9,
+                1.3
+            ],
+            "system_runs_ms": [
+                120.1299,
+                116.5,
+                117.4245,
+                117.1994,
+                117.1836,
+                117.2871,
+                128.0559
+            ],
+            "bundled_runs_ms": [
+                116.3252,
+                117.6384,
+                117.2799,
+                117.2422,
+                117.3959,
+                117.6773,
+                117.9051
+            ],
+            "paired_ratios": [
+                0.96833,
+                1.00977,
+                0.99877,
+                1.00037,
+                1.00181,
+                1.00333,
+                0.92073
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00065,
+            "delta_pct": 0.06,
+            "ci_delta_pct": [
+                -0.16,
+                0.18
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.02,
+                "B2/C2": 0.24,
+                "B3/C3": -0.05
+            },
+            "build_spread_pct": 0.29,
+            "builds": 3,
+            "system_ms": 16.106,
+            "bundled_ms": 16.1056,
+            "raw_delta_pct": -0,
+            "spread_pct": [
+                9.6,
+                0.8
+            ],
+            "system_runs_ms": [
+                16.0783,
+                16.1541,
+                16.1484,
+                16.1,
+                16.0881,
+                16.106,
+                17.6253
+            ],
+            "bundled_runs_ms": [
+                16.0709,
+                16.1919,
+                16.1478,
+                16.1048,
+                16.1056,
+                16.07,
+                16.1168
+            ],
+            "paired_ratios": [
+                0.99954,
+                1.00234,
+                0.99996,
+                1.0003,
+                1.00109,
+                0.99776,
+                0.91441
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99765,
+            "delta_pct": -0.23,
+            "ci_delta_pct": [
+                -0.51,
+                -0.02
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.41,
+                "B2/C2": -0.13,
+                "B3/C3": -0.28
+            },
+            "build_spread_pct": 0.28,
+            "builds": 3,
+            "system_ms": 19.0359,
+            "bundled_ms": 18.9782,
+            "raw_delta_pct": -0.3,
+            "spread_pct": [
+                11.6,
+                1.2
+            ],
+            "system_runs_ms": [
+                19.0369,
+                19.0359,
+                19.0777,
+                18.9729,
+                18.9983,
+                18.9743,
+                21.1886
+            ],
+            "bundled_runs_ms": [
+                18.9456,
+                18.9782,
+                18.9682,
+                19.1803,
+                18.9813,
+                18.9499,
+                19.0114
+            ],
+            "paired_ratios": [
+                0.9952,
+                0.99697,
+                0.99426,
+                1.01093,
+                0.99911,
+                0.99871,
+                0.89725
+            ]
+        },
+        "adv.optiter.ratio.increment.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99635,
+            "delta_pct": -0.37,
+            "ci_delta_pct": [
+                -0.5,
+                0.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.37,
+                "B2/C2": -0.3,
+                "B3/C3": -0.17
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 118.0889,
+            "bundled_ms": 117.8879,
+            "raw_delta_pct": -0.43,
+            "spread_pct": [
+                2,
+                1.6
+            ],
+            "system_runs_ms": [
+                118.4011,
+                117.8396,
+                118.1401,
+                117.8445,
+                118.0889,
+                117.8092,
+                120.2165
+            ],
+            "bundled_runs_ms": [
+                117.8879,
+                117.208,
+                117.4662,
+                119.0963,
+                117.8549,
+                117.9211,
+                117.9598
+            ],
+            "paired_ratios": [
+                0.99567,
+                0.99464,
+                0.9943,
+                1.01062,
+                0.99802,
+                1.00095,
+                0.98123
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99609,
+            "delta_pct": -0.39,
+            "ci_delta_pct": [
+                -0.52,
+                -0.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.01,
+                "B2/C2": -0.73,
+                "B3/C3": -0.34
+            },
+            "build_spread_pct": 0.72,
+            "builds": 3,
+            "system_ms": 30.5692,
+            "bundled_ms": 30.4597,
+            "raw_delta_pct": -0.46,
+            "spread_pct": [
+                1,
+                0.9
+            ],
+            "system_runs_ms": [
+                30.5983,
+                30.7798,
+                30.5483,
+                30.5692,
+                30.6216,
+                30.5688,
+                30.4826
+            ],
+            "bundled_runs_ms": [
+                30.6659,
+                30.4683,
+                30.4641,
+                30.4287,
+                30.4427,
+                30.4055,
+                30.4597
+            ],
+            "paired_ratios": [
+                1.00221,
+                0.98988,
+                0.99724,
+                0.9954,
+                0.99416,
+                0.99466,
+                0.99925
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00335,
+            "delta_pct": 0.34,
+            "ci_delta_pct": [
+                -0.47,
+                0.75
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.56,
+                "B2/C2": -0.09,
+                "B3/C3": 0.24
+            },
+            "build_spread_pct": 0.65,
+            "builds": 3,
+            "system_ms": 14.2447,
+            "bundled_ms": 14.2849,
+            "raw_delta_pct": 0.27,
+            "spread_pct": [
+                1.1,
+                1
+            ],
+            "system_runs_ms": [
+                14.2447,
+                14.2109,
+                14.3588,
+                14.2165,
+                14.2769,
+                14.1978,
+                14.3165
+            ],
+            "bundled_runs_ms": [
+                14.341,
+                14.2488,
+                14.2849,
+                14.2868,
+                14.1948,
+                14.3204,
+                14.239
+            ],
+            "paired_ratios": [
+                1.00676,
+                1.00267,
+                0.99485,
+                1.00494,
+                0.99425,
+                1.00864,
+                0.99459
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00523,
+            "delta_pct": 0.52,
+            "ci_delta_pct": [
+                -0.17,
+                1.36
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.52,
+                "B2/C2": 0.72,
+                "B3/C3": 0.65
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 46.5538,
+            "bundled_ms": 46.766,
+            "raw_delta_pct": 0.45,
+            "spread_pct": [
+                1.8,
+                1
+            ],
+            "system_runs_ms": [
+                46.5538,
+                46.1697,
+                47.0035,
+                46.5061,
+                46.6235,
+                46.4456,
+                46.9661
+            ],
+            "bundled_runs_ms": [
+                46.7653,
+                46.766,
+                46.8909,
+                46.9519,
+                46.628,
+                47.0979,
+                46.747
+            ],
+            "paired_ratios": [
+                1.00454,
+                1.01292,
+                0.9976,
+                1.00959,
+                1.0001,
+                1.01404,
+                0.99533
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.0004,
+            "delta_pct": 0.04,
+            "ci_delta_pct": [
+                -0.15,
+                0.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.04,
+                "B2/C2": 0.21,
+                "B3/C3": 0.14
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 29.2824,
+            "bundled_ms": 29.2597,
+            "raw_delta_pct": -0.03,
+            "spread_pct": [
+                0.8,
+                2.2
+            ],
+            "system_runs_ms": [
+                29.2824,
+                29.2934,
+                29.3215,
+                29.2364,
+                29.2572,
+                29.2002,
+                29.421
+            ],
+            "bundled_runs_ms": [
+                29.8504,
+                29.4169,
+                29.2578,
+                29.228,
+                29.2162,
+                29.3032,
+                29.2597
+            ],
+            "paired_ratios": [
+                1.0194,
+                1.00422,
+                0.99783,
+                0.99971,
+                0.9986,
+                1.00353,
+                0.99452
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00087,
+            "delta_pct": 0.09,
+            "ci_delta_pct": [
+                0.02,
+                0.18
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.14,
+                "B2/C2": 0.13,
+                "B3/C3": 0.03
+            },
+            "build_spread_pct": 0.11,
+            "builds": 3,
+            "system_ms": 12.4512,
+            "bundled_ms": 12.4459,
+            "raw_delta_pct": 0.02,
+            "spread_pct": [
+                0.7,
+                3.3
+            ],
+            "system_runs_ms": [
+                12.4952,
+                12.4169,
+                12.4512,
+                12.4372,
+                12.492,
+                12.446,
+                12.507
+            ],
+            "bundled_runs_ms": [
+                12.8399,
+                12.4302,
+                12.4452,
+                12.4459,
+                12.4943,
+                12.4432,
+                12.4904
+            ],
+            "paired_ratios": [
+                1.02759,
+                1.00107,
+                0.99952,
+                1.0007,
+                1.00018,
+                0.99978,
+                0.99867
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00227,
+            "delta_pct": 0.23,
+            "ci_delta_pct": [
+                -0.24,
+                0.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.49,
+                "B2/C2": -0.01,
+                "B3/C3": -0.03
+            },
+            "build_spread_pct": 0.52,
+            "builds": 3,
+            "system_ms": 42.5403,
+            "bundled_ms": 42.5823,
+            "raw_delta_pct": 0.16,
+            "spread_pct": [
+                0.7,
+                1.8
+            ],
+            "system_runs_ms": [
+                42.6714,
+                42.3879,
+                42.4644,
+                42.5403,
+                42.6972,
+                42.623,
+                42.5106
+            ],
+            "bundled_runs_ms": [
+                43.0141,
+                42.2552,
+                42.5362,
+                42.5823,
+                42.7649,
+                42.4637,
+                42.6881
+            ],
+            "paired_ratios": [
+                1.00803,
+                0.99687,
+                1.00169,
+                1.00099,
+                1.00159,
+                0.99626,
+                1.00418
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.0012,
+            "delta_pct": 0.12,
+            "ci_delta_pct": [
+                -0.19,
+                0.36
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.17,
+                "B2/C2": 0.08,
+                "B3/C3": 0
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 39.5588,
+            "bundled_ms": 39.5173,
+            "raw_delta_pct": 0.05,
+            "spread_pct": [
+                1,
+                2.4
+            ],
+            "system_runs_ms": [
+                39.5858,
+                39.5588,
+                39.497,
+                39.6081,
+                39.4108,
+                39.4781,
+                39.8238
+            ],
+            "bundled_runs_ms": [
+                40.3658,
+                39.4547,
+                39.5173,
+                39.6475,
+                39.5269,
+                39.4067,
+                39.4534
+            ],
+            "paired_ratios": [
+                1.0197,
+                0.99737,
+                1.00051,
+                1.00099,
+                1.00295,
+                0.99819,
+                0.9907
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00133,
+            "delta_pct": 0.13,
+            "ci_delta_pct": [
+                -0.14,
+                0.36
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.36,
+                "B2/C2": 0.17,
+                "B3/C3": -0
+            },
+            "build_spread_pct": 0.36,
+            "builds": 3,
+            "system_ms": 21.6168,
+            "bundled_ms": 21.6409,
+            "raw_delta_pct": 0.06,
+            "spread_pct": [
+                0.9,
+                5.4
+            ],
+            "system_runs_ms": [
+                21.6168,
+                21.6422,
+                21.611,
+                21.5966,
+                21.6046,
+                21.6859,
+                21.7945
+            ],
+            "bundled_runs_ms": [
+                22.7623,
+                21.6862,
+                21.6249,
+                21.6601,
+                21.6037,
+                21.6409,
+                21.6172
+            ],
+            "paired_ratios": [
+                1.05299,
+                1.00203,
+                1.00064,
+                1.00294,
+                0.99996,
+                0.99792,
+                0.99186
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00186,
+            "delta_pct": 0.19,
+            "ci_delta_pct": [
+                0.04,
+                0.54
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.26,
+                "B2/C2": 0.15,
+                "B3/C3": 0.06
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 54.7156,
+            "bundled_ms": 54.7916,
+            "raw_delta_pct": 0.12,
+            "spread_pct": [
+                0.7,
+                3.2
+            ],
+            "system_runs_ms": [
+                54.6074,
+                54.7088,
+                54.7156,
+                54.5257,
+                54.8189,
+                54.9314,
+                54.7274
+            ],
+            "bundled_runs_ms": [
+                56.3902,
+                54.9649,
+                54.7226,
+                54.6318,
+                54.6558,
+                54.9167,
+                54.7916
+            ],
+            "paired_ratios": [
+                1.03265,
+                1.00468,
+                1.00013,
+                1.00195,
+                0.99702,
+                0.99973,
+                1.00117
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.00073,
+            "delta_pct": 0.07,
+            "ci_delta_pct": [
+                -0.3,
+                0.59
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.06,
+                "B2/C2": 0.33,
+                "B3/C3": 0.05
+            },
+            "build_spread_pct": 0.39,
+            "builds": 3,
+            "system_ms": 24.2252,
+            "bundled_ms": 24.2827,
+            "raw_delta_pct": 0,
+            "spread_pct": [
+                0.8,
+                9.7
+            ],
+            "system_runs_ms": [
+                24.196,
+                24.1576,
+                24.2814,
+                24.3139,
+                24.1628,
+                24.2252,
+                24.3439
+            ],
+            "bundled_runs_ms": [
+                26.5198,
+                24.2827,
+                24.1634,
+                24.2255,
+                24.1638,
+                24.3338,
+                24.3131
+            ],
+            "paired_ratios": [
+                1.09604,
+                1.00518,
+                0.99514,
+                0.99636,
+                1.00004,
+                1.00448,
+                0.99873
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99954,
+            "delta_pct": -0.05,
+            "ci_delta_pct": [
+                -0.34,
+                0.42
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.05,
+                "B2/C2": 0.13,
+                "B3/C3": -0.24
+            },
+            "build_spread_pct": 0.37,
+            "builds": 3,
+            "system_ms": 26.384,
+            "bundled_ms": 26.3607,
+            "raw_delta_pct": -0.11,
+            "spread_pct": [
+                0.9,
+                0.3
+            ],
+            "system_runs_ms": [
+                26.3076,
+                26.3233,
+                26.384,
+                26.3661,
+                26.3913,
+                26.5337,
+                26.4684
+            ],
+            "bundled_runs_ms": [
+                26.4175,
+                26.4165,
+                26.4041,
+                26.336,
+                26.332,
+                26.3512,
+                26.3607
+            ],
+            "paired_ratios": [
+                1.00418,
+                1.00354,
+                1.00076,
+                0.99886,
+                0.99775,
+                0.99312,
+                0.99593
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.9984,
+            "delta_pct": -0.16,
+            "ci_delta_pct": [
+                -1.06,
+                0.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.21,
+                "B2/C2": -0.13,
+                "B3/C3": -0.21
+            },
+            "build_spread_pct": 0.08,
+            "builds": 3,
+            "system_ms": 108.727,
+            "bundled_ms": 108.7123,
+            "raw_delta_pct": -0.23,
+            "spread_pct": [
+                1,
+                8.9
+            ],
+            "system_runs_ms": [
+                108.727,
+                108.9651,
+                108.6593,
+                108.4403,
+                109.2231,
+                109.5296,
+                108.7269
+            ],
+            "bundled_runs_ms": [
+                99.6144,
+                108.7874,
+                109.2727,
+                108.7123,
+                108.9731,
+                108.2906,
+                108.4219
+            ],
+            "paired_ratios": [
+                0.91619,
+                0.99837,
+                1.00565,
+                1.00251,
+                0.99771,
+                0.98869,
+                0.99719
+            ]
+        }
+    },
+    "array_vs_bundled": {
+        "core.bitset.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.7084,
+            "delta_pct": 70.84,
+            "ci_delta_pct": [
+                68.06,
+                71.55
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.9788,
+                3.0425,
+                2.9809,
+                3,
+                3.0654,
+                3.0104,
+                2.9835
+            ],
+            "judy_runs_ms": [
+                5.1102,
+                5.1133,
+                5.1135,
+                5.1252,
+                5.1482,
+                5.1183,
+                5.1279
+            ],
+            "array_ms": 3,
+            "judy_ms": 5.1183,
+            "judy_over_array": 1.706,
+            "winner": "php-array"
+        },
+        "core.bitset.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.21478,
+            "delta_pct": 221.48,
+            "ci_delta_pct": [
+                214.6,
+                222.29
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.0698,
+                1.0705,
+                1.088,
+                1.0823,
+                1.0774,
+                1.0704,
+                1.0722
+            ],
+            "judy_runs_ms": [
+                3.4587,
+                3.4451,
+                3.4608,
+                3.3907,
+                3.3895,
+                3.4411,
+                3.4556
+            ],
+            "array_ms": 1.0722,
+            "judy_ms": 3.4451,
+            "judy_over_array": 3.213,
+            "winner": "php-array"
+        },
+        "core.bitset.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.8486,
+            "delta_pct": 484.86,
+            "ci_delta_pct": [
+                480.48,
+                496.36
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9129,
+                0.9123,
+                0.9128,
+                0.9132,
+                0.9145,
+                0.9123,
+                0.9215
+            ],
+            "judy_runs_ms": [
+                5.3182,
+                5.2957,
+                5.3386,
+                5.4066,
+                5.4537,
+                5.4756,
+                5.2981
+            ],
+            "array_ms": 0.9129,
+            "judy_ms": 5.3386,
+            "judy_over_array": 5.848,
+            "winner": "php-array"
+        },
+        "core.int_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.2954,
+            "delta_pct": 129.54,
+            "ci_delta_pct": [
+                128.1,
+                131.47
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                3.1063,
+                3.074,
+                3.1187,
+                3.0545,
+                3.1199,
+                3.1033,
+                3.0851
+            ],
+            "judy_runs_ms": [
+                7.1072,
+                7.1154,
+                7.1,
+                7.0997,
+                7.1166,
+                7.1233,
+                7.1249
+            ],
+            "array_ms": 3.1033,
+            "judy_ms": 7.1154,
+            "judy_over_array": 2.293,
+            "winner": "php-array"
+        },
+        "core.int_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.15964,
+            "delta_pct": 215.96,
+            "ci_delta_pct": [
+                209.33,
+                222.49
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.0774,
+                1.0681,
+                1.0697,
+                1.068,
+                1.0687,
+                1.0802,
+                1.0678
+            ],
+            "judy_runs_ms": [
+                3.4042,
+                3.4445,
+                3.4581,
+                3.3866,
+                3.3147,
+                3.3008,
+                3.303
+            ],
+            "array_ms": 1.0687,
+            "judy_ms": 3.3866,
+            "judy_over_array": 3.169,
+            "winner": "php-array"
+        },
+        "core.int_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.57847,
+            "delta_pct": 557.85,
+            "ci_delta_pct": [
+                549.71,
+                562.14
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9131,
+                0.9133,
+                0.9133,
+                0.9243,
+                0.9203,
+                0.9128,
+                0.9125
+            ],
+            "judy_runs_ms": [
+                6.0068,
+                5.9338,
+                6.0167,
+                5.9632,
+                6.0377,
+                6.069,
+                6.042
+            ],
+            "array_ms": 0.9133,
+            "judy_ms": 6.0167,
+            "judy_over_array": 6.588,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.48734,
+            "delta_pct": 148.73,
+            "ci_delta_pct": [
+                147.41,
+                150.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.0088,
+                4.037,
+                4.0107,
+                4.0667,
+                4.0081,
+                3.9899,
+                4.0186
+            ],
+            "judy_runs_ms": [
+                10.0371,
+                10.0414,
+                10.065,
+                10.0191,
+                9.9164,
+                9.9517,
+                9.9694
+            ],
+            "array_ms": 4.0107,
+            "judy_ms": 10.0191,
+            "judy_over_array": 2.498,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.39563,
+            "delta_pct": 139.56,
+            "ci_delta_pct": [
+                136.99,
+                140.35
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.5428,
+                1.5362,
+                1.6096,
+                1.5636,
+                1.5632,
+                1.5906,
+                1.5451
+            ],
+            "judy_runs_ms": [
+                3.6947,
+                3.7126,
+                3.7202,
+                3.7458,
+                3.7047,
+                3.8153,
+                3.7136
+            ],
+            "array_ms": 1.5632,
+            "judy_ms": 3.7136,
+            "judy_over_array": 2.376,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.10876,
+            "delta_pct": 510.88,
+            "ci_delta_pct": [
+                502.27,
+                514.12
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9438,
+                0.959,
+                0.9379,
+                0.9322,
+                0.9351,
+                0.9348,
+                1.0002
+            ],
+            "judy_runs_ms": [
+                5.6842,
+                5.7989,
+                5.7351,
+                5.7248,
+                5.7123,
+                5.8057,
+                5.695
+            ],
+            "array_ms": 0.9379,
+            "judy_ms": 5.7248,
+            "judy_over_array": 6.104,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.66021,
+            "delta_pct": 166.02,
+            "ci_delta_pct": [
+                164.35,
+                167.86
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6132,
+                1.6301,
+                1.6255,
+                1.6169,
+                1.6241,
+                1.6169,
+                1.6377
+            ],
+            "judy_runs_ms": [
+                4.3459,
+                4.3091,
+                4.2848,
+                4.3013,
+                4.3155,
+                4.3311,
+                4.3799
+            ],
+            "array_ms": 1.6241,
+            "judy_ms": 4.3155,
+            "judy_over_array": 2.657,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.77516,
+            "delta_pct": 177.52,
+            "ci_delta_pct": [
+                175.96,
+                178.77
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.94,
+                4.9298,
+                5.0645,
+                4.9732,
+                4.9359,
+                4.9162,
+                5.2846
+            ],
+            "judy_runs_ms": [
+                13.7714,
+                13.7339,
+                13.7643,
+                13.7978,
+                13.6979,
+                13.7993,
+                14.5833
+            ],
+            "array_ms": 4.94,
+            "judy_ms": 13.7714,
+            "judy_over_array": 2.788,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.33669,
+            "delta_pct": 533.67,
+            "ci_delta_pct": [
+                525.97,
+                538.2
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.5639,
+                1.5479,
+                1.5894,
+                1.554,
+                1.5697,
+                1.5545,
+                1.7608
+            ],
+            "judy_runs_ms": [
+                9.9063,
+                9.8838,
+                9.9491,
+                9.9176,
+                9.9467,
+                9.8887,
+                10.6086
+            ],
+            "array_ms": 1.5639,
+            "judy_ms": 9.9176,
+            "judy_over_array": 6.342,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.12278,
+            "delta_pct": 1212.28,
+            "ci_delta_pct": [
+                1197.88,
+                1231.67
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9344,
+                0.9366,
+                0.936,
+                0.9463,
+                0.9543,
+                0.9361,
+                0.9802
+            ],
+            "judy_runs_ms": [
+                12.6576,
+                12.2908,
+                12.2773,
+                12.2707,
+                12.3857,
+                12.3844,
+                13.053
+            ],
+            "array_ms": 0.9366,
+            "judy_ms": 12.3844,
+            "judy_over_array": 13.223,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.58292,
+            "delta_pct": 58.29,
+            "ci_delta_pct": [
+                51.41,
+                62.81
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6156,
+                1.6201,
+                1.6413,
+                1.6589,
+                1.6958,
+                1.6076,
+                1.7826
+            ],
+            "judy_runs_ms": [
+                2.6508,
+                2.6,
+                2.5895,
+                2.6259,
+                2.5676,
+                2.6174,
+                2.6034
+            ],
+            "array_ms": 1.6413,
+            "judy_ms": 2.6034,
+            "judy_over_array": 1.586,
+            "winner": "php-array"
+        },
+        "core.string_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.22645,
+            "delta_pct": 122.64,
+            "ci_delta_pct": [
+                121.8,
+                124.19
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.6518,
+                11.6417,
+                11.6924,
+                12.4132,
+                11.7485,
+                11.7493,
+                11.7467
+            ],
+            "judy_runs_ms": [
+                26.1222,
+                26.1217,
+                26.1155,
+                26.7308,
+                26.14,
+                26.1592,
+                26.0546
+            ],
+            "array_ms": 11.7467,
+            "judy_ms": 26.1222,
+            "judy_over_array": 2.224,
+            "winner": "php-array"
+        },
+        "core.string_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.41966,
+            "delta_pct": 341.97,
+            "ci_delta_pct": [
+                320.75,
+                352.69
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.3163,
+                2.2577,
+                2.2213,
+                2.2031,
+                2.1443,
+                2.1692,
+                2.3098
+            ],
+            "judy_runs_ms": [
+                9.7458,
+                9.7635,
+                9.8174,
+                9.9733,
+                9.8152,
+                9.8194,
+                9.7134
+            ],
+            "array_ms": 2.2213,
+            "judy_ms": 9.8152,
+            "judy_over_array": 4.419,
+            "winner": "php-array"
+        },
+        "core.string_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 9.87043,
+            "delta_pct": 887.04,
+            "ci_delta_pct": [
+                859.28,
+                900.17
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.3777,
+                1.4155,
+                1.4175,
+                1.5011,
+                1.4219,
+                1.3622,
+                1.4441
+            ],
+            "judy_runs_ms": [
+                13.7794,
+                13.9716,
+                14.0603,
+                14.1865,
+                13.8491,
+                13.7953,
+                13.853
+            ],
+            "array_ms": 1.4175,
+            "judy_ms": 13.853,
+            "judy_over_array": 9.773,
+            "winner": "php-array"
+        },
+        "core.string_to_int.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.91593,
+            "delta_pct": 391.59,
+            "ci_delta_pct": [
+                385.64,
+                393.45
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.939,
+                0.9282,
+                0.929,
+                0.9359,
+                0.9267,
+                0.9448,
+                0.9197
+            ],
+            "judy_runs_ms": [
+                4.5597,
+                4.5802,
+                4.5669,
+                4.5997,
+                4.5656,
+                4.5883,
+                4.628
+            ],
+            "array_ms": 0.929,
+            "judy_ms": 4.5802,
+            "judy_over_array": 4.93,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.27667,
+            "delta_pct": 127.67,
+            "ci_delta_pct": [
+                127.3,
+                127.74
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.7621,
+                12.7938,
+                13.4036,
+                12.8235,
+                12.8178,
+                12.8124,
+                12.8599
+            ],
+            "judy_runs_ms": [
+                29.3425,
+                29.134,
+                29.8145,
+                29.1482,
+                29.1909,
+                29.1315,
+                29.2777
+            ],
+            "array_ms": 12.8178,
+            "judy_ms": 29.1909,
+            "judy_over_array": 2.277,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.95302,
+            "delta_pct": 295.3,
+            "ci_delta_pct": [
+                293.4,
+                299.62
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5181,
+                2.5007,
+                2.5949,
+                2.5863,
+                2.4958,
+                2.4859,
+                2.5066
+            ],
+            "judy_runs_ms": [
+                9.9061,
+                9.9921,
+                10.1408,
+                10.2237,
+                9.994,
+                9.9341,
+                9.8957
+            ],
+            "array_ms": 2.5066,
+            "judy_ms": 9.9921,
+            "judy_over_array": 3.986,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 8.64276,
+            "delta_pct": 764.28,
+            "ci_delta_pct": [
+                762.32,
+                766.64
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6063,
+                1.641,
+                1.683,
+                1.6609,
+                1.6402,
+                1.63,
+                1.6246
+            ],
+            "judy_runs_ms": [
+                14.2254,
+                14.1506,
+                14.1252,
+                14.3941,
+                14.1493,
+                14.0877,
+                14.0661
+            ],
+            "array_ms": 1.6402,
+            "judy_ms": 14.1493,
+            "judy_over_array": 8.627,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.56559,
+            "delta_pct": 456.56,
+            "ci_delta_pct": [
+                453.08,
+                457.65
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.6604,
+                2.6789,
+                2.6918,
+                2.8591,
+                2.6807,
+                2.6691,
+                2.6841
+            ],
+            "judy_runs_ms": [
+                14.7741,
+                14.8165,
+                15.0108,
+                15.2036,
+                14.9429,
+                14.9361,
+                14.9386
+            ],
+            "array_ms": 2.6807,
+            "judy_ms": 14.9386,
+            "judy_over_array": 5.573,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.16992,
+            "delta_pct": 316.99,
+            "ci_delta_pct": [
+                314.13,
+                318.18
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.4395,
+                11.4608,
+                11.6734,
+                11.4402,
+                11.4525,
+                11.5373,
+                11.5036
+            ],
+            "judy_runs_ms": [
+                47.8196,
+                47.6963,
+                48.9595,
+                47.8412,
+                47.756,
+                47.7799,
+                47.6093
+            ],
+            "array_ms": 11.4608,
+            "judy_ms": 47.7799,
+            "judy_over_array": 4.169,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.6657,
+            "delta_pct": 266.57,
+            "ci_delta_pct": [
+                252.12,
+                277.41
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.2022,
+                2.1827,
+                2.24,
+                2.2583,
+                2.1636,
+                2.2869,
+                2.286
+            ],
+            "judy_runs_ms": [
+                8.0726,
+                8.0225,
+                8.4539,
+                8.1708,
+                8.2425,
+                8.0527,
+                8.0357
+            ],
+            "array_ms": 2.24,
+            "judy_ms": 8.0726,
+            "judy_over_array": 3.604,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.04173,
+            "delta_pct": 1204.17,
+            "ci_delta_pct": [
+                1197.52,
+                1229.53
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.3733,
+                1.4258,
+                1.4341,
+                1.4176,
+                1.4558,
+                1.4054,
+                1.4361
+            ],
+            "judy_runs_ms": [
+                18.5964,
+                18.5949,
+                18.6077,
+                18.7139,
+                18.5814,
+                18.6852,
+                18.7011
+            ],
+            "array_ms": 1.4258,
+            "judy_ms": 18.6077,
+            "judy_over_array": 13.051,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.8174,
+            "delta_pct": 981.74,
+            "ci_delta_pct": [
+                978.13,
+                1008.22
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9064,
+                0.9067,
+                0.9124,
+                0.9142,
+                0.8857,
+                0.8835,
+                0.905
+            ],
+            "judy_runs_ms": [
+                9.7915,
+                9.7754,
+                9.8698,
+                9.832,
+                9.8155,
+                9.7947,
+                9.9172
+            ],
+            "array_ms": 0.9064,
+            "judy_ms": 9.8155,
+            "judy_over_array": 10.829,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.75538,
+            "delta_pct": 375.54,
+            "ci_delta_pct": [
+                373.91,
+                376.26
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.3485,
+                12.34,
+                12.3952,
+                12.3827,
+                12.4317,
+                12.3834,
+                12.4013
+            ],
+            "judy_runs_ms": [
+                58.8113,
+                58.6998,
+                58.7561,
+                58.8844,
+                58.8546,
+                58.9994,
+                58.7714
+            ],
+            "array_ms": 12.3834,
+            "judy_ms": 58.8113,
+            "judy_over_array": 4.749,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.27637,
+            "delta_pct": 227.64,
+            "ci_delta_pct": [
+                220.42,
+                232.04
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5002,
+                2.5455,
+                2.59,
+                2.5415,
+                2.5159,
+                2.6381,
+                2.4973
+            ],
+            "judy_runs_ms": [
+                8.3016,
+                8.2953,
+                8.2988,
+                8.3269,
+                8.2812,
+                8.2816,
+                8.3727
+            ],
+            "array_ms": 2.5415,
+            "judy_ms": 8.2988,
+            "judy_over_array": 3.265,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.24957,
+            "delta_pct": 1124.96,
+            "ci_delta_pct": [
+                1120.06,
+                1127.57
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.616,
+                1.6218,
+                1.621,
+                1.6254,
+                1.6203,
+                1.6015,
+                1.6207
+            ],
+            "judy_runs_ms": [
+                19.7953,
+                19.8564,
+                19.7772,
+                19.9147,
+                19.7203,
+                19.7842,
+                19.8953
+            ],
+            "array_ms": 1.6207,
+            "judy_ms": 19.7953,
+            "judy_over_array": 12.214,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.27855,
+            "delta_pct": 927.85,
+            "ci_delta_pct": [
+                924.12,
+                930.41
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.7948,
+                2.6385,
+                2.6628,
+                2.6635,
+                2.6577,
+                2.657,
+                2.6482
+            ],
+            "judy_runs_ms": [
+                27.6238,
+                27.1793,
+                27.2703,
+                28.2612,
+                27.3173,
+                27.2114,
+                27.2872
+            ],
+            "array_ms": 2.6577,
+            "judy_ms": 27.2872,
+            "judy_over_array": 10.267,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.18794,
+            "delta_pct": 318.79,
+            "ci_delta_pct": [
+                316.61,
+                319.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.3866,
+                11.4082,
+                11.4284,
+                11.4529,
+                11.4517,
+                11.4519,
+                11.4638
+            ],
+            "judy_runs_ms": [
+                48.4329,
+                47.8494,
+                47.8614,
+                47.7202,
+                47.7094,
+                48.0472,
+                47.5988
+            ],
+            "array_ms": 11.4517,
+            "judy_ms": 47.8494,
+            "judy_over_array": 4.178,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.51638,
+            "delta_pct": 251.64,
+            "ci_delta_pct": [
+                236.44,
+                258.6
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5039,
+                2.314,
+                2.1793,
+                2.2994,
+                2.0674,
+                2.1703,
+                2.2007
+            ],
+            "judy_runs_ms": [
+                7.782,
+                7.7852,
+                7.7642,
+                7.9052,
+                7.7421,
+                7.7826,
+                7.7385
+            ],
+            "array_ms": 2.2007,
+            "judy_ms": 7.782,
+            "judy_over_array": 3.536,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.36722,
+            "delta_pct": 1236.72,
+            "ci_delta_pct": [
+                1205.11,
+                1260.11
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.3476,
+                1.3505,
+                1.4256,
+                1.3723,
+                1.4012,
+                1.3858,
+                1.4159
+            ],
+            "judy_runs_ms": [
+                18.3288,
+                18.3693,
+                18.4204,
+                18.3658,
+                18.4994,
+                18.5243,
+                18.479
+            ],
+            "array_ms": 1.3858,
+            "judy_ms": 18.4204,
+            "judy_over_array": 13.292,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.80583,
+            "delta_pct": 980.58,
+            "ci_delta_pct": [
+                976.82,
+                988.94
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9114,
+                0.9163,
+                0.9156,
+                0.9257,
+                0.9025,
+                0.9049,
+                0.8977
+            ],
+            "judy_runs_ms": [
+                9.8379,
+                9.8669,
+                9.9703,
+                9.7561,
+                9.9224,
+                9.7782,
+                9.7606
+            ],
+            "array_ms": 0.9114,
+            "judy_ms": 9.8379,
+            "judy_over_array": 10.794,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.83554,
+            "delta_pct": 383.55,
+            "ci_delta_pct": [
+                382.89,
+                383.84
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.3771,
+                12.3478,
+                12.3705,
+                12.3844,
+                12.3608,
+                12.3586,
+                12.3559
+            ],
+            "judy_runs_ms": [
+                59.746,
+                59.719,
+                59.7365,
+                59.8853,
+                59.7177,
+                59.7955,
+                60.0553
+            ],
+            "array_ms": 12.3608,
+            "judy_ms": 59.746,
+            "judy_over_array": 4.834,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.19013,
+            "delta_pct": 219.01,
+            "ci_delta_pct": [
+                211.33,
+                225.28
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5456,
+                2.5983,
+                2.5021,
+                2.5382,
+                2.5188,
+                2.6182,
+                2.4774
+            ],
+            "judy_runs_ms": [
+                8.0643,
+                8.0894,
+                8.1389,
+                8.0972,
+                8.1315,
+                8.0972,
+                8.1071
+            ],
+            "array_ms": 2.5382,
+            "judy_ms": 8.0972,
+            "judy_over_array": 3.19,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.26594,
+            "delta_pct": 1126.59,
+            "ci_delta_pct": [
+                1123.5,
+                1144.37
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6311,
+                1.6298,
+                1.6502,
+                1.6176,
+                1.6316,
+                1.6239,
+                1.6067
+            ],
+            "judy_runs_ms": [
+                19.9695,
+                19.9406,
+                19.9689,
+                20.129,
+                20.0131,
+                20.0729,
+                20.1669
+            ],
+            "array_ms": 1.6298,
+            "judy_ms": 20.0131,
+            "judy_over_array": 12.279,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.46683,
+            "delta_pct": 946.68,
+            "ci_delta_pct": [
+                944.02,
+                950.12
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.648,
+                2.6358,
+                2.6557,
+                2.6498,
+                2.6599,
+                2.6539,
+                2.634
+            ],
+            "judy_runs_ms": [
+                27.7882,
+                27.7439,
+                27.7702,
+                27.735,
+                27.6949,
+                27.7072,
+                27.6602
+            ],
+            "array_ms": 2.6498,
+            "judy_ms": 27.735,
+            "judy_over_array": 10.467,
+            "winner": "php-array"
+        },
+        "api.increment.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.48712,
+            "delta_pct": 148.71,
+            "ci_delta_pct": [
+                146.9,
+                151.81
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.8928,
+                2.8906,
+                2.8765,
+                2.929,
+                2.8444,
+                2.8917,
+                2.8192
+            ],
+            "judy_runs_ms": [
+                7.2845,
+                7.1369,
+                7.3316,
+                7.175,
+                7.0694,
+                7.2085,
+                7.0117
+            ],
+            "array_ms": 2.8906,
+            "judy_ms": 7.175,
+            "judy_over_array": 2.482,
+            "winner": "php-array"
+        },
+        "api.setop.union.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.84089,
+            "delta_pct": 284.09,
+            "ci_delta_pct": [
+                281.94,
+                288.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.3446,
+                2.343,
+                2.306,
+                2.3711,
+                2.3414,
+                2.3341,
+                2.3967
+            ],
+            "judy_runs_ms": [
+                8.9278,
+                8.9992,
+                8.9568,
+                9.0698,
+                9.1086,
+                9.0728,
+                9.154
+            ],
+            "array_ms": 2.343,
+            "judy_ms": 9.0698,
+            "judy_over_array": 3.871,
+            "winner": "php-array"
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9447,
+            "delta_pct": -5.53,
+            "ci_delta_pct": [
+                -6.46,
+                -5.32
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.6116,
+                4.5789,
+                4.6141,
+                4.6099,
+                4.5657,
+                4.5818,
+                4.5642
+            ],
+            "judy_runs_ms": [
+                4.2987,
+                4.3257,
+                4.3462,
+                4.3121,
+                4.3228,
+                4.3393,
+                4.3208
+            ],
+            "array_ms": 4.5818,
+            "judy_ms": 4.3228,
+            "judy_over_array": 0.943,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.63518,
+            "delta_pct": 163.52,
+            "ci_delta_pct": [
+                159.01,
+                164.49
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.651,
+                1.6617,
+                1.6535,
+                1.7327,
+                1.6492,
+                1.6581,
+                1.6432
+            ],
+            "judy_runs_ms": [
+                4.3427,
+                4.3039,
+                4.3733,
+                4.3662,
+                4.3477,
+                4.3694,
+                4.367
+            ],
+            "array_ms": 1.6535,
+            "judy_ms": 4.3662,
+            "judy_over_array": 2.641,
+            "winner": "php-array"
+        },
+        "api.setop.xor.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.12177,
+            "delta_pct": 12.18,
+            "ci_delta_pct": [
+                11.96,
+                12.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                7.6424,
+                7.6286,
+                7.5867,
+                7.665,
+                7.5896,
+                7.6783,
+                7.5795
+            ],
+            "judy_runs_ms": [
+                8.5478,
+                8.5406,
+                8.5699,
+                8.5984,
+                8.5855,
+                8.6083,
+                8.5627
+            ],
+            "array_ms": 7.6286,
+            "judy_ms": 8.5699,
+            "judy_over_array": 1.123,
+            "winner": "php-array"
+        }
+    },
+    "judy_vs_phploop": {
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68166,
+            "delta_pct": -31.83,
+            "ci_delta_pct": [
+                -32.32,
+                -31.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                9.06,
+                9.2264,
+                9.0535,
+                9.5818,
+                9.1309,
+                9.0781,
+                9.0901
+            ],
+            "judy_runs_ms": [
+                6.1978,
+                6.2893,
+                6.294,
+                6.2236,
+                6.1796,
+                6.1601,
+                6.2175
+            ],
+            "array_ms": 9.0901,
+            "judy_ms": 6.2175,
+            "judy_over_array": 0.684,
+            "winner": "php-judy"
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68022,
+            "delta_pct": -31.98,
+            "ci_delta_pct": [
+                -32.83,
+                -31.44
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                9.06,
+                9.2264,
+                9.0535,
+                9.5818,
+                9.1309,
+                9.0781,
+                9.0901
+            ],
+            "judy_runs_ms": [
+                6.2114,
+                6.1975,
+                6.2369,
+                6.1579,
+                6.187,
+                6.1751,
+                6.2052
+            ],
+            "array_ms": 9.0901,
+            "judy_ms": 6.1975,
+            "judy_over_array": 0.682,
+            "winner": "php-judy"
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75703,
+            "delta_pct": -24.3,
+            "ci_delta_pct": [
+                -27.05,
+                -24.08
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.9821,
+                18.1999,
+                18.1917,
+                19.0007,
+                19.0114,
+                18.3163,
+                18.2091
+            ],
+            "judy_runs_ms": [
+                13.8481,
+                13.8166,
+                13.801,
+                13.9707,
+                13.8353,
+                13.866,
+                13.8581
+            ],
+            "array_ms": 18.3163,
+            "judy_ms": 13.8481,
+            "judy_over_array": 0.756,
+            "winner": "php-judy"
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.51928,
+            "delta_pct": -48.07,
+            "ci_delta_pct": [
+                -49.09,
+                -47.54
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.5726,
+                0.5712,
+                0.5849,
+                0.7838,
+                0.5783,
+                0.5728,
+                0.5783
+            ],
+            "judy_runs_ms": [
+                0.3004,
+                0.2973,
+                0.2978,
+                0.2959,
+                0.3003,
+                0.3035,
+                0.2964
+            ],
+            "array_ms": 0.5783,
+            "judy_ms": 0.2978,
+            "judy_over_array": 0.515,
+            "winner": "php-judy"
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.53664,
+            "delta_pct": -46.34,
+            "ci_delta_pct": [
+                -46.49,
+                -46.2
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                8.217,
+                8.1767,
+                8.1668,
+                8.1296,
+                8.0937,
+                8.1228,
+                8.1858
+            ],
+            "judy_runs_ms": [
+                4.3712,
+                4.3751,
+                4.3826,
+                4.3735,
+                4.3744,
+                4.3694,
+                4.3805
+            ],
+            "array_ms": 8.1668,
+            "judy_ms": 4.3744,
+            "judy_over_array": 0.536,
+            "winner": "php-judy"
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.54528,
+            "delta_pct": -45.47,
+            "ci_delta_pct": [
+                -45.66,
+                -45.17
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                8.1887,
+                8.0989,
+                8.1116,
+                8.0589,
+                8.1269,
+                8.1518,
+                8.2294
+            ],
+            "judy_runs_ms": [
+                4.4501,
+                4.4046,
+                4.4369,
+                4.4183,
+                4.4927,
+                4.445,
+                4.4526
+            ],
+            "array_ms": 8.1269,
+            "judy_ms": 4.445,
+            "judy_over_array": 0.547,
+            "winner": "php-judy"
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.04405,
+            "delta_pct": -95.59,
+            "ci_delta_pct": [
+                -95.62,
+                -95.58
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                7.0326,
+                7.1258,
+                7.0736,
+                7.0896,
+                7.0535,
+                7.1251,
+                7.1132
+            ],
+            "judy_runs_ms": [
+                0.312,
+                0.312,
+                0.3122,
+                0.3123,
+                0.312,
+                0.3122,
+                0.3072
+            ],
+            "array_ms": 7.0896,
+            "judy_ms": 0.312,
+            "judy_over_array": 0.044,
+            "winner": "php-judy"
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.39363,
+            "delta_pct": -60.64,
+            "ci_delta_pct": [
+                -61.29,
+                -60.4
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.8382,
+                5.8002,
+                5.7828,
+                5.8637,
+                5.7754,
+                5.6877,
+                5.8056
+            ],
+            "judy_runs_ms": [
+                2.2981,
+                2.2966,
+                2.2964,
+                2.2271,
+                2.2766,
+                2.2017,
+                2.2621
+            ],
+            "array_ms": 5.8002,
+            "judy_ms": 2.2766,
+            "judy_over_array": 0.393,
+            "winner": "php-judy"
+        },
+        "api.populationCount.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 2.0e-5,
+            "delta_pct": -100,
+            "ci_delta_pct": [
+                -100,
+                -100
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.8806,
+                5.8857,
+                5.8396,
+                5.8811,
+                5.9739,
+                5.8067,
+                5.8938
+            ],
+            "judy_runs_ms": [
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001
+            ],
+            "array_ms": 5.8811,
+            "judy_ms": 0.0001,
+            "judy_over_array": 0,
+            "winner": "php-judy"
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69281,
+            "delta_pct": -30.72,
+            "ci_delta_pct": [
+                -31,
+                -30.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                16.9874,
+                17.1413,
+                17.1168,
+                17.0979,
+                16.9958,
+                17.0224,
+                16.9514
+            ],
+            "judy_runs_ms": [
+                11.769,
+                11.9673,
+                11.8742,
+                11.8564,
+                11.7272,
+                11.7348,
+                11.7372
+            ],
+            "array_ms": 17.0224,
+            "judy_ms": 11.769,
+            "judy_over_array": 0.691,
+            "winner": "php-judy"
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.23978,
+            "delta_pct": -76.02,
+            "ci_delta_pct": [
+                -76.92,
+                -75.39
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                13.6764,
+                14.014,
+                13.7455,
+                13.4421,
+                13.8027,
+                13.6049,
+                13.6271
+            ],
+            "judy_runs_ms": [
+                3.3656,
+                3.2347,
+                3.1731,
+                3.3335,
+                3.3096,
+                3.3148,
+                3.2499
+            ],
+            "array_ms": 13.6764,
+            "judy_ms": 3.3096,
+            "judy_over_array": 0.242,
+            "winner": "php-judy"
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.50272,
+            "delta_pct": -49.73,
+            "ci_delta_pct": [
+                -49.9,
+                -49.16
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                25.3414,
+                25.1976,
+                25.2469,
+                26.6194,
+                25.195,
+                28.4346,
+                25.3565
+            ],
+            "judy_runs_ms": [
+                12.6951,
+                12.6442,
+                12.8349,
+                13.0289,
+                12.7974,
+                16.3835,
+                12.7473
+            ],
+            "array_ms": 25.3414,
+            "judy_ms": 12.7974,
+            "judy_over_array": 0.505,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.4245,
+            "delta_pct": -57.55,
+            "ci_delta_pct": [
+                -57.81,
+                -57.12
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.3556,
+                12.4307,
+                12.4425,
+                13.3169,
+                12.4117,
+                12.3813,
+                12.288
+            ],
+            "judy_runs_ms": [
+                5.2248,
+                5.2443,
+                5.2818,
+                5.4889,
+                5.2999,
+                5.3707,
+                5.2687
+            ],
+            "array_ms": 12.4117,
+            "judy_ms": 5.2818,
+            "judy_over_array": 0.426,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.40808,
+            "delta_pct": -59.19,
+            "ci_delta_pct": [
+                -59.39,
+                -58.85
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.6946,
+                12.7537,
+                12.6607,
+                12.7963,
+                12.6659,
+                12.7115,
+                12.8188
+            ],
+            "judy_runs_ms": [
+                5.145,
+                5.2378,
+                5.2103,
+                5.5967,
+                5.1687,
+                5.1617,
+                5.2151
+            ],
+            "array_ms": 12.7115,
+            "judy_ms": 5.2103,
+            "judy_over_array": 0.41,
+            "winner": "php-judy"
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41122,
+            "delta_pct": -58.88,
+            "ci_delta_pct": [
+                -59.22,
+                -58.33
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                25.4781,
+                26.2672,
+                25.5345,
+                25.7243,
+                25.4436,
+                25.5875,
+                25.6164
+            ],
+            "judy_runs_ms": [
+                10.477,
+                10.6173,
+                10.6415,
+                10.8456,
+                10.4978,
+                10.4335,
+                10.5184
+            ],
+            "array_ms": 25.5875,
+            "judy_ms": 10.5184,
+            "judy_over_array": 0.411,
+            "winner": "php-judy"
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91088,
+            "delta_pct": -8.91,
+            "ci_delta_pct": [
+                -9.12,
+                -7.65
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                93.3512,
+                93.7812,
+                93.7515,
+                93.4723,
+                93.1359,
+                93.4148,
+                93.4335
+            ],
+            "judy_runs_ms": [
+                85.1631,
+                86.7113,
+                84.8711,
+                86.3258,
+                84.8353,
+                85.0684,
+                84.914
+            ],
+            "array_ms": 93.4335,
+            "judy_ms": 85.0684,
+            "judy_over_array": 0.91,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86662,
+            "delta_pct": -13.34,
+            "ci_delta_pct": [
+                -13.4,
+                -13.08
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                41.417,
+                41.4007,
+                41.6521,
+                41.4403,
+                41.5019,
+                41.5423,
+                41.7221
+            ],
+            "judy_runs_ms": [
+                35.893,
+                35.9869,
+                36.2632,
+                35.9986,
+                35.9419,
+                35.942,
+                36.1455
+            ],
+            "array_ms": 41.5019,
+            "judy_ms": 35.9869,
+            "judy_over_array": 0.867,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8385,
+            "delta_pct": -16.15,
+            "ci_delta_pct": [
+                -16.27,
+                -16.13
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                38.7152,
+                38.8089,
+                38.8829,
+                38.7918,
+                38.6748,
+                38.7512,
+                38.9002
+            ],
+            "judy_runs_ms": [
+                32.4688,
+                32.5414,
+                32.7528,
+                32.4909,
+                32.4366,
+                32.4478,
+                32.5055
+            ],
+            "array_ms": 38.7918,
+            "judy_ms": 32.4909,
+            "judy_over_array": 0.838,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76854,
+            "delta_pct": -23.15,
+            "ci_delta_pct": [
+                -23.25,
+                -22.89
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                19.376,
+                19.2526,
+                19.2754,
+                19.2927,
+                19.3704,
+                19.2686,
+                19.4733
+            ],
+            "judy_runs_ms": [
+                14.8909,
+                14.8463,
+                14.9045,
+                14.8065,
+                14.7455,
+                14.8087,
+                14.9984
+            ],
+            "array_ms": 19.2927,
+            "judy_ms": 14.8463,
+            "judy_over_array": 0.77,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92629,
+            "delta_pct": -7.37,
+            "ci_delta_pct": [
+                -7.61,
+                -7.32
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                72.9631,
+                73.222,
+                73.1942,
+                72.8957,
+                73.3509,
+                73.2708,
+                73.2929
+            ],
+            "judy_runs_ms": [
+                67.7424,
+                67.8634,
+                67.6761,
+                67.3453,
+                67.9445,
+                67.911,
+                67.6347
+            ],
+            "array_ms": 73.222,
+            "judy_ms": 67.7424,
+            "judy_over_array": 0.925,
+            "winner": "php-judy"
+        },
+        "adv.forEach.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.5274,
+            "delta_pct": 52.74,
+            "ci_delta_pct": [
+                50.7,
+                54.5
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                6.3834,
+                6.3106,
+                6.254,
+                6.3209,
+                6.2376,
+                6.3062,
+                6.3221
+            ],
+            "judy_runs_ms": [
+                9.5332,
+                9.6657,
+                9.6627,
+                9.5453,
+                9.6848,
+                9.6321,
+                9.5276
+            ],
+            "array_ms": 6.3106,
+            "judy_ms": 9.6321,
+            "judy_over_array": 1.526,
+            "winner": "php-array"
+        },
+        "adv.forEach.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.17372,
+            "delta_pct": 17.37,
+            "ci_delta_pct": [
+                17.17,
+                17.48
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                14.4522,
+                14.3919,
+                14.3808,
+                14.4073,
+                14.4097,
+                14.3678,
+                14.4393
+            ],
+            "judy_runs_ms": [
+                16.934,
+                16.9077,
+                16.8836,
+                16.8645,
+                17.0773,
+                16.8638,
+                16.9424
+            ],
+            "array_ms": 14.4073,
+            "judy_ms": 16.9077,
+            "judy_over_array": 1.174,
+            "winner": "php-array"
+        },
+        "adv.filter.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.23083,
+            "delta_pct": 23.08,
+            "ci_delta_pct": [
+                22.84,
+                23.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.3285,
+                11.296,
+                11.327,
+                11.3886,
+                11.2984,
+                11.3546,
+                11.2983
+            ],
+            "judy_runs_ms": [
+                13.9435,
+                13.9604,
+                13.9144,
+                13.8699,
+                13.9716,
+                13.9602,
+                13.9579
+            ],
+            "array_ms": 11.327,
+            "judy_ms": 13.9579,
+            "judy_over_array": 1.232,
+            "winner": "php-array"
+        },
+        "adv.filter.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.068,
+            "delta_pct": 6.8,
+            "ci_delta_pct": [
+                6.65,
+                7.12
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                34.4179,
+                34.3948,
+                34.4857,
+                34.4184,
+                34.4709,
+                34.4751,
+                34.3306
+            ],
+            "judy_runs_ms": [
+                36.9227,
+                36.7672,
+                36.8306,
+                36.6926,
+                36.7632,
+                36.7693,
+                36.7744
+            ],
+            "array_ms": 34.4184,
+            "judy_ms": 36.7693,
+            "judy_over_array": 1.068,
+            "winner": "php-array"
+        },
+        "adv.map.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.08925,
+            "delta_pct": 8.92,
+            "ci_delta_pct": [
+                8.12,
+                9.41
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                13.507,
+                13.452,
+                13.4595,
+                13.4762,
+                13.5636,
+                13.5003,
+                13.4851
+            ],
+            "judy_runs_ms": [
+                14.6512,
+                14.5149,
+                14.6742,
+                14.7437,
+                14.6653,
+                14.8238,
+                14.6886
+            ],
+            "array_ms": 13.4851,
+            "judy_ms": 14.6742,
+            "judy_over_array": 1.088,
+            "winner": "php-array"
+        },
+        "adv.map.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.02082,
+            "delta_pct": 2.08,
+            "ci_delta_pct": [
+                1.86,
+                2.22
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                49.0327,
+                48.9491,
+                48.8771,
+                48.966,
+                49.0765,
+                49.2531,
+                48.9526
+            ],
+            "judy_runs_ms": [
+                49.9932,
+                49.8591,
+                49.9642,
+                49.9856,
+                50.2496,
+                50.0041,
+                50.0084
+            ],
+            "array_ms": 48.966,
+            "judy_ms": 49.9932,
+            "judy_over_array": 1.021,
+            "winner": "parity"
+        }
+    },
+    "memory": [],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-464/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-464/B2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-464/B3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-464/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-464/C2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-464/C3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/run3-cc-control.txt
+++ b/research/three-arm-benchmark/results/run3-cc-control.txt
@@ -1,0 +1,181 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /work/builds/judy-C-1.so, /work/builds/judy-C-2.so, /work/builds/judy-C-3.so
+  C  php-judy + bundled libJudy : /work/builds/judy-C-2.so, /work/builds/judy-C-3.so, /work/builds/judy-C-1.so
+  timing core.int     round 1/7  timing core.int     round 2/7  timing core.int     round 3/7  timing core.int     round 4/7  timing core.int     round 5/7  timing core.int     round 6/7  timing core.int     round 7/7  timing core.int     done          
+  timing core.str     round 1/7  timing core.str     round 2/7  timing core.str     round 3/7  timing core.str     round 4/7  timing core.str     round 5/7  timing core.str     round 6/7  timing core.str     round 7/7  timing core.str     done          
+  timing api.batch    round 1/7  timing api.batch    round 2/7  timing api.batch    round 3/7  timing api.batch    round 4/7  timing api.batch    round 5/7  timing api.batch    round 6/7  timing api.batch    round 7/7  timing api.batch    done          
+  timing api.setops   round 1/7  timing api.setops   round 2/7  timing api.setops   round 3/7  timing api.setops   round 4/7  timing api.setops   round 5/7  timing api.setops   round 6/7  timing api.setops   round 7/7  timing api.setops   done          
+  timing adv.iter     round 1/7  timing adv.iter     round 2/7  timing adv.iter     round 3/7  timing adv.iter     round 4/7  timing adv.iter     round 5/7  timing adv.iter     round 6/7  timing adv.iter     round 7/7  timing adv.iter     done          
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — linux-x86_64-gcc14.2-php8.4-CvsC-rebuild-control
+------------------------------------------------------------------------------------------------
+  PHP 8.4.24, Linux x86_64
+  arm B system libJudy : CONTROL bundled C1/C2/C3
+  arm C bundled libJudy: CONTROL bundled C2/C3/C1 (offset: no round self-compares)
+  size 300000 (cache-resident), 7 rounds, 3 iterations, floor 3.0%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=1.02   cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-timing   load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    end            load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+
+  control (PHP-only rows, touch no libJudy): -0.07% [-0.19, +0.01] over 43 rows
+  measured control scatter: 5.12%  (assumed floor 3.0%)
+
+------------------------------------------------------------------------------------------------
+  B vs C — bundled libJudy against system libJudy (this project's contribution)
+  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears
+  the 3.0% floor assert anything; everything else is null.
+------------------------------------------------------------------------------------------------
+  benchmark                                     system   bundled    delta CI                 verdict
+  core.bitset.iter                                5.40      5.34   -1.34% [ -1.61, +2.02] null
+  adv.forEach.int_to_int                          9.66      9.63   -1.12% [ -1.58, +0.43] null
+  api.sumValues.int_to_int                        2.30      2.28   -0.79% [ -4.04, +4.22] null
+  api.setop.intersect.bitset                      4.35      4.32   -0.55% [ -1.09, +0.06] null
+  api.fromArray.int_to_int                        6.23      6.20   -0.48% [ -1.27, +0.11] null
+  api.mergeWith.string_to_int                    67.86     67.74   -0.43% [ -2.87, +0.27] null
+  adv.optiter.foreach.string_to_int_adaptive.default     30.57     30.46   -0.39% [ -0.52, -0.01] null
+  adv.optiter.ratio.increment.string_to_int_hash    118.09    117.89   -0.37% [ -0.50, +0.16] null
+  adv.optiter.toArray.string_to_int_hash.optimized     17.89     17.92   -0.33% [ -0.64, +0.24] null
+  core.int_to_mixed.write                        10.05     10.02   -0.28% [ -1.32, +0.20] null
+  core.string_to_int_hash.free                    9.81      9.82   -0.24% [ -0.32, +0.89] null
+  adv.optiter.overwrite.string_to_int_hash.default     16.14     16.09   -0.23% [ -1.69, -0.07] null
+  adv.optiter.increment.string_to_int_hash.optimized     19.04     18.98   -0.23% [ -0.51, -0.02] null
+  core.string_to_mixed_hash.write                58.98     58.81   -0.22% [ -0.40, +0.44] null
+  adv.optiter.ratio.toArray.string_to_int_hash     61.19     61.01   -0.20% [ -0.35, +0.05] null
+  api.setop.diff.string_to_int                   32.55     32.49   -0.18% [ -0.40, +0.21] null
+  adv.optiter.values.string_to_int_hash.default     20.63     20.60   -0.16% [ -0.52, +0.00] null
+  adv.optiter.ratio.overwrite.string_to_int_adaptive    108.73    108.71   -0.16% [ -1.06, +0.32] null
+  core.int_to_int.write                           7.12      7.12   -0.15% [ -0.37, +0.46] null
+  core.int_to_mixed.iter                          5.73      5.72   -0.14% [ -0.60, +2.18] null
+  adv.map.string_to_int                          50.11     49.99   -0.14% [ -0.23, +0.45] null
+  core.string_to_mixed_adaptive.free             27.78     27.73   -0.13% [ -0.99, +0.03] null
+  adv.filter.int_to_int                          13.94     13.96   -0.12% [ -0.22, +0.33] null
+  adv.forEach.string_to_int                      16.92     16.91   -0.09% [ -0.62, +1.01] null
+  adv.optiter.foreach.string_to_int_hash.optimized     13.15     13.15   -0.09% [ -0.33, +0.64] null
+  core.string_to_int_hash.iter                   18.64     18.61   -0.08% [ -0.59, +0.62] null
+  api.setop.xor.bitset                            8.56      8.57   -0.07% [ -0.17, +0.54] null
+  adv.optiter.ratio.foreach.string_to_int_hash     59.13     59.13   -0.06% [ -0.19, +0.44] null
+  api.range.size.string_to_int                    1.00      1.00   -0.05% [ -0.58, +0.60] null
+  adv.optiter.overwrite.string_to_int_adaptive.optimized     26.38     26.36   -0.05% [ -0.34, +0.42] null
+  core.string_to_mixed.iter                      14.16     14.15   -0.04% [ -0.44, +0.06] null
+  adv.filter.string_to_int                       36.79     36.77   -0.03% [ -0.29, +0.31] null
+  adv.optiter.overwrite.string_to_int_hash.optimized     18.92     18.90   -0.03% [ -4.80, +0.10] null
+  adv.optiter.values.string_to_int_hash.optimized     10.54     10.54   -0.02% [ -0.48, +0.21] null
+  core.string_to_int.read                         9.75      9.82   -0.01% [ -0.28, +0.90] null
+  core.string_to_int_adaptive.iter               18.44     18.42   -0.01% [ -0.79, +0.56] null
+  core.string_to_int_adaptive.free                9.81      9.84    0.01% [ -0.42, +1.17] null
+  api.values.int_to_int                           4.44      4.45    0.01% [ -0.71, +1.12] null
+  api.keys.int_to_int                             4.38      4.37    0.03% [ -0.44, +0.27] null
+  api.setop.union.string_to_int                  84.99     85.07    0.03% [ -0.16, +0.32] null
+  core.int_to_packed.write                       13.80     13.77    0.04% [ -0.43, +0.32] null
+  core.string_to_int_adaptive.read                7.78      7.78    0.04% [ -0.28, +0.55] null
+  adv.optiter.values.string_to_int_adaptive.default     29.28     29.26    0.04% [ -0.15, +0.49] null
+  core.string_to_mixed.free                      14.91     14.94    0.05% [ -0.11, +0.78] null
+  core.string_to_mixed_hash.read                  8.30      8.30    0.05% [ -0.45, +0.58] null
+  adv.optiter.increment.string_to_int_hash.default     16.11     16.11    0.06% [ -0.16, +0.18] null
+  adv.optiter.overwrite.string_to_int_adaptive.default     24.23     24.28    0.07% [ -0.30, +0.59] null
+  api.increment.int_to_int                        7.19      7.17    0.09% [ -2.80, +1.32] null
+  api.deleteRange.int_to_int                     11.76     11.77    0.09% [ -0.34, +0.84] null
+  adv.optiter.values.string_to_int_adaptive.optimized     12.45     12.45    0.09% [ +0.02, +0.18] null
+  core.string_to_int.iter                        13.88     13.85    0.10% [ +0.03, +1.15] null
+  core.string_to_mixed_adaptive.iter             20.05     20.01    0.10% [ -0.19, +0.35] null
+  core.string_to_mixed_adaptive.read              8.09      8.10    0.11% [ -0.16, +0.30] null
+  adv.optiter.ratio.overwrite.string_to_int_hash    117.29    117.40    0.11% [ -3.10, +0.40] null
+  core.bitset.write                               5.13      5.12    0.12% [ -0.25, +0.31] null
+  adv.optiter.foreach.string_to_int_hash.default     22.27     22.26    0.12% [ -0.16, +0.26] null
+  adv.optiter.toArray.string_to_int_adaptive.default     39.56     39.52    0.12% [ -0.19, +0.36] null
+  adv.optiter.toArray.string_to_int_adaptive.optimized     21.62     21.64    0.13% [ -0.14, +0.36] null
+  core.string_to_mixed.write                     29.13     29.19    0.14% [ -0.30, +1.16] null
+  api.setop.intersect.string_to_int              35.97     35.99    0.14% [ -0.02, +0.25] null
+  core.int_to_packed.read                         9.90      9.92    0.15% [ -0.64, +1.26] null
+  core.string_to_int_hash.write                  47.72     47.78    0.15% [ +0.01, +0.41] null
+  adv.optiter.toArray.string_to_int_hash.default     29.35     29.33    0.15% [ -0.48, +0.59] null
+  api.putAll.int_to_int                           6.21      6.22    0.19% [ -0.41, +0.95] null
+  adv.optiter.ratio.toArray.string_to_int_adaptive     54.72     54.79    0.19% [ +0.04, +0.54] null
+  adv.optiter.ratio.values.string_to_int_hash     51.18     51.25    0.20% [ -0.25, +1.12] null
+  core.int_to_mixed.free                          4.33      4.32    0.22% [ -1.00, +0.97] null
+  core.string_to_mixed_hash.iter                 19.80     19.80    0.22% [ +0.09, +0.53] null
+  core.int_to_packed.iter                        12.33     12.38    0.23% [ -0.31, +2.92] null
+  core.string_to_mixed_hash.free                 27.24     27.29    0.23% [ -0.22, +1.61] null
+  adv.map.int_to_int                             14.64     14.67    0.23% [ -0.63, +0.77] null
+  adv.optiter.ratio.values.string_to_int_adaptive     42.54     42.58    0.23% [ -0.24, +0.49] null
+  core.string_to_mixed_adaptive.write            59.65     59.75    0.24% [ +0.11, +0.73] null
+  api.setop.union.int_to_int                     12.75     12.80    0.25% [ -0.98, +3.04] null
+  api.mergeWith.int_to_int                       14.82     14.85    0.25% [ -0.14, +1.02] null
+  api.toArray.int_to_int                         13.84     13.85    0.29% [ -0.34, +0.66] null
+  core.int_to_int.read                            3.36      3.39    0.34% [ -1.91, +3.52] null
+  api.setop.xor.int_to_int                       10.52     10.52    0.34% [ -0.76, +1.41] null
+  adv.optiter.foreach.string_to_int_adaptive.optimized     14.24     14.28    0.34% [ -0.47, +0.75] null
+  core.string_to_int.write                       26.15     26.12    0.37% [ -0.08, +0.51] null
+  api.setop.diff.int_to_int                       5.21      5.21    0.42% [ -0.42, +1.99] null
+  core.int_to_packed.free                         2.59      2.60    0.46% [ -0.68, +1.12] null
+  core.string_to_int_hash.read                    8.04      8.07    0.47% [ -0.16, +2.35] null
+  core.int_to_int.iter                            5.99      6.02    0.48% [ -0.24, +0.96] null
+  adv.optiter.ratio.foreach.string_to_int_adaptive     46.55     46.77    0.52% [ -0.17, +1.36] null
+  api.equals.int_to_int                           3.28      3.31    0.53% [ -1.26, +1.25] null
+  core.string_to_int_adaptive.write              47.70     47.85    0.54% [ -0.07, +0.70] null
+  core.string_to_mixed.read                       9.93      9.99    0.70% [ -0.16, +2.44] null
+  core.string_to_int.free                         4.56      4.58    0.72% [ -0.12, +0.93] null
+  api.setop.union.bitset                          9.04      9.07    0.73% [ -1.43, +0.94] null
+  api.setop.intersect.int_to_int                  5.25      5.28    0.87% [ +0.10, +2.03] null
+  api.setop.diff.bitset                           4.30      4.37    1.31% [ +0.75, +1.61] null
+  core.int_to_mixed.read                          3.71      3.71    1.36% [ -0.17, +1.90] null
+  core.bitset.read                                3.40      3.45    1.54% [ -0.20, +2.60] null
+  totals: 0 faster, 0 slower, 94 null
+
+------------------------------------------------------------------------------------------------
+  A vs C — PHP native array against php-judy (bundled)
+  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means
+  the PHP array is FASTER — publish these, they are the honest half of the story.
+------------------------------------------------------------------------------------------------
+  benchmark                                   array ms   judy ms  judy/arr winner
+  api.setop.intersect.bitset                      4.58      4.32     0.94x php-judy
+  api.setop.xor.bitset                            7.63      8.57     1.12x php-array
+  core.int_to_packed.free                         1.64      2.60     1.59x php-array
+  core.bitset.write                               3.00      5.12     1.71x php-array
+  core.string_to_int.write                       11.75     26.12     2.22x php-array
+  core.string_to_mixed.write                     12.82     29.19     2.28x php-array
+  core.int_to_int.write                           3.10      7.12     2.29x php-array
+  core.int_to_mixed.read                          1.56      3.71     2.38x php-array
+  api.increment.int_to_int                        2.89      7.17     2.48x php-array
+  core.int_to_mixed.write                         4.01     10.02     2.50x php-array
+  api.setop.diff.bitset                           1.65      4.37     2.64x php-array
+  core.int_to_mixed.free                          1.62      4.32     2.66x php-array
+  core.int_to_packed.write                        4.94     13.77     2.79x php-array
+  core.int_to_int.read                            1.07      3.39     3.17x php-array
+  core.string_to_mixed_adaptive.read              2.54      8.10     3.19x php-array
+  core.bitset.read                                1.07      3.45     3.21x php-array
+  core.string_to_mixed_hash.read                  2.54      8.30     3.27x php-array
+  core.string_to_int_adaptive.read                2.20      7.78     3.54x php-array
+  core.string_to_int_hash.read                    2.24      8.07     3.60x php-array
+  api.setop.union.bitset                          2.34      9.07     3.87x php-array
+  core.string_to_mixed.read                       2.51      9.99     3.99x php-array
+  core.string_to_int_hash.write                  11.46     47.78     4.17x php-array
+  core.string_to_int_adaptive.write              11.45     47.85     4.18x php-array
+  core.string_to_int.read                         2.22      9.82     4.42x php-array
+  core.string_to_mixed_hash.write                12.38     58.81     4.75x php-array
+  core.string_to_mixed_adaptive.write            12.36     59.75     4.83x php-array
+  core.string_to_int.free                         0.93      4.58     4.93x php-array
+  core.string_to_mixed.free                       2.68     14.94     5.57x php-array
+  core.bitset.iter                                0.91      5.34     5.85x php-array
+  core.int_to_mixed.iter                          0.94      5.72     6.10x php-array
+  core.int_to_packed.read                         1.56      9.92     6.34x php-array
+  core.int_to_int.iter                            0.91      6.02     6.59x php-array
+  core.string_to_mixed.iter                       1.64     14.15     8.63x php-array
+  core.string_to_int.iter                         1.42     13.85     9.77x php-array
+  core.string_to_mixed_hash.free                  2.66     27.29    10.27x php-array
+  core.string_to_mixed_adaptive.free              2.65     27.73    10.47x php-array
+  core.string_to_int_adaptive.free                0.91      9.84    10.79x php-array
+  core.string_to_int_hash.free                    0.91      9.82    10.83x php-array
+  core.string_to_mixed_hash.iter                  1.62     19.80    12.21x php-array
+  core.string_to_mixed_adaptive.iter              1.63     20.01    12.28x php-array
+  core.string_to_int_hash.iter                    1.43     18.61    13.05x php-array
+  core.int_to_packed.iter                         0.94     12.38    13.22x php-array
+  core.string_to_int_adaptive.iter                1.39     18.42    13.29x php-array
+  totals: php-judy wins 1, PHP array wins 42, parity 0
+
+Wrote /work/results2/run3-cc-control.json

--- a/research/three-arm-benchmark/results/run5-attribution.json
+++ b/research/three-arm-benchmark/results/run5-attribution.json
@@ -1,0 +1,7936 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "linux-x86_64-gcc14.2-php8.4-ATTRIBUTION-S-vs-C-patches-only",
+        "date": "2026-08-19T02:38:39+00:00",
+        "php_version": "8.4.24",
+        "platform": "Linux x86_64",
+        "uname": "Linux 9306d323497c 6.8.0-136-generic #136~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  3 16:29:11 UTC  x86_64",
+        "judy_version": "2.5.2",
+        "system_so": [
+            "/work/builds/judy-S-1.so",
+            "/work/builds/judy-S-2.so",
+            "/work/builds/judy-S-3.so"
+        ],
+        "bundled_so": [
+            "/work/builds/judy-C-1.so",
+            "/work/builds/judy-C-2.so",
+            "/work/builds/judy-C-3.so"
+        ],
+        "system_so_sha256": [
+            "b975b000c63322873aa3bb4d7484d723115cf48afcdcef6fe31a677d994ab6e1",
+            "d602a32840513c30698efb92a712c1b59435f52977aea4f03e4438d41f3a4322",
+            "dfcd481f1ad08c738a077d68be3fd630ba738c57b48f96ce793a89b5a6c9a85f"
+        ],
+        "bundled_so_sha256": [
+            "354dc68ce9ed49662f5fcb51c033683b0e63073db69384178903d520617726b0",
+            "1cb7ca0eda6ae78552276e8b211a08474902df7d58e08eb1c4a50d404570bb2b",
+            "cfce55bc85a2126e779d7d23e9ad1cdb0e1cdf4002d064f5587a3fe31e8f43f1"
+        ],
+        "system_provenance": "ARM S: PRISTINE Judy-1.0.5 (official tarball sha256 d2704089...), STATIC into the extension, IDENTICAL pinned CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt -fPIC. Isolates the php-judy source patches ALONE.",
+        "bundled_provenance": "ARM C: bundled libjudy/ (P1-P7, O1, O3, O4), static, same flags",
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 300000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            100000,
+            1000000,
+            8000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "cache-resident",
+        "claim_floor_pct": 3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 70,
+        "memory_children": 0,
+        "wall_seconds": 189.7
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T02:35:29+00:00",
+                "load1": 1.47,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T02:38:39+00:00",
+                "load1": 1.03,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T02:38:39+00:00",
+                "load1": 1.03,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "note": "load average alone is necessary but not sufficient: a co-resident memory-bound benchmark contends for LLC and memory bandwidth at low load, and a PHP-array control does not detect it"
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 0.99917,
+            "delta_pct": -0.08,
+            "ci_delta_pct": [
+                -0.21,
+                0.05
+            ],
+            "measured_spread_pct": 2.36,
+            "row_count": 43,
+            "eligibility": "genuine PHP-array rows only (TAM_ARM_A_ROWS); Judy-touching .php rows are excluded because they carry real signal",
+            "rows": {
+                "core.bitset.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00779,
+                    "delta_pct": 0.78,
+                    "ci_delta_pct": [
+                        -1.21,
+                        2.28
+                    ],
+                    "n": 7,
+                    "b_ms": 2.9912,
+                    "c_ms": 3.0435
+                },
+                "core.bitset.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00159,
+                    "delta_pct": 0.16,
+                    "ci_delta_pct": [
+                        -0.02,
+                        1.1
+                    ],
+                    "n": 7,
+                    "b_ms": 1.0698,
+                    "c_ms": 1.0737
+                },
+                "core.bitset.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99967,
+                    "delta_pct": -0.03,
+                    "ci_delta_pct": [
+                        -0.24,
+                        0.48
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9129,
+                    "c_ms": 0.9132
+                },
+                "core.int_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99206,
+                    "delta_pct": -0.79,
+                    "ci_delta_pct": [
+                        -1.42,
+                        1.86
+                    ],
+                    "n": 7,
+                    "b_ms": 3.0716,
+                    "c_ms": 3.0667
+                },
+                "core.int_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00421,
+                    "delta_pct": 0.42,
+                    "ci_delta_pct": [
+                        -2.21,
+                        9.66
+                    ],
+                    "n": 7,
+                    "b_ms": 1.0703,
+                    "c_ms": 1.0814
+                },
+                "core.int_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99967,
+                    "delta_pct": -0.03,
+                    "ci_delta_pct": [
+                        -2.07,
+                        0.1
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9126,
+                    "c_ms": 0.9128
+                },
+                "core.int_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99718,
+                    "delta_pct": -0.28,
+                    "ci_delta_pct": [
+                        -0.41,
+                        0.15
+                    ],
+                    "n": 7,
+                    "b_ms": 4.0354,
+                    "c_ms": 4.0281
+                },
+                "core.int_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9832,
+                    "delta_pct": -1.68,
+                    "ci_delta_pct": [
+                        -2.94,
+                        0.45
+                    ],
+                    "n": 7,
+                    "b_ms": 1.5679,
+                    "c_ms": 1.5459
+                },
+                "core.int_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99118,
+                    "delta_pct": -0.88,
+                    "ci_delta_pct": [
+                        -2.42,
+                        0.06
+                    ],
+                    "n": 7,
+                    "b_ms": 0.9409,
+                    "c_ms": 0.9355
+                },
+                "core.int_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9808,
+                    "delta_pct": -1.92,
+                    "ci_delta_pct": [
+                        -2.25,
+                        -0.93
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6337,
+                    "c_ms": 1.6091
+                },
+                "core.int_to_packed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99655,
+                    "delta_pct": -0.35,
+                    "ci_delta_pct": [
+                        -0.92,
+                        0.49
+                    ],
+                    "n": 7,
+                    "b_ms": 4.9388,
+                    "c_ms": 4.9328
+                },
+                "core.int_to_packed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99643,
+                    "delta_pct": -0.36,
+                    "ci_delta_pct": [
+                        -1.27,
+                        2.1
+                    ],
+                    "n": 7,
+                    "b_ms": 1.5721,
+                    "c_ms": 1.562
+                },
+                "core.int_to_packed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99507,
+                    "delta_pct": -0.49,
+                    "ci_delta_pct": [
+                        -0.78,
+                        -0.04
+                    ],
+                    "n": 7,
+                    "b_ms": 0.944,
+                    "c_ms": 0.9361
+                },
+                "core.int_to_packed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98956,
+                    "delta_pct": -1.04,
+                    "ci_delta_pct": [
+                        -1.64,
+                        -0.33
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6257,
+                    "c_ms": 1.6204
+                },
+                "core.string_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00381,
+                    "delta_pct": 0.38,
+                    "ci_delta_pct": [
+                        -0.66,
+                        0.85
+                    ],
+                    "n": 7,
+                    "b_ms": 11.6627,
+                    "c_ms": 11.7034
+                },
+                "core.string_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01666,
+                    "delta_pct": 1.67,
+                    "ci_delta_pct": [
+                        -0.87,
+                        5.86
+                    ],
+                    "n": 7,
+                    "b_ms": 2.2031,
+                    "c_ms": 2.2577
+                },
+                "core.string_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01429,
+                    "delta_pct": 1.43,
+                    "ci_delta_pct": [
+                        -3.38,
+                        6.09
+                    ],
+                    "n": 7,
+                    "b_ms": 1.3881,
+                    "c_ms": 1.4052
+                },
+                "core.string_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01546,
+                    "delta_pct": 1.55,
+                    "ci_delta_pct": [
+                        -1.94,
+                        2.92
+                    ],
+                    "n": 7,
+                    "b_ms": 0.8986,
+                    "c_ms": 0.9094
+                },
+                "core.string_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99947,
+                    "delta_pct": -0.05,
+                    "ci_delta_pct": [
+                        -2.89,
+                        0.62
+                    ],
+                    "n": 7,
+                    "b_ms": 12.7387,
+                    "c_ms": 12.7297
+                },
+                "core.string_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99841,
+                    "delta_pct": -0.16,
+                    "ci_delta_pct": [
+                        -1.48,
+                        0.71
+                    ],
+                    "n": 7,
+                    "b_ms": 2.5363,
+                    "c_ms": 2.5125
+                },
+                "core.string_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99424,
+                    "delta_pct": -0.58,
+                    "ci_delta_pct": [
+                        -1.61,
+                        1.13
+                    ],
+                    "n": 7,
+                    "b_ms": 1.632,
+                    "c_ms": 1.6329
+                },
+                "core.string_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00345,
+                    "delta_pct": 0.35,
+                    "ci_delta_pct": [
+                        -1.26,
+                        0.52
+                    ],
+                    "n": 7,
+                    "b_ms": 2.611,
+                    "c_ms": 2.614
+                },
+                "core.string_to_int_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99907,
+                    "delta_pct": -0.09,
+                    "ci_delta_pct": [
+                        -0.82,
+                        0.04
+                    ],
+                    "n": 7,
+                    "b_ms": 11.3742,
+                    "c_ms": 11.3402
+                },
+                "core.string_to_int_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00255,
+                    "delta_pct": 0.25,
+                    "ci_delta_pct": [
+                        -4.05,
+                        7.02
+                    ],
+                    "n": 7,
+                    "b_ms": 2.1975,
+                    "c_ms": 2.2031
+                },
+                "core.string_to_int_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.02363,
+                    "delta_pct": 2.36,
+                    "ci_delta_pct": [
+                        0.47,
+                        4.93
+                    ],
+                    "n": 7,
+                    "b_ms": 1.3555,
+                    "c_ms": 1.4105
+                },
+                "core.string_to_int_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00046,
+                    "delta_pct": 0.05,
+                    "ci_delta_pct": [
+                        -0.3,
+                        1.77
+                    ],
+                    "n": 7,
+                    "b_ms": 0.8789,
+                    "c_ms": 0.8761
+                },
+                "core.string_to_mixed_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99943,
+                    "delta_pct": -0.06,
+                    "ci_delta_pct": [
+                        -0.48,
+                        0.25
+                    ],
+                    "n": 7,
+                    "b_ms": 12.2887,
+                    "c_ms": 12.2933
+                },
+                "core.string_to_mixed_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99821,
+                    "delta_pct": -0.18,
+                    "ci_delta_pct": [
+                        -1.43,
+                        1.01
+                    ],
+                    "n": 7,
+                    "b_ms": 2.509,
+                    "c_ms": 2.5076
+                },
+                "core.string_to_mixed_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00118,
+                    "delta_pct": 0.12,
+                    "ci_delta_pct": [
+                        -2.05,
+                        1.25
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6121,
+                    "c_ms": 1.6101
+                },
+                "core.string_to_mixed_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01253,
+                    "delta_pct": 1.25,
+                    "ci_delta_pct": [
+                        -1.08,
+                        1.56
+                    ],
+                    "n": 7,
+                    "b_ms": 2.6094,
+                    "c_ms": 2.6184
+                },
+                "core.string_to_int_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99898,
+                    "delta_pct": -0.1,
+                    "ci_delta_pct": [
+                        -0.51,
+                        0.27
+                    ],
+                    "n": 7,
+                    "b_ms": 11.4045,
+                    "c_ms": 11.3851
+                },
+                "core.string_to_int_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98487,
+                    "delta_pct": -1.51,
+                    "ci_delta_pct": [
+                        -6.23,
+                        2.7
+                    ],
+                    "n": 7,
+                    "b_ms": 2.2423,
+                    "c_ms": 2.1919
+                },
+                "core.string_to_int_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.97905,
+                    "delta_pct": -2.1,
+                    "ci_delta_pct": [
+                        -5.74,
+                        2.75
+                    ],
+                    "n": 7,
+                    "b_ms": 1.4078,
+                    "c_ms": 1.3598
+                },
+                "core.string_to_int_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.01193,
+                    "delta_pct": 1.19,
+                    "ci_delta_pct": [
+                        -0.83,
+                        1.86
+                    ],
+                    "n": 7,
+                    "b_ms": 0.8792,
+                    "c_ms": 0.8925
+                },
+                "core.string_to_mixed_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99722,
+                    "delta_pct": -0.28,
+                    "ci_delta_pct": [
+                        -0.47,
+                        0.02
+                    ],
+                    "n": 7,
+                    "b_ms": 12.3269,
+                    "c_ms": 12.2947
+                },
+                "core.string_to_mixed_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.98082,
+                    "delta_pct": -1.92,
+                    "ci_delta_pct": [
+                        -2.52,
+                        -0.7
+                    ],
+                    "n": 7,
+                    "b_ms": 2.5481,
+                    "c_ms": 2.5127
+                },
+                "core.string_to_mixed_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00462,
+                    "delta_pct": 0.46,
+                    "ci_delta_pct": [
+                        -1.06,
+                        1.24
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6228,
+                    "c_ms": 1.6287
+                },
+                "core.string_to_mixed_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 1.00669,
+                    "delta_pct": 0.67,
+                    "ci_delta_pct": [
+                        -1.62,
+                        1.88
+                    ],
+                    "n": 7,
+                    "b_ms": 2.6164,
+                    "c_ms": 2.6339
+                },
+                "api.increment.int_to_int": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99917,
+                    "delta_pct": -0.08,
+                    "ci_delta_pct": [
+                        -0.58,
+                        0.52
+                    ],
+                    "n": 7,
+                    "b_ms": 2.9024,
+                    "c_ms": 2.901
+                },
+                "api.setop.union.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99419,
+                    "delta_pct": -0.58,
+                    "ci_delta_pct": [
+                        -1.1,
+                        0.64
+                    ],
+                    "n": 7,
+                    "b_ms": 2.3692,
+                    "c_ms": 2.3674
+                },
+                "api.setop.intersect.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99793,
+                    "delta_pct": -0.21,
+                    "ci_delta_pct": [
+                        -0.55,
+                        0.19
+                    ],
+                    "n": 7,
+                    "b_ms": 4.5934,
+                    "c_ms": 4.5839
+                },
+                "api.setop.diff.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.9997,
+                    "delta_pct": -0.03,
+                    "ci_delta_pct": [
+                        -0.48,
+                        1.05
+                    ],
+                    "n": 7,
+                    "b_ms": 1.6539,
+                    "c_ms": 1.6577
+                },
+                "api.setop.xor.bitset": {
+                    "status": "null",
+                    "reason": "inside the 3.0% claim floor (CI straddles it)",
+                    "ratio": 0.99804,
+                    "delta_pct": -0.2,
+                    "ci_delta_pct": [
+                        -0.59,
+                        0.28
+                    ],
+                    "n": 7,
+                    "b_ms": 7.6343,
+                    "c_ms": 7.6104
+                }
+            }
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 81,
+        "slower": 0,
+        "null": 13
+    },
+    "a_counts": {
+        "php-judy": 1,
+        "php-array": 42,
+        "parity": 0
+    },
+    "bundled_vs_system": {
+        "core.bitset.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91076,
+            "delta_pct": -8.92,
+            "ci_delta_pct": [
+                -9.06,
+                -8.14
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.14,
+                "B2/C2": -8.8,
+                "B3/C3": -9.2
+            },
+            "build_spread_pct": 1.06,
+            "builds": 3,
+            "system_ms": 5.6107,
+            "bundled_ms": 5.1278,
+            "raw_delta_pct": -9,
+            "spread_pct": [
+                0.8,
+                5.1
+            ],
+            "system_runs_ms": [
+                5.6076,
+                5.6247,
+                5.5989,
+                5.6107,
+                5.637,
+                5.6458,
+                5.6063
+            ],
+            "bundled_runs_ms": [
+                5.1471,
+                5.1338,
+                5.095,
+                5.098,
+                5.1278,
+                5.1063,
+                5.3571
+            ],
+            "paired_ratios": [
+                0.91788,
+                0.91272,
+                0.91,
+                0.90862,
+                0.90967,
+                0.90444,
+                0.95555
+            ]
+        },
+        "core.bitset.read": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.9797,
+            "delta_pct": -2.03,
+            "ci_delta_pct": [
+                -2.23,
+                0.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.03,
+                "B2/C2": -2.36,
+                "B3/C3": -0.68
+            },
+            "build_spread_pct": 1.68,
+            "builds": 3,
+            "system_ms": 3.4442,
+            "bundled_ms": 3.3768,
+            "raw_delta_pct": -2.11,
+            "spread_pct": [
+                3,
+                1.8
+            ],
+            "system_runs_ms": [
+                3.4442,
+                3.4513,
+                3.4401,
+                3.42,
+                3.4545,
+                3.3921,
+                3.4955
+            ],
+            "bundled_runs_ms": [
+                3.3646,
+                3.3748,
+                3.3768,
+                3.4197,
+                3.3626,
+                3.4027,
+                3.4217
+            ],
+            "paired_ratios": [
+                0.97689,
+                0.97783,
+                0.9816,
+                0.99991,
+                0.9734,
+                1.00312,
+                0.97889
+            ]
+        },
+        "core.bitset.iter": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.96142,
+            "delta_pct": -3.86,
+            "ci_delta_pct": [
+                -4.66,
+                -2.81
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.86,
+                "B2/C2": -3.72,
+                "B3/C3": -2.58
+            },
+            "build_spread_pct": 1.28,
+            "builds": 3,
+            "system_ms": 5.4986,
+            "bundled_ms": 5.2938,
+            "raw_delta_pct": -3.94,
+            "spread_pct": [
+                7.2,
+                6.9
+            ],
+            "system_runs_ms": [
+                5.5569,
+                5.4986,
+                5.62,
+                5.444,
+                5.424,
+                5.4256,
+                5.821
+            ],
+            "bundled_runs_ms": [
+                5.2938,
+                5.2783,
+                5.3388,
+                5.2868,
+                5.2286,
+                5.408,
+                5.5918
+            ],
+            "paired_ratios": [
+                0.95265,
+                0.95994,
+                0.94996,
+                0.97112,
+                0.96397,
+                0.99676,
+                0.96063
+            ]
+        },
+        "core.int_to_int.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77445,
+            "delta_pct": -22.55,
+            "ci_delta_pct": [
+                -22.97,
+                -22.52
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.97,
+                "B2/C2": -22.67,
+                "B3/C3": -22.53
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 9.2171,
+            "bundled_ms": 7.109,
+            "raw_delta_pct": -22.62,
+            "spread_pct": [
+                4.6,
+                1.6
+            ],
+            "system_runs_ms": [
+                9.2171,
+                9.2013,
+                9.2906,
+                9.2259,
+                9.1839,
+                9.1993,
+                9.6097
+            ],
+            "bundled_runs_ms": [
+                7.1355,
+                7.0958,
+                7.1931,
+                7.101,
+                7.109,
+                7.1185,
+                7.0812
+            ],
+            "paired_ratios": [
+                0.77416,
+                0.77117,
+                0.77423,
+                0.76968,
+                0.77407,
+                0.77381,
+                0.73688
+            ]
+        },
+        "core.int_to_int.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85721,
+            "delta_pct": -14.28,
+            "ci_delta_pct": [
+                -17.07,
+                -13.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.4,
+                "B2/C2": -15.55,
+                "B3/C3": -13.53
+            },
+            "build_spread_pct": 2.02,
+            "builds": 3,
+            "system_ms": 4.0128,
+            "bundled_ms": 3.4397,
+            "raw_delta_pct": -14.35,
+            "spread_pct": [
+                5.3,
+                4.4
+            ],
+            "system_runs_ms": [
+                4.0043,
+                4.0266,
+                3.956,
+                4.0128,
+                4.0088,
+                4.016,
+                4.1687
+            ],
+            "bundled_runs_ms": [
+                3.4716,
+                3.4587,
+                3.4473,
+                3.3921,
+                3.3218,
+                3.4397,
+                3.3922
+            ],
+            "paired_ratios": [
+                0.86697,
+                0.85896,
+                0.87141,
+                0.84532,
+                0.82863,
+                0.8565,
+                0.81373
+            ]
+        },
+        "core.int_to_int.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91318,
+            "delta_pct": -8.68,
+            "ci_delta_pct": [
+                -9.4,
+                -7.3
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.36,
+                "B2/C2": -7.59,
+                "B3/C3": -9.92
+            },
+            "build_spread_pct": 2.33,
+            "builds": 3,
+            "system_ms": 6.498,
+            "bundled_ms": 5.9298,
+            "raw_delta_pct": -8.76,
+            "spread_pct": [
+                3.7,
+                2.8
+            ],
+            "system_runs_ms": [
+                6.4444,
+                6.5108,
+                6.5339,
+                6.498,
+                6.2982,
+                6.5356,
+                6.4406
+            ],
+            "bundled_runs_ms": [
+                5.9689,
+                5.8936,
+                5.9617,
+                5.9499,
+                5.9298,
+                5.8016,
+                5.8527
+            ],
+            "paired_ratios": [
+                0.92622,
+                0.9052,
+                0.91243,
+                0.91565,
+                0.94151,
+                0.88769,
+                0.90872
+            ]
+        },
+        "core.int_to_mixed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83228,
+            "delta_pct": -16.77,
+            "ci_delta_pct": [
+                -17.52,
+                -15.67
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.77,
+                "B2/C2": -16.81,
+                "B3/C3": -16.3
+            },
+            "build_spread_pct": 0.51,
+            "builds": 3,
+            "system_ms": 12.0653,
+            "bundled_ms": 10.0334,
+            "raw_delta_pct": -16.84,
+            "spread_pct": [
+                7.3,
+                1.9
+            ],
+            "system_runs_ms": [
+                12.0653,
+                12.0583,
+                12.0876,
+                11.9692,
+                12.1731,
+                12.0387,
+                12.8492
+            ],
+            "bundled_runs_ms": [
+                10.0334,
+                10.1078,
+                10.1848,
+                10.1041,
+                10.0323,
+                9.9914,
+                10.0188
+            ],
+            "paired_ratios": [
+                0.83159,
+                0.83824,
+                0.84258,
+                0.84418,
+                0.82414,
+                0.82994,
+                0.77972
+            ]
+        },
+        "core.int_to_mixed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77441,
+            "delta_pct": -22.56,
+            "ci_delta_pct": [
+                -24.18,
+                -21.72
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.18,
+                "B2/C2": -22.48,
+                "B3/C3": -21.84
+            },
+            "build_spread_pct": 2.34,
+            "builds": 3,
+            "system_ms": 4.7677,
+            "bundled_ms": 3.6891,
+            "raw_delta_pct": -22.62,
+            "spread_pct": [
+                5.8,
+                3.7
+            ],
+            "system_runs_ms": [
+                4.7677,
+                4.7442,
+                4.7139,
+                4.7257,
+                4.7949,
+                4.7677,
+                4.9926
+            ],
+            "bundled_runs_ms": [
+                3.612,
+                3.7109,
+                3.7155,
+                3.687,
+                3.6775,
+                3.6891,
+                3.749
+            ],
+            "paired_ratios": [
+                0.7576,
+                0.7822,
+                0.7882,
+                0.7802,
+                0.76696,
+                0.77377,
+                0.75091
+            ]
+        },
+        "core.int_to_mixed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91861,
+            "delta_pct": -8.14,
+            "ci_delta_pct": [
+                -8.53,
+                -6.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.53,
+                "B2/C2": -6.41,
+                "B3/C3": -8.21
+            },
+            "build_spread_pct": 2.12,
+            "builds": 3,
+            "system_ms": 6.1971,
+            "bundled_ms": 5.7385,
+            "raw_delta_pct": -8.21,
+            "spread_pct": [
+                2.5,
+                2.6
+            ],
+            "system_runs_ms": [
+                6.2521,
+                6.1921,
+                6.1971,
+                6.2535,
+                6.163,
+                6.1701,
+                6.3159
+            ],
+            "bundled_runs_ms": [
+                5.7385,
+                5.7628,
+                5.6912,
+                5.6401,
+                5.7903,
+                5.6509,
+                5.7723
+            ],
+            "paired_ratios": [
+                0.91785,
+                0.93067,
+                0.91837,
+                0.90191,
+                0.93953,
+                0.91585,
+                0.91393
+            ]
+        },
+        "core.int_to_mixed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88449,
+            "delta_pct": -11.55,
+            "ci_delta_pct": [
+                -12.68,
+                -11.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.33,
+                "B2/C2": -11.47,
+                "B3/C3": -12.21
+            },
+            "build_spread_pct": 0.88,
+            "builds": 3,
+            "system_ms": 4.9177,
+            "bundled_ms": 4.3536,
+            "raw_delta_pct": -11.62,
+            "spread_pct": [
+                3.9,
+                1.5
+            ],
+            "system_runs_ms": [
+                4.9177,
+                4.9302,
+                4.9322,
+                4.916,
+                4.9174,
+                4.8998,
+                5.0912
+            ],
+            "bundled_runs_ms": [
+                4.3692,
+                4.3571,
+                4.3033,
+                4.3555,
+                4.3536,
+                4.3211,
+                4.3353
+            ],
+            "paired_ratios": [
+                0.88846,
+                0.88376,
+                0.87249,
+                0.88598,
+                0.88535,
+                0.88189,
+                0.85153
+            ]
+        },
+        "core.int_to_packed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89342,
+            "delta_pct": -10.66,
+            "ci_delta_pct": [
+                -10.92,
+                -10.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.92,
+                "B2/C2": -9.64,
+                "B3/C3": -10.39
+            },
+            "build_spread_pct": 1.28,
+            "builds": 3,
+            "system_ms": 15.4088,
+            "bundled_ms": 13.7805,
+            "raw_delta_pct": -10.73,
+            "spread_pct": [
+                2.4,
+                2.5
+            ],
+            "system_runs_ms": [
+                15.4166,
+                15.3823,
+                15.4088,
+                15.3902,
+                15.4071,
+                15.4359,
+                15.7584
+            ],
+            "bundled_runs_ms": [
+                13.7218,
+                13.7314,
+                13.8331,
+                13.7176,
+                14.067,
+                13.784,
+                13.7805
+            ],
+            "paired_ratios": [
+                0.89007,
+                0.89268,
+                0.89774,
+                0.89132,
+                0.91302,
+                0.89298,
+                0.87449
+            ]
+        },
+        "core.int_to_packed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.96586,
+            "delta_pct": -3.41,
+            "ci_delta_pct": [
+                -3.66,
+                -3.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.47,
+                "B2/C2": -3.03,
+                "B3/C3": -3.54
+            },
+            "build_spread_pct": 0.51,
+            "builds": 3,
+            "system_ms": 10.2442,
+            "bundled_ms": 9.9015,
+            "raw_delta_pct": -3.49,
+            "spread_pct": [
+                1.8,
+                0.9
+            ],
+            "system_runs_ms": [
+                10.2271,
+                10.2429,
+                10.2442,
+                10.4077,
+                10.2442,
+                10.2847,
+                10.2948
+            ],
+            "bundled_runs_ms": [
+                9.8908,
+                9.9015,
+                9.8606,
+                9.8731,
+                9.9484,
+                9.9253,
+                9.9289
+            ],
+            "paired_ratios": [
+                0.96712,
+                0.96667,
+                0.96255,
+                0.94863,
+                0.97113,
+                0.96505,
+                0.96446
+            ]
+        },
+        "core.int_to_packed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95901,
+            "delta_pct": -4.1,
+            "ci_delta_pct": [
+                -4.35,
+                -4.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.35,
+                "B2/C2": -4.13,
+                "B3/C3": -3.91
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 12.8122,
+            "bundled_ms": 12.2723,
+            "raw_delta_pct": -4.18,
+            "spread_pct": [
+                1.2,
+                0.6
+            ],
+            "system_runs_ms": [
+                12.7657,
+                12.8468,
+                12.8005,
+                12.8122,
+                12.7641,
+                12.8217,
+                12.9155
+            ],
+            "bundled_runs_ms": [
+                12.2349,
+                12.301,
+                12.3062,
+                12.2448,
+                12.2307,
+                12.2925,
+                12.2723
+            ],
+            "paired_ratios": [
+                0.95842,
+                0.95751,
+                0.96138,
+                0.95571,
+                0.95821,
+                0.95873,
+                0.9502
+            ]
+        },
+        "core.int_to_packed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85094,
+            "delta_pct": -14.91,
+            "ci_delta_pct": [
+                -16.89,
+                -14.64
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.91,
+                "B2/C2": -13.94,
+                "B3/C3": -16.21
+            },
+            "build_spread_pct": 2.27,
+            "builds": 3,
+            "system_ms": 3.0739,
+            "bundled_ms": 2.5938,
+            "raw_delta_pct": -14.98,
+            "spread_pct": [
+                7,
+                2.6
+            ],
+            "system_runs_ms": [
+                3.0419,
+                3.0545,
+                3.1125,
+                3.0889,
+                3.0739,
+                3.0706,
+                3.2564
+            ],
+            "bundled_runs_ms": [
+                2.5938,
+                2.6479,
+                2.5845,
+                2.6263,
+                2.6217,
+                2.5918,
+                2.5804
+            ],
+            "paired_ratios": [
+                0.85269,
+                0.86688,
+                0.83036,
+                0.85024,
+                0.85289,
+                0.84407,
+                0.79241
+            ]
+        },
+        "core.string_to_int.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87995,
+            "delta_pct": -12,
+            "ci_delta_pct": [
+                -12.3,
+                -11.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12,
+                "B2/C2": -11.99,
+                "B3/C3": -11.75
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 29.6964,
+            "bundled_ms": 26.1422,
+            "raw_delta_pct": -12.08,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                29.6964,
+                29.6425,
+                29.4999,
+                29.5839,
+                29.8168,
+                29.7879,
+                29.7333
+            ],
+            "bundled_runs_ms": [
+                26.0231,
+                26.2001,
+                26.1623,
+                26.171,
+                26.0853,
+                26.1152,
+                26.1422
+            ],
+            "paired_ratios": [
+                0.8763,
+                0.88387,
+                0.88686,
+                0.88464,
+                0.87485,
+                0.8767,
+                0.87922
+            ]
+        },
+        "core.string_to_int.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86149,
+            "delta_pct": -13.85,
+            "ci_delta_pct": [
+                -14.08,
+                -13.5
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.04,
+                "B2/C2": -13.52,
+                "B3/C3": -13.97
+            },
+            "build_spread_pct": 0.52,
+            "builds": 3,
+            "system_ms": 11.3559,
+            "bundled_ms": 9.7428,
+            "raw_delta_pct": -13.92,
+            "spread_pct": [
+                1.1,
+                1.7
+            ],
+            "system_runs_ms": [
+                11.3431,
+                11.3559,
+                11.3923,
+                11.4046,
+                11.2783,
+                11.308,
+                11.4047
+            ],
+            "bundled_runs_ms": [
+                9.7428,
+                9.8151,
+                9.78,
+                9.8733,
+                9.7426,
+                9.7336,
+                9.7029
+            ],
+            "paired_ratios": [
+                0.85892,
+                0.86432,
+                0.85847,
+                0.86573,
+                0.86384,
+                0.86077,
+                0.85078
+            ]
+        },
+        "core.string_to_int.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87664,
+            "delta_pct": -12.34,
+            "ci_delta_pct": [
+                -13.3,
+                -12.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.3,
+                "B2/C2": -12.27,
+                "B3/C3": -12.15
+            },
+            "build_spread_pct": 1.15,
+            "builds": 3,
+            "system_ms": 15.9274,
+            "bundled_ms": 13.9124,
+            "raw_delta_pct": -12.41,
+            "spread_pct": [
+                1.3,
+                1.2
+            ],
+            "system_runs_ms": [
+                16.0235,
+                15.9175,
+                15.9968,
+                15.8507,
+                15.9274,
+                15.8353,
+                16.0384
+            ],
+            "bundled_runs_ms": [
+                13.881,
+                13.9619,
+                14.0281,
+                13.8625,
+                13.951,
+                13.9124,
+                13.8598
+            ],
+            "paired_ratios": [
+                0.86629,
+                0.87714,
+                0.87693,
+                0.87457,
+                0.87591,
+                0.87857,
+                0.86416
+            ]
+        },
+        "core.string_to_int.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88164,
+            "delta_pct": -11.84,
+            "ci_delta_pct": [
+                -12.28,
+                -9.9
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.01,
+                "B2/C2": -12.1,
+                "B3/C3": -10.94
+            },
+            "build_spread_pct": 1.16,
+            "builds": 3,
+            "system_ms": 5.1761,
+            "bundled_ms": 4.561,
+            "raw_delta_pct": -11.91,
+            "spread_pct": [
+                3.1,
+                3.8
+            ],
+            "system_runs_ms": [
+                5.0653,
+                5.1491,
+                5.1511,
+                5.1844,
+                5.2092,
+                5.226,
+                5.1761
+            ],
+            "bundled_runs_ms": [
+                4.5817,
+                4.5359,
+                4.5301,
+                4.544,
+                4.561,
+                4.7047,
+                4.6026
+            ],
+            "paired_ratios": [
+                0.90453,
+                0.88091,
+                0.87944,
+                0.87648,
+                0.87557,
+                0.90025,
+                0.8892
+            ]
+        },
+        "core.string_to_mixed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86851,
+            "delta_pct": -13.15,
+            "ci_delta_pct": [
+                -14.25,
+                -12.91
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.15,
+                "B2/C2": -14.32,
+                "B3/C3": -12.48
+            },
+            "build_spread_pct": 1.84,
+            "builds": 3,
+            "system_ms": 33.5661,
+            "bundled_ms": 29.1389,
+            "raw_delta_pct": -13.22,
+            "spread_pct": [
+                3.2,
+                3.1
+            ],
+            "system_runs_ms": [
+                33.5593,
+                34.5593,
+                33.5661,
+                33.509,
+                33.487,
+                34.0405,
+                33.5834
+            ],
+            "bundled_runs_ms": [
+                29.0561,
+                29.1016,
+                29.9467,
+                29.0965,
+                29.1389,
+                29.1647,
+                29.1432
+            ],
+            "paired_ratios": [
+                0.86581,
+                0.84208,
+                0.89217,
+                0.86832,
+                0.87016,
+                0.85676,
+                0.86779
+            ]
+        },
+        "core.string_to_mixed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8638,
+            "delta_pct": -13.62,
+            "ci_delta_pct": [
+                -16.11,
+                -13.11
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.11,
+                "B2/C2": -14.86,
+                "B3/C3": -14.96
+            },
+            "build_spread_pct": 1.85,
+            "builds": 3,
+            "system_ms": 11.5133,
+            "bundled_ms": 9.9117,
+            "raw_delta_pct": -13.69,
+            "spread_pct": [
+                3.6,
+                1.9
+            ],
+            "system_runs_ms": [
+                11.5211,
+                11.8231,
+                11.4493,
+                11.5133,
+                11.4841,
+                11.8649,
+                11.4663
+            ],
+            "bundled_runs_ms": [
+                10.0598,
+                9.9102,
+                9.9301,
+                9.9959,
+                9.9117,
+                9.8717,
+                9.881
+            ],
+            "paired_ratios": [
+                0.87316,
+                0.83821,
+                0.86731,
+                0.8682,
+                0.86308,
+                0.83201,
+                0.86174
+            ]
+        },
+        "core.string_to_mixed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87831,
+            "delta_pct": -12.17,
+            "ci_delta_pct": [
+                -12.34,
+                -11.84
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.17,
+                "B2/C2": -11.9,
+                "B3/C3": -14.33
+            },
+            "build_spread_pct": 2.43,
+            "builds": 3,
+            "system_ms": 16.1021,
+            "bundled_ms": 14.1056,
+            "raw_delta_pct": -12.24,
+            "spread_pct": [
+                5.2,
+                1.4
+            ],
+            "system_runs_ms": [
+                16.2142,
+                16.1021,
+                16.1426,
+                16.0927,
+                16.0804,
+                16.9007,
+                16.0686
+            ],
+            "bundled_runs_ms": [
+                14.2832,
+                14.1056,
+                14.1848,
+                14.0946,
+                14.2236,
+                14.0826,
+                14.1015
+            ],
+            "paired_ratios": [
+                0.88091,
+                0.87601,
+                0.87872,
+                0.87584,
+                0.88453,
+                0.83326,
+                0.87758
+            ]
+        },
+        "core.string_to_mixed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83217,
+            "delta_pct": -16.78,
+            "ci_delta_pct": [
+                -17.15,
+                -16.48
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.87,
+                "B2/C2": -16.91,
+                "B3/C3": -16.63
+            },
+            "build_spread_pct": 0.28,
+            "builds": 3,
+            "system_ms": 17.9469,
+            "bundled_ms": 14.8932,
+            "raw_delta_pct": -16.85,
+            "spread_pct": [
+                1.1,
+                0.9
+            ],
+            "system_runs_ms": [
+                17.84,
+                17.8874,
+                17.9469,
+                17.8769,
+                17.9701,
+                17.9538,
+                18.0374
+            ],
+            "bundled_runs_ms": [
+                14.888,
+                14.8932,
+                14.9781,
+                14.8494,
+                14.8767,
+                14.9283,
+                14.8978
+            ],
+            "paired_ratios": [
+                0.83453,
+                0.83261,
+                0.83458,
+                0.83065,
+                0.82786,
+                0.83148,
+                0.82594
+            ]
+        },
+        "core.string_to_int_hash.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90846,
+            "delta_pct": -9.15,
+            "ci_delta_pct": [
+                -9.37,
+                -8.91
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.91,
+                "B2/C2": -9.41,
+                "B3/C3": -9.23
+            },
+            "build_spread_pct": 0.5,
+            "builds": 3,
+            "system_ms": 52.6155,
+            "bundled_ms": 47.7596,
+            "raw_delta_pct": -9.23,
+            "spread_pct": [
+                0.4,
+                0.5
+            ],
+            "system_runs_ms": [
+                52.5904,
+                52.7693,
+                52.5533,
+                52.5485,
+                52.6155,
+                52.6695,
+                52.6322
+            ],
+            "bundled_runs_ms": [
+                47.865,
+                47.6307,
+                47.7415,
+                47.8902,
+                47.7596,
+                47.6935,
+                47.7744
+            ],
+            "paired_ratios": [
+                0.91015,
+                0.90262,
+                0.90844,
+                0.91135,
+                0.90771,
+                0.90552,
+                0.9077
+            ]
+        },
+        "core.string_to_int_hash.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9035,
+            "delta_pct": -9.65,
+            "ci_delta_pct": [
+                -10.16,
+                -8.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.23,
+                "B2/C2": -10.19,
+                "B3/C3": -9.03
+            },
+            "build_spread_pct": 1.16,
+            "builds": 3,
+            "system_ms": 8.9294,
+            "bundled_ms": 8.0641,
+            "raw_delta_pct": -9.73,
+            "spread_pct": [
+                0.8,
+                3.8
+            ],
+            "system_runs_ms": [
+                8.9425,
+                8.903,
+                8.9076,
+                8.9283,
+                8.9705,
+                8.9294,
+                8.9442
+            ],
+            "bundled_runs_ms": [
+                8.0641,
+                7.9915,
+                8.1517,
+                8.2951,
+                8.0469,
+                8.061,
+                8.1121
+            ],
+            "paired_ratios": [
+                0.90177,
+                0.89762,
+                0.91514,
+                0.92908,
+                0.89704,
+                0.90275,
+                0.90697
+            ]
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85824,
+            "delta_pct": -14.18,
+            "ci_delta_pct": [
+                -14.35,
+                -14.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.18,
+                "B2/C2": -13.73,
+                "B3/C3": -14.26
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 21.7766,
+            "bundled_ms": 18.6842,
+            "raw_delta_pct": -14.25,
+            "spread_pct": [
+                0.8,
+                2
+            ],
+            "system_runs_ms": [
+                21.681,
+                21.7143,
+                21.8487,
+                21.7807,
+                21.7306,
+                21.7869,
+                21.7766
+            ],
+            "bundled_runs_ms": [
+                18.5921,
+                18.9103,
+                18.6987,
+                18.7081,
+                18.5374,
+                18.6842,
+                18.6513
+            ],
+            "paired_ratios": [
+                0.85753,
+                0.87087,
+                0.85583,
+                0.85893,
+                0.85306,
+                0.85759,
+                0.85648
+            ]
+        },
+        "core.string_to_int_hash.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87696,
+            "delta_pct": -12.3,
+            "ci_delta_pct": [
+                -13.08,
+                -11.74
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.74,
+                "B2/C2": -13.56,
+                "B3/C3": -12.19
+            },
+            "build_spread_pct": 1.82,
+            "builds": 3,
+            "system_ms": 11.1711,
+            "bundled_ms": 9.8051,
+            "raw_delta_pct": -12.38,
+            "spread_pct": [
+                2,
+                2
+            ],
+            "system_runs_ms": [
+                11.1406,
+                11.35,
+                11.1711,
+                11.1237,
+                11.2903,
+                11.1937,
+                11.1577
+            ],
+            "bundled_runs_ms": [
+                9.7618,
+                9.7481,
+                9.8406,
+                9.8101,
+                9.8051,
+                9.7814,
+                9.9477
+            ],
+            "paired_ratios": [
+                0.87624,
+                0.85886,
+                0.8809,
+                0.88191,
+                0.86845,
+                0.87383,
+                0.89155
+            ]
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88641,
+            "delta_pct": -11.36,
+            "ci_delta_pct": [
+                -11.46,
+                -11.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.37,
+                "B2/C2": -11.44,
+                "B3/C3": -11.34
+            },
+            "build_spread_pct": 0.1,
+            "builds": 3,
+            "system_ms": 66.3629,
+            "bundled_ms": 58.7629,
+            "raw_delta_pct": -11.43,
+            "spread_pct": [
+                0.7,
+                0.2
+            ],
+            "system_runs_ms": [
+                66.1865,
+                66.1896,
+                66.2735,
+                66.4265,
+                66.6395,
+                66.3629,
+                66.3906
+            ],
+            "bundled_runs_ms": [
+                58.716,
+                58.8322,
+                58.6967,
+                58.7629,
+                58.6979,
+                58.7947,
+                58.7941
+            ],
+            "paired_ratios": [
+                0.88713,
+                0.88884,
+                0.88567,
+                0.88463,
+                0.88083,
+                0.88596,
+                0.88558
+            ]
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89777,
+            "delta_pct": -10.22,
+            "ci_delta_pct": [
+                -10.47,
+                -9.85
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.47,
+                "B2/C2": -10.05,
+                "B3/C3": -10
+            },
+            "build_spread_pct": 0.47,
+            "builds": 3,
+            "system_ms": 9.2239,
+            "bundled_ms": 8.2743,
+            "raw_delta_pct": -10.3,
+            "spread_pct": [
+                1,
+                0.9
+            ],
+            "system_runs_ms": [
+                9.2779,
+                9.2032,
+                9.233,
+                9.1859,
+                9.2219,
+                9.2239,
+                9.2651
+            ],
+            "bundled_runs_ms": [
+                8.2718,
+                8.2555,
+                8.2679,
+                8.2743,
+                8.3043,
+                8.3287,
+                8.2878
+            ],
+            "paired_ratios": [
+                0.89156,
+                0.89702,
+                0.89547,
+                0.90076,
+                0.9005,
+                0.90295,
+                0.89452
+            ]
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85624,
+            "delta_pct": -14.38,
+            "ci_delta_pct": [
+                -14.69,
+                -14.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.38,
+                "B2/C2": -14.28,
+                "B3/C3": -14.82
+            },
+            "build_spread_pct": 0.54,
+            "builds": 3,
+            "system_ms": 23.221,
+            "bundled_ms": 19.8406,
+            "raw_delta_pct": -14.45,
+            "spread_pct": [
+                1,
+                0.6
+            ],
+            "system_runs_ms": [
+                23.2164,
+                23.221,
+                23.3135,
+                23.226,
+                23.1337,
+                23.3756,
+                23.1731
+            ],
+            "bundled_runs_ms": [
+                19.9172,
+                19.8904,
+                19.8106,
+                19.8406,
+                19.813,
+                19.9252,
+                19.8253
+            ],
+            "paired_ratios": [
+                0.85789,
+                0.85657,
+                0.84975,
+                0.85424,
+                0.85646,
+                0.85239,
+                0.85553
+            ]
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8542,
+            "delta_pct": -14.58,
+            "ci_delta_pct": [
+                -14.85,
+                -14.47
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.58,
+                "B2/C2": -14.78,
+                "B3/C3": -14.29
+            },
+            "build_spread_pct": 0.49,
+            "builds": 3,
+            "system_ms": 31.9347,
+            "bundled_ms": 27.2298,
+            "raw_delta_pct": -14.65,
+            "spread_pct": [
+                0.4,
+                0.9
+            ],
+            "system_runs_ms": [
+                31.9347,
+                31.9147,
+                31.9617,
+                31.9492,
+                32.0023,
+                31.8641,
+                31.898
+            ],
+            "bundled_runs_ms": [
+                27.1698,
+                27.2083,
+                27.4276,
+                27.2684,
+                27.2164,
+                27.2298,
+                27.2473
+            ],
+            "paired_ratios": [
+                0.85079,
+                0.85253,
+                0.85814,
+                0.85349,
+                0.85045,
+                0.85456,
+                0.8542
+            ]
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91496,
+            "delta_pct": -8.5,
+            "ci_delta_pct": [
+                -8.68,
+                -8.26
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.42,
+                "B2/C2": -8.39,
+                "B3/C3": -8.59
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 52.3556,
+            "bundled_ms": 47.8433,
+            "raw_delta_pct": -8.58,
+            "spread_pct": [
+                0.4,
+                1.2
+            ],
+            "system_runs_ms": [
+                52.3556,
+                52.1932,
+                52.3406,
+                52.3826,
+                52.3214,
+                52.3734,
+                52.419
+            ],
+            "bundled_runs_ms": [
+                48.2818,
+                47.8433,
+                47.85,
+                47.9344,
+                47.8185,
+                47.7863,
+                47.7275
+            ],
+            "paired_ratios": [
+                0.92219,
+                0.91666,
+                0.9142,
+                0.91508,
+                0.91394,
+                0.91242,
+                0.9105
+            ]
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88289,
+            "delta_pct": -11.71,
+            "ci_delta_pct": [
+                -12.23,
+                -11.51
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.51,
+                "B2/C2": -12.33,
+                "B3/C3": -11.74
+            },
+            "build_spread_pct": 0.82,
+            "builds": 3,
+            "system_ms": 8.8033,
+            "bundled_ms": 7.7609,
+            "raw_delta_pct": -11.78,
+            "spread_pct": [
+                0.9,
+                1
+            ],
+            "system_runs_ms": [
+                8.7701,
+                8.7977,
+                8.8033,
+                8.7672,
+                8.8445,
+                8.8427,
+                8.8293
+            ],
+            "bundled_runs_ms": [
+                7.7542,
+                7.715,
+                7.776,
+                7.7609,
+                7.7389,
+                7.7849,
+                7.7888
+            ],
+            "paired_ratios": [
+                0.88416,
+                0.87693,
+                0.88331,
+                0.88522,
+                0.875,
+                0.88038,
+                0.88215
+            ]
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85486,
+            "delta_pct": -14.51,
+            "ci_delta_pct": [
+                -14.86,
+                -14.22
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.51,
+                "B2/C2": -16.13,
+                "B3/C3": -14.26
+            },
+            "build_spread_pct": 1.87,
+            "builds": 3,
+            "system_ms": 21.6042,
+            "bundled_ms": 18.4555,
+            "raw_delta_pct": -14.58,
+            "spread_pct": [
+                3.8,
+                0.6
+            ],
+            "system_runs_ms": [
+                21.6325,
+                21.6123,
+                21.5427,
+                21.5637,
+                22.3547,
+                21.5483,
+                21.6042
+            ],
+            "bundled_runs_ms": [
+                18.4775,
+                18.4555,
+                18.4388,
+                18.483,
+                18.3786,
+                18.478,
+                18.3779
+            ],
+            "paired_ratios": [
+                0.85415,
+                0.85394,
+                0.85592,
+                0.85713,
+                0.82214,
+                0.85752,
+                0.85066
+            ]
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87368,
+            "delta_pct": -12.63,
+            "ci_delta_pct": [
+                -15.74,
+                -12.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.71,
+                "B2/C2": -14.19,
+                "B3/C3": -12.29
+            },
+            "build_spread_pct": 1.9,
+            "builds": 3,
+            "system_ms": 11.2123,
+            "bundled_ms": 9.7944,
+            "raw_delta_pct": -12.7,
+            "spread_pct": [
+                5.1,
+                1.6
+            ],
+            "system_runs_ms": [
+                11.2123,
+                11.1483,
+                11.1589,
+                11.7157,
+                11.6819,
+                11.1868,
+                11.2175
+            ],
+            "bundled_runs_ms": [
+                9.7791,
+                9.732,
+                9.7944,
+                9.8588,
+                9.8345,
+                9.7885,
+                9.8857
+            ],
+            "paired_ratios": [
+                0.87218,
+                0.87296,
+                0.87772,
+                0.8415,
+                0.84186,
+                0.875,
+                0.88127
+            ]
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88736,
+            "delta_pct": -11.26,
+            "ci_delta_pct": [
+                -11.41,
+                -10.8
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.34,
+                "B2/C2": -12.74,
+                "B3/C3": -11.03
+            },
+            "build_spread_pct": 1.71,
+            "builds": 3,
+            "system_ms": 67.2076,
+            "bundled_ms": 59.6431,
+            "raw_delta_pct": -11.34,
+            "spread_pct": [
+                4.5,
+                0.6
+            ],
+            "system_runs_ms": [
+                67.1369,
+                67.0618,
+                67.0532,
+                67.2401,
+                70.0584,
+                67.2076,
+                67.3308
+            ],
+            "bundled_runs_ms": [
+                59.6507,
+                59.8548,
+                59.7606,
+                59.5208,
+                59.6376,
+                59.5879,
+                59.6431
+            ],
+            "paired_ratios": [
+                0.88849,
+                0.89253,
+                0.89124,
+                0.8852,
+                0.85126,
+                0.88662,
+                0.88582
+            ]
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88764,
+            "delta_pct": -11.24,
+            "ci_delta_pct": [
+                -12.31,
+                -11
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.24,
+                "B2/C2": -12.21,
+                "B3/C3": -11.51
+            },
+            "build_spread_pct": 0.97,
+            "builds": 3,
+            "system_ms": 9.126,
+            "bundled_ms": 8.1103,
+            "raw_delta_pct": -11.31,
+            "spread_pct": [
+                2.4,
+                0.6
+            ],
+            "system_runs_ms": [
+                9.126,
+                9.1247,
+                9.1099,
+                9.109,
+                9.3324,
+                9.2733,
+                9.1277
+            ],
+            "bundled_runs_ms": [
+                8.0891,
+                8.1103,
+                8.1274,
+                8.0788,
+                8.0781,
+                8.1249,
+                8.1169
+            ],
+            "paired_ratios": [
+                0.88638,
+                0.88883,
+                0.89215,
+                0.8869,
+                0.8656,
+                0.87616,
+                0.88926
+            ]
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85188,
+            "delta_pct": -14.81,
+            "ci_delta_pct": [
+                -16.03,
+                -14.45
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.6,
+                "B2/C2": -15.24,
+                "B3/C3": -15.65
+            },
+            "build_spread_pct": 1.05,
+            "builds": 3,
+            "system_ms": 23.6177,
+            "bundled_ms": 20.1009,
+            "raw_delta_pct": -14.88,
+            "spread_pct": [
+                2.4,
+                1.4
+            ],
+            "system_runs_ms": [
+                23.4927,
+                24.0234,
+                24.0643,
+                23.6177,
+                23.5863,
+                23.8781,
+                23.4992
+            ],
+            "bundled_runs_ms": [
+                20.0452,
+                20.1566,
+                20.0806,
+                20.0838,
+                20.1611,
+                20.3244,
+                20.1009
+            ],
+            "paired_ratios": [
+                0.85325,
+                0.83904,
+                0.83446,
+                0.85037,
+                0.85478,
+                0.85117,
+                0.85539
+            ]
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84604,
+            "delta_pct": -15.4,
+            "ci_delta_pct": [
+                -16.27,
+                -15.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.4,
+                "B2/C2": -15.2,
+                "B3/C3": -16.75
+            },
+            "build_spread_pct": 1.55,
+            "builds": 3,
+            "system_ms": 32.7683,
+            "bundled_ms": 27.6954,
+            "raw_delta_pct": -15.47,
+            "spread_pct": [
+                2.9,
+                0.5
+            ],
+            "system_runs_ms": [
+                32.534,
+                32.5729,
+                33.497,
+                33.0516,
+                32.6596,
+                33.0529,
+                32.7683
+            ],
+            "bundled_runs_ms": [
+                27.6458,
+                27.5586,
+                27.7008,
+                27.6954,
+                27.7104,
+                27.6538,
+                27.7002
+            ],
+            "paired_ratios": [
+                0.84975,
+                0.84606,
+                0.82696,
+                0.83794,
+                0.84846,
+                0.83665,
+                0.84534
+            ]
+        },
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74655,
+            "delta_pct": -25.35,
+            "ci_delta_pct": [
+                -25.39,
+                -24.76
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.39,
+                "B2/C2": -24.96,
+                "B3/C3": -25.36
+            },
+            "build_spread_pct": 0.43,
+            "builds": 3,
+            "system_ms": 8.3248,
+            "bundled_ms": 6.2155,
+            "raw_delta_pct": -25.41,
+            "spread_pct": [
+                0.6,
+                2.1
+            ],
+            "system_runs_ms": [
+                8.3374,
+                8.3248,
+                8.3077,
+                8.3342,
+                8.3109,
+                8.3452,
+                8.298
+            ],
+            "bundled_runs_ms": [
+                6.2155,
+                6.258,
+                6.1944,
+                6.2019,
+                6.215,
+                6.2249,
+                6.3268
+            ],
+            "paired_ratios": [
+                0.7455,
+                0.75173,
+                0.74562,
+                0.74415,
+                0.74781,
+                0.74593,
+                0.76245
+            ]
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74321,
+            "delta_pct": -25.68,
+            "ci_delta_pct": [
+                -26.1,
+                -24.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.05,
+                "B2/C2": -26.21,
+                "B3/C3": -24.88
+            },
+            "build_spread_pct": 1.33,
+            "builds": 3,
+            "system_ms": 8.323,
+            "bundled_ms": 6.1806,
+            "raw_delta_pct": -25.74,
+            "spread_pct": [
+                1.9,
+                2.1
+            ],
+            "system_runs_ms": [
+                8.3533,
+                8.4522,
+                8.323,
+                8.3674,
+                8.3183,
+                8.2922,
+                8.3035
+            ],
+            "bundled_runs_ms": [
+                6.1724,
+                6.1727,
+                6.1806,
+                6.1781,
+                6.1915,
+                6.2904,
+                6.2994
+            ],
+            "paired_ratios": [
+                0.73892,
+                0.73031,
+                0.74259,
+                0.73835,
+                0.74432,
+                0.75859,
+                0.75864
+            ]
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94184,
+            "delta_pct": -5.82,
+            "ci_delta_pct": [
+                -6.23,
+                -5.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.23,
+                "B2/C2": -5.57,
+                "B3/C3": -5.51
+            },
+            "build_spread_pct": 0.72,
+            "builds": 3,
+            "system_ms": 14.6117,
+            "bundled_ms": 13.7697,
+            "raw_delta_pct": -5.89,
+            "spread_pct": [
+                2.2,
+                1.1
+            ],
+            "system_runs_ms": [
+                14.8383,
+                14.532,
+                14.6117,
+                14.571,
+                14.6566,
+                14.522,
+                14.697
+            ],
+            "bundled_runs_ms": [
+                13.8938,
+                13.7983,
+                13.7504,
+                13.7974,
+                13.7404,
+                13.754,
+                13.7697
+            ],
+            "paired_ratios": [
+                0.93635,
+                0.94951,
+                0.94105,
+                0.94691,
+                0.93749,
+                0.94711,
+                0.93691
+            ]
+        },
+        "api.increment.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90491,
+            "delta_pct": -9.51,
+            "ci_delta_pct": [
+                -10.15,
+                -7.48
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.08,
+                "B2/C2": -7.73,
+                "B3/C3": -8.83
+            },
+            "build_spread_pct": 2.35,
+            "builds": 3,
+            "system_ms": 7.8648,
+            "bundled_ms": 7.1894,
+            "raw_delta_pct": -9.58,
+            "spread_pct": [
+                2.8,
+                3.8
+            ],
+            "system_runs_ms": [
+                7.8504,
+                7.9187,
+                8.0465,
+                7.8867,
+                7.8267,
+                7.8648,
+                7.8529
+            ],
+            "bundled_runs_ms": [
+                7.0532,
+                7.3202,
+                7.1894,
+                7.1308,
+                7.1967,
+                7.3014,
+                7.05
+            ],
+            "paired_ratios": [
+                0.89845,
+                0.92442,
+                0.89348,
+                0.90416,
+                0.91951,
+                0.92836,
+                0.89776
+            ]
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88816,
+            "delta_pct": -11.18,
+            "ci_delta_pct": [
+                -11.39,
+                -10.89
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.39,
+                "B2/C2": -11.08,
+                "B3/C3": -10.86
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 4.9188,
+            "bundled_ms": 4.3559,
+            "raw_delta_pct": -11.26,
+            "spread_pct": [
+                1.4,
+                1.2
+            ],
+            "system_runs_ms": [
+                4.9439,
+                4.8982,
+                4.9192,
+                4.9392,
+                4.8932,
+                4.8759,
+                4.9188
+            ],
+            "bundled_runs_ms": [
+                4.3559,
+                4.345,
+                4.3654,
+                4.3975,
+                4.3547,
+                4.3586,
+                4.3548
+            ],
+            "paired_ratios": [
+                0.88107,
+                0.88706,
+                0.88742,
+                0.89033,
+                0.88995,
+                0.89391,
+                0.88534
+            ]
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88361,
+            "delta_pct": -11.64,
+            "ci_delta_pct": [
+                -11.74,
+                -11.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.08,
+                "B2/C2": -11.69,
+                "B3/C3": -11.1
+            },
+            "build_spread_pct": 0.61,
+            "builds": 3,
+            "system_ms": 4.9845,
+            "bundled_ms": 4.4071,
+            "raw_delta_pct": -11.71,
+            "spread_pct": [
+                0.6,
+                1.3
+            ],
+            "system_runs_ms": [
+                4.9871,
+                4.9938,
+                4.9745,
+                4.9747,
+                4.9845,
+                4.9745,
+                5.0026
+            ],
+            "bundled_runs_ms": [
+                4.4344,
+                4.404,
+                4.4484,
+                4.4198,
+                4.4007,
+                4.3891,
+                4.4071
+            ],
+            "paired_ratios": [
+                0.88917,
+                0.88189,
+                0.89424,
+                0.88846,
+                0.88288,
+                0.88232,
+                0.88096
+            ]
+        },
+        "api.range.size.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76907,
+            "delta_pct": -23.09,
+            "ci_delta_pct": [
+                -23.17,
+                -23.02
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.03,
+                "B2/C2": -23.38,
+                "B3/C3": -22.68
+            },
+            "build_spread_pct": 0.7,
+            "builds": 3,
+            "system_ms": 1.2979,
+            "bundled_ms": 0.9964,
+            "raw_delta_pct": -23.16,
+            "spread_pct": [
+                0.9,
+                1.5
+            ],
+            "system_runs_ms": [
+                1.292,
+                1.3041,
+                1.2979,
+                1.2997,
+                1.2938,
+                1.297,
+                1.3009
+            ],
+            "bundled_runs_ms": [
+                0.9936,
+                0.9945,
+                0.9964,
+                0.9997,
+                0.9942,
+                1.0084,
+                0.9989
+            ],
+            "paired_ratios": [
+                0.76904,
+                0.76259,
+                0.7677,
+                0.76918,
+                0.76843,
+                0.77749,
+                0.76785
+            ]
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79101,
+            "delta_pct": -20.9,
+            "ci_delta_pct": [
+                -21.56,
+                -19.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.9,
+                "B2/C2": -19.14,
+                "B3/C3": -23.7
+            },
+            "build_spread_pct": 4.56,
+            "builds": 3,
+            "system_ms": 2.8764,
+            "bundled_ms": 2.2797,
+            "raw_delta_pct": -20.96,
+            "spread_pct": [
+                4.1,
+                6.3
+            ],
+            "system_runs_ms": [
+                2.8764,
+                2.8417,
+                2.9087,
+                2.7911,
+                2.8116,
+                2.9064,
+                2.9063
+            ],
+            "bundled_runs_ms": [
+                2.2638,
+                2.2965,
+                2.2797,
+                2.2964,
+                2.2712,
+                2.1535,
+                2.297
+            ],
+            "paired_ratios": [
+                0.78703,
+                0.80814,
+                0.78375,
+                0.82276,
+                0.8078,
+                0.74095,
+                0.79035
+            ]
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7731,
+            "delta_pct": -22.69,
+            "ci_delta_pct": [
+                -23.31,
+                -22.52
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.69,
+                "B2/C2": -23.55,
+                "B3/C3": -22.22
+            },
+            "build_spread_pct": 1.33,
+            "builds": 3,
+            "system_ms": 15.2226,
+            "bundled_ms": 11.747,
+            "raw_delta_pct": -22.75,
+            "spread_pct": [
+                2.4,
+                2.3
+            ],
+            "system_runs_ms": [
+                15.2072,
+                15.1779,
+                15.2312,
+                15.1958,
+                15.5395,
+                15.2226,
+                15.3532
+            ],
+            "bundled_runs_ms": [
+                11.747,
+                11.727,
+                11.6994,
+                11.7636,
+                11.7335,
+                11.9673,
+                11.7639
+            ],
+            "paired_ratios": [
+                0.77246,
+                0.77264,
+                0.76812,
+                0.77413,
+                0.75508,
+                0.78615,
+                0.76622
+            ]
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.71672,
+            "delta_pct": -28.33,
+            "ci_delta_pct": [
+                -28.59,
+                -26.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -28.45,
+                "B2/C2": -25.77,
+                "B3/C3": -29.68
+            },
+            "build_spread_pct": 3.91,
+            "builds": 3,
+            "system_ms": 4.6021,
+            "bundled_ms": 3.2957,
+            "raw_delta_pct": -28.39,
+            "spread_pct": [
+                0.6,
+                8.7
+            ],
+            "system_runs_ms": [
+                4.6021,
+                4.5926,
+                4.5991,
+                4.6097,
+                4.6081,
+                4.6225,
+                4.5984
+            ],
+            "bundled_runs_ms": [
+                3.2957,
+                3.4225,
+                3.344,
+                3.2957,
+                3.4018,
+                3.1349,
+                3.2808
+            ],
+            "paired_ratios": [
+                0.71613,
+                0.74522,
+                0.7271,
+                0.71495,
+                0.73822,
+                0.67818,
+                0.71347
+            ]
+        },
+        "api.setop.union.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78592,
+            "delta_pct": -21.41,
+            "ci_delta_pct": [
+                -22.1,
+                -20.84
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.27,
+                "B2/C2": -21.08,
+                "B3/C3": -22.01
+            },
+            "build_spread_pct": 0.93,
+            "builds": 3,
+            "system_ms": 11.5625,
+            "bundled_ms": 9.0915,
+            "raw_delta_pct": -21.47,
+            "spread_pct": [
+                0.6,
+                1.6
+            ],
+            "system_runs_ms": [
+                11.56,
+                11.5542,
+                11.619,
+                11.5625,
+                11.5776,
+                11.5519,
+                11.5975
+            ],
+            "bundled_runs_ms": [
+                9.1437,
+                9.1489,
+                9.0037,
+                9.0951,
+                9.0915,
+                9.0526,
+                9.0265
+            ],
+            "paired_ratios": [
+                0.79098,
+                0.79182,
+                0.77491,
+                0.7866,
+                0.78527,
+                0.78365,
+                0.77831
+            ]
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.80908,
+            "delta_pct": -19.09,
+            "ci_delta_pct": [
+                -19.3,
+                -18.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -19.2,
+                "B2/C2": -19.29,
+                "B3/C3": -18.97
+            },
+            "build_spread_pct": 0.32,
+            "builds": 3,
+            "system_ms": 5.3874,
+            "bundled_ms": 4.3585,
+            "raw_delta_pct": -19.16,
+            "spread_pct": [
+                1.3,
+                1.1
+            ],
+            "system_runs_ms": [
+                5.3874,
+                5.3817,
+                5.3977,
+                5.3991,
+                5.3818,
+                5.3909,
+                5.3305
+            ],
+            "bundled_runs_ms": [
+                4.3441,
+                4.3297,
+                4.3762,
+                4.3586,
+                4.3507,
+                4.3585,
+                4.3767
+            ],
+            "paired_ratios": [
+                0.80634,
+                0.80452,
+                0.81075,
+                0.80728,
+                0.80841,
+                0.80849,
+                0.82107
+            ]
+        },
+        "api.setop.diff.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83699,
+            "delta_pct": -16.3,
+            "ci_delta_pct": [
+                -16.59,
+                -16.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.35,
+                "B2/C2": -16.3,
+                "B3/C3": -15.71
+            },
+            "build_spread_pct": 0.64,
+            "builds": 3,
+            "system_ms": 5.1692,
+            "bundled_ms": 4.326,
+            "raw_delta_pct": -16.37,
+            "spread_pct": [
+                0.5,
+                1.9
+            ],
+            "system_runs_ms": [
+                5.1712,
+                5.165,
+                5.1692,
+                5.1757,
+                5.1626,
+                5.1618,
+                5.1851
+            ],
+            "bundled_runs_ms": [
+                4.3388,
+                4.3044,
+                4.3843,
+                4.326,
+                4.3324,
+                4.3168,
+                4.3013
+            ],
+            "paired_ratios": [
+                0.83903,
+                0.83338,
+                0.84816,
+                0.83583,
+                0.83919,
+                0.8363,
+                0.82955
+            ]
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.80584,
+            "delta_pct": -19.42,
+            "ci_delta_pct": [
+                -19.63,
+                -18.88
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -19.42,
+                "B2/C2": -19.07,
+                "B3/C3": -19.56
+            },
+            "build_spread_pct": 0.49,
+            "builds": 3,
+            "system_ms": 10.6187,
+            "bundled_ms": 8.5755,
+            "raw_delta_pct": -19.48,
+            "spread_pct": [
+                0.5,
+                1.4
+            ],
+            "system_runs_ms": [
+                10.6505,
+                10.6187,
+                10.6538,
+                10.6046,
+                10.6218,
+                10.6136,
+                10.6125
+            ],
+            "bundled_runs_ms": [
+                8.5755,
+                8.6071,
+                8.5766,
+                8.6403,
+                8.5679,
+                8.517,
+                8.5223
+            ],
+            "paired_ratios": [
+                0.80517,
+                0.81056,
+                0.80503,
+                0.81477,
+                0.80663,
+                0.80246,
+                0.80304
+            ]
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75148,
+            "delta_pct": -24.85,
+            "ci_delta_pct": [
+                -24.87,
+                -24.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.85,
+                "B2/C2": -24.67,
+                "B3/C3": -24.68
+            },
+            "build_spread_pct": 0.18,
+            "builds": 3,
+            "system_ms": 16.9427,
+            "bundled_ms": 12.7625,
+            "raw_delta_pct": -24.91,
+            "spread_pct": [
+                0.7,
+                0.8
+            ],
+            "system_runs_ms": [
+                16.9121,
+                16.9547,
+                16.9378,
+                16.9599,
+                17.0234,
+                16.9427,
+                16.9361
+            ],
+            "bundled_runs_ms": [
+                12.6959,
+                12.7985,
+                12.7152,
+                12.7625,
+                12.7745,
+                12.7825,
+                12.7165
+            ],
+            "paired_ratios": [
+                0.7507,
+                0.75486,
+                0.7507,
+                0.75251,
+                0.75041,
+                0.75445,
+                0.75085
+            ]
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74983,
+            "delta_pct": -25.02,
+            "ci_delta_pct": [
+                -26.03,
+                -24.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.03,
+                "B2/C2": -24.8,
+                "B3/C3": -24.38
+            },
+            "build_spread_pct": 1.65,
+            "builds": 3,
+            "system_ms": 7.0175,
+            "bundled_ms": 5.2469,
+            "raw_delta_pct": -25.08,
+            "spread_pct": [
+                1.8,
+                2.7
+            ],
+            "system_runs_ms": [
+                7.0386,
+                6.9134,
+                6.9219,
+                6.9847,
+                7.0206,
+                7.0292,
+                7.0175
+            ],
+            "bundled_runs_ms": [
+                5.2021,
+                5.2216,
+                5.2736,
+                5.2469,
+                5.2473,
+                5.2663,
+                5.1329
+            ],
+            "paired_ratios": [
+                0.73908,
+                0.75529,
+                0.76187,
+                0.7512,
+                0.74741,
+                0.7492,
+                0.73144
+            ]
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7817,
+            "delta_pct": -21.83,
+            "ci_delta_pct": [
+                -22.35,
+                -21.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.83,
+                "B2/C2": -21.83,
+                "B3/C3": -21.34
+            },
+            "build_spread_pct": 0.49,
+            "builds": 3,
+            "system_ms": 6.6378,
+            "bundled_ms": 5.1707,
+            "raw_delta_pct": -21.9,
+            "spread_pct": [
+                0.8,
+                2.4
+            ],
+            "system_runs_ms": [
+                6.6655,
+                6.6378,
+                6.6501,
+                6.6138,
+                6.6325,
+                6.6278,
+                6.6642
+            ],
+            "bundled_runs_ms": [
+                5.2251,
+                5.2226,
+                5.1675,
+                5.1657,
+                5.1421,
+                5.268,
+                5.1707
+            ],
+            "paired_ratios": [
+                0.7839,
+                0.7868,
+                0.77706,
+                0.78105,
+                0.77529,
+                0.79483,
+                0.77589
+            ]
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77135,
+            "delta_pct": -22.86,
+            "ci_delta_pct": [
+                -23.62,
+                -22.78
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.78,
+                "B2/C2": -23.24,
+                "B3/C3": -22.97
+            },
+            "build_spread_pct": 0.46,
+            "builds": 3,
+            "system_ms": 13.5618,
+            "bundled_ms": 10.4449,
+            "raw_delta_pct": -22.93,
+            "spread_pct": [
+                5,
+                1
+            ],
+            "system_runs_ms": [
+                13.5214,
+                13.5855,
+                13.5955,
+                13.5369,
+                13.5318,
+                13.5618,
+                14.1972
+            ],
+            "bundled_runs_ms": [
+                10.4323,
+                10.3682,
+                10.4449,
+                10.4753,
+                10.4291,
+                10.4562,
+                10.4595
+            ],
+            "paired_ratios": [
+                0.77154,
+                0.76318,
+                0.76826,
+                0.77383,
+                0.77071,
+                0.771,
+                0.73673
+            ]
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85204,
+            "delta_pct": -14.8,
+            "ci_delta_pct": [
+                -16.34,
+                -14.54
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.84,
+                "B2/C2": -14.45,
+                "B3/C3": -19.51
+            },
+            "build_spread_pct": 5.06,
+            "builds": 3,
+            "system_ms": 99.6884,
+            "bundled_ms": 84.9776,
+            "raw_delta_pct": -14.87,
+            "spread_pct": [
+                12.8,
+                0.5
+            ],
+            "system_runs_ms": [
+                101.5135,
+                99.6151,
+                112.248,
+                99.6884,
+                99.4955,
+                99.9089,
+                99.637
+            ],
+            "bundled_runs_ms": [
+                84.8587,
+                85.2341,
+                84.9776,
+                84.8269,
+                84.9548,
+                85.0561,
+                85.0572
+            ],
+            "paired_ratios": [
+                0.83594,
+                0.85563,
+                0.75705,
+                0.85092,
+                0.85386,
+                0.85134,
+                0.85367
+            ]
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.82869,
+            "delta_pct": -17.13,
+            "ci_delta_pct": [
+                -17.49,
+                -16.7
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.91,
+                "B2/C2": -16.92,
+                "B3/C3": -20.39
+            },
+            "build_spread_pct": 3.48,
+            "builds": 3,
+            "system_ms": 43.2909,
+            "bundled_ms": 35.8626,
+            "raw_delta_pct": -17.2,
+            "spread_pct": [
+                8.3,
+                0.6
+            ],
+            "system_runs_ms": [
+                43.4326,
+                43.2119,
+                46.7085,
+                43.2909,
+                43.2379,
+                43.4927,
+                43.1199
+            ],
+            "bundled_runs_ms": [
+                35.8626,
+                35.7796,
+                35.7999,
+                35.9413,
+                35.986,
+                35.8563,
+                35.9512
+            ],
+            "paired_ratios": [
+                0.82571,
+                0.828,
+                0.76645,
+                0.83023,
+                0.83228,
+                0.82442,
+                0.83375
+            ]
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.82094,
+            "delta_pct": -17.91,
+            "ci_delta_pct": [
+                -18.08,
+                -17.83
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -17.91,
+                "B2/C2": -17.75,
+                "B3/C3": -20.22
+            },
+            "build_spread_pct": 2.47,
+            "builds": 3,
+            "system_ms": 39.614,
+            "bundled_ms": 32.4669,
+            "raw_delta_pct": -17.97,
+            "spread_pct": [
+                5.8,
+                0.3
+            ],
+            "system_runs_ms": [
+                39.5438,
+                39.4939,
+                41.798,
+                39.6205,
+                39.532,
+                39.7095,
+                39.614
+            ],
+            "bundled_runs_ms": [
+                32.4669,
+                32.5158,
+                32.4237,
+                32.4992,
+                32.4286,
+                32.5033,
+                32.4457
+            ],
+            "paired_ratios": [
+                0.82104,
+                0.82331,
+                0.77572,
+                0.82026,
+                0.82031,
+                0.81853,
+                0.81905
+            ]
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79794,
+            "delta_pct": -20.21,
+            "ci_delta_pct": [
+                -20.49,
+                -19.97
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.25,
+                "B2/C2": -19.73,
+                "B3/C3": -20.35
+            },
+            "build_spread_pct": 0.62,
+            "builds": 3,
+            "system_ms": 18.6383,
+            "bundled_ms": 14.8737,
+            "raw_delta_pct": -20.27,
+            "spread_pct": [
+                0.2,
+                1.2
+            ],
+            "system_runs_ms": [
+                18.6406,
+                18.6173,
+                18.6383,
+                18.6345,
+                18.6358,
+                18.6557,
+                18.6506
+            ],
+            "bundled_runs_ms": [
+                14.796,
+                14.9747,
+                14.8068,
+                14.8481,
+                14.9026,
+                14.8737,
+                14.8878
+            ],
+            "paired_ratios": [
+                0.79375,
+                0.80434,
+                0.79443,
+                0.79681,
+                0.79968,
+                0.79727,
+                0.79825
+            ]
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84759,
+            "delta_pct": -15.24,
+            "ci_delta_pct": [
+                -15.46,
+                -14.91
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.24,
+                "B2/C2": -15.02,
+                "B3/C3": -22.15
+            },
+            "build_spread_pct": 7.13,
+            "builds": 3,
+            "system_ms": 79.8668,
+            "bundled_ms": 67.6739,
+            "raw_delta_pct": -15.31,
+            "spread_pct": [
+                19.4,
+                3.1
+            ],
+            "system_runs_ms": [
+                79.8668,
+                79.6992,
+                95.0965,
+                79.9092,
+                79.6036,
+                80.1801,
+                79.8113
+            ],
+            "bundled_runs_ms": [
+                67.5804,
+                67.7568,
+                67.6124,
+                67.6739,
+                67.5049,
+                67.7307,
+                69.5787
+            ],
+            "paired_ratios": [
+                0.84616,
+                0.85016,
+                0.71099,
+                0.84688,
+                0.84801,
+                0.84473,
+                0.87179
+            ]
+        },
+        "adv.forEach.int_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.95638,
+            "delta_pct": -4.36,
+            "ci_delta_pct": [
+                -4.87,
+                -1.88
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.84,
+                "B2/C2": -3.12,
+                "B3/C3": -6.98
+            },
+            "build_spread_pct": 4.14,
+            "builds": 3,
+            "system_ms": 10.0129,
+            "bundled_ms": 9.5925,
+            "raw_delta_pct": -4.44,
+            "spread_pct": [
+                6.4,
+                4.6
+            ],
+            "system_runs_ms": [
+                10.0129,
+                10.0922,
+                10.0386,
+                9.5717,
+                9.8436,
+                10.21,
+                9.9544
+            ],
+            "bundled_runs_ms": [
+                9.72,
+                9.644,
+                9.5418,
+                9.5925,
+                9.651,
+                9.2749,
+                9.4849
+            ],
+            "paired_ratios": [
+                0.97075,
+                0.95559,
+                0.95051,
+                1.00217,
+                0.98043,
+                0.90841,
+                0.95283
+            ]
+        },
+        "adv.forEach.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90915,
+            "delta_pct": -9.09,
+            "ci_delta_pct": [
+                -9.58,
+                -8.97
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.09,
+                "B2/C2": -7.98,
+                "B3/C3": -9.36
+            },
+            "build_spread_pct": 1.38,
+            "builds": 3,
+            "system_ms": 18.5924,
+            "bundled_ms": 16.8375,
+            "raw_delta_pct": -9.16,
+            "spread_pct": [
+                1.2,
+                3.2
+            ],
+            "system_runs_ms": [
+                18.6094,
+                18.6312,
+                18.5429,
+                18.7285,
+                18.5924,
+                18.589,
+                18.5111
+            ],
+            "bundled_runs_ms": [
+                16.8135,
+                17.326,
+                16.8375,
+                17.0128,
+                16.9005,
+                16.7914,
+                16.8373
+            ],
+            "paired_ratios": [
+                0.9035,
+                0.92995,
+                0.90803,
+                0.90839,
+                0.909,
+                0.9033,
+                0.90958
+            ]
+        },
+        "adv.filter.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93458,
+            "delta_pct": -6.54,
+            "ci_delta_pct": [
+                -7.03,
+                -5.69
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.54,
+                "B2/C2": -5.46,
+                "B3/C3": -7.46
+            },
+            "build_spread_pct": 2,
+            "builds": 3,
+            "system_ms": 14.9476,
+            "bundled_ms": 13.9192,
+            "raw_delta_pct": -6.62,
+            "spread_pct": [
+                4.4,
+                5.7
+            ],
+            "system_runs_ms": [
+                14.9617,
+                15.4378,
+                14.9848,
+                14.8985,
+                14.7835,
+                14.9476,
+                14.8298
+            ],
+            "bundled_runs_ms": [
+                14.048,
+                14.5472,
+                13.9192,
+                13.903,
+                13.9977,
+                13.757,
+                13.8482
+            ],
+            "paired_ratios": [
+                0.93893,
+                0.94231,
+                0.92889,
+                0.93318,
+                0.94685,
+                0.92035,
+                0.93381
+            ]
+        },
+        "adv.filter.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90951,
+            "delta_pct": -9.05,
+            "ci_delta_pct": [
+                -9.3,
+                -8.93
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.97,
+                "B2/C2": -10.05,
+                "B3/C3": -8.73
+            },
+            "build_spread_pct": 1.32,
+            "builds": 3,
+            "system_ms": 40.4695,
+            "bundled_ms": 36.7611,
+            "raw_delta_pct": -9.12,
+            "spread_pct": [
+                2.9,
+                1.3
+            ],
+            "system_runs_ms": [
+                40.5897,
+                41.4165,
+                40.4695,
+                40.3493,
+                40.5663,
+                40.303,
+                40.2532
+            ],
+            "bundled_runs_ms": [
+                36.9198,
+                36.9169,
+                37.0348,
+                36.7172,
+                36.7611,
+                36.6254,
+                36.5541
+            ],
+            "paired_ratios": [
+                0.90959,
+                0.89136,
+                0.91513,
+                0.90998,
+                0.9062,
+                0.90875,
+                0.9081
+            ]
+        },
+        "adv.map.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92664,
+            "delta_pct": -7.34,
+            "ci_delta_pct": [
+                -7.83,
+                -6.92
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.34,
+                "B2/C2": -7.37,
+                "B3/C3": -7.14
+            },
+            "build_spread_pct": 0.23,
+            "builds": 3,
+            "system_ms": 15.7623,
+            "bundled_ms": 14.6071,
+            "raw_delta_pct": -7.41,
+            "spread_pct": [
+                0.9,
+                1.6
+            ],
+            "system_runs_ms": [
+                15.7489,
+                15.7775,
+                15.7091,
+                15.8152,
+                15.8556,
+                15.7561,
+                15.7623
+            ],
+            "bundled_runs_ms": [
+                14.6071,
+                14.6738,
+                14.7141,
+                14.6113,
+                14.6019,
+                14.4803,
+                14.5939
+            ],
+            "paired_ratios": [
+                0.9275,
+                0.93005,
+                0.93666,
+                0.92388,
+                0.92093,
+                0.91903,
+                0.92587
+            ]
+        },
+        "adv.map.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90837,
+            "delta_pct": -9.16,
+            "ci_delta_pct": [
+                -9.57,
+                -9.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.57,
+                "B2/C2": -9.08,
+                "B3/C3": -9.36
+            },
+            "build_spread_pct": 0.49,
+            "builds": 3,
+            "system_ms": 55.0613,
+            "bundled_ms": 49.9615,
+            "raw_delta_pct": -9.24,
+            "spread_pct": [
+                3.1,
+                0.9
+            ],
+            "system_runs_ms": [
+                56.6267,
+                55.0613,
+                55.2782,
+                54.934,
+                55.0372,
+                55.0852,
+                55.0483
+            ],
+            "bundled_runs_ms": [
+                49.9545,
+                50.0013,
+                50.1712,
+                49.9615,
+                50.0138,
+                49.7844,
+                49.7411
+            ],
+            "paired_ratios": [
+                0.88217,
+                0.9081,
+                0.90761,
+                0.90948,
+                0.90873,
+                0.90377,
+                0.90359
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91869,
+            "delta_pct": -8.13,
+            "ci_delta_pct": [
+                -8.16,
+                -7.64
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.16,
+                "B2/C2": -7.76,
+                "B3/C3": -8.13
+            },
+            "build_spread_pct": 0.4,
+            "builds": 3,
+            "system_ms": 24.1615,
+            "bundled_ms": 22.2174,
+            "raw_delta_pct": -8.21,
+            "spread_pct": [
+                0.5,
+                0.7
+            ],
+            "system_runs_ms": [
+                24.2477,
+                24.1366,
+                24.1615,
+                24.1827,
+                24.1375,
+                24.1974,
+                24.1568
+            ],
+            "bundled_runs_ms": [
+                22.2504,
+                22.2174,
+                22.1772,
+                22.1861,
+                22.2752,
+                22.2115,
+                22.3315
+            ],
+            "paired_ratios": [
+                0.91763,
+                0.92049,
+                0.91787,
+                0.91744,
+                0.92285,
+                0.91793,
+                0.92444
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8984,
+            "delta_pct": -10.16,
+            "ci_delta_pct": [
+                -10.3,
+                -9.71
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.16,
+                "B2/C2": -9.95,
+                "B3/C3": -10.03
+            },
+            "build_spread_pct": 0.21,
+            "builds": 3,
+            "system_ms": 14.6361,
+            "bundled_ms": 13.1339,
+            "raw_delta_pct": -10.23,
+            "spread_pct": [
+                2,
+                0.5
+            ],
+            "system_runs_ms": [
+                14.82,
+                14.6399,
+                14.6361,
+                14.5245,
+                14.5664,
+                14.5668,
+                14.6608
+            ],
+            "bundled_runs_ms": [
+                13.1744,
+                13.1336,
+                13.1173,
+                13.1028,
+                13.1447,
+                13.1339,
+                13.1604
+            ],
+            "paired_ratios": [
+                0.88896,
+                0.89711,
+                0.89623,
+                0.90212,
+                0.9024,
+                0.90163,
+                0.89766
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.97723,
+            "delta_pct": -2.28,
+            "ci_delta_pct": [
+                -2.82,
+                -1.69
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.82,
+                "B2/C2": -2.3,
+                "B3/C3": -1.99
+            },
+            "build_spread_pct": 0.83,
+            "builds": 3,
+            "system_ms": 60.576,
+            "bundled_ms": 59.1143,
+            "raw_delta_pct": -2.36,
+            "spread_pct": [
+                1.7,
+                0.5
+            ],
+            "system_runs_ms": [
+                61.1191,
+                60.6543,
+                60.576,
+                60.0617,
+                60.3475,
+                60.1997,
+                60.69
+            ],
+            "bundled_runs_ms": [
+                59.2096,
+                59.1143,
+                59.1477,
+                59.0586,
+                59.0103,
+                59.1311,
+                58.9318
+            ],
+            "paired_ratios": [
+                0.96876,
+                0.97461,
+                0.97642,
+                0.9833,
+                0.97784,
+                0.98225,
+                0.97103
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92481,
+            "delta_pct": -7.52,
+            "ci_delta_pct": [
+                -7.66,
+                -7.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.59,
+                "B2/C2": -7.35,
+                "B3/C3": -7.58
+            },
+            "build_spread_pct": 0.24,
+            "builds": 3,
+            "system_ms": 22.3001,
+            "bundled_ms": 20.6063,
+            "raw_delta_pct": -7.6,
+            "spread_pct": [
+                9.9,
+                0.5
+            ],
+            "system_runs_ms": [
+                24.4772,
+                22.2859,
+                22.3071,
+                22.2959,
+                22.3001,
+                22.3006,
+                22.2806
+            ],
+            "bundled_runs_ms": [
+                20.568,
+                20.6704,
+                20.5821,
+                20.616,
+                20.6063,
+                20.6099,
+                20.5727
+            ],
+            "paired_ratios": [
+                0.84029,
+                0.92751,
+                0.92267,
+                0.92465,
+                0.92405,
+                0.92419,
+                0.92335
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85387,
+            "delta_pct": -14.61,
+            "ci_delta_pct": [
+                -14.99,
+                -14.47
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.99,
+                "B2/C2": -14.55,
+                "B3/C3": -14.36
+            },
+            "build_spread_pct": 0.63,
+            "builds": 3,
+            "system_ms": 12.3504,
+            "bundled_ms": 10.5413,
+            "raw_delta_pct": -14.68,
+            "spread_pct": [
+                5.3,
+                0.5
+            ],
+            "system_runs_ms": [
+                12.9846,
+                12.3307,
+                12.3265,
+                12.3556,
+                12.3336,
+                12.3504,
+                12.435
+            ],
+            "bundled_runs_ms": [
+                10.5163,
+                10.5382,
+                10.5714,
+                10.5413,
+                10.521,
+                10.5436,
+                10.562
+            ],
+            "paired_ratios": [
+                0.80991,
+                0.85463,
+                0.85762,
+                0.85316,
+                0.85304,
+                0.85371,
+                0.84938
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92392,
+            "delta_pct": -7.61,
+            "ci_delta_pct": [
+                -7.78,
+                -6.97
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.66,
+                "B2/C2": -7.69,
+                "B3/C3": -7.26
+            },
+            "build_spread_pct": 0.43,
+            "builds": 3,
+            "system_ms": 55.3294,
+            "bundled_ms": 51.1316,
+            "raw_delta_pct": -7.68,
+            "spread_pct": [
+                5,
+                0.7
+            ],
+            "system_runs_ms": [
+                53.0479,
+                55.3294,
+                55.2583,
+                55.4164,
+                55.3071,
+                55.3815,
+                55.8107
+            ],
+            "bundled_runs_ms": [
+                51.1295,
+                50.9819,
+                51.3621,
+                51.1316,
+                51.0571,
+                51.1578,
+                51.3398
+            ],
+            "paired_ratios": [
+                0.96384,
+                0.92143,
+                0.92949,
+                0.92268,
+                0.92316,
+                0.92373,
+                0.91989
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9443,
+            "delta_pct": -5.57,
+            "ci_delta_pct": [
+                -6.29,
+                -5.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.57,
+                "B2/C2": -5.41,
+                "B3/C3": -5.99
+            },
+            "build_spread_pct": 0.58,
+            "builds": 3,
+            "system_ms": 31.0492,
+            "bundled_ms": 29.2581,
+            "raw_delta_pct": -5.65,
+            "spread_pct": [
+                5.2,
+                0.5
+            ],
+            "system_runs_ms": [
+                32.5906,
+                30.9995,
+                31.0492,
+                30.985,
+                30.9802,
+                31.2326,
+                31.0571
+            ],
+            "bundled_runs_ms": [
+                29.2161,
+                29.2581,
+                29.2593,
+                29.2347,
+                29.3173,
+                29.2428,
+                29.3526
+            ],
+            "paired_ratios": [
+                0.89646,
+                0.94382,
+                0.94235,
+                0.94351,
+                0.94632,
+                0.93629,
+                0.94512
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91678,
+            "delta_pct": -8.32,
+            "ci_delta_pct": [
+                -8.47,
+                -8.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.47,
+                "B2/C2": -7.79,
+                "B3/C3": -8.24
+            },
+            "build_spread_pct": 0.68,
+            "builds": 3,
+            "system_ms": 19.5285,
+            "bundled_ms": 17.8885,
+            "raw_delta_pct": -8.4,
+            "spread_pct": [
+                1.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                19.6834,
+                19.5258,
+                19.5367,
+                19.5348,
+                19.3661,
+                19.5285,
+                19.4954
+            ],
+            "bundled_runs_ms": [
+                17.9147,
+                17.8653,
+                17.9298,
+                17.8646,
+                17.966,
+                17.8885,
+                17.8818
+            ],
+            "paired_ratios": [
+                0.91014,
+                0.91496,
+                0.91775,
+                0.9145,
+                0.9277,
+                0.91602,
+                0.91723
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.9747,
+            "delta_pct": -2.53,
+            "ci_delta_pct": [
+                -2.98,
+                -1.89
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.87,
+                "B2/C2": -2.43,
+                "B3/C3": -2.31
+            },
+            "build_spread_pct": 0.56,
+            "builds": 3,
+            "system_ms": 62.7729,
+            "bundled_ms": 61.1724,
+            "raw_delta_pct": -2.61,
+            "spread_pct": [
+                4.2,
+                0.6
+            ],
+            "system_runs_ms": [
+                60.3958,
+                62.9874,
+                62.9218,
+                63.0461,
+                62.5112,
+                62.5258,
+                62.7729
+            ],
+            "bundled_runs_ms": [
+                61.3178,
+                61.0613,
+                61.2792,
+                61.1077,
+                61.2813,
+                61.1724,
+                60.9206
+            ],
+            "paired_ratios": [
+                1.01527,
+                0.96942,
+                0.97389,
+                0.96925,
+                0.98033,
+                0.97835,
+                0.97049
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.97183,
+            "delta_pct": -2.82,
+            "ci_delta_pct": [
+                -3.28,
+                -2.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.82,
+                "B2/C2": -2.68,
+                "B3/C3": -2.94
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 16.6124,
+            "bundled_ms": 16.1128,
+            "raw_delta_pct": -2.9,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                16.5658,
+                16.5426,
+                16.673,
+                16.5423,
+                16.6272,
+                16.6124,
+                16.7295
+            ],
+            "bundled_runs_ms": [
+                16.1085,
+                16.1767,
+                16.1128,
+                16.0629,
+                16.0753,
+                16.1664,
+                16.126
+            ],
+            "paired_ratios": [
+                0.97239,
+                0.97788,
+                0.9664,
+                0.97102,
+                0.96681,
+                0.97315,
+                0.96393
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95252,
+            "delta_pct": -4.75,
+            "ci_delta_pct": [
+                -4.83,
+                -4.62
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.77,
+                "B2/C2": -4.6,
+                "B3/C3": -4.68
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 19.8585,
+            "bundled_ms": 18.9,
+            "raw_delta_pct": -4.83,
+            "spread_pct": [
+                0.6,
+                0.7
+            ],
+            "system_runs_ms": [
+                19.8973,
+                19.824,
+                19.8585,
+                19.9417,
+                19.9289,
+                19.831,
+                19.8332
+            ],
+            "bundled_runs_ms": [
+                18.8345,
+                18.9406,
+                18.9,
+                18.9755,
+                18.9502,
+                18.8997,
+                18.8989
+            ],
+            "paired_ratios": [
+                0.94659,
+                0.95544,
+                0.95173,
+                0.95155,
+                0.95089,
+                0.95304,
+                0.95289
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.98077,
+            "delta_pct": -1.92,
+            "ci_delta_pct": [
+                -2.21,
+                -1.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.92,
+                "B2/C2": -1.89,
+                "B3/C3": -1.71
+            },
+            "build_spread_pct": 0.21,
+            "builds": 3,
+            "system_ms": 119.8362,
+            "bundled_ms": 117.1954,
+            "raw_delta_pct": -2,
+            "spread_pct": [
+                1.7,
+                1
+            ],
+            "system_runs_ms": [
+                120.1108,
+                119.8362,
+                119.1052,
+                120.5492,
+                119.8569,
+                119.3743,
+                118.5523
+            ],
+            "bundled_runs_ms": [
+                116.9227,
+                117.086,
+                117.2982,
+                118.1323,
+                117.8839,
+                116.9075,
+                117.1954
+            ],
+            "paired_ratios": [
+                0.97346,
+                0.97705,
+                0.98483,
+                0.97995,
+                0.98354,
+                0.97934,
+                0.98855
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.96578,
+            "delta_pct": -3.42,
+            "ci_delta_pct": [
+                -3.54,
+                -2.98
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.45,
+                "B2/C2": -2.98,
+                "B3/C3": -3.5
+            },
+            "build_spread_pct": 0.52,
+            "builds": 3,
+            "system_ms": 16.6683,
+            "bundled_ms": 16.1122,
+            "raw_delta_pct": -3.5,
+            "spread_pct": [
+                0.7,
+                0.8
+            ],
+            "system_runs_ms": [
+                16.6669,
+                16.6832,
+                16.7356,
+                16.6237,
+                16.6215,
+                16.6683,
+                16.7048
+            ],
+            "bundled_runs_ms": [
+                16.0642,
+                16.1737,
+                16.1228,
+                16.0368,
+                16.1122,
+                16.0845,
+                16.1619
+            ],
+            "paired_ratios": [
+                0.96384,
+                0.96946,
+                0.96338,
+                0.96469,
+                0.96936,
+                0.96498,
+                0.9675
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9507,
+            "delta_pct": -4.93,
+            "ci_delta_pct": [
+                -5.09,
+                -4.71
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5,
+                "B2/C2": -5.38,
+                "B3/C3": -4.63
+            },
+            "build_spread_pct": 0.75,
+            "builds": 3,
+            "system_ms": 20.0083,
+            "bundled_ms": 19.0209,
+            "raw_delta_pct": -5.01,
+            "spread_pct": [
+                1.6,
+                0.5
+            ],
+            "system_runs_ms": [
+                20.0269,
+                20.2777,
+                19.9776,
+                20.0138,
+                20.0083,
+                19.9646,
+                19.9585
+            ],
+            "bundled_runs_ms": [
+                18.992,
+                19.035,
+                19.0209,
+                18.9974,
+                19.0504,
+                19.0421,
+                18.9588
+            ],
+            "paired_ratios": [
+                0.94832,
+                0.93872,
+                0.95211,
+                0.94922,
+                0.95212,
+                0.95379,
+                0.94991
+            ]
+        },
+        "adv.optiter.ratio.increment.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.98472,
+            "delta_pct": -1.53,
+            "ci_delta_pct": [
+                -1.74,
+                -1.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.53,
+                "B2/C2": -2.39,
+                "B3/C3": -1.08
+            },
+            "build_spread_pct": 1.31,
+            "builds": 3,
+            "system_ms": 120.1599,
+            "bundled_ms": 118.2258,
+            "raw_delta_pct": -1.61,
+            "spread_pct": [
+                1.8,
+                1
+            ],
+            "system_runs_ms": [
+                120.1599,
+                121.5453,
+                119.3719,
+                120.3928,
+                120.376,
+                119.7764,
+                119.4778
+            ],
+            "bundled_runs_ms": [
+                118.2258,
+                117.6911,
+                117.9746,
+                118.4614,
+                118.2361,
+                118.3875,
+                117.306
+            ],
+            "paired_ratios": [
+                0.9839,
+                0.96829,
+                0.98829,
+                0.98396,
+                0.98222,
+                0.9884,
+                0.98182
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94233,
+            "delta_pct": -5.77,
+            "ci_delta_pct": [
+                -5.88,
+                -5.58
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.77,
+                "B2/C2": -5.56,
+                "B3/C3": -5.91
+            },
+            "build_spread_pct": 0.35,
+            "builds": 3,
+            "system_ms": 32.3099,
+            "bundled_ms": 30.4135,
+            "raw_delta_pct": -5.85,
+            "spread_pct": [
+                0.2,
+                0.2
+            ],
+            "system_runs_ms": [
+                32.2912,
+                32.2642,
+                32.3418,
+                32.3099,
+                32.2721,
+                32.3417,
+                32.3105
+            ],
+            "bundled_runs_ms": [
+                30.4054,
+                30.4377,
+                30.3941,
+                30.4213,
+                30.4587,
+                30.4135,
+                30.3856
+            ],
+            "paired_ratios": [
+                0.9416,
+                0.94339,
+                0.93978,
+                0.94155,
+                0.94381,
+                0.94038,
+                0.94042
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88653,
+            "delta_pct": -11.35,
+            "ci_delta_pct": [
+                -11.84,
+                -10.69
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.35,
+                "B2/C2": -10.13,
+                "B3/C3": -11.94
+            },
+            "build_spread_pct": 1.81,
+            "builds": 3,
+            "system_ms": 16.044,
+            "bundled_ms": 14.2031,
+            "raw_delta_pct": -11.42,
+            "spread_pct": [
+                1.3,
+                3.1
+            ],
+            "system_runs_ms": [
+                15.994,
+                16.1683,
+                16.2016,
+                16.1176,
+                16.0267,
+                16.044,
+                16.0344
+            ],
+            "bundled_runs_ms": [
+                14.2521,
+                14.609,
+                14.196,
+                14.1969,
+                14.3022,
+                14.174,
+                14.2031
+            ],
+            "paired_ratios": [
+                0.89109,
+                0.90356,
+                0.87621,
+                0.88083,
+                0.8924,
+                0.88345,
+                0.88579
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94269,
+            "delta_pct": -5.73,
+            "ci_delta_pct": [
+                -6.37,
+                -5.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.73,
+                "B2/C2": -4.76,
+                "B3/C3": -6.33
+            },
+            "build_spread_pct": 1.57,
+            "builds": 3,
+            "system_ms": 49.6613,
+            "bundled_ms": 46.7429,
+            "raw_delta_pct": -5.81,
+            "spread_pct": [
+                1.2,
+                3
+            ],
+            "system_runs_ms": [
+                49.5305,
+                50.1122,
+                50.0949,
+                49.8845,
+                49.6613,
+                49.6078,
+                49.6259
+            ],
+            "bundled_runs_ms": [
+                46.8737,
+                47.9964,
+                46.7064,
+                46.6677,
+                46.9559,
+                46.6043,
+                46.7429
+            ],
+            "paired_ratios": [
+                0.94636,
+                0.95778,
+                0.93236,
+                0.93552,
+                0.94552,
+                0.93946,
+                0.94191
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93937,
+            "delta_pct": -6.06,
+            "ci_delta_pct": [
+                -6.15,
+                -5.82
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.12,
+                "B2/C2": -5.73,
+                "B3/C3": -6.1
+            },
+            "build_spread_pct": 0.39,
+            "builds": 3,
+            "system_ms": 31.1228,
+            "bundled_ms": 29.2238,
+            "raw_delta_pct": -6.14,
+            "spread_pct": [
+                0.4,
+                0.6
+            ],
+            "system_runs_ms": [
+                31.1228,
+                31.2029,
+                31.1633,
+                31.1185,
+                31.0982,
+                31.0933,
+                31.124
+            ],
+            "bundled_runs_ms": [
+                29.1926,
+                29.3479,
+                29.2238,
+                29.2828,
+                29.3323,
+                29.1838,
+                29.1665
+            ],
+            "paired_ratios": [
+                0.93798,
+                0.94055,
+                0.93776,
+                0.94101,
+                0.94322,
+                0.93859,
+                0.93711
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87353,
+            "delta_pct": -12.65,
+            "ci_delta_pct": [
+                -13.85,
+                -12.63
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.85,
+                "B2/C2": -12.56,
+                "B3/C3": -12.64
+            },
+            "build_spread_pct": 0.29,
+            "builds": 3,
+            "system_ms": 14.2894,
+            "bundled_ms": 12.4657,
+            "raw_delta_pct": -12.72,
+            "spread_pct": [
+                1.3,
+                1.8
+            ],
+            "system_runs_ms": [
+                14.3169,
+                14.4371,
+                14.2894,
+                14.4429,
+                14.2607,
+                14.2824,
+                14.2785
+            ],
+            "bundled_runs_ms": [
+                12.4674,
+                12.4214,
+                12.4738,
+                12.4323,
+                12.6485,
+                12.4657,
+                12.4653
+            ],
+            "paired_ratios": [
+                0.87082,
+                0.86038,
+                0.87294,
+                0.86079,
+                0.88695,
+                0.8728,
+                0.87301
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93069,
+            "delta_pct": -6.93,
+            "ci_delta_pct": [
+                -8.45,
+                -6.76
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.08,
+                "B2/C2": -7.17,
+                "B3/C3": -6.88
+            },
+            "build_spread_pct": 0.29,
+            "builds": 3,
+            "system_ms": 45.9339,
+            "bundled_ms": 42.7074,
+            "raw_delta_pct": -7.01,
+            "spread_pct": [
+                1.2,
+                1.9
+            ],
+            "system_runs_ms": [
+                46.0013,
+                46.2685,
+                45.8533,
+                46.4125,
+                45.8569,
+                45.9339,
+                45.8762
+            ],
+            "bundled_runs_ms": [
+                42.7074,
+                42.3246,
+                42.6836,
+                42.4559,
+                43.1213,
+                42.7147,
+                42.7383
+            ],
+            "paired_ratios": [
+                0.9284,
+                0.91476,
+                0.93087,
+                0.91475,
+                0.94034,
+                0.92992,
+                0.9316
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94177,
+            "delta_pct": -5.82,
+            "ci_delta_pct": [
+                -5.94,
+                -5.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.94,
+                "B2/C2": -5.47,
+                "B3/C3": -5.68
+            },
+            "build_spread_pct": 0.47,
+            "builds": 3,
+            "system_ms": 42.043,
+            "bundled_ms": 39.5352,
+            "raw_delta_pct": -5.9,
+            "spread_pct": [
+                2.2,
+                0.8
+            ],
+            "system_runs_ms": [
+                42.7585,
+                42.0448,
+                41.9145,
+                42.043,
+                41.8827,
+                41.8534,
+                42.0815
+            ],
+            "bundled_runs_ms": [
+                39.4871,
+                39.5521,
+                39.5352,
+                39.5121,
+                39.7157,
+                39.4088,
+                39.5982
+            ],
+            "paired_ratios": [
+                0.92349,
+                0.94071,
+                0.94323,
+                0.9398,
+                0.94826,
+                0.94159,
+                0.94099
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93449,
+            "delta_pct": -6.55,
+            "ci_delta_pct": [
+                -7.16,
+                -6.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.55,
+                "B2/C2": -6.44,
+                "B3/C3": -7.14
+            },
+            "build_spread_pct": 0.7,
+            "builds": 3,
+            "system_ms": 23.2482,
+            "bundled_ms": 21.6948,
+            "raw_delta_pct": -6.63,
+            "spread_pct": [
+                0.3,
+                2.4
+            ],
+            "system_runs_ms": [
+                23.2909,
+                23.2345,
+                23.2506,
+                23.2562,
+                23.2181,
+                23.2365,
+                23.2482
+            ],
+            "bundled_runs_ms": [
+                22.0892,
+                21.6948,
+                21.5671,
+                21.5653,
+                21.7293,
+                21.5647,
+                21.7072
+            ],
+            "paired_ratios": [
+                0.9484,
+                0.93373,
+                0.92759,
+                0.92729,
+                0.93588,
+                0.92805,
+                0.93372
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.98776,
+            "delta_pct": -1.22,
+            "ci_delta_pct": [
+                -1.36,
+                -0.66
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.69,
+                "B2/C2": -0.94,
+                "B3/C3": -1.47
+            },
+            "build_spread_pct": 0.78,
+            "builds": 3,
+            "system_ms": 55.3152,
+            "bundled_ms": 54.7204,
+            "raw_delta_pct": -1.31,
+            "spread_pct": [
+                1.9,
+                2.5
+            ],
+            "system_runs_ms": [
+                54.4707,
+                55.2612,
+                55.4716,
+                55.3152,
+                55.4359,
+                55.5188,
+                55.2457
+            ],
+            "bundled_runs_ms": [
+                55.9403,
+                54.8512,
+                54.5516,
+                54.5791,
+                54.712,
+                54.7204,
+                54.8187
+            ],
+            "paired_ratios": [
+                1.02698,
+                0.99258,
+                0.98341,
+                0.98669,
+                0.98694,
+                0.98562,
+                0.99227
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.9723,
+            "delta_pct": -2.77,
+            "ci_delta_pct": [
+                -3.63,
+                -1.85
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.66,
+                "B2/C2": -2.31,
+                "B3/C3": -3.38
+            },
+            "build_spread_pct": 1.07,
+            "builds": 3,
+            "system_ms": 24.9209,
+            "bundled_ms": 24.2149,
+            "raw_delta_pct": -2.85,
+            "spread_pct": [
+                10.9,
+                1.3
+            ],
+            "system_runs_ms": [
+                27.3914,
+                24.8856,
+                25.0189,
+                24.6783,
+                24.9209,
+                25.0558,
+                24.8139
+            ],
+            "bundled_runs_ms": [
+                24.2245,
+                24.1763,
+                24.2149,
+                24.3607,
+                24.439,
+                24.1263,
+                24.1346
+            ],
+            "paired_ratios": [
+                0.88438,
+                0.9715,
+                0.96786,
+                0.98713,
+                0.98066,
+                0.9629,
+                0.97262
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.9687,
+            "delta_pct": -3.13,
+            "ci_delta_pct": [
+                -3.23,
+                -2.88
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.23,
+                "B2/C2": -3.03,
+                "B3/C3": -3.03
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 27.1703,
+            "bundled_ms": 26.328,
+            "raw_delta_pct": -3.21,
+            "spread_pct": [
+                9,
+                5.4
+            ],
+            "system_runs_ms": [
+                29.5458,
+                27.1464,
+                27.1777,
+                27.1038,
+                27.1703,
+                27.1506,
+                27.2306
+            ],
+            "bundled_runs_ms": [
+                27.727,
+                26.3267,
+                26.2936,
+                26.3651,
+                26.2981,
+                26.3466,
+                26.328
+            ],
+            "paired_ratios": [
+                0.93844,
+                0.9698,
+                0.96747,
+                0.97275,
+                0.9679,
+                0.97039,
+                0.96685
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 0.99909,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -1.22,
+                0.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.51,
+                "B2/C2": -0.66,
+                "B3/C3": 0.45
+            },
+            "build_spread_pct": 1.11,
+            "builds": 3,
+            "system_ms": 109.0263,
+            "bundled_ms": 108.895,
+            "raw_delta_pct": -0.17,
+            "spread_pct": [
+                1.8,
+                6.3
+            ],
+            "system_runs_ms": [
+                107.8652,
+                109.0847,
+                108.6289,
+                109.8286,
+                109.0263,
+                108.3604,
+                109.7393
+            ],
+            "bundled_runs_ms": [
+                114.4586,
+                108.895,
+                108.5845,
+                108.2279,
+                107.6071,
+                109.2029,
+                109.0882
+            ],
+            "paired_ratios": [
+                1.06113,
+                0.99826,
+                0.99959,
+                0.98543,
+                0.98698,
+                1.00777,
+                0.99407
+            ]
+        }
+    },
+    "array_vs_bundled": {
+        "core.bitset.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.70366,
+            "delta_pct": 70.37,
+            "ci_delta_pct": [
+                67.16,
+                72.46
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.9962,
+                3.0134,
+                3.0435,
+                3.0498,
+                2.9734,
+                3.0725,
+                3.1023
+            ],
+            "judy_runs_ms": [
+                5.1471,
+                5.1338,
+                5.095,
+                5.098,
+                5.1278,
+                5.1063,
+                5.3571
+            ],
+            "array_ms": 3.0435,
+            "judy_ms": 5.1278,
+            "judy_over_array": 1.685,
+            "winner": "php-array"
+        },
+        "core.bitset.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.15461,
+            "delta_pct": 215.46,
+            "ci_delta_pct": [
+                213.36,
+                216.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.0737,
+                1.0698,
+                1.0699,
+                1.0811,
+                1.0688,
+                1.0763,
+                1.117
+            ],
+            "judy_runs_ms": [
+                3.3646,
+                3.3748,
+                3.3768,
+                3.4197,
+                3.3626,
+                3.4027,
+                3.4217
+            ],
+            "array_ms": 1.0737,
+            "judy_ms": 3.3768,
+            "judy_over_array": 3.145,
+            "winner": "php-array"
+        },
+        "core.bitset.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.80142,
+            "delta_pct": 480.14,
+            "ci_delta_pct": [
+                478.44,
+                492.27
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9125,
+                0.9125,
+                0.9173,
+                0.9132,
+                0.9324,
+                0.9131,
+                0.9334
+            ],
+            "judy_runs_ms": [
+                5.2938,
+                5.2783,
+                5.3388,
+                5.2868,
+                5.2286,
+                5.408,
+                5.5918
+            ],
+            "array_ms": 0.9132,
+            "judy_ms": 5.2938,
+            "judy_over_array": 5.797,
+            "winner": "php-array"
+        },
+        "core.int_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.33018,
+            "delta_pct": 133.02,
+            "ci_delta_pct": [
+                128.24,
+                134.47
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                3.1263,
+                3.0263,
+                3.0667,
+                3.0474,
+                3.2115,
+                3.0421,
+                3.0732
+            ],
+            "judy_runs_ms": [
+                7.1355,
+                7.0958,
+                7.1931,
+                7.101,
+                7.109,
+                7.1185,
+                7.0812
+            ],
+            "array_ms": 3.0667,
+            "judy_ms": 7.109,
+            "judy_over_array": 2.318,
+            "winner": "php-array"
+        },
+        "core.int_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.13686,
+            "delta_pct": 213.69,
+            "ci_delta_pct": [
+                192.57,
+                220.55
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.0866,
+                1.079,
+                1.1783,
+                1.3352,
+                1.0709,
+                1.0723,
+                1.0814
+            ],
+            "judy_runs_ms": [
+                3.4716,
+                3.4587,
+                3.4473,
+                3.3921,
+                3.3218,
+                3.4397,
+                3.3922
+            ],
+            "array_ms": 1.0814,
+            "judy_ms": 3.4397,
+            "judy_over_array": 3.181,
+            "winner": "php-array"
+        },
+        "core.int_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.49628,
+            "delta_pct": 549.63,
+            "ci_delta_pct": [
+                541.46,
+                553.27
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9135,
+                0.9176,
+                0.9126,
+                0.9122,
+                0.9128,
+                0.9142,
+                0.9124
+            ],
+            "judy_runs_ms": [
+                5.9689,
+                5.8936,
+                5.9617,
+                5.9499,
+                5.9298,
+                5.8016,
+                5.8527
+            ],
+            "array_ms": 0.9128,
+            "judy_ms": 5.9298,
+            "judy_over_array": 6.496,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.50592,
+            "delta_pct": 150.59,
+            "ci_delta_pct": [
+                149.06,
+                150.79
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.0203,
+                4.0304,
+                4.0474,
+                4.0321,
+                4.0281,
+                4.0272,
+                3.998
+            ],
+            "judy_runs_ms": [
+                10.0334,
+                10.1078,
+                10.1848,
+                10.1041,
+                10.0323,
+                9.9914,
+                10.0188
+            ],
+            "array_ms": 4.0281,
+            "judy_ms": 10.0334,
+            "judy_over_array": 2.491,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.38259,
+            "delta_pct": 138.26,
+            "ci_delta_pct": [
+                135.31,
+                140.24
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.535,
+                1.6225,
+                1.5466,
+                1.5449,
+                1.5459,
+                1.5275,
+                1.5735
+            ],
+            "judy_runs_ms": [
+                3.612,
+                3.7109,
+                3.7155,
+                3.687,
+                3.6775,
+                3.6891,
+                3.749
+            ],
+            "array_ms": 1.5459,
+            "judy_ms": 3.6891,
+            "judy_over_array": 2.386,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.12446,
+            "delta_pct": 512.45,
+            "ci_delta_pct": [
+                505.93,
+                515.62
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9367,
+                0.9361,
+                0.9355,
+                0.9354,
+                0.9336,
+                0.9326,
+                0.9425
+            ],
+            "judy_runs_ms": [
+                5.7385,
+                5.7628,
+                5.6912,
+                5.6401,
+                5.7903,
+                5.6509,
+                5.7723
+            ],
+            "array_ms": 0.9355,
+            "judy_ms": 5.7385,
+            "judy_over_array": 6.134,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.68923,
+            "delta_pct": 168.92,
+            "ci_delta_pct": [
+                167.66,
+                173.58
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.597,
+                1.5926,
+                1.6091,
+                1.6254,
+                1.6051,
+                1.6144,
+                1.6121
+            ],
+            "judy_runs_ms": [
+                4.3692,
+                4.3571,
+                4.3033,
+                4.3555,
+                4.3536,
+                4.3211,
+                4.3353
+            ],
+            "array_ms": 1.6091,
+            "judy_ms": 4.3536,
+            "judy_over_array": 2.706,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.80187,
+            "delta_pct": 180.19,
+            "ci_delta_pct": [
+                177.7,
+                180.41
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.8934,
+                4.9008,
+                5.0037,
+                4.9354,
+                4.9328,
+                4.9636,
+                4.9171
+            ],
+            "judy_runs_ms": [
+                13.7218,
+                13.7314,
+                13.8331,
+                13.7176,
+                14.067,
+                13.784,
+                13.7805
+            ],
+            "array_ms": 4.9328,
+            "judy_ms": 13.7805,
+            "judy_over_array": 2.794,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.35307,
+            "delta_pct": 535.31,
+            "ci_delta_pct": [
+                510.51,
+                536.9
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6002,
+                1.6447,
+                1.5521,
+                1.6172,
+                1.562,
+                1.5526,
+                1.5615
+            ],
+            "judy_runs_ms": [
+                9.8908,
+                9.9015,
+                9.8606,
+                9.8731,
+                9.9484,
+                9.9253,
+                9.9289
+            ],
+            "array_ms": 1.562,
+            "judy_ms": 9.9015,
+            "judy_over_array": 6.339,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.09464,
+            "delta_pct": 1209.46,
+            "ci_delta_pct": [
+                1195.94,
+                1214.94
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9361,
+                0.939,
+                0.9496,
+                0.9351,
+                0.9569,
+                0.9327,
+                0.9333
+            ],
+            "judy_runs_ms": [
+                12.2349,
+                12.301,
+                12.3062,
+                12.2448,
+                12.2307,
+                12.2925,
+                12.2723
+            ],
+            "array_ms": 0.9361,
+            "judy_ms": 12.2723,
+            "judy_over_array": 13.11,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.61839,
+            "delta_pct": 61.84,
+            "ci_delta_pct": [
+                57.45,
+                62.33
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6027,
+                1.5925,
+                1.6436,
+                1.6204,
+                1.615,
+                1.6302,
+                1.6389
+            ],
+            "judy_runs_ms": [
+                2.5938,
+                2.6479,
+                2.5845,
+                2.6263,
+                2.6217,
+                2.5918,
+                2.5804
+            ],
+            "array_ms": 1.6204,
+            "judy_ms": 2.5938,
+            "judy_over_array": 1.601,
+            "winner": "php-array"
+        },
+        "core.string_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.2331,
+            "delta_pct": 123.31,
+            "ci_delta_pct": [
+                122.41,
+                124.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.7025,
+                11.5319,
+                11.7071,
+                11.6331,
+                11.7284,
+                11.7034,
+                11.7067
+            ],
+            "judy_runs_ms": [
+                26.0231,
+                26.2001,
+                26.1623,
+                26.171,
+                26.0853,
+                26.1152,
+                26.1422
+            ],
+            "array_ms": 11.7034,
+            "judy_ms": 26.1422,
+            "judy_over_array": 2.234,
+            "winner": "php-array"
+        },
+        "core.string_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.34739,
+            "delta_pct": 334.74,
+            "ci_delta_pct": [
+                326.81,
+                339.27
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.238,
+                2.2577,
+                2.2914,
+                2.3937,
+                2.2179,
+                2.197,
+                2.2581
+            ],
+            "judy_runs_ms": [
+                9.7428,
+                9.8151,
+                9.78,
+                9.8733,
+                9.7426,
+                9.7336,
+                9.7029
+            ],
+            "array_ms": 2.2577,
+            "judy_ms": 9.7428,
+            "judy_over_array": 4.315,
+            "winner": "php-array"
+        },
+        "core.string_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 9.86322,
+            "delta_pct": 886.32,
+            "ci_delta_pct": [
+                875.49,
+                926.91
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.4043,
+                1.3596,
+                1.3412,
+                1.5014,
+                1.4261,
+                1.4262,
+                1.4052
+            ],
+            "judy_runs_ms": [
+                13.881,
+                13.9619,
+                14.0281,
+                13.8625,
+                13.951,
+                13.9124,
+                13.8598
+            ],
+            "array_ms": 1.4052,
+            "judy_ms": 13.9124,
+            "judy_over_array": 9.901,
+            "winner": "php-array"
+        },
+        "core.string_to_int.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.06448,
+            "delta_pct": 406.45,
+            "ci_delta_pct": [
+                401.54,
+                413.17
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9129,
+                0.8934,
+                1.0981,
+                0.8812,
+                0.9094,
+                0.9168,
+                0.9088
+            ],
+            "judy_runs_ms": [
+                4.5817,
+                4.5359,
+                4.5301,
+                4.544,
+                4.561,
+                4.7047,
+                4.6026
+            ],
+            "array_ms": 0.9094,
+            "judy_ms": 4.561,
+            "judy_over_array": 5.015,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.29108,
+            "delta_pct": 129.11,
+            "ci_delta_pct": [
+                128.43,
+                129.21
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.6972,
+                12.6982,
+                12.8181,
+                12.6945,
+                12.7744,
+                12.7297,
+                12.7579
+            ],
+            "judy_runs_ms": [
+                29.0561,
+                29.1016,
+                29.9467,
+                29.0965,
+                29.1389,
+                29.1647,
+                29.1432
+            ],
+            "array_ms": 12.7297,
+            "judy_ms": 29.1389,
+            "judy_over_array": 2.289,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.93299,
+            "delta_pct": 293.3,
+            "ci_delta_pct": [
+                291.31,
+                296.47
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5578,
+                2.5833,
+                2.5046,
+                2.5545,
+                2.4932,
+                2.5125,
+                2.5103
+            ],
+            "judy_runs_ms": [
+                10.0598,
+                9.9102,
+                9.9301,
+                9.9959,
+                9.9117,
+                9.8717,
+                9.881
+            ],
+            "array_ms": 2.5125,
+            "judy_ms": 9.9117,
+            "judy_over_array": 3.945,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 8.63375,
+            "delta_pct": 763.38,
+            "ci_delta_pct": [
+                762.01,
+                776.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6628,
+                1.6329,
+                1.6147,
+                1.6325,
+                1.6226,
+                1.6337,
+                1.6341
+            ],
+            "judy_runs_ms": [
+                14.2832,
+                14.1056,
+                14.1848,
+                14.0946,
+                14.2236,
+                14.0826,
+                14.1015
+            ],
+            "array_ms": 1.6329,
+            "judy_ms": 14.1056,
+            "judy_over_array": 8.638,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.68228,
+            "delta_pct": 468.23,
+            "ci_delta_pct": [
+                466.82,
+                476.43
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5709,
+                2.5837,
+                2.6425,
+                2.614,
+                2.6134,
+                2.6422,
+                2.6218
+            ],
+            "judy_runs_ms": [
+                14.888,
+                14.8932,
+                14.9781,
+                14.8494,
+                14.8767,
+                14.9283,
+                14.8978
+            ],
+            "array_ms": 2.614,
+            "judy_ms": 14.8932,
+            "judy_over_array": 5.697,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.20993,
+            "delta_pct": 320.99,
+            "ci_delta_pct": [
+                319.16,
+                322.96
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.3391,
+                11.2614,
+                11.3402,
+                11.3072,
+                11.3649,
+                11.3784,
+                11.4103
+            ],
+            "judy_runs_ms": [
+                47.865,
+                47.6307,
+                47.7415,
+                47.8902,
+                47.7596,
+                47.6935,
+                47.7744
+            ],
+            "array_ms": 11.3402,
+            "judy_ms": 47.7596,
+            "judy_over_array": 4.212,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.68213,
+            "delta_pct": 268.21,
+            "ci_delta_pct": [
+                259.14,
+                275.72
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.1463,
+                2.1782,
+                2.0375,
+                2.2486,
+                2.2406,
+                2.3402,
+                2.2031
+            ],
+            "judy_runs_ms": [
+                8.0641,
+                7.9915,
+                8.1517,
+                8.2951,
+                8.0469,
+                8.061,
+                8.1121
+            ],
+            "array_ms": 2.2031,
+            "judy_ms": 8.0641,
+            "judy_over_array": 3.66,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.24695,
+            "delta_pct": 1224.7,
+            "ci_delta_pct": [
+                1221.74,
+                1255.77
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.4035,
+                1.4144,
+                1.4147,
+                1.3556,
+                1.4214,
+                1.4105,
+                1.3757
+            ],
+            "judy_runs_ms": [
+                18.5921,
+                18.9103,
+                18.6987,
+                18.7081,
+                18.5374,
+                18.6842,
+                18.6513
+            ],
+            "array_ms": 1.4105,
+            "judy_ms": 18.6842,
+            "judy_over_array": 13.247,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 11.15889,
+            "delta_pct": 1015.89,
+            "ci_delta_pct": [
+                993.5,
+                1034.23
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.8748,
+                0.8732,
+                0.8676,
+                0.8817,
+                0.9,
+                0.8945,
+                0.8761
+            ],
+            "judy_runs_ms": [
+                9.7618,
+                9.7481,
+                9.8406,
+                9.8101,
+                9.8051,
+                9.7814,
+                9.9477
+            ],
+            "array_ms": 0.8761,
+            "judy_ms": 9.8051,
+            "judy_over_array": 11.192,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.77794,
+            "delta_pct": 377.79,
+            "ci_delta_pct": [
+                376.13,
+                381
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.2071,
+                12.2053,
+                12.2933,
+                12.2988,
+                12.328,
+                12.3508,
+                12.2816
+            ],
+            "judy_runs_ms": [
+                58.716,
+                58.8322,
+                58.6967,
+                58.7629,
+                58.6979,
+                58.7947,
+                58.7941
+            ],
+            "array_ms": 12.2933,
+            "judy_ms": 58.7629,
+            "judy_over_array": 4.78,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.30278,
+            "delta_pct": 230.28,
+            "ci_delta_pct": [
+                225.09,
+                231.17
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5045,
+                2.5616,
+                2.4982,
+                2.5452,
+                2.5076,
+                2.4866,
+                2.5228
+            ],
+            "judy_runs_ms": [
+                8.2718,
+                8.2555,
+                8.2679,
+                8.2743,
+                8.3043,
+                8.3287,
+                8.2878
+            ],
+            "array_ms": 2.5076,
+            "judy_ms": 8.2743,
+            "judy_over_array": 3.3,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.34152,
+            "delta_pct": 1134.15,
+            "ci_delta_pct": [
+                1118.55,
+                1149.28
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.5943,
+                1.6323,
+                1.6052,
+                1.6212,
+                1.5805,
+                1.6101,
+                1.6461
+            ],
+            "judy_runs_ms": [
+                19.9172,
+                19.8904,
+                19.8106,
+                19.8406,
+                19.813,
+                19.9252,
+                19.8253
+            ],
+            "array_ms": 1.6101,
+            "judy_ms": 19.8406,
+            "judy_over_array": 12.323,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.41415,
+            "delta_pct": 941.41,
+            "ci_delta_pct": [
+                927.06,
+                953.43
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.6454,
+                2.5905,
+                2.5944,
+                2.6184,
+                2.5836,
+                2.6541,
+                2.6295
+            ],
+            "judy_runs_ms": [
+                27.1698,
+                27.2083,
+                27.4276,
+                27.2684,
+                27.2164,
+                27.2298,
+                27.2473
+            ],
+            "array_ms": 2.6184,
+            "judy_ms": 27.2298,
+            "judy_over_array": 10.399,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.20739,
+            "delta_pct": 320.74,
+            "ci_delta_pct": [
+                320.09,
+                322.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.4242,
+                11.3087,
+                11.3851,
+                11.3929,
+                11.354,
+                11.3752,
+                11.4041
+            ],
+            "judy_runs_ms": [
+                48.2818,
+                47.8433,
+                47.85,
+                47.9344,
+                47.8185,
+                47.7863,
+                47.7275
+            ],
+            "array_ms": 11.3851,
+            "judy_ms": 47.8433,
+            "judy_over_array": 4.202,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.51978,
+            "delta_pct": 251.98,
+            "ci_delta_pct": [
+                242.82,
+                260.33
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.152,
+                2.1919,
+                2.1703,
+                2.0383,
+                2.2583,
+                2.2136,
+                2.272
+            ],
+            "judy_runs_ms": [
+                7.7542,
+                7.715,
+                7.776,
+                7.7609,
+                7.7389,
+                7.7849,
+                7.7888
+            ],
+            "array_ms": 2.1919,
+            "judy_ms": 7.7609,
+            "judy_over_array": 3.541,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.59244,
+            "delta_pct": 1259.24,
+            "ci_delta_pct": [
+                1187.24,
+                1280.67
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.4525,
+                1.4245,
+                1.3355,
+                1.3598,
+                1.2944,
+                1.3391,
+                1.4277
+            ],
+            "judy_runs_ms": [
+                18.4775,
+                18.4555,
+                18.4388,
+                18.483,
+                18.3786,
+                18.478,
+                18.3779
+            ],
+            "array_ms": 1.3598,
+            "judy_ms": 18.4555,
+            "judy_over_array": 13.572,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.99091,
+            "delta_pct": 999.09,
+            "ci_delta_pct": [
+                986.22,
+                1021.07
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.9092,
+                0.8681,
+                0.894,
+                0.8925,
+                0.874,
+                0.8906,
+                0.9101
+            ],
+            "judy_runs_ms": [
+                9.7791,
+                9.732,
+                9.7944,
+                9.8588,
+                9.8345,
+                9.7885,
+                9.8857
+            ],
+            "array_ms": 0.8925,
+            "judy_ms": 9.7944,
+            "judy_over_array": 10.974,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.84833,
+            "delta_pct": 384.83,
+            "ci_delta_pct": [
+                384.25,
+                386.07
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.3181,
+                12.2405,
+                12.2947,
+                12.2986,
+                12.2753,
+                12.2904,
+                12.314
+            ],
+            "judy_runs_ms": [
+                59.6507,
+                59.8548,
+                59.7606,
+                59.5208,
+                59.6376,
+                59.5879,
+                59.6431
+            ],
+            "array_ms": 12.2947,
+            "judy_ms": 59.6431,
+            "judy_over_array": 4.851,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.21933,
+            "delta_pct": 221.93,
+            "ci_delta_pct": [
+                221.49,
+                225.66
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.5569,
+                2.5207,
+                2.4838,
+                2.5044,
+                2.5127,
+                2.4949,
+                2.5213
+            ],
+            "judy_runs_ms": [
+                8.0891,
+                8.1103,
+                8.1274,
+                8.0788,
+                8.0781,
+                8.1249,
+                8.1169
+            ],
+            "array_ms": 2.5127,
+            "judy_ms": 8.1103,
+            "judy_over_array": 3.228,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.37865,
+            "delta_pct": 1137.86,
+            "ci_delta_pct": [
+                1126.59,
+                1142.35
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6056,
+                1.6433,
+                1.6309,
+                1.6166,
+                1.6287,
+                1.6579,
+                1.6183
+            ],
+            "judy_runs_ms": [
+                20.0452,
+                20.1566,
+                20.0806,
+                20.0838,
+                20.1611,
+                20.3244,
+                20.1009
+            ],
+            "array_ms": 1.6287,
+            "judy_ms": 20.1009,
+            "judy_over_array": 12.342,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.51703,
+            "delta_pct": 951.7,
+            "ci_delta_pct": [
+                943.4,
+                955.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.6496,
+                2.6072,
+                2.6339,
+                2.6343,
+                2.6287,
+                2.6188,
+                2.7007
+            ],
+            "judy_runs_ms": [
+                27.6458,
+                27.5586,
+                27.7008,
+                27.6954,
+                27.7104,
+                27.6538,
+                27.7002
+            ],
+            "array_ms": 2.6339,
+            "judy_ms": 27.6954,
+            "judy_over_array": 10.515,
+            "winner": "php-array"
+        },
+        "api.increment.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.4664,
+            "delta_pct": 146.64,
+            "ci_delta_pct": [
+                143.47,
+                151.37
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.901,
+                2.8847,
+                2.889,
+                2.9081,
+                2.9179,
+                2.9046,
+                2.8956
+            ],
+            "judy_runs_ms": [
+                7.0532,
+                7.3202,
+                7.1894,
+                7.1308,
+                7.1967,
+                7.3014,
+                7.05
+            ],
+            "array_ms": 2.901,
+            "judy_ms": 7.1894,
+            "judy_over_array": 2.478,
+            "winner": "php-array"
+        },
+        "api.setop.union.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.84181,
+            "delta_pct": 284.18,
+            "ci_delta_pct": [
+                281.05,
+                288.64
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                2.3395,
+                2.3784,
+                2.3843,
+                2.3674,
+                2.3859,
+                2.3293,
+                2.3635
+            ],
+            "judy_runs_ms": [
+                9.1437,
+                9.1489,
+                9.0037,
+                9.0951,
+                9.0915,
+                9.0526,
+                9.0265
+            ],
+            "array_ms": 2.3674,
+            "judy_ms": 9.0915,
+            "judy_over_array": 3.84,
+            "winner": "php-array"
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94584,
+            "delta_pct": -5.42,
+            "ci_delta_pct": [
+                -5.49,
+                -4.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                4.5963,
+                4.5776,
+                4.7392,
+                4.5811,
+                4.6029,
+                4.5741,
+                4.5839
+            ],
+            "judy_runs_ms": [
+                4.3441,
+                4.3297,
+                4.3762,
+                4.3586,
+                4.3507,
+                4.3585,
+                4.3767
+            ],
+            "array_ms": 4.5839,
+            "judy_ms": 4.3585,
+            "judy_over_array": 0.951,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.61086,
+            "delta_pct": 161.09,
+            "ci_delta_pct": [
+                160.57,
+                161.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1.6586,
+                1.6519,
+                1.6769,
+                1.6512,
+                1.6616,
+                1.6534,
+                1.6577
+            ],
+            "judy_runs_ms": [
+                4.3388,
+                4.3044,
+                4.3843,
+                4.326,
+                4.3324,
+                4.3168,
+                4.3013
+            ],
+            "array_ms": 1.6577,
+            "judy_ms": 4.326,
+            "judy_over_array": 2.61,
+            "winner": "php-array"
+        },
+        "api.setop.xor.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.12299,
+            "delta_pct": 12.3,
+            "ci_delta_pct": [
+                11.94,
+                13.1
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                7.6096,
+                7.6104,
+                7.6729,
+                7.6037,
+                7.6299,
+                7.5842,
+                7.6135
+            ],
+            "judy_runs_ms": [
+                8.5755,
+                8.6071,
+                8.5766,
+                8.6403,
+                8.5679,
+                8.517,
+                8.5223
+            ],
+            "array_ms": 7.6104,
+            "judy_ms": 8.5755,
+            "judy_over_array": 1.127,
+            "winner": "php-array"
+        }
+    },
+    "judy_vs_phploop": {
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68293,
+            "delta_pct": -31.71,
+            "ci_delta_pct": [
+                -32.1,
+                -30.95
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                9.1171,
+                9.0629,
+                9.1229,
+                9.1434,
+                9.1005,
+                9.1129,
+                9.1531
+            ],
+            "judy_runs_ms": [
+                6.2155,
+                6.258,
+                6.1944,
+                6.2019,
+                6.215,
+                6.2249,
+                6.3268
+            ],
+            "array_ms": 9.1171,
+            "judy_ms": 6.2155,
+            "judy_over_array": 0.682,
+            "winner": "php-judy"
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68035,
+            "delta_pct": -31.97,
+            "ci_delta_pct": [
+                -32.3,
+                -31.18
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                9.1171,
+                9.0629,
+                9.1229,
+                9.1434,
+                9.1005,
+                9.1129,
+                9.1531
+            ],
+            "judy_runs_ms": [
+                6.1724,
+                6.1727,
+                6.1806,
+                6.1781,
+                6.1915,
+                6.2904,
+                6.2994
+            ],
+            "array_ms": 9.1171,
+            "judy_ms": 6.1806,
+            "judy_over_array": 0.678,
+            "winner": "php-judy"
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.73327,
+            "delta_pct": -26.67,
+            "ci_delta_pct": [
+                -27.25,
+                -23.78
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                19.2189,
+                18.1,
+                18.8026,
+                18.8163,
+                18.8876,
+                18.1607,
+                18.0649
+            ],
+            "judy_runs_ms": [
+                13.8938,
+                13.7983,
+                13.7504,
+                13.7974,
+                13.7404,
+                13.754,
+                13.7697
+            ],
+            "array_ms": 18.8026,
+            "judy_ms": 13.7697,
+            "judy_over_array": 0.732,
+            "winner": "php-judy"
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.51452,
+            "delta_pct": -48.55,
+            "ci_delta_pct": [
+                -48.87,
+                -48.09
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                0.5555,
+                0.5737,
+                0.5821,
+                0.5818,
+                0.5854,
+                0.5634,
+                0.5732
+            ],
+            "judy_runs_ms": [
+                0.3023,
+                0.2978,
+                0.2995,
+                0.2975,
+                0.2948,
+                0.2914,
+                0.2946
+            ],
+            "array_ms": 0.5737,
+            "judy_ms": 0.2975,
+            "judy_over_array": 0.519,
+            "winner": "php-judy"
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.53331,
+            "delta_pct": -46.67,
+            "ci_delta_pct": [
+                -46.82,
+                -46.51
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                8.1737,
+                8.1696,
+                8.1632,
+                8.2205,
+                8.1654,
+                8.2457,
+                8.1209
+            ],
+            "judy_runs_ms": [
+                4.3559,
+                4.345,
+                4.3654,
+                4.3975,
+                4.3547,
+                4.3586,
+                4.3548
+            ],
+            "array_ms": 8.1696,
+            "judy_ms": 4.3559,
+            "judy_over_array": 0.533,
+            "winner": "php-judy"
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.54358,
+            "delta_pct": -45.64,
+            "ci_delta_pct": [
+                -45.93,
+                -45.37
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                8.1176,
+                8.1019,
+                8.0889,
+                8.174,
+                8.1643,
+                8.0976,
+                8.0719
+            ],
+            "judy_runs_ms": [
+                4.4344,
+                4.404,
+                4.4484,
+                4.4198,
+                4.4007,
+                4.3891,
+                4.4071
+            ],
+            "array_ms": 8.1019,
+            "judy_ms": 4.4071,
+            "judy_over_array": 0.544,
+            "winner": "php-judy"
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.04409,
+            "delta_pct": -95.59,
+            "ci_delta_pct": [
+                -95.61,
+                -95.58
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                7.0774,
+                7.1315,
+                6.9894,
+                7.0847,
+                7.0658,
+                7.1017,
+                7.0786
+            ],
+            "judy_runs_ms": [
+                0.3119,
+                0.3119,
+                0.3122,
+                0.3124,
+                0.3122,
+                0.3121,
+                0.3121
+            ],
+            "array_ms": 7.0786,
+            "judy_ms": 0.3121,
+            "judy_over_array": 0.044,
+            "winner": "php-judy"
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.39502,
+            "delta_pct": -60.5,
+            "ci_delta_pct": [
+                -60.77,
+                -60.4
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.745,
+                5.8058,
+                5.7555,
+                5.8134,
+                5.7892,
+                5.7182,
+                5.8012
+            ],
+            "judy_runs_ms": [
+                2.2638,
+                2.2965,
+                2.2797,
+                2.2964,
+                2.2712,
+                2.1535,
+                2.297
+            ],
+            "array_ms": 5.7892,
+            "judy_ms": 2.2797,
+            "judy_over_array": 0.394,
+            "winner": "php-judy"
+        },
+        "api.populationCount.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 2.0e-5,
+            "delta_pct": -100,
+            "ci_delta_pct": [
+                -100,
+                -100
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.7674,
+                5.904,
+                5.9639,
+                5.8619,
+                5.9414,
+                5.984,
+                5.8907
+            ],
+            "judy_runs_ms": [
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001
+            ],
+            "array_ms": 5.904,
+            "judy_ms": 0.0001,
+            "judy_over_array": 0,
+            "winner": "php-judy"
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69129,
+            "delta_pct": -30.87,
+            "ci_delta_pct": [
+                -31.14,
+                -30.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                16.9529,
+                16.9596,
+                16.9897,
+                17.0169,
+                16.9789,
+                18.2585,
+                16.9517
+            ],
+            "judy_runs_ms": [
+                11.747,
+                11.727,
+                11.6994,
+                11.7636,
+                11.7335,
+                11.9673,
+                11.7639
+            ],
+            "array_ms": 16.9789,
+            "judy_ms": 11.747,
+            "judy_over_array": 0.692,
+            "winner": "php-judy"
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.24267,
+            "delta_pct": -75.73,
+            "ci_delta_pct": [
+                -76.49,
+                -75.42
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                13.6445,
+                13.6882,
+                13.7096,
+                13.581,
+                13.8393,
+                13.8229,
+                13.9545
+            ],
+            "judy_runs_ms": [
+                3.2957,
+                3.4225,
+                3.344,
+                3.2957,
+                3.4018,
+                3.1349,
+                3.2808
+            ],
+            "array_ms": 13.7096,
+            "judy_ms": 3.2957,
+            "judy_over_array": 0.24,
+            "winner": "php-judy"
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.50435,
+            "delta_pct": -49.57,
+            "ci_delta_pct": [
+                -49.81,
+                -49.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                25.2462,
+                25.2829,
+                25.3547,
+                25.3049,
+                25.1357,
+                25.3231,
+                25.3388
+            ],
+            "judy_runs_ms": [
+                12.6959,
+                12.7985,
+                12.7152,
+                12.7625,
+                12.7745,
+                12.7825,
+                12.7165
+            ],
+            "array_ms": 25.3049,
+            "judy_ms": 12.7625,
+            "judy_over_array": 0.504,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42421,
+            "delta_pct": -57.58,
+            "ci_delta_pct": [
+                -57.85,
+                -57.4
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.3367,
+                12.309,
+                12.343,
+                12.4492,
+                12.3405,
+                12.362,
+                12.3214
+            ],
+            "judy_runs_ms": [
+                5.2021,
+                5.2216,
+                5.2736,
+                5.2469,
+                5.2473,
+                5.2663,
+                5.1329
+            ],
+            "array_ms": 12.3405,
+            "judy_ms": 5.2469,
+            "judy_over_array": 0.425,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41027,
+            "delta_pct": -58.97,
+            "ci_delta_pct": [
+                -59.33,
+                -58.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                12.6076,
+                12.7213,
+                12.5953,
+                12.7002,
+                12.7441,
+                12.7001,
+                12.7138
+            ],
+            "judy_runs_ms": [
+                5.2251,
+                5.2226,
+                5.1675,
+                5.1657,
+                5.1421,
+                5.268,
+                5.1707
+            ],
+            "array_ms": 12.7002,
+            "judy_ms": 5.1707,
+            "judy_over_array": 0.407,
+            "winner": "php-judy"
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.40981,
+            "delta_pct": -59.02,
+            "ci_delta_pct": [
+                -59.2,
+                -58.9
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                25.5705,
+                25.4634,
+                25.486,
+                25.4863,
+                25.5479,
+                25.515,
+                25.4132
+            ],
+            "judy_runs_ms": [
+                10.4323,
+                10.3682,
+                10.4449,
+                10.4753,
+                10.4291,
+                10.4562,
+                10.4595
+            ],
+            "array_ms": 25.4863,
+            "judy_ms": 10.4449,
+            "judy_over_array": 0.41,
+            "winner": "php-judy"
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91325,
+            "delta_pct": -8.68,
+            "ci_delta_pct": [
+                -9.1,
+                -8.51
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                93.3495,
+                93.1638,
+                93.0182,
+                93.341,
+                92.8244,
+                93.1359,
+                93.312
+            ],
+            "judy_runs_ms": [
+                84.8587,
+                85.2341,
+                84.9776,
+                84.8269,
+                84.9548,
+                85.0561,
+                85.0572
+            ],
+            "array_ms": 93.1638,
+            "judy_ms": 84.9776,
+            "judy_over_array": 0.912,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86524,
+            "delta_pct": -13.48,
+            "ci_delta_pct": [
+                -13.7,
+                -13.2
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                41.498,
+                41.2801,
+                41.4879,
+                41.4066,
+                41.3181,
+                41.4407,
+                41.6604
+            ],
+            "judy_runs_ms": [
+                35.8626,
+                35.7796,
+                35.7999,
+                35.9413,
+                35.986,
+                35.8563,
+                35.9512
+            ],
+            "array_ms": 41.4407,
+            "judy_ms": 35.8626,
+            "judy_over_array": 0.865,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83701,
+            "delta_pct": -16.3,
+            "ci_delta_pct": [
+                -16.57,
+                -16.17
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                38.9134,
+                38.8488,
+                38.7376,
+                38.7529,
+                38.6904,
+                38.7724,
+                39.1511
+            ],
+            "judy_runs_ms": [
+                32.4669,
+                32.5158,
+                32.4237,
+                32.4992,
+                32.4286,
+                32.5033,
+                32.4457
+            ],
+            "array_ms": 38.7724,
+            "judy_ms": 32.4669,
+            "judy_over_array": 0.837,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76842,
+            "delta_pct": -23.16,
+            "ci_delta_pct": [
+                -23.32,
+                -22.76
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                19.2696,
+                19.462,
+                19.3235,
+                19.1376,
+                19.3937,
+                19.2567,
+                19.4158
+            ],
+            "judy_runs_ms": [
+                14.796,
+                14.9747,
+                14.8068,
+                14.8481,
+                14.9026,
+                14.8737,
+                14.8878
+            ],
+            "array_ms": 19.3235,
+            "judy_ms": 14.8737,
+            "judy_over_array": 0.77,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92638,
+            "delta_pct": -7.36,
+            "ci_delta_pct": [
+                -7.65,
+                -7.21
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                73.1315,
+                73.1414,
+                72.8648,
+                73.0309,
+                73.1045,
+                73.3425,
+                74.8919
+            ],
+            "judy_runs_ms": [
+                67.5804,
+                67.7568,
+                67.6124,
+                67.6739,
+                67.5049,
+                67.7307,
+                69.5787
+            ],
+            "array_ms": 73.1315,
+            "judy_ms": 67.6739,
+            "judy_over_array": 0.925,
+            "winner": "php-judy"
+        },
+        "adv.forEach.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.49685,
+            "delta_pct": 49.68,
+            "ci_delta_pct": [
+                47.67,
+                54.57
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                6.2861,
+                6.5307,
+                6.3746,
+                6.3471,
+                6.2439,
+                6.3831,
+                6.3993
+            ],
+            "judy_runs_ms": [
+                9.72,
+                9.644,
+                9.5418,
+                9.5925,
+                9.651,
+                9.2749,
+                9.4849
+            ],
+            "array_ms": 6.3746,
+            "judy_ms": 9.5925,
+            "judy_over_array": 1.505,
+            "winner": "php-array"
+        },
+        "adv.forEach.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.1643,
+            "delta_pct": 16.43,
+            "ci_delta_pct": [
+                16.18,
+                19.2
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                14.4001,
+                14.3953,
+                14.6127,
+                14.2729,
+                14.5256,
+                14.4219,
+                14.4923
+            ],
+            "judy_runs_ms": [
+                16.8135,
+                17.326,
+                16.8375,
+                17.0128,
+                16.9005,
+                16.7914,
+                16.8373
+            ],
+            "array_ms": 14.4219,
+            "judy_ms": 16.8375,
+            "judy_over_array": 1.167,
+            "winner": "php-array"
+        },
+        "adv.filter.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.23258,
+            "delta_pct": 23.26,
+            "ci_delta_pct": [
+                21.96,
+                24.12
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                11.3949,
+                11.3929,
+                11.2927,
+                11.3401,
+                11.2774,
+                11.3278,
+                11.3551
+            ],
+            "judy_runs_ms": [
+                14.048,
+                14.5472,
+                13.9192,
+                13.903,
+                13.9977,
+                13.757,
+                13.8482
+            ],
+            "array_ms": 11.3401,
+            "judy_ms": 13.9192,
+            "judy_over_array": 1.227,
+            "winner": "php-array"
+        },
+        "adv.filter.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.0638,
+            "delta_pct": 6.38,
+            "ci_delta_pct": [
+                6.16,
+                7.22
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                34.4045,
+                34.4298,
+                34.6063,
+                34.5857,
+                34.5719,
+                34.4289,
+                34.4338
+            ],
+            "judy_runs_ms": [
+                36.9198,
+                36.9169,
+                37.0348,
+                36.7172,
+                36.7611,
+                36.6254,
+                36.5541
+            ],
+            "array_ms": 34.4338,
+            "judy_ms": 36.7611,
+            "judy_over_array": 1.068,
+            "winner": "php-array"
+        },
+        "adv.map.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.08655,
+            "delta_pct": 8.66,
+            "ci_delta_pct": [
+                8.25,
+                9.29
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                13.4606,
+                13.4244,
+                13.4628,
+                13.4474,
+                13.436,
+                13.4813,
+                13.4819
+            ],
+            "judy_runs_ms": [
+                14.6071,
+                14.6738,
+                14.7141,
+                14.6113,
+                14.6019,
+                14.4803,
+                14.5939
+            ],
+            "array_ms": 13.4606,
+            "judy_ms": 14.6071,
+            "judy_over_array": 1.085,
+            "winner": "php-array"
+        },
+        "adv.map.string_to_int": {
+            "status": "null",
+            "reason": "inside the 3.0% claim floor (CI straddles it)",
+            "ratio": 1.01873,
+            "delta_pct": 1.87,
+            "ci_delta_pct": [
+                1.42,
+                1.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                49.0286,
+                49.0335,
+                49.0253,
+                49.0431,
+                49.1073,
+                49.0886,
+                49.1847
+            ],
+            "judy_runs_ms": [
+                49.9545,
+                50.0013,
+                50.1712,
+                49.9615,
+                50.0138,
+                49.7844,
+                49.7411
+            ],
+            "array_ms": 49.0431,
+            "judy_ms": 49.9615,
+            "judy_over_array": 1.019,
+            "winner": "parity"
+        }
+    },
+    "memory": [],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-S-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-18446/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-S-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-18446/B2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-S-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-18446/B3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-18446/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-18446/C2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-18446/C3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/run5-attribution.txt
+++ b/research/three-arm-benchmark/results/run5-attribution.txt
@@ -1,0 +1,181 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /work/builds/judy-S-1.so, /work/builds/judy-S-2.so, /work/builds/judy-S-3.so
+  C  php-judy + bundled libJudy : /work/builds/judy-C-1.so, /work/builds/judy-C-2.so, /work/builds/judy-C-3.so
+  timing core.int     round 1/7  timing core.int     round 2/7  timing core.int     round 3/7  timing core.int     round 4/7  timing core.int     round 5/7  timing core.int     round 6/7  timing core.int     round 7/7  timing core.int     done          
+  timing core.str     round 1/7  timing core.str     round 2/7  timing core.str     round 3/7  timing core.str     round 4/7  timing core.str     round 5/7  timing core.str     round 6/7  timing core.str     round 7/7  timing core.str     done          
+  timing api.batch    round 1/7  timing api.batch    round 2/7  timing api.batch    round 3/7  timing api.batch    round 4/7  timing api.batch    round 5/7  timing api.batch    round 6/7  timing api.batch    round 7/7  timing api.batch    done          
+  timing api.setops   round 1/7  timing api.setops   round 2/7  timing api.setops   round 3/7  timing api.setops   round 4/7  timing api.setops   round 5/7  timing api.setops   round 6/7  timing api.setops   round 7/7  timing api.setops   done          
+  timing adv.iter     round 1/7  timing adv.iter     round 2/7  timing adv.iter     round 3/7  timing adv.iter     round 4/7  timing adv.iter     round 5/7  timing adv.iter     round 6/7  timing adv.iter     round 7/7  timing adv.iter     done          
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — linux-x86_64-gcc14.2-php8.4-ATTRIBUTION-S-vs-C-patches-only
+------------------------------------------------------------------------------------------------
+  PHP 8.4.24, Linux x86_64
+  arm B system libJudy : ARM S: PRISTINE Judy-1.0.5 (official tarball sha256 d2704089...), STATIC into the extension, IDENTICAL pinned CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt -fPIC. Isolates the php-judy source patches ALONE.
+  arm C bundled libJudy: ARM C: bundled libjudy/ (P1-P7, O1, O3, O4), static, same flags
+  size 300000 (cache-resident), 7 rounds, 3 iterations, floor 3.0%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=1.47   cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-timing   load1=1.03   cpus=24   threshold=12.0  foreign=  0.0% ok
+    end            load1=1.03   cpus=24   threshold=12.0  foreign=  0.0% ok
+
+  control (PHP-only rows, touch no libJudy): -0.08% [-0.21, +0.05] over 43 rows
+  measured control scatter: 2.36%  (assumed floor 3.0%)
+
+------------------------------------------------------------------------------------------------
+  B vs C — bundled libJudy against system libJudy (this project's contribution)
+  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears
+  the 3.0% floor assert anything; everything else is null.
+------------------------------------------------------------------------------------------------
+  benchmark                                     system   bundled    delta CI                 verdict
+  api.equals.int_to_int                           4.60      3.30  -28.33% [-28.59,-26.12] FASTER
+  api.fromArray.int_to_int                        8.32      6.18  -25.68% [-26.10,-24.08] FASTER
+  api.putAll.int_to_int                           8.32      6.22  -25.35% [-25.39,-24.76] FASTER
+  api.setop.intersect.int_to_int                  7.02      5.25  -25.02% [-26.03,-24.41] FASTER
+  api.setop.union.int_to_int                     16.94     12.76  -24.85% [-24.87,-24.49] FASTER
+  api.range.size.string_to_int                    1.30      1.00  -23.09% [-23.17,-23.02] FASTER
+  api.setop.xor.int_to_int                       13.56     10.44  -22.86% [-23.62,-22.78] FASTER
+  api.deleteRange.int_to_int                     15.22     11.75  -22.69% [-23.31,-22.52] FASTER
+  core.int_to_mixed.read                          4.77      3.69  -22.56% [-24.18,-21.72] FASTER
+  core.int_to_int.write                           9.22      7.11  -22.55% [-22.97,-22.52] FASTER
+  api.setop.diff.int_to_int                       6.64      5.17  -21.83% [-22.35,-21.25] FASTER
+  api.setop.union.bitset                         11.56      9.09  -21.41% [-22.10,-20.84] FASTER
+  api.sumValues.int_to_int                        2.88      2.28  -20.90% [-21.56,-19.12] FASTER
+  api.mergeWith.int_to_int                       18.64     14.87  -20.21% [-20.49,-19.97] FASTER
+  api.setop.xor.bitset                           10.62      8.58  -19.42% [-19.63,-18.88] FASTER
+  api.setop.intersect.bitset                      5.39      4.36  -19.09% [-19.30,-18.86] FASTER
+  api.setop.diff.string_to_int                   39.61     32.47  -17.91% [-18.08,-17.83] FASTER
+  api.setop.intersect.string_to_int              43.29     35.86  -17.13% [-17.49,-16.70] FASTER
+  core.string_to_mixed.free                      17.95     14.89  -16.78% [-17.15,-16.48] FASTER
+  core.int_to_mixed.write                        12.07     10.03  -16.77% [-17.52,-15.67] FASTER
+  api.setop.diff.bitset                           5.17      4.33  -16.30% [-16.59,-16.01] FASTER
+  core.string_to_mixed_adaptive.free             32.77     27.70  -15.40% [-16.27,-15.08] FASTER
+  api.mergeWith.string_to_int                    79.87     67.67  -15.24% [-15.46,-14.91] FASTER
+  core.int_to_packed.free                         3.07      2.59  -14.91% [-16.89,-14.64] FASTER
+  core.string_to_mixed_adaptive.iter             23.62     20.10  -14.81% [-16.03,-14.45] FASTER
+  api.setop.union.string_to_int                  99.69     84.98  -14.80% [-16.34,-14.54] FASTER
+  adv.optiter.values.string_to_int_hash.optimized     12.35     10.54  -14.61% [-14.99,-14.47] FASTER
+  core.string_to_mixed_hash.free                 31.93     27.23  -14.58% [-14.85,-14.47] FASTER
+  core.string_to_int_adaptive.iter               21.60     18.46  -14.51% [-14.86,-14.22] FASTER
+  core.string_to_mixed_hash.iter                 23.22     19.84  -14.38% [-14.69,-14.27] FASTER
+  core.int_to_int.read                            4.01      3.44  -14.28% [-17.07,-13.23] FASTER
+  core.string_to_int_hash.iter                   21.78     18.68  -14.18% [-14.35,-14.04] FASTER
+  core.string_to_int.read                        11.36      9.74  -13.85% [-14.08,-13.50] FASTER
+  core.string_to_mixed.read                      11.51      9.91  -13.62% [-16.11,-13.11] FASTER
+  core.string_to_mixed.write                     33.57     29.14  -13.15% [-14.25,-12.91] FASTER
+  adv.optiter.values.string_to_int_adaptive.optimized     14.29     12.47  -12.65% [-13.85,-12.63] FASTER
+  core.string_to_int_adaptive.free               11.21      9.79  -12.63% [-15.74,-12.15] FASTER
+  core.string_to_int.iter                        15.93     13.91  -12.34% [-13.30,-12.21] FASTER
+  core.string_to_int_hash.free                   11.17      9.81  -12.30% [-13.08,-11.74] FASTER
+  core.string_to_mixed.iter                      16.10     14.11  -12.17% [-12.34,-11.84] FASTER
+  core.string_to_int.write                       29.70     26.14  -12.00% [-12.30,-11.46] FASTER
+  core.string_to_int.free                         5.18      4.56  -11.84% [-12.28, -9.90] FASTER
+  core.string_to_int_adaptive.read                8.80      7.76  -11.71% [-12.23,-11.51] FASTER
+  api.values.int_to_int                           4.98      4.41  -11.64% [-11.74,-11.01] FASTER
+  core.int_to_mixed.free                          4.92      4.35  -11.55% [-12.68,-11.33] FASTER
+  core.string_to_mixed_hash.write                66.36     58.76  -11.36% [-11.46,-11.21] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.optimized     16.04     14.20  -11.35% [-11.84,-10.69] FASTER
+  core.string_to_mixed_adaptive.write            67.21     59.64  -11.26% [-11.41,-10.80] FASTER
+  core.string_to_mixed_adaptive.read              9.13      8.11  -11.24% [-12.31,-11.00] FASTER
+  api.keys.int_to_int                             4.92      4.36  -11.18% [-11.39,-10.89] FASTER
+  core.int_to_packed.write                       15.41     13.78  -10.66% [-10.92,-10.15] FASTER
+  core.string_to_mixed_hash.read                  9.22      8.27  -10.22% [-10.47, -9.85] FASTER
+  adv.optiter.foreach.string_to_int_hash.optimized     14.64     13.13  -10.16% [-10.30, -9.71] FASTER
+  core.string_to_int_hash.read                    8.93      8.06   -9.65% [-10.16, -8.41] FASTER
+  api.increment.int_to_int                        7.86      7.19   -9.51% [-10.15, -7.48] FASTER
+  adv.map.string_to_int                          55.06     49.96   -9.16% [ -9.57, -9.05] FASTER
+  core.string_to_int_hash.write                  52.62     47.76   -9.15% [ -9.37, -8.91] FASTER
+  adv.forEach.string_to_int                      18.59     16.84   -9.09% [ -9.58, -8.97] FASTER
+  adv.filter.string_to_int                       40.47     36.76   -9.05% [ -9.30, -8.93] FASTER
+  core.bitset.write                               5.61      5.13   -8.92% [ -9.06, -8.14] FASTER
+  core.int_to_int.iter                            6.50      5.93   -8.68% [ -9.40, -7.30] FASTER
+  core.string_to_int_adaptive.write              52.36     47.84   -8.50% [ -8.68, -8.26] FASTER
+  adv.optiter.toArray.string_to_int_hash.optimized     19.53     17.89   -8.32% [ -8.47, -8.15] FASTER
+  core.int_to_mixed.iter                          6.20      5.74   -8.14% [ -8.53, -6.86] FASTER
+  adv.optiter.foreach.string_to_int_hash.default     24.16     22.22   -8.13% [ -8.16, -7.64] FASTER
+  adv.optiter.ratio.values.string_to_int_hash     55.33     51.13   -7.61% [ -7.78, -6.97] FASTER
+  adv.optiter.values.string_to_int_hash.default     22.30     20.61   -7.52% [ -7.66, -7.46] FASTER
+  adv.map.int_to_int                             15.76     14.61   -7.34% [ -7.83, -6.92] FASTER
+  adv.optiter.ratio.values.string_to_int_adaptive     45.93     42.71   -6.93% [ -8.45, -6.76] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.optimized     23.25     21.69   -6.55% [ -7.16, -6.33] FASTER
+  adv.filter.int_to_int                          14.95     13.92   -6.54% [ -7.03, -5.69] FASTER
+  adv.optiter.values.string_to_int_adaptive.default     31.12     29.22   -6.06% [ -6.15, -5.82] FASTER
+  api.toArray.int_to_int                         14.61     13.77   -5.82% [ -6.23, -5.21] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.default     42.04     39.54   -5.82% [ -5.94, -5.60] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.default     32.31     30.41   -5.77% [ -5.88, -5.58] FASTER
+  adv.optiter.ratio.foreach.string_to_int_adaptive     49.66     46.74   -5.73% [ -6.37, -5.29] FASTER
+  adv.optiter.toArray.string_to_int_hash.default     31.05     29.26   -5.57% [ -6.29, -5.41] FASTER
+  adv.optiter.increment.string_to_int_hash.optimized     20.01     19.02   -4.93% [ -5.09, -4.71] FASTER
+  adv.optiter.overwrite.string_to_int_hash.optimized     19.86     18.90   -4.75% [ -4.83, -4.62] FASTER
+  adv.forEach.int_to_int                         10.01      9.59   -4.36% [ -4.87, -1.88] null
+  core.int_to_packed.iter                        12.81     12.27   -4.10% [ -4.35, -4.05] FASTER
+  core.bitset.iter                                5.50      5.29   -3.86% [ -4.66, -2.81] null
+  adv.optiter.increment.string_to_int_hash.default     16.67     16.11   -3.42% [ -3.54, -2.98] null
+  core.int_to_packed.read                        10.24      9.90   -3.41% [ -3.66, -3.21] FASTER
+  adv.optiter.overwrite.string_to_int_adaptive.optimized     27.17     26.33   -3.13% [ -3.23, -2.88] null
+  adv.optiter.overwrite.string_to_int_hash.default     16.61     16.11   -2.82% [ -3.28, -2.60] null
+  adv.optiter.overwrite.string_to_int_adaptive.default     24.92     24.21   -2.77% [ -3.63, -1.85] null
+  adv.optiter.ratio.toArray.string_to_int_hash     62.77     61.17   -2.53% [ -2.98, -1.89] null
+  adv.optiter.ratio.foreach.string_to_int_hash     60.58     59.11   -2.28% [ -2.82, -1.69] null
+  core.bitset.read                                3.44      3.38   -2.03% [ -2.23, +0.07] null
+  adv.optiter.ratio.overwrite.string_to_int_hash    119.84    117.20   -1.92% [ -2.21, -1.44] null
+  adv.optiter.ratio.increment.string_to_int_hash    120.16    118.23   -1.53% [ -1.74, -1.09] null
+  adv.optiter.ratio.toArray.string_to_int_adaptive     55.32     54.72   -1.22% [ -1.36, -0.66] null
+  adv.optiter.ratio.overwrite.string_to_int_adaptive    109.03    108.89   -0.09% [ -1.22, +0.86] null
+  totals: 81 faster, 0 slower, 13 null
+
+------------------------------------------------------------------------------------------------
+  A vs C — PHP native array against php-judy (bundled)
+  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means
+  the PHP array is FASTER — publish these, they are the honest half of the story.
+------------------------------------------------------------------------------------------------
+  benchmark                                   array ms   judy ms  judy/arr winner
+  api.setop.intersect.bitset                      4.58      4.36     0.95x php-judy
+  api.setop.xor.bitset                            7.61      8.58     1.13x php-array
+  core.int_to_packed.free                         1.62      2.59     1.60x php-array
+  core.bitset.write                               3.04      5.13     1.69x php-array
+  core.string_to_int.write                       11.70     26.14     2.23x php-array
+  core.string_to_mixed.write                     12.73     29.14     2.29x php-array
+  core.int_to_int.write                           3.07      7.11     2.32x php-array
+  core.int_to_mixed.read                          1.55      3.69     2.39x php-array
+  api.increment.int_to_int                        2.90      7.19     2.48x php-array
+  core.int_to_mixed.write                         4.03     10.03     2.49x php-array
+  api.setop.diff.bitset                           1.66      4.33     2.61x php-array
+  core.int_to_mixed.free                          1.61      4.35     2.71x php-array
+  core.int_to_packed.write                        4.93     13.78     2.79x php-array
+  core.bitset.read                                1.07      3.38     3.15x php-array
+  core.int_to_int.read                            1.08      3.44     3.18x php-array
+  core.string_to_mixed_adaptive.read              2.51      8.11     3.23x php-array
+  core.string_to_mixed_hash.read                  2.51      8.27     3.30x php-array
+  core.string_to_int_adaptive.read                2.19      7.76     3.54x php-array
+  core.string_to_int_hash.read                    2.20      8.06     3.66x php-array
+  api.setop.union.bitset                          2.37      9.09     3.84x php-array
+  core.string_to_mixed.read                       2.51      9.91     3.94x php-array
+  core.string_to_int_adaptive.write              11.39     47.84     4.20x php-array
+  core.string_to_int_hash.write                  11.34     47.76     4.21x php-array
+  core.string_to_int.read                         2.26      9.74     4.32x php-array
+  core.string_to_mixed_hash.write                12.29     58.76     4.78x php-array
+  core.string_to_mixed_adaptive.write            12.29     59.64     4.85x php-array
+  core.string_to_int.free                         0.91      4.56     5.01x php-array
+  core.string_to_mixed.free                       2.61     14.89     5.70x php-array
+  core.bitset.iter                                0.91      5.29     5.80x php-array
+  core.int_to_mixed.iter                          0.94      5.74     6.13x php-array
+  core.int_to_packed.read                         1.56      9.90     6.34x php-array
+  core.int_to_int.iter                            0.91      5.93     6.50x php-array
+  core.string_to_mixed.iter                       1.63     14.11     8.64x php-array
+  core.string_to_int.iter                         1.41     13.91     9.90x php-array
+  core.string_to_mixed_hash.free                  2.62     27.23    10.40x php-array
+  core.string_to_mixed_adaptive.free              2.63     27.70    10.52x php-array
+  core.string_to_int_adaptive.free                0.89      9.79    10.97x php-array
+  core.string_to_int_hash.free                    0.88      9.81    11.19x php-array
+  core.string_to_mixed_hash.iter                  1.61     19.84    12.32x php-array
+  core.string_to_mixed_adaptive.iter              1.63     20.10    12.34x php-array
+  core.int_to_packed.iter                         0.94     12.27    13.11x php-array
+  core.string_to_int_hash.iter                    1.41     18.68    13.25x php-array
+  core.string_to_int_adaptive.iter                1.36     18.46    13.57x php-array
+  totals: php-judy wins 1, PHP array wins 42, parity 0
+
+Wrote /work/results2/run5-attribution.json

--- a/scripts/bench-threearm.php
+++ b/scripts/bench-threearm.php
@@ -1,0 +1,1248 @@
+<?php
+/**
+ * Three-arm performance and memory benchmark driver.
+ *
+ * The three arms
+ * --------------
+ *   A  PHP native array          — the "why use php-judy at all" baseline.
+ *   B  php-judy + SYSTEM libJudy — what a user gets today from PECL plus a
+ *                                  distro/Homebrew libJudy (`--with-judy=DIR`).
+ *   C  php-judy + BUNDLED tree   — what they get from the vendored libJudy
+ *                                  (default build): P1-P7 correctness patches,
+ *                                  O1 popcount, O3 word-access metadata, O4
+ *                                  string-layer, pinned isolated vendor CFLAGS.
+ *
+ * B vs C is the headline: it isolates this project's contribution, because the
+ * ONLY difference between the two arms is which libJudy is linked. A vs C
+ * answers "should I use php-judy", and its honest answer is not uniformly
+ * favourable — see the "where PHP arrays win" rows in the output.
+ *
+ * Methodology this driver enforces
+ * --------------------------------
+ *  1. SAME TOOLCHAIN, SAME SOURCE. This driver does not build anything; it
+ *     takes two `.so` paths. The caller MUST produce them from one working
+ *     tree with one compiler and one PHP, changing only `--with-judy`. A
+ *     distro- or PECL-installed `judy.so` is NOT a valid arm B: a prior
+ *     comparison did exactly that and its ~9.4% "win" turned out to bundle
+ *     toolchain provenance differences (BENCHMARK.md / FINDINGS §11.10).
+ *     `--assert-same-source` records the caller's attestation into the JSON so
+ *     a reader can see whether the rule was honoured.
+ *
+ *  2. LIBJUDY PROVENANCE IS RECORDED, NOT ASSUMED. `--system-provenance`
+ *     carries the distro, package version and patch status of arm B's library.
+ *     This matters: Debian/Ubuntu and Fedora ship Judy 1.0.5 *with* the Baskins
+ *     `jp_1Index` fix (Debian patch 04, the same undefined behaviour the
+ *     bundled tree fixes as P1), while Homebrew ships pristine 1.0.5 with no
+ *     patches at all. "System libJudy" therefore means different code on
+ *     different platforms, and a B-vs-C delta is only interpretable next to it.
+ *
+ *  3. ARMS ARE INTERLEAVED, NEVER RUN BACK-TO-BACK. Timing runs one benchmark
+ *     *group* at a time and alternates the arm order every round (ABBA), so the
+ *     two arms' measurements of a given group sit seconds apart rather than
+ *     minutes. Sequential suites produced false regressions before (#87). All
+ *     statistics are computed on per-round PAIRED RATIOS, so whatever the
+ *     machine was doing during round r hits both members of that round's pair
+ *     and divides out.
+ *
+ *     A vs C is paired more tightly still: judy-bench.php measures its PHP-array
+ *     rows and its Judy rows inside the SAME process, microseconds apart, so the
+ *     A/C ratio is immune to between-process drift entirely.
+ *
+ *  4. CLAIM FLOORS ARE PER-RESIDENCY, AND MEASURED IN THIS RUN. Pooled controls
+ *     across four measurement rounds put the floor at ~3% for cache-resident
+ *     cells and ~1.3% out-of-cache (FINDINGS §11.10). This driver does not
+ *     merely assume those: it runs two controls and reports what they measured
+ *     here. Anything inside the floor is reported as null, never as a claim.
+ *
+ *       - PHP-only control: the `.php` rows do not execute one instruction of
+ *         libJudy, so a B-vs-C difference on them is pure runner movement.
+ *       - C-vs-C rebuild control: pass the same arm twice (or two independently
+ *         linked C builds) and every cell should read null. Cells that do not
+ *         are measuring binary layout, not libJudy.
+ *
+ *  5. HOST HYGIENE IS GATED, NOT HOPED FOR. Load is sampled before, between and
+ *     after the phases. The threshold is N/2 for an N-core box. Over it, the
+ *     run is marked `contaminated` and every verdict is suppressed to null:
+ *     the numbers stay in the JSON as diagnostics but assert nothing.
+ *
+ *  6. MULTIPLE BUILDS PER ARM. Pass `--system-so`/`--bundled-so` more than once
+ *     to rotate independently linked builds across rounds. The per-build spread
+ *     is reported so a layout artifact in one binary cannot masquerade as a
+ *     libJudy effect. Fewer builds is permitted for PHP-level end-to-end work
+ *     but then the confidence tier must be labelled honestly.
+ *
+ * Memory is a first-class axis, not a footnote
+ * --------------------------------------------
+ * php-judy's measured, defensible headline is MEMORY, not uniform speed. The
+ * existing judy-bench.php `heap_bytes` rows use `memory_get_usage()`, which
+ * only sees PHP's emalloc heap — libJudy allocates through malloc, OUTSIDE it,
+ * so those rows badly understate Judy's real footprint and are not usable for a
+ * memory claim. This driver therefore measures PEAK RSS in a dedicated child
+ * process per (arm, workload, size), the same approach
+ * examples/coverage-index.php and judy-bench-alternatives.php use, and
+ * subtracts a per-arm empty-process floor so the interpreter and the loaded
+ * extension are not charged to the data structure.
+ *
+ * Usage
+ * -----
+ *   php scripts/bench-threearm.php \
+ *       --system-so  /path/to/build-B/judy.so \
+ *       --bundled-so /path/to/build-C/judy.so \
+ *       [--rounds 7] [--size 300000] [--iterations 3] \
+ *       [--groups core.int,core.str,api.batch,api.setops,adv.iter] \
+ *       [--mem-sizes 100000,1000000,8000000] \
+ *       [--skip-memory] [--skip-timing] \
+ *       [--system-provenance "Debian 13 / libjudy-dev 1.0.5-5.1 / patch 04 applied"] \
+ *       [--assert-same-source] [--label "linux-x86_64-gcc14"] \
+ *       [--out bench-threearm.json]
+ *
+ * A C-vs-C rebuild control is just the same driver with two C builds:
+ *   php scripts/bench-threearm.php --system-so C1.so --bundled-so C2.so ...
+ *
+ * Output: a JSON document (schema `judy-bench-threearm/1`) plus a human table.
+ */
+
+// ── Internal child mode: peak-RSS memory measurement ────────────────────────
+//
+// Runs first, before the driver's own CLI parsing, because the driver re-execs
+// this same file to measure memory in a clean process. `ru_maxrss` is bytes on
+// macOS and kilobytes on Linux.
+
+function tam_peak_rss(): int
+{
+    $ru = getrusage();
+    return (int) $ru['ru_maxrss'] * (PHP_OS_FAMILY === 'Darwin' ? 1 : 1024);
+}
+
+if (in_array('--mem-child', $argv, true)) {
+    $mi        = array_search('--mem-child', $argv, true);
+    $workload  = $argv[$mi + 1] ?? 'floor';
+    $impl      = $argv[$mi + 2] ?? 'array';   // 'array' | 'judy'
+    $n         = (int) ($argv[$mi + 3] ?? 0);
+
+    $indexBytes = null;
+    $heapBytes  = null;
+    $count      = 0;
+    $checksum   = 0;
+
+    $before = memory_get_usage();
+
+    if ($workload === 'floor') {
+        // Nothing built. Establishes the per-arm process floor: interpreter +
+        // whichever extension is loaded, with no data structure at all.
+        $store = null;
+    } elseif ($impl === 'array') {
+        $store = [];
+        switch ($workload) {
+            case 'int_to_int':
+                for ($i = 0; $i < $n; $i++) { $store[$i] = $i * 3; }
+                break;
+            case 'int_sparse':
+                // Sparse int keys: the regime Judy is built for and the one a
+                // PHP array handles worst (a packed array cannot represent it,
+                // so it falls back to a full hash table).
+                for ($i = 0; $i < $n; $i++) { $store[$i * 4099] = $i; }
+                break;
+            case 'int_to_mixed':
+                for ($i = 0; $i < $n; $i++) { $store[$i] = ($i & 1) ? (string) $i : $i; }
+                break;
+            case 'string_to_int':
+                for ($i = 0; $i < $n; $i++) { $store['key:' . $i] = $i; }
+                break;
+            case 'bitset':
+                for ($i = 0; $i < $n; $i++) { $store[$i * 7] = true; }
+                break;
+            default:
+                fwrite(STDERR, "unknown workload $workload\n");
+                exit(2);
+        }
+        $count = count($store);
+    } else {
+        if (!extension_loaded('judy')) {
+            fwrite(STDERR, "judy extension not loaded in memory child\n");
+            exit(2);
+        }
+        switch ($workload) {
+            case 'int_to_int':
+                $store = new Judy(Judy::INT_TO_INT);
+                for ($i = 0; $i < $n; $i++) { $store[$i] = $i * 3; }
+                break;
+            case 'int_sparse':
+                $store = new Judy(Judy::INT_TO_INT);
+                for ($i = 0; $i < $n; $i++) { $store[$i * 4099] = $i; }
+                break;
+            case 'int_to_mixed':
+                $store = new Judy(Judy::INT_TO_MIXED);
+                for ($i = 0; $i < $n; $i++) { $store[$i] = ($i & 1) ? (string) $i : $i; }
+                break;
+            case 'string_to_int':
+                $store = new Judy(Judy::STRING_TO_INT);
+                for ($i = 0; $i < $n; $i++) { $store['key:' . $i] = $i; }
+                break;
+            case 'bitset':
+                $store = new Judy(Judy::BITSET);
+                for ($i = 0; $i < $n; $i++) { $store[$i * 7] = true; }
+                break;
+            default:
+                fwrite(STDERR, "unknown workload $workload\n");
+                exit(2);
+        }
+        $count      = count($store);
+        $indexBytes = $store->memoryUsage();
+    }
+
+    $heapBytes = memory_get_usage() - $before;
+
+    // Touch the structure so a clever optimiser cannot elide the build, and so
+    // the pages are genuinely resident when peak RSS is read.
+    if ($workload !== 'floor' && $count > 0) {
+        $checksum = $count;
+    }
+
+    echo json_encode([
+        'workload'     => $workload,
+        'impl'         => $impl,
+        'n'            => $n,
+        'count'        => $count,
+        'checksum'     => $checksum,
+        'peak_rss'     => tam_peak_rss(),
+        'index_bytes'  => $indexBytes,   // Judy::memoryUsage(); null for arrays
+        'heap_bytes'   => $heapBytes,    // emalloc only — understates Judy
+        'php_peak'     => memory_get_peak_usage(true),
+    ]), "\n";
+    exit(0);
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+$opts = getopt('', [
+    'system-so:', 'bundled-so:', 'bench:', 'rounds:', 'size:', 'iterations:',
+    'groups:', 'mem-sizes:', 'mem-workloads:', 'mem-runs:',
+    'cache-floor:', 'dram-floor:', 'dram-size:', 'min-ms:',
+    'system-provenance:', 'bundled-provenance:', 'label:',
+    'assert-same-source', 'skip-memory', 'skip-timing', 'allow-contaminated',
+    'out:', 'quiet',
+]);
+
+/** getopt returns a string for one occurrence and an array for several. */
+function tam_multi(array $opts, string $key): array
+{
+    if (!isset($opts[$key])) { return []; }
+    return is_array($opts[$key]) ? $opts[$key] : [$opts[$key]];
+}
+
+$system_sos  = tam_multi($opts, 'system-so');
+$bundled_sos = tam_multi($opts, 'bundled-so');
+
+if (!$system_sos || !$bundled_sos) {
+    fwrite(STDERR, <<<USAGE
+Usage: bench-threearm.php --system-so <path> --bundled-so <path> [options]
+
+  --system-so PATH        arm B: php-judy linked against a SYSTEM libJudy.
+                          Repeat for several independently linked builds.
+  --bundled-so PATH       arm C: php-judy linked against the BUNDLED libJudy.
+                          Repeat for several builds. Passing two C builds turns
+                          the run into the C-vs-C rebuild control.
+  --rounds N              interleaved ABBA rounds per group (default 7).
+  --size N                elements for the timing suite (default 300000).
+  --iterations N          timed repeats inside each child (default 3).
+  --groups A,B,...        judy-bench.php groups (default core.int,core.str,
+                          api.batch,api.setops,adv.iter).
+  --mem-sizes A,B,...     element counts for the memory matrix
+                          (default 100000,1000000,8000000).
+  --mem-workloads A,B,... default int_to_int,int_sparse,int_to_mixed,
+                          string_to_int,bitset.
+  --mem-runs N            repeats per memory cell (default 3).
+  --min-ms MS             ignore rows shorter than this in both arms; a row too
+                          short to time carries no signal (default 0.5).
+  --cache-floor PCT       claim floor for cache-resident cells (default 3.0).
+  --dram-floor PCT        claim floor out-of-cache (default 1.3).
+  --dram-size N           element count at/above which a cell counts as
+                          out-of-cache (default 4000000).
+  --system-provenance S   distro / package / patch status of arm B's libJudy.
+  --bundled-provenance S  description of arm C's vendored tree.
+  --label S               short platform label recorded in the JSON.
+  --assert-same-source    caller attests both .so came from one source tree
+                          and one toolchain, differing only in --with-judy.
+  --skip-memory           timing phase only.
+  --skip-timing           memory phase only.
+  --allow-contaminated    record numbers even if the host hygiene gate fails
+                          (they are still marked contaminated and assert nothing).
+  --out FILE              JSON output (default bench-threearm.json).
+
+USAGE);
+    exit(2);
+}
+
+foreach (array_merge($system_sos, $bundled_sos) as $so) {
+    if (!is_file($so)) {
+        fwrite(STDERR, "No such extension: $so\n");
+        exit(2);
+    }
+}
+
+$bench_script = $opts['bench'] ?? __DIR__ . '/../examples/benchmarks/judy-bench.php';
+if (!is_file($bench_script)) {
+    fwrite(STDERR, "No such benchmark script: $bench_script\n");
+    exit(2);
+}
+
+$rounds      = max(3, (int) ($opts['rounds']     ?? 7));
+$size        = max(1, (int) ($opts['size']       ?? 300000));
+$iterations  = max(1, (int) ($opts['iterations'] ?? 3));
+$mem_runs    = max(1, (int) ($opts['mem-runs']   ?? 3));
+$min_ms      = (float) ($opts['min-ms'] ?? 0.5);
+$cache_floor = (float) ($opts['cache-floor'] ?? 3.0);
+$dram_floor  = (float) ($opts['dram-floor']  ?? 1.3);
+$dram_size   = (int) ($opts['dram-size']     ?? 4000000);
+$out_file    = $opts['out'] ?? 'bench-threearm.json';
+$quiet       = isset($opts['quiet']);
+$skip_memory = isset($opts['skip-memory']);
+$skip_timing = isset($opts['skip-timing']);
+$allow_dirty = isset($opts['allow-contaminated']);
+$label       = $opts['label'] ?? (PHP_OS . '-' . php_uname('m'));
+
+$groups = array_values(array_filter(array_map('trim', explode(
+    ',', (string) ($opts['groups'] ?? 'core.int,core.str,api.batch,api.setops,adv.iter')
+)), 'strlen'));
+
+$mem_sizes = array_values(array_filter(array_map('intval', explode(
+    ',', (string) ($opts['mem-sizes'] ?? '100000,1000000,8000000')
+))));
+
+$mem_workloads = array_values(array_filter(array_map('trim', explode(
+    ',', (string) ($opts['mem-workloads'] ?? 'int_to_int,int_sparse,int_to_mixed,string_to_int,bitset')
+)), 'strlen'));
+
+// ── Arm A row classification ────────────────────────────────────────────────
+//
+// judy-bench.php names its comparison rows `<id>.judy` and `<id>.php`. The
+// `.php` suffix does NOT uniformly mean "PHP native array": in several groups
+// the `.php` closure still operates on a Judy instance, measuring "PHP userland
+// loop over Judy" against "Judy native method". Those rows are a legitimate API
+// comparison but they are NOT arm A, and quoting them as "PHP array vs Judy"
+// would be a fabricated claim.
+//
+// TAM_ARM_A_ROWS lists the ids whose `.php` arm is a genuine PHP native array,
+// verified by reading each closure's `use (...)` clause and body. Everything
+// else is recorded under `judy_vs_phploop` instead, and labelled as such.
+//
+// Populated by auditing every `.php` closure in judy-bench.php: its `use (...)`
+// clause and the first operation in its body. The audit found three traps:
+//
+//   - adv.iter's `.php` rows (`adv.forEach|filter|map.*`) capture `$j_int` /
+//     `$j_str`, which are Judy INSTANCES. They measure a PHP foreach over Judy
+//     against Judy's native method — no PHP array is involved anywhere.
+//   - api.setop's `int_to_int` and `string_to_int` `.php` arms build their
+//     result into `new Judy(...)` and iterate Judy sources. ONLY the `bitset`
+//     arms use real arrays (array_replace / array_intersect_key /
+//     array_diff_key over `$php_a` / `$php_b`).
+//   - api.batch is almost entirely Judy-vs-Judy; `api.increment.int_to_int` is
+//     the single genuine array row in that group.
+//
+// `.heap` rows are excluded here on purpose: judy-bench.php records them with
+// `median_ms = 0` and the payload in `heap_bytes`, so they carry no timing.
+const TAM_ARM_A_ROWS = [
+    // core.* — bench_core_type() times caller-supplied closures, and every
+    // call site's `$populate_php` / `$read_php` builds and reads a real array.
+    'core.bitset.write', 'core.bitset.read', 'core.bitset.iter', 'core.bitset.free',
+    'core.int_to_int.write', 'core.int_to_int.read', 'core.int_to_int.iter', 'core.int_to_int.free',
+    'core.int_to_mixed.write', 'core.int_to_mixed.read', 'core.int_to_mixed.iter', 'core.int_to_mixed.free',
+    'core.int_to_packed.write', 'core.int_to_packed.read', 'core.int_to_packed.iter', 'core.int_to_packed.free',
+    'core.string_to_int.write', 'core.string_to_int.read', 'core.string_to_int.iter', 'core.string_to_int.free',
+    'core.string_to_mixed.write', 'core.string_to_mixed.read', 'core.string_to_mixed.iter', 'core.string_to_mixed.free',
+    'core.string_to_int_hash.write', 'core.string_to_int_hash.read', 'core.string_to_int_hash.iter', 'core.string_to_int_hash.free',
+    'core.string_to_mixed_hash.write', 'core.string_to_mixed_hash.read', 'core.string_to_mixed_hash.iter', 'core.string_to_mixed_hash.free',
+    'core.string_to_int_adaptive.write', 'core.string_to_int_adaptive.read', 'core.string_to_int_adaptive.iter', 'core.string_to_int_adaptive.free',
+    'core.string_to_mixed_adaptive.write', 'core.string_to_mixed_adaptive.read', 'core.string_to_mixed_adaptive.iter', 'core.string_to_mixed_adaptive.free',
+    // api.batch — the only true-array row in the group.
+    'api.increment.int_to_int',
+    // api.setops — BITSET arms only; the int_to_int / string_to_int arms build
+    // into a Judy and are recorded as judy_vs_phploop instead.
+    'api.setop.union.bitset', 'api.setop.intersect.bitset',
+    'api.setop.diff.bitset', 'api.setop.xor.bitset',
+];
+
+// ── Small statistics library ────────────────────────────────────────────────
+//
+// Same estimators as scripts/bench-compare.php and
+// examples/benchmarks/judy-bench-alternatives.php: median point estimate with a
+// 95% percentile-bootstrap CI, seeded so a rerun of the same samples reproduces
+// the same interval.
+
+function tam_median(array $xs): float
+{
+    sort($xs);
+    $c = count($xs);
+    if ($c === 0) { return 0.0; }
+    return $c % 2 ? (float) $xs[intdiv($c, 2)] : ((float) $xs[$c / 2 - 1] + (float) $xs[$c / 2]) / 2;
+}
+
+/** 95% percentile-bootstrap CI for the median. */
+function tam_median_ci(array $xs, int $resamples = 2000): array
+{
+    $n = count($xs);
+    if ($n === 0) { return [0.0, 0.0]; }
+    if ($n < 3)   { return [(float) min($xs), (float) max($xs)]; }
+    mt_srand(20260818);
+    $meds = [];
+    for ($b = 0; $b < $resamples; $b++) {
+        $s = [];
+        for ($i = 0; $i < $n; $i++) { $s[] = $xs[mt_rand(0, $n - 1)]; }
+        $meds[] = tam_median($s);
+    }
+    sort($meds);
+    return [$meds[(int) floor(0.025 * $resamples)], $meds[(int) ceil(0.975 * $resamples) - 1]];
+}
+
+function tam_spread_pct(array $xs): float
+{
+    $m = tam_median($xs);
+    if ($m <= 0.0) { return 0.0; }
+    return (max($xs) - min($xs)) / $m * 100.0;
+}
+
+/**
+ * Verdict for a ratio series against a per-residency claim floor.
+ *
+ * A cell is only allowed to claim a direction when the WHOLE confidence
+ * interval clears the floor. A point estimate past the floor with a CI that
+ * straddles it is "null" — inside demonstrated noise — not a win.
+ */
+function tam_verdict(array $ratios, float $floor_pct): array
+{
+    if (count($ratios) < 3) {
+        return ['status' => 'null', 'reason' => 'too few paired rounds'];
+    }
+    $ratio = tam_median($ratios);
+    $ci    = tam_median_ci($ratios);
+    $lo    = 1.0 - $floor_pct / 100.0;
+    $hi    = 1.0 + $floor_pct / 100.0;
+
+    if ($ci[1] < $lo) {
+        $status = 'FASTER';
+        $reason = null;
+    } elseif ($ci[0] > $hi) {
+        $status = 'SLOWER';
+        $reason = null;
+    } else {
+        $status = 'null';
+        $reason = sprintf('inside the %.1f%% claim floor (CI straddles it)', $floor_pct);
+    }
+    return [
+        'status'       => $status,
+        'reason'       => $reason,
+        'ratio'        => round($ratio, 5),
+        'delta_pct'    => round(($ratio - 1.0) * 100.0, 2),
+        'ci_delta_pct' => [round(($ci[0] - 1.0) * 100.0, 2), round(($ci[1] - 1.0) * 100.0, 2)],
+        'n'            => count($ratios),
+    ];
+}
+
+// ── Host hygiene ────────────────────────────────────────────────────────────
+//
+// The rule the project works to: a benchmark is only trustworthy when the box
+// is quiet, and "quiet" means load average below N/2 for an N-core host. A
+// sibling process eating cores can manufacture a 3x "regression" with no code
+// change whatsoever, so load is sampled at every phase boundary rather than
+// once at the start.
+
+function tam_cpu_count(): int
+{
+    static $n = null;
+    if ($n !== null) { return $n; }
+
+    if (PHP_OS_FAMILY === 'Darwin') {
+        $n = (int) trim((string) @shell_exec('sysctl -n hw.ncpu 2>/dev/null'));
+        return $n = max(1, $n);
+    }
+
+    // Order matters. `nproc` is absent from slim container images, and falling
+    // back to 1 there is not a harmless default: it drops the hygiene threshold
+    // to 0.5 and marks a perfectly idle 24-core host contaminated, suppressing
+    // every verdict in the run. Count real siblings from /proc/cpuinfo first
+    // and treat the external command as the fallback, not the primary.
+    if (is_readable('/proc/cpuinfo')) {
+        $c = substr_count((string) @file_get_contents('/proc/cpuinfo'), 'processor');
+        if ($c > 0) { return $n = $c; }
+    }
+    // A cpuset (docker --cpuset-cpus, taskset) is the effective width when it
+    // is narrower than the machine.
+    if (function_exists('posix_getpid') && is_readable('/proc/self/status')) {
+        if (preg_match('/^Cpus_allowed_list:\s*(\S+)/m', (string) @file_get_contents('/proc/self/status'), $m)) {
+            $w = 0;
+            foreach (explode(',', $m[1]) as $part) {
+                if (str_contains($part, '-')) {
+                    [$a, $b] = array_map('intval', explode('-', $part, 2));
+                    $w += max(0, $b - $a + 1);
+                } elseif ($part !== '') {
+                    $w++;
+                }
+            }
+            if ($w > 0) { return $n = $w; }
+        }
+    }
+    $c = (int) trim((string) @shell_exec('nproc 2>/dev/null'));
+    if ($c > 0) { return $n = $c; }
+
+    // Unknown rather than 1: refuse to invent a threshold that would silently
+    // condemn or bless the run.
+    return $n = 0;
+}
+
+function tam_load_snapshot(string $phase): array
+{
+    $load1 = null;
+    if (function_exists('sys_getloadavg')) {
+        $la    = sys_getloadavg();
+        $load1 = $la === false ? null : round((float) $la[0], 2);
+    }
+
+    // Snapshots are taken at PHASE BOUNDARIES, when none of this driver's own
+    // benchmark children are running. Anything heavy at that moment is somebody
+    // else's work, so the foreign-CPU total below is a direct co-tenancy
+    // detector rather than a guess.
+    //
+    // This exists because load average alone is NOT sufficient. Two benchmark
+    // campaigns once ran concurrently on a 24-core host, each individually
+    // passing the load < N/2 gate at load ~2, and corrupted each other anyway:
+    // a co-resident memory-bound benchmark contends for last-level cache and
+    // memory bandwidth no matter where the scheduler puts it. The damage was
+    // 2.2x on an untouched baseline arm. Worse, a PHP-array control does not
+    // notice — array operations are not pointer-chasing and not DRAM-bound, so
+    // the control stayed flat while every Judy cell moved.
+    $top  = [];
+    $self = getmypid();
+    if (PHP_OS_FAMILY === 'Darwin') {
+        $raw = (string) shell_exec("ps -A -o pid,pcpu,rss,comm -r 2>/dev/null | head -12");
+    } else {
+        $raw = (string) shell_exec("ps -A -o pid,pcpu,rss,comm --sort=-pcpu 2>/dev/null | head -12");
+    }
+    foreach (array_slice(array_filter(explode("\n", trim($raw))), 1) as $line) {
+        $line = trim($line);
+        if ($line === '') { continue; }
+        $parts = preg_split('/\s+/', $line, 4);
+        if (count($parts) !== 4) { continue; }
+        [$pid, $cpu, $rss, $cmd] = $parts;
+        if ((int) $pid === $self) { continue; }
+        if ((float) $cpu > 5.0) {
+            $top[] = ['pid' => (int) $pid, 'cpu_pct' => (float) $cpu, 'rss_kb' => (int) $rss, 'cmd' => $cmd];
+        }
+    }
+    $foreign = 0.0;
+    foreach ($top as $t) { $foreign += $t['cpu_pct']; }
+
+    $cpus = tam_cpu_count();
+    return [
+        'phase'     => $phase,
+        'at'        => date('Y-m-d\TH:i:sP'),
+        'load1'     => $load1,
+        'cpus'      => $cpus ?: null,
+        'threshold' => $cpus ? $cpus / 2 : null,
+        // Unknown CPU width is reported, never guessed: an invented threshold
+        // would either condemn a clean run or bless a dirty one.
+        'over'      => $cpus > 0 && $load1 !== null && $load1 > $cpus / 2,
+        'cpus_known'=> $cpus > 0,
+        // Half a core of foreign work is enough to move a DRAM-bound cell.
+        'foreign_cpu_pct' => round($foreign, 1),
+        'foreign_busy'    => $foreign > 50.0,
+        'heavy'     => $top,
+    ];
+}
+
+// ── Per-arm PHP invocation ──────────────────────────────────────────────────
+//
+// The extension is selected with PHP_INI_SCAN_DIR pointing at a directory
+// holding exactly one judy.ini, NOT with `-d extension=`. On an image that
+// already enables judy in conf.d — which the project's own bench image does —
+// `-d extension=` is a silent no-op ("Module already loaded") and the run
+// measures the pre-installed copy while reporting the path you passed. That
+// failure mode has bitten this project before: the stale in-image judy.so wins
+// and judy_version() does not reveal it, because both copies report the same
+// version string. Only the mapped-path check below can tell them apart.
+
+$tmp_root = sys_get_temp_dir() . '/judy-bench-threearm-' . getmypid();
+$arm_ini  = [];
+
+/** Register an ini scan dir for one build and return its handle. */
+function tam_register(string $handle, string $so): void
+{
+    global $tmp_root, $arm_ini;
+    $dir = "$tmp_root/$handle-ini";
+    if (!is_dir($dir) && !mkdir($dir, 0700, true)) {
+        fwrite(STDERR, "cannot create $dir\n");
+        exit(2);
+    }
+    file_put_contents("$dir/judy.ini", 'extension=' . realpath($so) . "\n");
+    $arm_ini[$handle] = $dir;
+}
+
+register_shutdown_function(static function () use (&$tmp_root) {
+    foreach (glob("$tmp_root/*-ini/judy.ini") ?: [] as $f) { @unlink($f); }
+    foreach (glob("$tmp_root/*-ini") ?: [] as $d) { @rmdir($d); }
+    foreach (glob("$tmp_root/*") ?: [] as $f) { @is_file($f) && @unlink($f); }
+    @rmdir($tmp_root);
+});
+
+/**
+ * Command prefix for one arm. `$handle === 'array'` means arm A: no judy at
+ * all, so PHP_INI_SCAN_DIR points at an empty directory to guarantee the
+ * extension cannot be loaded even if the host php.ini would have enabled it.
+ */
+function tam_php(string $handle): string
+{
+    global $arm_ini, $tmp_root;
+    if ($handle === 'array') {
+        $empty = "$tmp_root/none-ini";
+        if (!is_dir($empty)) { @mkdir($empty, 0700, true); }
+        // No `-n`: arm A must differ from B and C ONLY in that judy is absent.
+        // The empty scan dir already suppresses every conf.d extension, exactly
+        // as the judy arms' single-file scan dir does.
+        return 'PHP_INI_SCAN_DIR=' . escapeshellarg($empty) . ' '
+            . escapeshellarg(PHP_BINARY) . ' -d memory_limit=-1 ';
+    }
+    return 'PHP_INI_SCAN_DIR=' . escapeshellarg($arm_ini[$handle]) . ' '
+        . escapeshellarg(PHP_BINARY) . ' -d memory_limit=-1 ';
+}
+
+/**
+ * Prove that the arm really loaded the .so we asked for.
+ *
+ * Checks, in order: the extension loaded at all; no "already loaded" warning;
+ * the main php.ini does not itself pull in a judy; exactly one scanned ini; and
+ * — on Linux, where /proc/self/maps is available — that the set of mapped judy
+ * object paths is exactly the realpath we intended. Without this last check a
+ * pre-enabled copy is indistinguishable from the one under test.
+ */
+function tam_verify(string $handle, string $so): array
+{
+    $probe = <<<'PHP'
+$paths = [];
+if (@is_readable('/proc/self/maps')) {
+    preg_match_all('#/\S*judy\S*\.so#', (string)file_get_contents('/proc/self/maps'), $m);
+    $paths = array_values(array_unique($m[0]));
+}
+$main = php_ini_loaded_file();
+echo json_encode([
+    'loaded'  => (int)extension_loaded('judy'),
+    'version' => extension_loaded('judy') ? judy_version() : null,
+    'paths'   => $paths,
+    'inis'    => php_ini_scanned_files() ? array_values(array_filter(array_map('trim', explode(',', php_ini_scanned_files())), 'strlen')) : [],
+    'main_loads_judy' => $main && preg_match('#^\s*(zend_)?extension\s*=.*judy#mi', (string)@file_get_contents($main)) ? 1 : 0,
+]);
+PHP;
+    $err = sys_get_temp_dir() . '/judy-threearm-verify-' . getmypid() . '.err';
+    $out = shell_exec(tam_php($handle) . '-r ' . escapeshellarg($probe) . ' 2> ' . escapeshellarg($err));
+    $stderr = (string) @file_get_contents($err);
+    @unlink($err);
+
+    if (stripos($stderr, 'already loaded') !== false || stripos($stderr, 'Unable to load dynamic library') !== false) {
+        fwrite(STDERR, "arm $handle: extension loading is not under our control:\n$stderr\n");
+        exit(1);
+    }
+    $j = json_decode((string) $out, true);
+    if (!is_array($j) || !isset($j['loaded'])) {
+        fwrite(STDERR, "arm $handle: unusable probe output: $out\n$stderr\n");
+        exit(1);
+    }
+    if (!$j['loaded']) {
+        fwrite(STDERR, "arm $handle: judy did not load from $so\n$stderr\n");
+        exit(1);
+    }
+    if (!empty($j['main_loads_judy'])) {
+        fwrite(STDERR, "arm $handle: the main php.ini itself loads a judy extension; cannot isolate arms\n");
+        exit(1);
+    }
+    if (count($j['inis']) > 1) {
+        fwrite(STDERR, "arm $handle: more than one scanned ini: " . implode(', ', $j['inis']) . "\n");
+        exit(1);
+    }
+    $want = realpath($so);
+    if ($j['paths'] && $j['paths'] !== [$want]) {
+        fwrite(STDERR, "arm $handle: mapped judy objects " . implode(', ', $j['paths'])
+            . " do not match the requested $want — a pre-installed copy is winning\n");
+        exit(1);
+    }
+    return $j;
+}
+
+/** Confirm arm A really has no judy loaded. */
+function tam_verify_array_arm(): void
+{
+    $out = shell_exec(tam_php('array') . '-r ' . escapeshellarg('echo (int)extension_loaded("judy");') . ' 2>/dev/null');
+    if (trim((string) $out) !== '0') {
+        fwrite(STDERR, "arm A: judy is loaded in the PHP-array arm; it must not be\n");
+        exit(1);
+    }
+}
+
+// ── Timing phase ────────────────────────────────────────────────────────────
+
+/** Run one judy-bench.php group under one arm and return its benchmarks map. */
+function tam_run_group(string $handle, string $group, int $size, int $iterations, string $bench_script): array
+{
+    global $tmp_root, $arm_meta;
+    $json = "$tmp_root/out-$handle.json";
+    $err  = "$tmp_root/err-$handle.txt";
+    @unlink($json);
+
+    $cmd = tam_php($handle)
+        . escapeshellarg($bench_script)
+        . ' --group ' . escapeshellarg($group)
+        . ' --size ' . $size
+        . ' --iterations ' . $iterations
+        . ' --json ' . escapeshellarg($json)
+        . ' > /dev/null 2> ' . escapeshellarg($err);
+
+    exec($cmd, $_, $status);
+    $stderr = (string) @file_get_contents($err);
+    if (stripos($stderr, 'already loaded') !== false || stripos($stderr, 'Unable to load dynamic library') !== false) {
+        fwrite(STDERR, "arm $handle: extension loading broke mid-run:\n$stderr\n");
+        exit(1);
+    }
+    if ($status !== 0 || !is_file($json)) {
+        fwrite(STDERR, "arm $handle: group $group failed (status $status)\n$stderr\n");
+        exit(1);
+    }
+    $data = json_decode((string) file_get_contents($json), true);
+    if (!is_array($data) || !isset($data['benchmarks'])) {
+        fwrite(STDERR, "arm $handle: group $group produced no benchmarks\n");
+        exit(1);
+    }
+    $arm_meta[$handle] = $data['metadata'] ?? [];
+    return $data['benchmarks'];
+}
+
+// ── Memory phase ────────────────────────────────────────────────────────────
+
+/**
+ * Measure one memory cell: peak RSS over $runs clean child processes, with the
+ * matching per-arm empty-process floor subtracted.
+ *
+ * The floor matters: arm A's process never loads the extension while B and C
+ * do, so charging the raw peak to the data structure would credit Judy with the
+ * extension's own footprint (or, worse, flatter the array arm by the same
+ * amount). Subtracting a per-arm floor removes the interpreter and the loaded
+ * .so from every cell.
+ */
+function tam_mem_cell(string $handle, string $workload, string $impl, int $n, int $runs): ?array
+{
+    $self = __FILE__;
+    $rss = $idx = $heap = [];
+    for ($r = 0; $r < $runs; $r++) {
+        $cmd = tam_php($handle) . escapeshellarg($self)
+            . ' --mem-child ' . escapeshellarg($workload) . ' ' . escapeshellarg($impl) . ' ' . $n
+            . ' 2>/dev/null';
+        $j = json_decode(trim((string) shell_exec($cmd)), true);
+        if (!is_array($j) || !isset($j['peak_rss'])) { return null; }
+        $rss[] = (float) $j['peak_rss'];
+        if ($j['index_bytes'] !== null) { $idx[] = (float) $j['index_bytes']; }
+        $heap[] = (float) $j['heap_bytes'];
+        $count  = (int) $j['count'];
+    }
+    return [
+        'peak_rss_bytes'  => (int) tam_median($rss),
+        'peak_rss_ci'     => array_map('intval', tam_median_ci($rss)),
+        'index_bytes'     => $idx ? (int) tam_median($idx) : null,
+        'php_heap_bytes'  => (int) tam_median($heap),
+        'count'           => $count ?? 0,
+        'runs'            => $runs,
+    ];
+}
+
+function tam_fmt_bytes(int $b): string
+{
+    if ($b < 0) { return '-' . tam_fmt_bytes(-$b); }
+    if ($b >= 1073741824) { return sprintf('%.2f GB', $b / 1073741824); }
+    if ($b >= 1048576)    { return sprintf('%.1f MB', $b / 1048576); }
+    if ($b >= 1024)       { return sprintf('%.1f KB', $b / 1024); }
+    return $b . ' B';
+}
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+$arm_meta = [];
+
+// Register every build under its own handle so several independently linked
+// binaries of the same arm can be rotated across rounds.
+$b_handles = [];
+foreach ($system_sos as $i => $so)  { $h = 'B' . ($i + 1); tam_register($h, $so); $b_handles[] = $h; }
+$c_handles = [];
+foreach ($bundled_sos as $i => $so) { $h = 'C' . ($i + 1); tam_register($h, $so); $c_handles[] = $h; }
+
+// A run whose two arms are byte-identical, or whose "system" arm is in fact a
+// second bundled build, is a CONTROL run: every cell should read null, and any
+// cell that does not is measuring binary layout rather than libJudy.
+$b_hashes = array_map(fn($p) => hash_file('sha256', $p), $system_sos);
+$c_hashes = array_map(fn($p) => hash_file('sha256', $p), $bundled_sos);
+$identical = count(array_unique(array_merge($b_hashes, $c_hashes))) === 1;
+
+if (!$quiet) {
+    fwrite(STDERR, "php-judy three-arm benchmark\n");
+    fwrite(STDERR, "  A  PHP native array\n");
+    fwrite(STDERR, "  B  php-judy + system libJudy  : " . implode(', ', $system_sos) . "\n");
+    fwrite(STDERR, "  C  php-judy + bundled libJudy : " . implode(', ', $bundled_sos) . "\n");
+    if ($identical) {
+        fwrite(STDERR, "  NOTE: all builds are byte-identical — this is a self-comparison control run.\n");
+    }
+    if (!isset($opts['assert-same-source'])) {
+        fwrite(STDERR, "  WARNING: --assert-same-source not given. A B-vs-C delta is only\n");
+        fwrite(STDERR, "           interpretable when both .so came from ONE source tree and ONE\n");
+        fwrite(STDERR, "           toolchain, differing only in --with-judy.\n");
+    }
+}
+
+// Prove each handle really maps the .so we intend, and that arm A has no judy.
+$verify = [];
+foreach ($b_handles as $i => $h) { $verify[$h] = tam_verify($h, $system_sos[$i]); }
+foreach ($c_handles as $i => $h) { $verify[$h] = tam_verify($h, $bundled_sos[$i]); }
+tam_verify_array_arm();
+
+$loads   = [];
+$loads[] = tam_load_snapshot('start');
+$started = microtime(true);
+
+// ── Phase 1: interleaved timing ─────────────────────────────────────────────
+
+/** @var array<string,array<string,array<float>>> class => id => ms[] */
+$judy_ms = ['B' => [], 'C' => []];
+/** @var array<string,array<string,array<float>>> class => id => ms[] */
+$php_ms  = ['B' => [], 'C' => []];
+/** @var array<string,array<string,array<int>>> class => id => bytes[] */
+$heaps   = ['B' => [], 'C' => []];
+/** per-round record of which concrete build served each class */
+$build_of = ['B' => [], 'C' => []];
+
+$timing_children = 0;
+
+if (!$skip_timing) {
+    foreach ($groups as $group) {
+        for ($r = 1; $r <= $rounds; $r++) {
+            // Rotate builds so no single binary's page layout can carry a cell.
+            $bh = $b_handles[($r - 1) % count($b_handles)];
+            $ch = $c_handles[($r - 1) % count($c_handles)];
+            $build_of['B'][] = $bh;
+            $build_of['C'][] = $ch;
+
+            // ABBA: alternate which arm goes first so linear drift cancels
+            // instead of loading onto whichever arm always ran second.
+            $order = ($r % 2 === 1) ? [['B', $bh], ['C', $ch]] : [['C', $ch], ['B', $bh]];
+
+            foreach ($order as [$class, $handle]) {
+                $bm = tam_run_group($handle, $group, $size, $iterations, $bench_script);
+                $timing_children++;
+                foreach ($bm as $id => $entry) {
+                    if (array_key_exists('heap_bytes', $entry)) {
+                        $heaps[$class][$id][] = (int) $entry['heap_bytes'];
+                        continue;
+                    }
+                    if (str_ends_with($id, '.judy')) {
+                        $judy_ms[$class][substr($id, 0, -5)][] = (float) $entry['median_ms'];
+                    } elseif (str_ends_with($id, '.php')) {
+                        $php_ms[$class][substr($id, 0, -4)][] = (float) $entry['median_ms'];
+                    }
+                }
+            }
+            if (!$quiet) {
+                fwrite(STDERR, sprintf("  timing %-12s round %d/%d\r", $group, $r, $rounds));
+            }
+        }
+        if (!$quiet) { fwrite(STDERR, sprintf("  timing %-12s done          \n", $group)); }
+    }
+    $loads[] = tam_load_snapshot('after-timing');
+}
+
+// ── Phase 2: peak-RSS memory matrix ─────────────────────────────────────────
+
+$memory = [];
+$mem_children = 0;
+
+if (!$skip_memory) {
+    // Per-arm empty-process floor. Arm A loads no extension; B and C each load
+    // theirs. Subtracting the matching floor keeps the interpreter and the .so
+    // itself out of every data-structure number.
+    $floor = [];
+    foreach ([['A', 'array'], ['B', $b_handles[0]], ['C', $c_handles[0]]] as [$class, $handle]) {
+        $cell = tam_mem_cell($handle, 'floor', $class === 'A' ? 'array' : 'judy', 0, $mem_runs);
+        $mem_children += $mem_runs;
+        $floor[$class] = $cell['peak_rss_bytes'] ?? 0;
+    }
+
+    foreach ($mem_workloads as $workload) {
+        foreach ($mem_sizes as $n) {
+            $row = ['workload' => $workload, 'n' => $n, 'arms' => []];
+            foreach ([['A', 'array', 'array'], ['B', $b_handles[0], 'judy'], ['C', $c_handles[0], 'judy']] as [$class, $handle, $impl]) {
+                $cell = tam_mem_cell($handle, $workload, $impl, $n, $mem_runs);
+                $mem_children += $mem_runs;
+                if ($cell === null) {
+                    $row['arms'][$class] = null;
+                    continue;
+                }
+                $cell['over_floor_bytes'] = max(0, $cell['peak_rss_bytes'] - $floor[$class]);
+                $cell['bytes_per_element'] = $n > 0
+                    ? round($cell['over_floor_bytes'] / $n, 2)
+                    : null;
+                $row['arms'][$class] = $cell;
+            }
+            // Headline memory ratios. >1 means the arm in the numerator uses
+            // more memory, so "array / C" above 1 is a php-judy win.
+            $a = $row['arms']['A']['over_floor_bytes'] ?? null;
+            $b = $row['arms']['B']['over_floor_bytes'] ?? null;
+            $c = $row['arms']['C']['over_floor_bytes'] ?? null;
+            $row['array_over_bundled'] = ($a !== null && $c) ? round($a / $c, 3) : null;
+            $row['system_over_bundled'] = ($b !== null && $c) ? round($b / $c, 3) : null;
+            $memory[] = $row;
+
+            if (!$quiet) {
+                fwrite(STDERR, sprintf("  memory %-14s n=%-9d A=%-10s B=%-10s C=%-10s  A/C=%s\n",
+                    $workload, $n,
+                    $a === null ? '-' : tam_fmt_bytes($a),
+                    $b === null ? '-' : tam_fmt_bytes($b),
+                    $c === null ? '-' : tam_fmt_bytes($c),
+                    $row['array_over_bundled'] === null ? '-' : sprintf('%.2fx', $row['array_over_bundled'])));
+            }
+        }
+    }
+    $loads[] = tam_load_snapshot('after-memory');
+}
+
+$loads[] = tam_load_snapshot('end');
+$wall = microtime(true) - $started;
+
+// ── Analysis ────────────────────────────────────────────────────────────────
+
+// Which claim floor applies to this run. The project's pooled controls put it
+// at ~3% for cache-resident cells and ~1.3% out-of-cache; the timing suite runs
+// at a single --size, so the applicable floor follows that size.
+$residency    = $size >= $dram_size ? 'out-of-cache' : 'cache-resident';
+$applied_floor = $size >= $dram_size ? $dram_floor : $cache_floor;
+
+/**
+ * Per-build breakdown of a paired-ratio series.
+ *
+ * Rounds rotate the concrete builds, so pair index r was served by system build
+ * r % nB and bundled build r % nC. Grouping the ratios by that pair and
+ * reporting the spread across groups is what separates a real libJudy effect
+ * (every build pair agrees) from a page/cache-layout artifact of one particular
+ * binary (one pair carries the whole delta). A cell whose per-build spread is
+ * comparable to its own delta is layout noise, not a library change.
+ */
+function tam_per_build(array $pairs, int $n_b, int $n_c): array
+{
+    $by = [];
+    foreach ($pairs as $r => $ratio) {
+        $key = 'B' . (($r % $n_b) + 1) . '/C' . (($r % $n_c) + 1);
+        $by[$key][] = $ratio;
+    }
+    $meds = [];
+    foreach ($by as $key => $xs) {
+        $meds[$key] = round((tam_median($xs) - 1.0) * 100.0, 2);
+    }
+    $vals = array_values($meds);
+    return [
+        'per_build_delta_pct' => $meds,
+        'build_spread_pct'    => count($vals) > 1 ? round(max($vals) - min($vals), 2) : 0.0,
+        'builds'              => count($meds),
+    ];
+}
+
+/** Per-round paired ratios of two same-length series. */
+function tam_pairs(array $num, array $den): array
+{
+    $pairs = [];
+    $n = min(count($num), count($den));
+    for ($r = 0; $r < $n; $r++) {
+        if ($den[$r] > 0.0) { $pairs[] = $num[$r] / $den[$r]; }
+    }
+    return $pairs;
+}
+
+// ---- The control: PHP-only work, measured under both arms -------------------
+//
+// The `.php` rows execute not one instruction of libJudy, so a B-vs-C
+// difference on them cannot be a libJudy effect. Their median is this run's own
+// measurement of the noise floor, and it re-centres every judy cell.
+
+$control_rows = [];
+$control_deltas = [];
+foreach ($php_ms['C'] as $id => $cser) {
+    // ONLY genuine PHP-array rows may serve as the control. The `.php` arms in
+    // api.* and adv.* build into and iterate over Judy instances, so they
+    // execute libJudy and carry real B-vs-C signal. Using them here would be
+    // self-defeating: a bundled tree that is genuinely faster would speed those
+    // rows up too, drag the control median below 1.0, and then dividing by it
+    // would subtract the very effect the run exists to measure.
+    if (!in_array($id, TAM_ARM_A_ROWS, true)) { continue; }
+    $bser = $php_ms['B'][$id] ?? null;
+    if ($bser === null) { continue; }
+    $pairs = tam_pairs($cser, $bser);
+    if (count($pairs) < 3) { continue; }
+    if (tam_median($bser) < $min_ms && tam_median($cser) < $min_ms) { continue; }
+    $v = tam_verdict($pairs, $applied_floor);
+    $control_rows[$id] = $v + ['b_ms' => round(tam_median($bser), 4), 'c_ms' => round(tam_median($cser), 4)];
+    $control_deltas[] = tam_median($pairs);
+}
+$control_median = $control_deltas ? tam_median($control_deltas) : 1.0;
+$control_ci     = $control_deltas ? tam_median_ci($control_deltas) : [1.0, 1.0];
+
+// The measured floor: how far the control rows themselves scatter. If this
+// exceeds the assumed claim floor, the assumed floor is too optimistic FOR THIS
+// RUN and the larger of the two governs.
+$control_spread_pct = $control_deltas
+    ? max(abs(max($control_deltas) - 1.0), abs(min($control_deltas) - 1.0)) * 100.0
+    : 0.0;
+
+$hygiene_failed = false;
+$foreign_seen   = false;
+foreach ($loads as $l) {
+    if ($l['over']) { $hygiene_failed = true; }
+    // Co-tenancy is its own failure mode, independent of load average.
+    if (!empty($l['foreign_busy'])) { $hygiene_failed = true; $foreign_seen = true; }
+}
+$contaminated = $hygiene_failed || abs($control_median - 1.0) * 100.0 > $applied_floor;
+
+// ---- B vs C: this project's isolated contribution --------------------------
+
+$bvc = [];
+foreach ($judy_ms['C'] as $id => $cser) {
+    $bser = $judy_ms['B'][$id] ?? null;
+    if ($bser === null) { continue; }
+    $pairs = tam_pairs($cser, $bser);
+    if (count($pairs) < 3) { continue; }
+    $b_med = tam_median($bser);
+    $c_med = tam_median($cser);
+    if ($b_med < $min_ms && $c_med < $min_ms) { continue; }
+
+    // Re-centre by what the PHP-only control measured, so runner movement
+    // divides out while a genuine library-wide shift survives.
+    $adj = array_map(fn($p) => $p / $control_median, $pairs);
+    $v   = tam_verdict($adj, $applied_floor);
+
+    if ($contaminated && $v['status'] !== 'null') {
+        $v['status'] = 'null';
+        $v['reason'] = 'suppressed: run flagged contaminated';
+    }
+    $pb = tam_per_build($adj, count($b_handles), count($c_handles));
+    // A delta no larger than the disagreement between build pairs is not a
+    // library effect, whatever its CI says.
+    if ($v['status'] !== 'null' && $pb['builds'] > 1
+        && $pb['build_spread_pct'] > abs($v['delta_pct'])) {
+        $v['status'] = 'null';
+        $v['reason'] = sprintf('per-build spread %.2f%% exceeds the %.2f%% delta — layout, not libJudy',
+            $pb['build_spread_pct'], abs($v['delta_pct']));
+    }
+    $bvc[$id] = $v + $pb + [
+        'system_ms'    => round($b_med, 4),
+        'bundled_ms'   => round($c_med, 4),
+        'raw_delta_pct'=> round((tam_median($pairs) - 1.0) * 100.0, 2),
+        'spread_pct'   => [round(tam_spread_pct($bser), 1), round(tam_spread_pct($cser), 1)],
+        // Raw per-round series, so this run can be re-analysed (different floor,
+        // different drift model) without paying for the measurement again.
+        'system_runs_ms'  => array_map(fn($x) => round($x, 4), $bser),
+        'bundled_runs_ms' => array_map(fn($x) => round($x, 4), $cser),
+        'paired_ratios'   => array_map(fn($x) => round($x, 5), $pairs),
+    ];
+}
+
+// ---- A vs C: should you use php-judy at all --------------------------------
+//
+// Paired inside one process: judy-bench.php measures the array row and the Judy
+// row microseconds apart in the same child, so this ratio carries no
+// between-process drift at all. Only rows whose `.php` arm is a genuine PHP
+// array are eligible (TAM_ARM_A_ROWS); the rest are recorded separately as
+// judy-native-method vs PHP-loop-over-Judy, which is a different question.
+
+$avc = [];
+$judy_vs_phploop = [];
+foreach ($judy_ms['C'] as $id => $cjudy) {
+    $carr = $php_ms['C'][$id] ?? null;
+    if ($carr === null) { continue; }
+    $pairs = tam_pairs($cjudy, $carr);
+    if (count($pairs) < 3) { continue; }
+    $j_med = tam_median($cjudy);
+    $a_med = tam_median($carr);
+    if ($j_med < $min_ms && $a_med < $min_ms) { continue; }
+
+    // A vs C is a real magnitude question, not a noise question: a 2x gap is
+    // not "inside the floor". Still, apply the floor so near-parity cells are
+    // reported as parity rather than as a spurious direction.
+    $v = tam_verdict($pairs, $applied_floor);
+    $rec = $v + [
+        'array_runs_ms' => array_map(fn($x) => round($x, 4), $carr),
+        'judy_runs_ms'  => array_map(fn($x) => round($x, 4), $cjudy),
+        'array_ms'  => round($a_med, 4),
+        'judy_ms'   => round($j_med, 4),
+        'judy_over_array' => round($j_med / max($a_med, 1e-9), 3),
+        'winner'    => $v['status'] === 'FASTER' ? 'php-judy'
+                     : ($v['status'] === 'SLOWER' ? 'php-array' : 'parity'),
+    ];
+    if (in_array($id, TAM_ARM_A_ROWS, true)) {
+        $avc[$id] = $rec;
+    } else {
+        $judy_vs_phploop[$id] = $rec;
+    }
+}
+
+// ── Output ──────────────────────────────────────────────────────────────────
+
+$counts = ['faster' => 0, 'slower' => 0, 'null' => 0];
+foreach ($bvc as $row) {
+    $k = $row['status'] === 'FASTER' ? 'faster' : ($row['status'] === 'SLOWER' ? 'slower' : 'null');
+    $counts[$k]++;
+}
+$a_counts = ['php-judy' => 0, 'php-array' => 0, 'parity' => 0];
+foreach ($avc as $row) { $a_counts[$row['winner']]++; }
+
+$result = [
+    'metadata' => [
+        'schema'              => 'judy-bench-threearm/1',
+        'label'               => $label,
+        'date'                => date('Y-m-d\TH:i:sP'),
+        'php_version'         => PHP_VERSION,
+        'platform'            => PHP_OS . ' ' . php_uname('m'),
+        'uname'               => php_uname(),
+        'judy_version'        => $arm_meta[$c_handles[0]]['judy_version'] ?? ($verify[$c_handles[0]]['version'] ?? null),
+        'system_so'           => array_map('realpath', $system_sos),
+        'bundled_so'          => array_map('realpath', $bundled_sos),
+        'system_so_sha256'    => $b_hashes,
+        'bundled_so_sha256'   => $c_hashes,
+        'system_provenance'   => $opts['system-provenance']  ?? null,
+        'bundled_provenance'  => $opts['bundled-provenance'] ?? null,
+        'same_source_asserted'=> isset($opts['assert-same-source']),
+        'identical_builds'    => $identical,
+        'is_control_run'      => $identical,
+        'size'                => $size,
+        'iterations'          => $iterations,
+        'rounds'              => $rounds,
+        'groups'              => $groups,
+        'mem_sizes'           => $mem_sizes,
+        'mem_workloads'       => $mem_workloads,
+        'mem_runs'            => $mem_runs,
+        'min_ms'              => $min_ms,
+        'residency'           => $residency,
+        'claim_floor_pct'     => $applied_floor,
+        'cache_floor_pct'     => $cache_floor,
+        'dram_floor_pct'      => $dram_floor,
+        'timing_children'     => $timing_children,
+        'memory_children'     => $mem_children,
+        'wall_seconds'        => round($wall, 1),
+    ],
+    'hygiene' => [
+        'snapshots'      => $loads,
+        'failed'         => $hygiene_failed,
+        'foreign_tenant' => $foreign_seen,
+        'contaminated'   => $contaminated,
+        'note'           => 'load average alone is necessary but not sufficient: a co-resident '
+                          . 'memory-bound benchmark contends for LLC and memory bandwidth at low load, '
+                          . 'and a PHP-array control does not detect it',
+    ],
+    'control' => [
+        'php_only' => [
+            'median_ratio'      => round($control_median, 5),
+            'delta_pct'         => round(($control_median - 1.0) * 100.0, 2),
+            'ci_delta_pct'      => [round(($control_ci[0] - 1.0) * 100.0, 2), round(($control_ci[1] - 1.0) * 100.0, 2)],
+            'measured_spread_pct' => round($control_spread_pct, 2),
+            'row_count'         => count($control_rows),
+            'eligibility'       => 'genuine PHP-array rows only (TAM_ARM_A_ROWS); '
+                                 . 'Judy-touching .php rows are excluded because they carry real signal',
+            'rows'              => $control_rows,
+        ],
+        'rebuild_control_run' => $identical,
+    ],
+    'counts'          => $counts,
+    'a_counts'        => $a_counts,
+    'bundled_vs_system' => $bvc,
+    'array_vs_bundled'  => $avc,
+    'judy_vs_phploop'   => $judy_vs_phploop,
+    'memory'            => $memory,
+    'verify'            => $verify,
+];
+
+file_put_contents($out_file, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+// ---- Human table -----------------------------------------------------------
+
+if (!$quiet) {
+    $line = str_repeat('-', 96);
+    echo "\n$line\n";
+    echo "php-judy three-arm benchmark — $label\n";
+    echo $line . "\n";
+    printf("  PHP %s, %s\n", PHP_VERSION, php_uname('s') . ' ' . php_uname('m'));
+    printf("  arm B system libJudy : %s\n", $opts['system-provenance'] ?? '(provenance NOT recorded — B is uninterpretable)');
+    printf("  arm C bundled libJudy: %s\n", $opts['bundled-provenance'] ?? 'vendored libjudy/ tree');
+    printf("  size %d (%s), %d rounds, %d iterations, floor %.1f%%\n",
+        $size, $residency, $rounds, $iterations, $applied_floor);
+    printf("  same-source attested : %s\n", isset($opts['assert-same-source']) ? 'yes' : 'NO — delta not interpretable');
+    if ($identical) {
+        echo "  *** CONTROL RUN: both arms are the same build. Every cell should read null. ***\n";
+    }
+
+    echo "\n  host hygiene\n";
+    foreach ($loads as $l) {
+        printf("    %-14s load1=%-6s cpus=%-4s threshold=%-5s foreign=%5.1f%% %s\n",
+            $l['phase'], $l['load1'] === null ? '?' : $l['load1'],
+            $l['cpus'] ?? '?', $l['threshold'] === null ? '?' : sprintf('%.1f', $l['threshold']),
+            $l['foreign_cpu_pct'],
+            $l['over'] ? '*** LOAD OVER THRESHOLD ***' : (!empty($l['foreign_busy']) ? '*** FOREIGN TENANT ***' : 'ok'));
+        foreach ($l['heavy'] as $h) {
+            printf("      foreign: pid=%-8d %5.1f%% %s\n", $h['pid'], $h['cpu_pct'], $h['cmd']);
+        }
+    }
+
+    printf("\n  control (PHP-only rows, touch no libJudy): %+.2f%% [%+.2f, %+.2f] over %d rows\n",
+        ($control_median - 1.0) * 100.0,
+        ($control_ci[0] - 1.0) * 100.0, ($control_ci[1] - 1.0) * 100.0, count($control_rows));
+    printf("  measured control scatter: %.2f%%  (assumed floor %.1f%%)\n", $control_spread_pct, $applied_floor);
+    if ($contaminated) {
+        echo "  *** RUN FLAGGED CONTAMINATED — all verdicts suppressed to null ***\n";
+    }
+
+    if ($memory) {
+        echo "\n$line\n  MEMORY — peak RSS over per-arm empty-process floor (the headline axis)\n$line\n";
+        printf("  %-14s %10s %12s %12s %12s %9s %9s\n",
+            'workload', 'n', 'A array', 'B system', 'C bundled', 'A/C', 'B/C');
+        foreach ($memory as $row) {
+            printf("  %-14s %10d %12s %12s %12s %9s %9s\n",
+                $row['workload'], $row['n'],
+                isset($row['arms']['A']) ? tam_fmt_bytes($row['arms']['A']['over_floor_bytes']) : '-',
+                isset($row['arms']['B']) ? tam_fmt_bytes($row['arms']['B']['over_floor_bytes']) : '-',
+                isset($row['arms']['C']) ? tam_fmt_bytes($row['arms']['C']['over_floor_bytes']) : '-',
+                $row['array_over_bundled']  === null ? '-' : sprintf('%.2fx', $row['array_over_bundled']),
+                $row['system_over_bundled'] === null ? '-' : sprintf('%.2fx', $row['system_over_bundled']));
+        }
+        echo "  A/C above 1.00 means the PHP array uses that many times more memory than php-judy.\n";
+    }
+
+    if ($bvc) {
+        echo "\n$line\n  B vs C — bundled libJudy against system libJudy (this project's contribution)\n";
+        echo "  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears\n";
+        printf("  the %.1f%% floor assert anything; everything else is null.\n$line\n", $applied_floor);
+        printf("  %-42s %9s %9s %8s %-18s %s\n", 'benchmark', 'system', 'bundled', 'delta', 'CI', 'verdict');
+        uasort($bvc, fn($x, $y) => $x['delta_pct'] <=> $y['delta_pct']);
+        foreach ($bvc as $id => $row) {
+            printf("  %-42s %9.2f %9.2f %7.2f%% [%+6.2f,%+6.2f] %s\n",
+                $id, $row['system_ms'], $row['bundled_ms'], $row['delta_pct'],
+                $row['ci_delta_pct'][0], $row['ci_delta_pct'][1],
+                $row['status'] === 'FASTER' ? 'FASTER' : ($row['status'] === 'SLOWER' ? 'SLOWER' : 'null'));
+        }
+        printf("  totals: %d faster, %d slower, %d null\n", $counts['faster'], $counts['slower'], $counts['null']);
+    }
+
+    if ($avc) {
+        echo "\n$line\n  A vs C — PHP native array against php-judy (bundled)\n";
+        echo "  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means\n";
+        echo "  the PHP array is FASTER — publish these, they are the honest half of the story.\n$line\n";
+        printf("  %-42s %9s %9s %9s %s\n", 'benchmark', 'array ms', 'judy ms', 'judy/arr', 'winner');
+        uasort($avc, fn($x, $y) => $x['judy_over_array'] <=> $y['judy_over_array']);
+        foreach ($avc as $id => $row) {
+            printf("  %-42s %9.2f %9.2f %8.2fx %s\n",
+                $id, $row['array_ms'], $row['judy_ms'], $row['judy_over_array'], $row['winner']);
+        }
+        printf("  totals: php-judy wins %d, PHP array wins %d, parity %d\n",
+            $a_counts['php-judy'], $a_counts['php-array'], $a_counts['parity']);
+    }
+
+    echo "\nWrote $out_file\n";
+}
+
+exit(0);


### PR DESCRIPTION
Adds a three-arm benchmark answering the two questions users actually ask, and a runner so both can be re-measured.

- **A** PHP native array — the "why bother" baseline
- **B** php-judy + system libJudy (`--with-judy=DIR`) — what PECL plus a distro library gives you today
- **C** php-judy + bundled vendored tree (default build) — what the vendoring work produced

## Headline: memory, not uniform speed

Peak RSS in dedicated child processes (`getrusage`), per-arm floor subtracted. `memory_get_usage()` is not used for this: libJudy allocates outside PHP's emalloc heap, so the existing heap rows cannot see most of a Judy index.

| workload (8M elements) | PHP array | php-judy | ratio |
| --- | ---: | ---: | ---: |
| `bitset` | 310.6 MB | 13.7 MB | **22.7x smaller** |
| `string_to_int` | 614.9 MB | 185.4 MB | **3.3x** |
| `int_sparse` | 310.6 MB | 99.6 MB | **3.1x** |
| `int_to_int` dense | 129.6 MB | 66.2 MB | **2.0x** |
| `int_to_mixed` | 244.3 MB | 310.5 MB | **0.79x — php-judy LOSES** |

The `INT_TO_MIXED` loss is published, not hidden. It is stable across scales and means: if your values are not integers, php-judy is not a memory win.

## The honest half: PHP arrays win 42 of 43 scalar cells

Median 4.19x faster on per-element operations. The PHP/C boundary costs ~16 ns per call and dominates at these sizes. That is stated plainly in the section — a benchmark that only shows wins is not credible. php-judy's case is memory, ordered iteration, bounded range reads, and set operations that stay in C (`keys($start,$end)` range read is 0.04x of the equivalent PHP loop).

## B vs C, decomposed rather than asserted

Delivered difference: **90 cells faster, 0 slower, 4 null**, against a control reading **+0.00% [-0.12, +0.17]**.

That figure bundles our patches with a switch from a shared distro library to a static in-extension one, so a third arm (pristine Judy 1.0.5, static, identical pinned CFLAGS, verified unpatched at instruction level) splits it:

| key type | delivered | our patches alone | share attributable to us |
| --- | ---: | ---: | ---: |
| integer / bitset | -17.7% | -16.5% | **96.5%** |
| string | -22.2% | -11.4% | **39.8%** |

**Integer paths: the gain is genuinely ours. String paths: users get all of it, but only ~40% is our source changes** — the rest is linkage. Publishing the undecomposed number as "the vendoring speedup" would have overstated the string result by roughly 2x.

The decomposition was **pre-registered with an explicit falsifier before the arm was measured** (`research/three-arm-benchmark/PREREGISTRATION.md`). Two competing predictions were recorded; both turned out partly wrong, and both are scored in the record.

## Controls

| control | result |
| --- | --- |
| C-vs-C rebuild control, 94 cells | **0 faster, 0 slower, 94 null** |
| PHP-array-only rows | -0.07% / +0.00% |
| per-build spread on faster cells | 0.07% - 2.15% |

Two independently linked builds of identical source, offset so no round self-compares. Every cell null — the apparatus demonstrating it does not manufacture wins.

## Methodology note worth reading

An earlier attempt was **discarded entirely** after a second benchmark ran concurrently on the same host. Both campaigns passed the `load < N/2` gate at load ~2 of 24 and corrupted each other anyway, via last-level-cache and memory-bandwidth contention.

The important part: **the PHP-array drift control did not detect it** — it read +0.36% while every Judy cell moved tens of percent, because array operations are neither pointer-chasing nor DRAM-bound while Judy's descend is both. A flat control is not evidence of a quiet host. The runner now gates on co-tenancy directly, and the generalizable rule (a control must share the memory-access character of what it controls) is documented in the section.

## Not measured, and labelled as such

- **macOS arm64: directional only.** Host failed the hygiene gate; no timing taken. Apple clang/arm64 remains this project's acknowledged gap — narrowed, not closed.
- **Out-of-cache (>=6M) timing: not measured**, blocked by the item below.
- **Alpine/musl: not measured**, deferred for host scheduling. Section has a slot for it.
- **Windows:** no rigorous number offered.

## Surfaced, not caused: a heap-corruption signal

The out-of-cache run aborted on an arm-B SIGSEGV. Off-host triage shows the **bundled arm corrupts identically** (`zend_mm_heap corrupted` at 3M and 6M), so it is neither caused nor fixed by the vendoring and is **not** claimed as a robustness difference. A plain 6M insert loop is clean on macOS under both arms. Root cause not established; flagged for its own investigation with raw evidence committed.

## Notes

- `package.xml` updated for the new script (CI `validate-pecl`).
- `baselines/latest.json` untouched, per repo rule.
- Raw JSON + console output for every quoted run committed under `research/three-arm-benchmark/results/`.
- Rebased onto main; the section appends well below where an O5 section would land.

Please do not merge without review — the attribution split in particular changes how the vendoring work should be described elsewhere.
