### PR TITLE
docs(findings): Stage 3 O5 reopen — partition validated, adoption dropped (§11.11) + gate harness

### DIFF
--- a/research/differential-fuzz/validation/build-stock.sh
+++ b/research/differential-fuzz/validation/build-stock.sh
@@ -64,6 +64,15 @@ c1 -DJUDYGETINLINE -c "$SRC/JudyCommon/JudyGet.c" -o 1_JudyGetInline.o
 cl -c "$SRC/JudyCommon/JudyGet.c" -o L_JudyGet.o
 cl -DJUDYGETINLINE -c "$SRC/JudyCommon/JudyGet.c" -o L_JudyGetInline.o
 
+# php-judy additions that exist only in the patched tree, never in a
+# pristine 1.0.5 export. Compile them when present so a bundled-tree build
+# carries the same TUs the vendored build ships (P7's JudyNoInline.c is in
+# libjudy/src today and was being silently omitted here).
+if [ -f "$SRC/JudyCommon/JudyNoInline.c" ]; then
+    # shellcheck disable=SC2086
+    $CC $COMMON -c "$SRC/JudyCommon/JudyNoInline.c" -o JudyNoInline.o
+fi
+
 for dir in NEXT PREV; do
     c1 -DJUDY$dir -c "$SRC/JudyCommon/JudyPrevNext.c" -o "1_$dir.o"
     cl -DJUDY$dir -c "$SRC/JudyCommon/JudyPrevNext.c" -o "L_$dir.o"

--- a/research/libjudy-modernization/FINDINGS.md
+++ b/research/libjudy-modernization/FINDINGS.md
@@ -35,7 +35,7 @@ execution record is
 | | |
 | --- | --- |
 | **Question** | Does libJudy 1.0.5 have exploitable headroom, and what does realising it cost? |
-| **Status** | Investigation closed; decision executed. First verdict retracted; round 2 measured; external review round-trip closed; vendoring executed via [#142](https://github.com/orieg/php-judy/issues/142) (Stages 0–2 plus optimizations O1, O3 and O4a/b/d merged; O2, O4c and O5 dropped at their gates, O5 since reopened behind a partition gate — see [§11](#11-execution-record-stages-03); Stage 3 re-reviewed 2026-08-18, §11.10). |
+| **Status** | Investigation closed; decision executed. First verdict retracted; round 2 measured; external review round-trip closed; vendoring executed via [#142](https://github.com/orieg/php-judy/issues/142) (Stages 0–2 plus optimizations O1, O3 and O4a/b/d merged; O2, O4c and O5 dropped at their gates, O5 since reopened behind a partition gate, measurement in progress in §11.11 — see [§11](#11-execution-record-stages-03); Stage 3 re-reviewed 2026-08-18, §11.10). |
 | **Primary issue** | [#113](https://github.com/orieg/php-judy/issues/113) (investigation, closed); [#142](https://github.com/orieg/php-judy/issues/142) (implementation tracker) |
 | **Correctness issues raised** | [#131](https://github.com/orieg/php-judy/issues/131), [#127](https://github.com/orieg/php-judy/issues/127) — both fixed and closed by [PR #147](https://github.com/orieg/php-judy/pull/147) |
 | **Harness defects raised** | [#122](https://github.com/orieg/php-judy/issues/122), fixed by [PR #124](https://github.com/orieg/php-judy/pull/124) |
@@ -1744,6 +1744,14 @@ documented workload constraints is explicitly requested on the tracker.
 > constraint, and the tiny-tree threshold evidence. Status: **reopened,
 > gated** on the partition experiment; nothing in the vendored tree changes
 > until that gate reports.
+>
+> **Follow-up in progress: §11.11** records the reopen's measurements. Two
+> corrections to this addendum's own expectations already stand there: the
+> tiny-tree threshold evidence is NOT upheld once the serial baseline is
+> corrected (the shipped `cJL_MULTIGET_SERIAL_POP1` = 262144 was derived
+> against the handicapped arm, and `wdense` loses at n=10^6 while winning
+> at n=8×10^6), and the corrected baseline shows a substantial part of
+> §11.9's own ×1.51–×2.17 C-level headline was baseline artifact.
 
 ### 11.10 The Stage 3 adversarial re-review — the claim floor revised, and what moved
 
@@ -1803,6 +1811,258 @@ CONTAMINATED. That run therefore corroborates only this much: **the shipped
 bundle is not slower than the previous release, and int reads moved in the
 right direction.** It is not per-optimization evidence, and must not be
 cited as such.
+
+### 11.11 Stage 3, O5 reopen — the partition measured, and a bench-host collision
+
+The §11.9 drop was AMENDED by the §11.10 re-review and reopened behind a
+partition gate. This section records the reopen **in progress**: the
+partition's own gate is measured and clean, the adoption's decisive
+PHP-level cells are **not yet measured**, and no verdict is claimed here.
+Nothing has landed. Provenance as always: honeycomb x86-64 gcc 11.4,
+`-O2 -mpopcnt`, arms `pre` (main, no batched entry point) / `ctl` (the
+archived unpartitioned `vendor/stage3-o5-amac` implementation) / `post`
+(partitioned) / `post0` (thresholds compiled out), **5 randomized-link
+builds per arm** with the build as the replication unit, interleaved
+trials, per-build medians, percentile-bootstrap CIs, `taskset -c 2`.
+Harness committed at `research/libjudy-modernization/o5p-harness/`.
+
+**The corrected serial baseline.** The §11.10 review found the original
+gate's serial arm handicapped: it computed each probe key in a dependent
+chain *inside* the timed loop. The reopen's bench pregenerates the probe
+stream and reports **both** baselines, so the record can be compared
+against the old numbers. The correction is large — the old-style column
+below runs ×1.4–×4.5 where the corrected column runs ×0.7–×1.6 — and it
+retroactively explains the §11.9 headline: **a substantial part of the
+original ×1.51–×2.17 was baseline artifact, not batching.**
+
+**Gate 1 — the partition does what the review predicted.** Against the
+archived implementation on heterogeneous batches (4096-key calls):
+
+| corpus | n | pre serial (ns/op) | post mg4096 vs pre (corrected) | vs pre (old-style) | post vs ctl (partition effect) | ctl vs pre (archived) | verdict |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wmix10` | 1,000,000 | 31.98 | **x1.284 [1.264,1.302]** | x2.04 [2.00,2.07] | x1.521 [1.493,1.542] WIN | x0.84 [0.84,0.85] REG | WIN |
+| `wmix25` | 1,000,000 | 29.49 | **x1.240 [1.214,1.271]** | x1.97 [1.93,2.02] | x1.831 [1.780,1.876] WIN | x0.68 [0.67,0.69] REG | WIN |
+| `wmix32_50` | 1,000,000 | 20.19 | **x1.086 [1.053,1.133]** | x1.69 [1.64,1.77] | x2.444 [2.366,2.549] WIN | x0.44 [0.44,0.45] REG | WIN |
+| `wmix32_90` | 1,000,000 | 10.53 | **x0.762 [0.724,0.794]** | x1.40 [1.33,1.46] | x2.442 [2.322,2.545] WIN | x0.31 [0.31,0.31] REG | REG |
+| `wmix50` | 1,000,000 | 25.69 | **x1.254 [1.206,1.298]** | x1.89 [1.81,1.95] | x2.387 [2.297,2.470] WIN | x0.53 [0.52,0.53] REG | WIN |
+| `wmix75` | 1,000,000 | 17.76 | **x1.060 [1.002,1.107]** | x1.65 [1.57,1.72] | x2.902 [2.746,3.032] WIN | x0.37 [0.35,0.37] REG | WIN |
+| `wmix90` | 1,000,000 | 11.92 | **x0.774 [0.725,0.800]** | x1.37 [1.28,1.41] | x2.547 [2.385,2.632] WIN | x0.30 [0.30,0.31] REG | REG |
+| `wmixc50` | 1,000,000 | 28.03 | **x0.659 [0.630,0.662]** | x0.99 [0.94,0.99] | x1.250 [1.193,1.271] WIN | x0.53 [0.52,0.53] REG | REG |
+| `wmixs50` | 1,000,000 | 28.07 | **x1.335 [1.296,1.373]** | x2.11 [2.04,2.16] | x2.341 [2.259,2.407] WIN | x0.57 [0.56,0.58] REG | WIN |
+
+Every heterogeneous cell improves against the archived implementation,
+×1.25 to ×2.90, which is the reopen's central claim. The review's
+prototype prediction for the 90%-dense cell replicates closely (predicted
+×0.77, measured ×0.774).
+
+**Gate 2 — and it costs nothing on unimodal batches.** The
+no-regression criterion is the `post vs ctl` column:
+
+| corpus | n | pre serial (ns/op) | post mg4096 vs pre (corrected) | vs pre (old-style) | post vs ctl (partition effect) | ctl vs pre (archived) | verdict |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wbase16` | 1,048,576 | 19.81 | **x1.422 [1.395,1.513]** | x2.14 [2.10,2.27] | x0.997 [0.935,1.056] null | x1.43 [1.40,1.52] WIN | WIN |
+| `wbase64` | 1,000,000 | 9.80 | **x1.038 [1.015,1.125]** | x1.95 [1.91,2.11] | x0.991 [0.917,1.075] null | x1.05 [1.02,1.13] WIN | WIN |
+| `wclust` | 1,000,000 | 31.21 | **x1.593 [1.589,1.635]** | x2.15 [2.14,2.20] | x0.999 [0.977,1.025] null | x1.60 [1.59,1.63] WIN | WIN |
+| `wdense` | 1,000,000 | 6.93 | **x0.902 [0.891,0.959]** | x1.85 [1.84,1.97] | x0.985 [0.925,1.054] null | x0.92 [0.90,0.97] REG | REG |
+| `wimm3` | 1,000,000 | 19.09 | **x1.349 [1.344,1.377]** | x1.86 [1.84,1.90] | x1.001 [0.985,1.017] null | x1.35 [1.34,1.38] WIN | WIN |
+| `wleaf1` | 1,000,000 | 22.14 | **x1.414 [1.406,1.451]** | x2.03 [2.02,2.06] | x0.994 [0.975,1.012] null | x1.42 [1.42,1.46] WIN | WIN |
+| `wpair` | 1,000,000 | 15.59 | **x1.186 [1.179,1.222]** | x1.73 [1.72,1.79] | x0.993 [0.967,1.023] null | x1.19 [1.18,1.23] WIN | WIN |
+| `wrand40` | 1,000,000 | 29.15 | **x1.422 [1.417,1.451]** | x2.15 [2.14,2.19] | x0.986 [0.968,1.006] null | x1.44 [1.44,1.47] WIN | WIN |
+| `wsparse` | 1,000,000 | 34.21 | **x1.570 [1.561,1.598]** | x2.51 [2.46,2.53] | x0.990 [0.979,0.999] REG | x1.59 [1.58,1.61] WIN | WIN |
+
+Null on eight of nine; `wsparse` −1.0% [−2.1%, −0.1%], inside both the
+~3% L3-resident and ~1.3% out-of-cache claim floors of §11.10. Controls
+and post-serial null checks are null throughout; `JLMU` was byte-identical
+across all four arms on all 13 corpora.
+
+**What the corrected baseline exposes, and it is not the partition's
+fault.** Four cells lose to plain serial: `wdense` ×0.902, `wmix90`
+×0.774, `wmix32_90` ×0.762, `wmixc50` ×0.659. On `wdense` the *archived*
+arm loses identically (×0.92), so this is the batched machine on
+cache-resident cheap-descend trees, newly visible only because the
+baseline stopped being handicapped. The mechanism is consistent with the
+sign — a tree that fits cache has no misses to overlap, so the lanes add
+overhead and buy nothing — but the host has no PMU, so that remains a
+hypothesis, per the standing §11.7/§11.10 caveat.
+
+**The shipped tiny-tree threshold is wrong under the corrected baseline.**
+`cJL_MULTIGET_SERIAL_POP1` = 262144 was derived against the handicapped
+arm. Measured now, `wdense` **loses ×0.902 at n=10^6 and wins ×1.50 at
+n=8×10^6** — a residency crossover far above the shipped cutoff. A
+population threshold is also the wrong *axis*: at the same n=10^6,
+`wsparse` wins ×1.57 while `wdense` loses. A JLMU (tree-bytes) threshold
+was considered and **rejected on measurement**: `wmixc50` loses at 15.5 MB
+while `wsparse` wins at 16.9 MB, so any byte cutoff separating them would
+be fitted to two points. Threshold re-derivation is an open item of this
+reopen, not a settled result.
+
+**Bench-host collision — disclosed, with the discarded data named.**
+Partway through this matrix a second php-judy benchmark campaign
+(`bench-threearm.php`, system-vs-bundled, in docker) started on the same
+host. The two corrupted each other. Both individually satisfied this
+project's `loadavg < N/2` hygiene rule — 24 cores, loadavg peaked at
+2.87 — and **that rule is insufficient**: two memory-bound benchmarks
+contend for LLC and memory bandwidth regardless of core pinning. This is
+a real limitation of a heuristic the project has leaned on since the O1
+round.
+
+- **Usable, and reported above:** the L3 sweep (loadavg 0.56–1.04) and the
+  heterogeneous-mix sweep (0.96–1.06). The mix sweep carried one
+  single-trial excursion (`wmixs50`, +20% in the `pre` baseline at trial
+  3); it is reported with that trial excluded, which moves the cell
+  ×1.338 → ×1.335 and changes no verdict.
+- **Discarded, to be re-run in full:** the out-of-cache sweep — valid for
+  trials 1–2 only (`wsparse` n=8×10^6 `pre`/serial reads 69.5 ns/op in
+  trials 1–2 and 156.6 ns/op in trial 3, a 2.2× shift in an *untouched
+  baseline*). The `wdense` ×1.50 and `wsparse` ×1.51 figures quoted above
+  come from the clean trials and are **provisional pending that re-run.**
+- **Never reached:** the crossover sweep, the PHP-level A/B, the
+  short-batch probe, and the residency sweep.
+
+Two process changes came out of it, both committed with the harness:
+`o5p-stability.py`, which fails any cell whose untouched `pre` baseline
+drifts across trials (it flags the collided sweep at 116–142% and clears
+the L3 sweep at ≤3.7%), and a `/var/tmp/BENCH_LOCK` mutex every driver now
+takes. The collision was originally caught by luck — a partial read
+disagreeing with a full read — which is not a control.
+
+**Pre-registration of the threshold decision (written BEFORE the probe ran).**
+The PHP-level A/B failed two gate criteria (sparse n=8×10^6 measured ×1.40
+against a ≥×1.5 bar, and unimodal `getAll` regressed ~10% against the
+archived arm), with a coherent mechanism: enabling the composition
+analysis required raising `getAll`'s gather from 256 to 4096 keys, which
+makes the caller's own key/value buffers 64 KB — larger than L1. The
+C-level data points the same way (`wsparse` 8×10^6 is ×1.546 at 256-key
+batches and ×1.506 at 4096-key batches). The obvious repair is to lower
+`cJL_MULTIGET_PART_MIN_COUNT` so a small gather can still be analyzed and
+partitioned.
+
+That repair would be **a hyperparameter change motivated by a failing
+gate result**, which the project's research discipline treats as claim-
+narrowing regardless of how well-motivated it is. Committing to the rule
+in advance, before the probe data exists:
+
+- The short-batch probe is a **measurement of the threshold landscape**,
+  not evidence for a claim. No PASS may be read off the probe run.
+- **Adopt only if** the probe shows the analysis running on 256-key
+  batches (a) within the claim floor of the archived arm on unimodal
+  corpora, AND (b) still beating it on heterogeneous corpora. Both
+  conditions, not either.
+- If adopted, the **entire gate matrix is re-run from scratch** on the new
+  configuration. Cells measured under the old configuration are not
+  spliced in, and the probe run that motivated the change is not cited as
+  its confirmation.
+- The result is then labelled **PASS_after_tuning** — a weaker claim than
+  passing as specced, and recorded as such even if the numbers come out
+  identical.
+- If the probe does not satisfy both conditions, the verdict is **DROP**,
+  and the tuning is not attempted a second time with a different knob.
+
+**A design finding worth keeping independent of the verdict.** Making a
+batched API self-tuning is not free at the boundary: the composition
+analysis needs enough keys per call to be worth its own cost, but a
+larger per-call gather pollutes the caller's cache with its own key and
+result buffers. Measured here as ~3% between 256-key and 4096-key gathers
+at C level and ~10% at PHP level. **The analysis has to be cheap enough to
+run on the batch size the caller would have used anyway, or it eats its
+own benefit.** That constraint applies to any batched-lookup API with an
+adaptive path, not just this one.
+
+**Gate outcome: the PHP-level adoption FAILED. O5 stays DROPPED.**
+The A/B is 3 arms (main serial / archived unpartitioned / partitioned) ×
+7 interleaved process-runs, docker-pinned, every raw invocation
+persisted; arms feature-checked (`pre` exports no `JudyLMultiGet`;
+all three verified mapped from the mount, not the image's baked-in `.so`):
+
+| op | shape | n | post vs pre (main serial) | post vs ctl (archived) | verdict |
+| --- | --- | --- | --- | --- | --- |
+| `foreach` | `clust` | 1,000,000 | x1.002 [0.990,1.008] | x0.996 [0.988,1.001] null | **null** |
+| `foreach` | `dense` | 1,000,000 | x0.997 [0.961,1.025] | x0.997 [0.960,1.008] null | **null** |
+| `foreach` | `mix` | 1,000,000 | x0.990 [0.981,1.005] | x0.985 [0.980,1.001] null | **null** |
+| `foreach` | `sparse` | 1,000,000 | x0.996 [0.987,1.001] | x0.998 [0.991,1.000] null | **null** |
+| `foreach` | `sparse` | 8,000,000 | x1.003 [0.995,1.006] | x0.999 [0.994,1.025] null | **null** |
+| `getall` | `clust` | 1,000,000 | x0.826 [0.818,0.831] | x1.072 [1.066,1.079] WIN | **REG** |
+| `getall` | `clust` | 8,000,000 | x1.218 [1.208,1.222] | x1.132 [1.124,1.133] WIN | **WIN** |
+| `getall` | `dense` | 1,000,000 | x0.997 [0.990,1.006] | x0.989 [0.979,0.998] REG | **null** |
+| `getall` | `dense` | 8,000,000 | x1.392 [1.380,1.402] | x0.988 [0.982,0.992] REG | **WIN** |
+| `getall` | `dense90` | 1,000,000 | x0.950 [0.945,0.959] | x1.340 [1.336,1.347] WIN | **REG** |
+| `getall` | `dense90` | 8,000,000 | x1.351 [1.341,1.367] | x1.162 [1.154,1.168] WIN | **WIN** |
+| `getall` | `mix` | 1,000,000 | x1.058 [1.049,1.068] | x1.391 [1.375,1.396] WIN | **WIN** |
+| `getall` | `mix` | 8,000,000 | x1.308 [1.302,1.316] | x1.229 [1.224,1.238] WIN | **WIN** |
+| `getall` | `sparse` | 1,000,000 | x0.976 [0.974,0.985] | x0.901 [0.899,0.907] REG | **REG** |
+| `getall` | `sparse` | 8,000,000 | x1.400 [1.395,1.407] | x0.909 [0.902,0.914] REG | **WIN** |
+
+Against the gate's stated criteria: the killing cell **passes** —
+`getAll` on a mixed tree at n=10^6 is ×1.058 [1.049, 1.068], against
+×0.72–0.77 at the §11.9 drop — but **sparse n=8×10^6 measured ×1.400
+against a ≥×1.5 bar, and the unimodal cells regress against the archived
+arm** (`sparse` ×0.901/×0.909, `dense` ×0.989/×0.988). Two criteria
+failed; the gate fails. Independently, the house rule bites: `getAll` on
+clustered n=10^6 is ×0.826 and on 90%-dense n=10^6 ×0.950 against plain
+serial — plausible workloads carrying a measured regression.
+
+Internal validity: all five `foreach` control cells are null across every
+shape (×0.990–1.003 vs main, ×0.985–0.999 vs archived), so the three
+builds are indistinguishable on the un-adopted path and the `getAll`
+deltas are attributable to the adoption rather than to build or link
+differences.
+
+**The threshold repair was pre-registered, measured, and REFUSED.** The
+mechanism proposed above — that a 4096-key gather pollutes the caller's
+cache — predicted that lowering `cJL_MULTIGET_PART_MIN_COUNT` so a
+256-key gather could still be analysed would fix it. **The probe refuted
+the prediction.** The composition analysis is a per-call fixed cost, so
+at 256-key batches it costs 13–15% against the archived arm (`wsparse`
+×0.869, `wdense` ×0.882, `wclust` ×0.952) — far outside the ~3% floor —
+and only amortises to free at 4096 keys (×0.990–1.000), which is exactly
+the gather size whose buffers cost ~10% at PHP level. Heterogeneous
+corpora still won at 256 keys (×1.30–×2.04), so pre-registered condition
+(b) held and condition (a) failed. Both were required. Per the
+pre-registration the verdict is DROP, and the tuning was not retried with
+a different knob.
+
+So the dilemma is structural, not a bad constant: **the analysis needs a
+large batch to amortise, and a large batch pollutes the caller's cache.**
+There is no setting of this knob that serves both, and the C-level
+evidence says the batched path additionally loses on cache-resident trees
+whether or not it partitions (`wdense` n=10^6 ×0.902, with the archived
+arm losing identically at ×0.92).
+
+**Status: DROPPED (second time), with the partition validated.** What
+stands as a real result: the counting partition does what the §11.10
+review predicted, beating the archived implementation on all nine
+heterogeneous cells (×1.25–×2.90) at no cost on unimodal ones, and
+`getAll` genuinely wins out-of-cache (mixed ×1.308, sparse ×1.400, dense
+×1.392, clustered ×1.218 at n=8×10^6). What does not stand is a shippable
+default: the same adoption regresses at n=10^6 on clustered, 90%-dense
+and sparse trees, and php-judy cannot know a caller's tree shape or
+batch composition in advance. With no consumer, the vendored TU would be
+dead code, so nothing is merged — the §11.9 reasoning, reached again from
+a stronger position. The implementation is archived complete on
+`vendor/stage3-o5-partition`.
+
+**What this says about the synthetic panel, stated in both directions.**
+The §11.10 panel was **right to reopen this**, and right about the
+mechanism: it diagnosed the heterogeneous-batch kill as an ordering
+effect, proposed the counting partition, and predicted the 90%-dense cell
+would still lose at ×0.77 — measured here at **×0.774**, from an
+independent implementation inside the library rather than their
+standalone prototype. A synthetic panel is not peer review and its
+convergence is not external evidence (§8), but on this occasion its
+analysis was specific enough to be falsifiable and it survived
+falsification. That is worth recording precisely because the optimization
+it rescued still failed: **the panel was right about the partition, and
+the adoption still does not pay.** Neither half of that sentence is safe
+to drop — treating the failed outcome as evidence the reopen was wasted
+would be as mistaken as treating the correct prediction as evidence the
+optimization should ship.
+
+Reopening conditions, narrowed by this round: (a) a PHP-facing bulk API
+whose contract lets the caller *declare* large out-of-cache batches, since
+that is the regime where every cell wins and the extension cannot infer
+it; or (b) a composition test cheap enough to run at the caller's natural
+batch size — this round's costs 13–15% at 256 keys, which is the number
+to beat.
 
 ## Limits of this record
 

--- a/research/libjudy-modernization/o5p-harness/README.md
+++ b/research/libjudy-modernization/o5p-harness/README.md
@@ -1,0 +1,55 @@
+# O5-reopen gate harness (#142)
+
+The measurement harness for the O5 reopen — the batched-lookup entry point
+`JudyLMultiGet` with its in-library counting partition. Committed because
+FINDINGS.md's "Reproduction" section records uncommitted harnesses as an
+open item; this one is re-runnable from the repo.
+
+| file | role |
+| --- | --- |
+| `o5pbench.c` | the C bench: serial vs batched on identical **pregenerated** probe streams, plus the old-style (dependent-chain) serial kernel for record comparability. Emits `FEAT` / `MEM` / `GATE` / `RES` rows. Corpora include the `wmix*` heterogeneous family added for the reopen (contiguous, strided, clustered, and 32-bit-ranged dense halves). |
+| `o5p-mkarm.sh` | builds one arm and links **five** binaries per arm with seeded randomized object order (the build is the replication unit); feature-checks the arm against its source so a stale build cannot masquerade. |
+| `o5p-bench.sh` | runs (trial × cell × arm × build), interleaved, pinned to core 2. |
+| `o5p-driver.sh` | full matrix: memory parity, L3, heterogeneous mix, out-of-cache, crossover. Gates its own output on the stability guard. |
+| `o5p-analyze.py` | per-build medians + percentile-bootstrap CIs; speedup, partition effect, controls, null checks. |
+| `o5p-table.py` | the same, rendered as a markdown gate table. `--exclude-trials` drops trials a run has reason to distrust. |
+| `o5p-stability.py` | **baseline-stability guard** (see below). |
+| `o5p-lock.sh` | `/var/tmp/BENCH_LOCK` mutual exclusion for the shared bench host. |
+| `phpbench4.php`, `php4-driver.sh` | PHP-level A/B: `getAll()` batched vs `foreach`, across sparse / mixed / dense / clustered shapes, persisting every raw invocation. |
+| `o5p-mincount-probe.sh`, `o5p-residency-sweep.sh` | threshold derivation. |
+
+## Why the stability guard exists
+
+On 2026-08-19 this matrix and a second php-judy benchmark campaign ran
+concurrently on the shared host and **corrupted each other**. Both
+individually satisfied the project's `loadavg < N/2` hygiene rule — 24
+cores, loadavg peaked at 2.87 — because that rule does not model the real
+coupling: two memory-bound benchmarks contend for LLC and memory
+bandwidth no matter how their cores are pinned.
+
+The corruption was caught by luck (a partial read of a cell disagreed with
+the full read). `o5p-stability.py` makes it mechanical: the `pre` arm is an
+untouched baseline, so a per-trial drift in *it* means the machine changed
+under the benchmark, and no ratio computed from those trials is
+interpretable. Validated both ways — it flags the collided out-of-cache
+sweep (baseline drift 116–142%, `wsparse` 8e6 `pre` 69.5 → 156.6 ns/op)
+and clears the L3 sweep (≤3.7%). It also caught a 20% single-trial
+excursion in `wmixs50` that eyeballing the ratios had dismissed.
+
+### Two pieces here are general-purpose, not O5-specific
+
+`o5p-stability.py` and `o5p-lock.sh` have nothing to do with batched
+lookups and should be reused by **any** benchmark campaign in this repo:
+
+- `o5p-stability.py <csv>...` takes any CSV in this harness's row format
+  (`arm,seed,corpus,n,trial,kernel,ns_per_op,hits`) and fails when an
+  untouched baseline arm drifts across trials. It is the mechanical
+  version of the `loadavg` hygiene rule, and strictly stronger — see the
+  incident above, where loadavg passed and the data was still garbage.
+- `o5p-lock.sh` is a generic `/var/tmp/BENCH_LOCK` mutex for the shared
+  bench host. Any campaign that does not take it can silently corrupt,
+  and be corrupted by, one that does.
+
+**Use the lock.** `. o5p-lock.sh; bench_lock_acquire <agent> "<what>"`
+before any run on the shared host; it refuses to start when another
+campaign holds `/var/tmp/BENCH_LOCK`.

--- a/research/libjudy-modernization/o5p-harness/o5p-analyze.py
+++ b/research/libjudy-modernization/o5p-harness/o5p-analyze.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""O5P (partition reopen) gate analysis.
+
+Replication unit = BUILD (randomized link order), per O1/O3/O4/O5: per
+(arm, seed, cell, kernel) take the median over interleaved trials, then
+percentile-bootstrap the ratio of build-median sets.
+
+Claims (per cell):
+  speedup     = pre/serial     vs post/mg256   (corrected baseline; CI-low > 1.0)
+  speedup-old = pre/serialold  vs post/mg256   (old-style baseline, record comparability)
+  partition   = ctl/mg256      vs post/mg256   (partition effect; unimodal cells
+                                                must NOT show CI-high < 1.0 = regression)
+  control     = pre/serial     vs ctl/serial   (expected null)
+  serialnull  = pre/serial     vs post/serial  (additive-TU null check)
+  raw         = pre/serial     vs post0/mg256  (thresholds off; crossover)
+"""
+import sys, csv, statistics as st, random
+from collections import defaultdict
+
+def boot_ratio(base, arm, n=20000, seed=7):
+    rnd = random.Random(seed)
+    out = []
+    for _ in range(n):
+        rb = [rnd.choice(base) for _ in base]
+        ra = [rnd.choice(arm) for _ in arm]
+        m = st.median(rb)
+        if m > 0:
+            out.append(m / st.median(ra))
+    out.sort()
+    return out[int(0.025 * len(out))], out[int(0.975 * len(out))]
+
+def main(paths):
+    data = defaultdict(lambda: defaultdict(list))
+    for path in paths:
+        with open(path) as f:
+            for row in csv.reader(x for x in f if not x.startswith("#")):
+                if not row or row[0] == "arm":
+                    continue
+                arm, seed, corpus, n, trial, kern, ns, hits = row
+                data[(corpus, int(n))][(arm, seed, kern)].append(float(ns))
+
+    for (corpus, n) in sorted(data):
+        cell = data[(corpus, n)]
+        def builds(arm, kern):
+            out = []
+            for s in "12345":
+                v = cell.get((arm, s, kern))
+                if v:
+                    out.append(st.median(v))
+            return out
+        pre = builds("pre", "serial")
+        preold = builds("pre", "serialold")
+        if not pre:
+            continue
+        pm = st.median(pre)
+        print(f"\n{corpus} n={n}  pre-serial={pm:.2f} ns/op (builds={len(pre)}"
+              f"; old-style={st.median(preold):.2f})" if preold else
+              f"\n{corpus} n={n}  pre-serial={pm:.2f} ns/op (builds={len(pre)})")
+        rows = [
+            ("pre",  "serial", pre,    "ctl", "serial", "control (expect null)"),
+            ("pre",  "serial", pre,    "post", "serial", "post-serial null-check"),
+            ("pre",  "serial", pre,    "post", "mg256", "SPEEDUP mg256 (corrected)"),
+            ("pre",  "serial", pre,    "post", "mg1024", "SPEEDUP mg1024 (corrected)"),
+            ("pre",  "serialold", preold, "post", "mg256", "speedup mg256 (old-style)"),
+            ("ctl",  "mg256", None,   "post", "mg256", "vs-ctl partition effect"),
+            ("pre",  "serial", pre,    "ctl", "mg256", "ctl (unpartitioned) mg256"),
+            ("pre",  "serial", pre,    "post0", "mg256", "raw (no threshold) mg256"),
+        ]
+        for barm, bkern, bset, aarm, akern, label in rows:
+            base = bset if bset is not None else builds(barm, bkern)
+            b = builds(aarm, akern)
+            if not b or not base:
+                continue
+            lo, hi = boot_ratio(base, b)
+            point = st.median(base) / st.median(b)
+            spread = (max(b) - min(b)) / st.median(b) * 100
+            mark = "** CI-low > 1.0" if lo > 1.0 else (
+                   "(regression, CI-high < 1.0)" if hi < 1.0 else "(null)")
+            print(f"  {label:30s} {st.median(b):8.2f} ns/op  "
+                  f"x{point:.4f} [{lo:.4f},{hi:.4f}] spread={spread:.1f}%  {mark}")
+
+if __name__ == "__main__":
+    main(sys.argv[1:] or ["o5p-bench-l3.csv"])

--- a/research/libjudy-modernization/o5p-harness/o5p-bench.sh
+++ b/research/libjudy-modernization/o5p-harness/o5p-bench.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# o5p-bench.sh <arms-csv> <buildseeds-csv> <corpusspec-csv> <trials> <outfile>
+# corpusspec = name:n:reps ; one binary invocation per (trial, cell, arm,
+# build) emits serial + serialold + mg256 + mg1024 rows. Trials interleave
+# across arms so slow drift hits every arm equally; every run pinned to
+# core 2. A GATE,...,FAIL line aborts the whole bench.
+ROOT=/var/tmp/jp113
+ARMS=$1; SEEDS=$2; SPECS=$3; TRIALS=$4; OUT=$5
+# Block sizes handed to each o5pbench invocation. 4096 is REQUIRED, not
+# optional: the partition only engages at Count >= cJL_MULTIGET_PART_MIN_COUNT
+# (2048), so a run limited to 256/1024 measures the UNPARTITIONED path in
+# every arm and would report "the partition does nothing". This was a live
+# bug on 2026-08-19 -- the value had been patched on the bench host only,
+# and re-shipping the script from the repo silently reverted it.
+BLOCKS=${BLOCKS:-256,1024,4096}
+echo "arm,seed,corpus,n,trial,kernel,ns_per_op,hits" > "$OUT"
+echo "# loadavg_start=$(cut -d' ' -f1 /proc/loadavg)" >> "$OUT"
+for t in $(seq 1 "$TRIALS"); do
+  for spec in ${SPECS//,/ }; do
+    c=${spec%%:*}; rest=${spec#*:}; n=${rest%%:*}; reps=${rest#*:}
+    for arm in ${ARMS//,/ }; do
+      for s in ${SEEDS//,/ }; do
+        B=$ROOT/bin/o5p${arm}_s${s}/o5pbench
+        [ -x "$B" ] || continue
+        OUTP=$(taskset -c 2 "$B" "$c" "$n" "$reps" 1 "$BLOCKS" 2>/dev/null)
+        if echo "$OUTP" | grep -q '^GATE.*FAIL'; then
+          echo "GATE FAIL arm=$arm s=$s cell=$spec" | tee -a "$OUT"; exit 1
+        fi
+        echo "$OUTP" | grep '^RES' | while IFS=, read -r _ cc nn rr kern ps ns hits; do
+          echo "$arm,$s,$cc,$nn,$t,$kern,$ns,$hits" >> "$OUT"
+        done
+      done
+    done
+  done
+  echo "# loadavg_trial${t}=$(cut -d' ' -f1 /proc/loadavg)" >> "$OUT"
+done
+echo "# loadavg_end=$(cut -d' ' -f1 /proc/loadavg)" >> "$OUT"

--- a/research/libjudy-modernization/o5p-harness/o5p-driver.sh
+++ b/research/libjudy-modernization/o5p-harness/o5p-driver.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# o5p-driver.sh -- full O5 REOPEN gate: env snapshots, memory parity,
+# L3-scale sweep (unimodal no-regression cells), heterogeneous-mix sweep
+# (the reopen's decisive cells incl. strided/clustered/32-bit dense
+# variants), crossover (threshold re-derivation) sweep, out-of-cache
+# cells. Writes o5p-bench.done when finished (coordinator watch marker).
+set -e
+
+. /var/tmp/jp113/o5p/o5p-lock.sh
+bench_lock_acquire "o5p-gate" "O5 reopen gate matrix (l3/mix/big/xover)" || exit 3
+ROOT=/var/tmp/jp113
+O5P=$ROOT/o5p
+cd $O5P
+ENV=$O5P/o5p-bench-env.txt
+echo "# pre-bench ps snapshot: $(date -u +%FT%TZ)" > $ENV
+ps -A -o %cpu,%mem,comm --sort=-%cpu | head -6 >> $ENV
+cat /proc/loadavg >> $ENV
+
+# memory parity: JLMU byte-identical across all arms on every corpus
+for c in wdense wsparse wbase16 wbase64 wclust wrand40 wleaf1 wimm3 wpair wmix50 wmixs50 wmixc50 wmix32_50; do
+  for arm in pre ctl post post0; do
+    taskset -c 2 $ROOT/bin/o5p${arm}_s1/o5pbench $c 1000000 1000 1 2>/dev/null \
+      | grep '^MEM' > $O5P/mem-$arm-$c.txt
+  done
+  for arm in ctl post post0; do
+    diff -q $O5P/mem-pre-$c.txt $O5P/mem-$arm-$c.txt >/dev/null \
+      || { echo "MEMPARITY MISMATCH $c $arm" | tee -a $ENV; exit 1; }
+  done
+done
+echo "MEMPARITY: pre/ctl/post/post0 byte-identical on 13 corpora" | tee -a $ENV
+
+# L3-resident unimodal cells (no-regression gate vs ctl)
+bash $O5P/o5p-bench.sh "pre,ctl,post,post0" "1,2,3,4,5" \
+  "wdense:1000000:2000000,wsparse:1000000:2000000,wbase16:1048576:2000000,wbase64:1000000:2000000,wclust:1000000:2000000,wrand40:1000000:2000000,wleaf1:1000000:2000000,wimm3:1000000:2000000,wpair:1000000:2000000" \
+  7 $O5P/o5p-bench-l3.csv
+echo "# after-l3: $(date -u +%FT%TZ)" >> $ENV; cat /proc/loadavg >> $ENV
+
+# heterogeneous-mix cells (the reopen's decisive family)
+bash $O5P/o5p-bench.sh "pre,ctl,post,post0" "1,2,3,4,5" \
+  "wmix10:1000000:2000000,wmix25:1000000:2000000,wmix50:1000000:2000000,wmix75:1000000:2000000,wmix90:1000000:2000000,wmixs50:1000000:2000000,wmixc50:1000000:2000000,wmix32_50:1000000:2000000,wmix32_90:1000000:2000000" \
+  7 $O5P/o5p-bench-mix.csv
+echo "# after-mix: $(date -u +%FT%TZ)" >> $ENV; cat /proc/loadavg >> $ENV
+
+# out-of-cache cells
+bash $O5P/o5p-bench.sh "pre,ctl,post,post0" "1,2,3,4,5" \
+  "wsparse:8000000:2000000,wdense:8000000:2000000,wmix50:8000000:2000000" \
+  5 $O5P/o5p-bench-big.csv
+echo "# after-big: $(date -u +%FT%TZ)" >> $ENV; cat /proc/loadavg >> $ENV
+
+# crossover sweep: raw pipelined+partitioned (post0) vs serial across
+# populations; shipped default (post) must be ~null below its threshold
+bash $O5P/o5p-bench.sh "pre,ctl,post,post0" "1,2,3,4,5" \
+  "wdense:1024:2000000,wdense:4096:2000000,wdense:16384:2000000,wdense:65536:2000000,wdense:262144:2000000,wsparse:1024:2000000,wsparse:4096:2000000,wsparse:16384:2000000,wsparse:65536:2000000,wsparse:262144:2000000,wclust:16384:2000000,wclust:65536:2000000,wbl:6561:2000000,wmix50:16384:2000000,wmix50:65536:2000000,wmix50:262144:2000000" \
+  5 $O5P/o5p-bench-xover.csv
+echo "# post-bench: $(date -u +%FT%TZ)" >> $ENV; cat /proc/loadavg >> $ENV
+ps -A -o %cpu,%mem,comm --sort=-%cpu | head -6 >> $ENV
+# Baseline-stability guard: the `pre` arm is untouched, so a per-trial
+# drift in it means the MACHINE changed, not the code. loadavg alone did
+# not catch the 2026-08-19 collision; this does.
+STAB=0
+python3 $O5P/o5p-stability.py $O5P/o5p-bench-l3.csv $O5P/o5p-bench-mix.csv \
+    $O5P/o5p-bench-big.csv $O5P/o5p-bench-xover.csv > $O5P/o5p-stability.txt 2>&1 || STAB=1
+if [ $STAB -ne 0 ]; then
+  echo "BASELINE-STABILITY GUARD FAILED -- see o5p-stability.txt" | tee -a $ENV
+  echo BENCH-CONTAMINATED > $O5P/o5p-bench.done
+  exit 1
+fi
+echo BENCH-DONE > $O5P/o5p-bench.done

--- a/research/libjudy-modernization/o5p-harness/o5p-lock.sh
+++ b/research/libjudy-modernization/o5p-harness/o5p-lock.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# o5p-lock.sh -- honeycomb exclusive-benchmark lock.
+#
+# WHY THIS EXISTS (2026-08-19): two php-judy benchmark campaigns ran
+# concurrently on honeycomb (this O5-reopen gate matrix pinned to core 2,
+# and a three-arm system-vs-bundled campaign in docker). BOTH individually
+# satisfied the project's loadavg < N/2 hygiene check -- 24 cores, loadavg
+# never exceeded 2.9 -- and both were corrupted anyway: an untouched
+# BASELINE arm (wsparse n=8e6, pre/serial) moved 69.4-69.8 -> 147-172
+# ns/op between trials. Two memory-bound benchmarks contend for LLC and
+# memory bandwidth no matter how their cores are pinned, so loadavg is
+# NOT a sufficient guard on a 24-core box. Mutual exclusion is.
+#
+# usage:  . o5p-lock.sh; bench_lock_acquire "<agent>" "<what>"; ... ; bench_lock_release
+LOCK=/var/tmp/BENCH_LOCK
+
+bench_lock_acquire() {
+    local who=$1 what=$2
+    if [ -e "$LOCK" ]; then
+        echo "BENCH_LOCK held -- refusing to start. Holder:" >&2
+        sed 's/^/  /' "$LOCK" >&2
+        echo "If the holder is dead, remove $LOCK by hand after confirming." >&2
+        return 3
+    fi
+    # O_EXCL create: loses safely if another job wins the race.
+    if ! (set -o noclobber; printf "agent=%s\npid=%s\nhost_pid=%s\nstarted=%s\nwhat=%s\n" \
+            "$who" "$$" "$(hostname)" "$(date -u +%FT%TZ)" "$what" > "$LOCK") 2>/dev/null; then
+        echo "BENCH_LOCK race lost -- another job took it. Not starting." >&2
+        return 3
+    fi
+    trap 'bench_lock_release' EXIT INT TERM
+    echo "BENCH_LOCK acquired by $who: $what"
+}
+
+bench_lock_release() {
+    rm -f "$LOCK"
+}

--- a/research/libjudy-modernization/o5p-harness/o5p-mincount-probe.sh
+++ b/research/libjudy-modernization/o5p-harness/o5p-mincount-probe.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# o5p-mincount-probe.sh -- what does the per-call composition analysis
+# actually cost now that jl_mg_step is inlined again?
+#
+# The shipped default only analyzes batches of >= cJL_MULTIGET_PART_MIN_COUNT
+# (2048) keys, so SHORT heterogeneous batches still run the archived
+# unpartitioned pipeline -- which the original O5 gate measured losing
+# x0.74 on mixed batches. That is a plausible-workload regression unless
+# either (a) the analysis is cheap enough at small Count to lower the
+# threshold, or (b) the caller declines the batched path below it.
+#
+# Arms: ctl (archived), post (MIN_COUNT=2048 default), postmc (MIN_COUNT=64
+# -- analysis on every batch). Cells: unimodal (analysis is pure overhead)
+# and mixed (analysis buys the partition) at block sizes 256/1024/4096.
+set -e
+
+. /var/tmp/jp113/o5p/o5p-lock.sh
+bench_lock_acquire "o5p-gate" "O5 reopen PART_MIN_COUNT probe" || exit 3
+ROOT=/var/tmp/jp113
+O5P=$ROOT/o5p
+OUT=$O5P/o5p-mincount.csv
+
+bash $O5P/build-stock.sh $O5P/src-post/libjudy/src $O5P/arm-postmc \
+  "-O2 -mpopcnt -DcJL_MULTIGET_PART_MIN_COUNT=64" > $O5P/postmc-build.log 2>&1
+for s in 1 2 3 4 5; do
+  mkdir -p $ROOT/bin/o5ppostmc_s${s}
+  OBJS=$(ls $O5P/arm-postmc/obj/*.o | shuf --random-source=<(yes s$s))
+  gcc -O2 -o $ROOT/bin/o5ppostmc_s${s}/o5pbench $O5P/o5pbench.c \
+      -I$O5P/arm-postmc/include $OBJS -lm
+done
+echo "arm postmc built"
+
+bash $O5P/o5p-bench.sh "pre,ctl,post,postmc" "1,2,3,4,5" \
+  "wsparse:1000000:2000000,wdense:1000000:2000000,wclust:1000000:2000000,wmix50:1000000:2000000,wmix10:1000000:2000000,wmixs50:1000000:2000000" \
+  7 $OUT
+echo MINCOUNT-DONE > $O5P/o5p-mincount.done

--- a/research/libjudy-modernization/o5p-harness/o5p-mkarm.sh
+++ b/research/libjudy-modernization/o5p-harness/o5p-mkarm.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# o5p-mkarm.sh <arm> [extra-cflags] -- build one O5P bench arm from
+# /var/tmp/jp113/o5p/src-<arm>/libjudy/src using build-stock.sh (CFLAGS
+# "-O2 -mpopcnt", matching the production vendored build), then link FIVE
+# o5pbench binaries per arm with seeded random object order (link-order
+# randomization is the per-build replication axis, as in O1/O3/O4/O5).
+#
+# Arms: pre  (origin/main -- no JudyLMultiGet)
+#       ctl  (vendor/stage3-o5-amac -- archived UNPARTITIONED multiget)
+#       post (vendor/stage3-o5-partition -- partitioned multiget)
+#       post0 (post src, serial thresholds compiled out -- crossover)
+# NOTE: a ctl built from the same objects as post would be byte-identical
+# only if sources matched; here ctl is a DIFFERENT source tree (the
+# archived impl). The layout control is the 5 randomized-link builds
+# within each arm; temporal noise is calibrated by interleaved trials.
+set -e
+ROOT=/var/tmp/jp113
+O5P=$ROOT/o5p
+ARM=$1
+EXTRA=${2:-}
+case $ARM in post0) SRCARM=post ;; *) SRCARM=$ARM ;; esac
+SRC=$O5P/src-$SRCARM/libjudy/src
+[ -d "$SRC" ] || { echo "no src at $SRC" >&2; exit 2; }
+
+bash $O5P/build-stock.sh "$SRC" "$O5P/arm-$ARM" "-O2 -mpopcnt $EXTRA" > $O5P/$ARM-build.log 2>&1
+
+# feature check on the built objects (stale-build hazard): the multiget TU
+# must exist exactly on ctl/post/post0 arms.
+if ls $O5P/arm-$ARM/obj/L_JudyMultiGet.o >/dev/null 2>&1; then MG=present; else MG=absent; fi
+echo "featurecheck arm=$ARM L_JudyMultiGet.o=$MG"
+case $ARM in
+  ctl|post|post0) [ $MG = present ] || { echo "ARM $ARM MISSING MULTIGET" >&2; exit 3; } ;;
+  *)              [ $MG = absent ]  || { echo "ARM $ARM UNEXPECTED MULTIGET" >&2; exit 3; } ;;
+esac
+# partition-presence check (ctl vs post must differ): the counting
+# partition's scatter loop exists only in the partitioned TU. Grep the
+# arm's source (the objects are built from it by this same script run).
+PARTSRC=$(grep -c "counting partition" $SRC/JudyCommon/JudyMultiGet.c 2>/dev/null || true)
+echo "featurecheck arm=$ARM partition-src-refs=$PARTSRC"
+case $ARM in
+  post|post0) [ "$PARTSRC" -ge 1 ] || { echo "ARM $ARM SRC LACKS PARTITION" >&2; exit 3; } ;;
+  ctl)        [ "$PARTSRC" = 0 ]   || { echo "ARM ctl SRC UNEXPECTEDLY PARTITIONED" >&2; exit 3; } ;;
+esac
+
+for s in 1 2 3 4 5; do
+  mkdir -p $ROOT/bin/o5p${ARM}_s${s}
+  OBJS=$(ls $O5P/arm-$ARM/obj/*.o | shuf --random-source=<(yes s$s))
+  gcc -O2 -o $ROOT/bin/o5p${ARM}_s${s}/o5pbench $O5P/o5pbench.c \
+      -I$O5P/arm-$ARM/include $OBJS -lm
+  R=$(taskset -c 2 $ROOT/bin/o5p${ARM}_s${s}/o5pbench wdense 1000 1000 1 | grep '^FEAT' | cut -d, -f4)
+  [ "$R" = "$MG" ] || { echo "ARM $ARM s$s FEATURE MISMATCH ($R vs $MG)" >&2; exit 3; }
+done
+echo "arm $ARM done"

--- a/research/libjudy-modernization/o5p-harness/o5p-residency-sweep.sh
+++ b/research/libjudy-modernization/o5p-harness/o5p-residency-sweep.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# o5p-residency-sweep.sh -- re-derive the serial-fallback threshold under
+# the CORRECTED serial baseline.
+#
+# The shipped cJL_MULTIGET_SERIAL_POP1 = 262144 was derived against the
+# handicapped baseline (probe keys computed in a dependent chain inside
+# the timed loop). Under the corrected baseline the batched path LOSES on
+# wdense at pop 1e6 (x0.90) while WINNING on wsparse at the same
+# population (x1.57) -- so POPULATION is the wrong axis. The distinguishing
+# variable is residency: a dense 1e6 tree fits L3, a sparse one does not.
+# JLMU (jpm_TotalMemWords) is O(1) from the JPM, so a memory-based
+# threshold is implementable.
+#
+# This sweep records ratio AND JLMU per (corpus, n) so the crossover can be
+# read as a function of tree BYTES rather than key count.
+set -e
+
+. /var/tmp/jp113/o5p/o5p-lock.sh
+bench_lock_acquire "o5p-gate" "O5 reopen residency/threshold sweep" || exit 3
+ROOT=/var/tmp/jp113
+O5P=$ROOT/o5p
+OUT=$O5P/o5p-residency.csv
+MEMOUT=$O5P/o5p-residency-mem.csv
+
+echo "corpus,n,jlmu_bytes" > $MEMOUT
+for spec in wdense:262144 wdense:1000000 wdense:2000000 wdense:4000000 wdense:8000000 wdense:16000000 \
+            wsparse:262144 wsparse:1000000 wsparse:4000000 wsparse:8000000 \
+            wclust:262144 wclust:1000000 wclust:4000000 wclust:8000000 \
+            wmix50:262144 wmix50:1000000 wmix50:4000000 wmix50:8000000; do
+  c=${spec%%:*}; n=${spec#*:}
+  taskset -c 2 $ROOT/bin/o5ppre_s1/o5pbench $c $n 1000 1 2>/dev/null \
+    | awk -F, '/^MEM/{print $2","$3","$4}' >> $MEMOUT
+done
+echo "memory census done"
+
+bash $O5P/o5p-bench.sh "pre,ctl,post,post0" "1,2,3,4,5" \
+  "wdense:262144:2000000,wdense:1000000:2000000,wdense:2000000:2000000,wdense:4000000:2000000,wdense:8000000:2000000,wdense:16000000:2000000,wsparse:262144:2000000,wsparse:1000000:2000000,wsparse:4000000:2000000,wclust:1000000:2000000,wclust:4000000:2000000,wmix50:1000000:2000000,wmix50:4000000:2000000" \
+  5 $OUT
+echo RESIDENCY-DONE > $O5P/o5p-residency.done

--- a/research/libjudy-modernization/o5p-harness/o5p-stability.py
+++ b/research/libjudy-modernization/o5p-harness/o5p-stability.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Baseline-stability guard for the O5P gate CSVs.
+
+WHY (2026-08-19): the O5-reopen out-of-cache sweep was corrupted by a
+concurrent php-judy benchmark campaign on the same host. Both campaigns
+passed the project's loadavg < N/2 hygiene check (24 cores, loadavg peaked
+at 2.87) and corrupted each other anyway, because two memory-bound
+benchmarks contend for LLC and memory bandwidth regardless of core
+pinning. The corruption was caught by LUCK -- a partial read of a cell
+disagreed with the full read.
+
+This makes that check mechanical. The `pre` arm is an untouched baseline:
+its per-trial medians must be stable within a cell. A spread beyond
+--tol (default 15%) means the machine changed under the benchmark, and
+NO ratio computed from those trials is interpretable.
+
+usage: o5p-stability.py [--tol 0.15] <csv> [csv...]
+exit 1 if any cell fails, so a driver can gate on it.
+"""
+import sys, csv, statistics as st
+from collections import defaultdict
+
+tol = 0.15
+args = sys.argv[1:]
+if args and args[0] == "--tol":
+    tol = float(args[1]); args = args[2:]
+
+# (corpus,n,arm,kernel) -> {trial: [ns]}
+data = defaultdict(lambda: defaultdict(list))
+loadavg = defaultdict(dict)
+for path in args:
+    for line in open(path):
+        if line.startswith("#"):
+            if "loadavg_" in line:
+                k, _, v = line.strip("# \n").partition("=")
+                loadavg[path][k] = v
+            continue
+        row = next(csv.reader([line]))
+        if not row or row[0] == "arm":
+            continue
+        arm, seed, corpus, n, trial, kern, ns, hits = row
+        data[(corpus, int(n), arm, kern)][int(trial)].append(float(ns))
+
+bad = 0
+print(f"{'cell':38s} {'arm/kernel':16s} {'trials':>7s} {'min':>9s} {'max':>9s} {'spread':>8s}  verdict")
+for (corpus, n, arm, kern) in sorted(data):
+    if arm != "pre" or kern not in ("serial", "serialold"):
+        continue           # the untouched baseline is the canary.
+    per_trial = {t: st.median(v) for t, v in data[(corpus, n, arm, kern)].items()}
+    if len(per_trial) < 2:
+        continue
+    lo, hi = min(per_trial.values()), max(per_trial.values())
+    spread = (hi - lo) / lo
+    ok = spread <= tol
+    if not ok:
+        bad += 1
+        drift = " ".join(f"t{t}={v:.1f}" for t, v in sorted(per_trial.items()))
+        verdict = f"CONTAMINATED ({drift})"
+    else:
+        verdict = "stable"
+    print(f"{corpus+' n='+str(n):38s} {arm+'/'+kern:16s} {len(per_trial):7d} "
+          f"{lo:9.2f} {hi:9.2f} {spread*100:7.1f}%  {verdict}")
+
+for path, la in loadavg.items():
+    vals = [float(v) for v in la.values()]
+    if vals and (max(vals) - min(vals)) > 0.5:
+        print(f"\nNOTE {path}: loadavg moved {min(vals)}..{max(vals)} during the run.")
+
+if bad:
+    print(f"\n{bad} cell(s) FAILED the baseline-stability guard at tol={tol:.0%}. "
+          f"Ratios from those trials are not interpretable -- re-run on an idle host.")
+    sys.exit(1)
+print(f"\nAll baseline cells stable within {tol:.0%}.")

--- a/research/libjudy-modernization/o5p-harness/o5p-table.py
+++ b/research/libjudy-modernization/o5p-harness/o5p-table.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Render the O5P gate cells as a markdown table (for the PR / #142 record).
+
+Columns: corpus, n, pre-serial ns/op (corrected), post mg ratio [CI]
+(corrected baseline), post mg ratio (old-style baseline), post-vs-ctl
+partition effect [CI], ctl-vs-pre (archived impl) [CI], verdict.
+Verdict rules: WIN = corrected CI-low > 1.0; REG = CI-high < 1.0; null
+otherwise. The no-regression gate is the post-vs-ctl column.
+"""
+import sys, csv, statistics as st, random
+from collections import defaultdict
+
+args = sys.argv[1:]
+EXCL = set()
+if args and args[0] == "--exclude-trials":
+    EXCL = {int(x) for x in args[1].split(",")}; args = args[2:]
+KERN = args[0] if args else "mg4096"
+FILES = args[1:]
+
+def boot(base, arm, n=20000, seed=7):
+    rnd = random.Random(seed); out=[]
+    for _ in range(n):
+        rb=[rnd.choice(base) for _ in base]; ra=[rnd.choice(arm) for _ in arm]
+        m=st.median(rb)
+        if m>0: out.append(m/st.median(ra))
+    out.sort(); return out[int(.025*len(out))], out[int(.975*len(out))]
+
+def mark(lo,hi):
+    return "WIN" if lo>1.0 else ("REG" if hi<1.0 else "null")
+
+data=defaultdict(lambda: defaultdict(list))
+for path in FILES:
+    with open(path) as f:
+        for row in csv.reader(x for x in f if not x.startswith("#")):
+            if not row or row[0]=="arm": continue
+            arm,seed,corpus,n,trial,kern,ns,hits=row
+            if int(trial) in EXCL: continue
+            data[(corpus,int(n))][(arm,seed,kern)].append(float(ns))
+
+print(f"| corpus | n | pre serial (ns/op) | post {KERN} vs pre (corrected) | vs pre (old-style) | post vs ctl (partition effect) | ctl vs pre (archived) | verdict |")
+print("| --- | --- | --- | --- | --- | --- | --- | --- |")
+for (c,n) in sorted(data):
+    cell=data[(c,n)]
+    B=lambda a,k:[st.median(cell[(a,s,k)]) for s in "12345" if cell.get((a,s,k))]
+    pre=B("pre","serial"); preold=B("pre","serialold")
+    post=B("post",KERN);  ctl=B("ctl",KERN)
+    if not (pre and post): continue
+    lo,hi=boot(pre,post); pt=st.median(pre)/st.median(post)
+    if preold:
+        lo2,hi2=boot(preold,post); pt2=st.median(preold)/st.median(post)
+        old=f"x{pt2:.2f} [{lo2:.2f},{hi2:.2f}]"
+    else: old="—"
+    if ctl:
+        lo3,hi3=boot(ctl,post); pt3=st.median(ctl)/st.median(post)
+        pc=f"x{pt3:.3f} [{lo3:.3f},{hi3:.3f}] {mark(lo3,hi3)}"
+        lo4,hi4=boot(pre,ctl); pt4=st.median(pre)/st.median(ctl)
+        cv=f"x{pt4:.2f} [{lo4:.2f},{hi4:.2f}] {mark(lo4,hi4)}"
+    else: pc=cv="—"
+    print(f"| `{c}` | {n:,} | {st.median(pre):.2f} | **x{pt:.3f} [{lo:.3f},{hi:.3f}]** | {old} | {pc} | {cv} | {mark(lo,hi)} |")

--- a/research/libjudy-modernization/o5p-harness/o5pbench.c
+++ b/research/libjudy-modernization/o5p-harness/o5pbench.c
@@ -1,0 +1,230 @@
+/* o5pbench.c -- O5 REOPEN (partition) gate bench: library JudyLMultiGet
+ * (now internally counting-partitioned) vs serial JudyLGet on identical
+ * PREGENERATED probe streams.
+ *
+ * Differences from the original o5bench.c, per the adversarial review:
+ *  - CORRECTED serial baseline: the probe stream is materialized into
+ *    probe[] BEFORE timing; the serial kernel reads probe[r] instead of
+ *    computing the next key through a dependent xorshift chain inside
+ *    the timed loop (the chain inflated the old serial ns/op ~25-30%,
+ *    flattering batched ratios).  The old-style kernel is retained and
+ *    reported as "serialold" so both baseline styles appear in the
+ *    record.
+ *  - Heterogeneous-batch corpora: wmixPP (PP% dense contiguous + sparse
+ *    64-bit), wmixsPP (dense STRIDED x16), wmixcPP (dense CLUSTERED in
+ *    1024-key runs at random 40-bit bases), wmix32_PP (PP% dense + sparse
+ *    32-bit -- keys whose top 4 bytes are all zero; catches a partition
+ *    that only looks at high bytes).
+ *
+ * Output (machine-parseable):
+ *   FEAT,<corpus>,multiget,<present|absent>
+ *   MEM,<corpus>,<n>,<jlmu-bytes>
+ *   GATE,<corpus>,<n>,<reps>,<serial-hits>,<mg-hits>,<PASS|FAIL>
+ *   RES,<corpus>,<n>,<reps>,<kernel>,<pass>,<ns-per-op>,<hits>
+ *
+ * usage: o5pbench <corpus> <n> <reps> [passes=1] [blocks=256,1024]
+ */
+#define _GNU_SOURCE
+#include <Judy.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+
+extern Word_t JudyLMultiGet(Pcvoid_t PArray, const Word_t *PIndex,
+                            PPvoid_t *PPValue, Word_t Count)
+    __attribute__((weak));
+
+static double now_ns(void){struct timespec t;clock_gettime(CLOCK_MONOTONIC,&t);
+    return (double)t.tv_sec*1e9+(double)t.tv_nsec;}
+
+static uint64_t sm_s;
+static uint64_t sm(void){uint64_t z=(sm_s+=0x9E3779B97F4A7C15ULL);
+    z=(z^(z>>30))*0xBF58476D1CE4E5B9ULL;z=(z^(z>>27))*0x94D049BB133111EBULL;return z^(z>>31);}
+
+/* ------------------------------------------------------------- corpora  */
+/* unimodal generators verbatim from o5bench.c / mlp2.c (comparability);
+ * wmix* families added for the reopen. */
+static int gen_corpus(const char *corpus, Word_t *wk, unsigned long n)
+{
+    if (!strncmp(corpus, "wmix", 4)) {
+        const char *p = corpus + 4;
+        int strided = 0, clustered = 0, sparse32 = 0;
+        if      (*p == 's') { strided = 1; p++; }
+        else if (*p == 'c') { clustered = 1; p++; }
+        else if (!strncmp(p, "32_", 3)) { sparse32 = 1; p += 3; }
+        int pct = atoi(p);
+        if (pct < 0 || pct > 100) return -1;
+        unsigned long dcount = (unsigned long)((double)n * pct / 100.0);
+        Word_t curbase = 0;
+        for (unsigned long i = 0; i < n; i++) {
+            if (i < dcount) {
+                if (strided)        wk[i] = i * 16;
+                else if (clustered) {
+                    if ((i & 1023) == 0) curbase = sm() & ((1UL<<40)-1);
+                    wk[i] = curbase + (i & 1023);
+                }
+                else                wk[i] = i;
+            } else {
+                wk[i] = sparse32 ? (sm() & 0xffffffffUL) : sm();
+            }
+        }
+        return 0;
+    }
+    for (unsigned long i = 0; i < n; i++) {
+        if      (!strcmp(corpus,"wdense"))   wk[i] = i;
+        else if (!strcmp(corpus,"wsparse"))  wk[i] = sm();
+        else if (!strcmp(corpus,"wclust"))   wk[i] = (sm()%4096)*65536UL + (i&0xffff);
+        else if (!strncmp(corpus,"wbase",5)) {
+            unsigned base = (unsigned)atoi(corpus+5);
+            unsigned long v = i, k = 0;
+            for (int b = 0; b < 8; b++) { k |= (v % base) << (8*b); v /= base; }
+            wk[i] = k;
+        }
+        else if (!strncmp(corpus,"wrand",5)) {
+            int bits = atoi(corpus+5);
+            wk[i] = sm() & ((bits >= 64) ? ~0UL : ((1UL << bits) - 1));
+        }
+        else if (!strcmp(corpus,"wleaf1"))   wk[i] = (i/12)*256 + (i%12)*21;
+        else if (!strcmp(corpus,"wimm3"))    wk[i] = (i/3)*256 + (i%3)*80;
+        else if (!strcmp(corpus,"wimm6"))    wk[i] = (i/6)*256 + (i%6)*40;
+        else if (!strcmp(corpus,"wimm1"))    wk[i] = i*256;
+        else if (!strcmp(corpus,"wpair"))    wk[i] = (i/2)*65536UL + (i%2)*300;
+        else if (!strcmp(corpus,"wtrip"))    wk[i] = (i/2)*16777216UL + (i%2)*70000;
+        else if (!strcmp(corpus,"wbl")) {
+            unsigned long v = i, k = 0;
+            for (int b = 0; b < 8; b++) { k |= ((v % 3) * 85UL) << (8*b); v /= 3; }
+            wk[i] = k;
+        }
+        else if (!strcmp(corpus,"wroot"))    wk[i] = i * 977;
+        else return -1;
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------- kernels  */
+
+/* OLD-STYLE serial baseline (dependent xorshift chain inside the timed
+ * loop) -- kept only so the record carries both styles: */
+static unsigned long kern_serial_old(Pvoid_t J, const Word_t *keys,
+                                     unsigned long n, unsigned long reps)
+{
+    PWord_t pv; unsigned long hits = 0; uint64_t rs = 88172645463325252ULL;
+    for (unsigned long r = 0; r < reps; r++) {
+        rs ^= rs<<13; rs ^= rs>>7; rs ^= rs<<17;
+        JLG(pv, J, keys[rs % n]); if (pv) hits++;
+    }
+    return hits;
+}
+
+/* CORRECTED serial baseline: probe stream pregenerated. */
+static unsigned long kern_serial(Pvoid_t J, const Word_t *probe,
+                                 unsigned long reps)
+{
+    PWord_t pv; unsigned long hits = 0;
+    for (unsigned long r = 0; r < reps; r++) {
+        JLG(pv, J, probe[r]); if (pv) hits++;
+    }
+    return hits;
+}
+
+#define MAXBLK 4096
+
+static unsigned long kern_mg(Pvoid_t J, const Word_t *probe,
+                             unsigned long reps, unsigned long blk)
+{
+    Word_t   kbuf[MAXBLK];
+    PPvoid_t vbuf[MAXBLK];
+    unsigned long hits = 0, done = 0;
+
+    if (blk > MAXBLK) blk = MAXBLK;
+    while (done < reps) {
+        unsigned long m = reps - done; if (m > blk) m = blk;
+        memcpy(kbuf, probe + done, m * sizeof(Word_t));
+        hits += JudyLMultiGet(J, kbuf, vbuf, m);
+        done += m;
+    }
+    return hits;
+}
+
+/* ------------------------------------------------------------- main     */
+
+int main(int argc, char **argv)
+{
+    const char *corpus = (argc>1)?argv[1]:"wdense";
+    unsigned long n    = (argc>2)?strtoul(argv[2],NULL,10):1000000;
+    unsigned long reps = (argc>3)?strtoul(argv[3],NULL,10):2000000;
+    int passes         = (argc>4)?atoi(argv[4]):1;
+    const char *blkcsv = (argc>5)?argv[5]:"256,1024";
+    sm_s = 12345;
+
+    int have_mg = (JudyLMultiGet != NULL);
+    printf("FEAT,%s,multiget,%s\n", corpus, have_mg ? "present" : "absent");
+
+    Word_t *keys = malloc(n*sizeof(Word_t));
+    if (!keys || gen_corpus(corpus, keys, n) != 0) {
+        fprintf(stderr,"bad corpus %s\n",corpus); return 2; }
+
+    Pvoid_t J=(Pvoid_t)NULL; PWord_t pv;
+    for(unsigned long i=0;i<n;i++){ JLI(pv,J,keys[i]); *pv=i+1; }
+
+    Word_t mem; JLMU(mem, J);
+    printf("MEM,%s,%lu,%lu\n", corpus, n, mem);
+
+    /* Pregenerated probe stream, identical to the old chain's sequence. */
+    Word_t *probe = malloc(reps*sizeof(Word_t));
+    if (!probe) { fprintf(stderr,"oom probe\n"); return 2; }
+    { uint64_t rs = 88172645463325252ULL;
+      for (unsigned long r = 0; r < reps; r++) {
+          rs ^= rs<<13; rs ^= rs>>7; rs ^= rs<<17;
+          probe[r] = keys[rs % n];
+      } }
+
+    /* correctness gate: identical probe streams must yield identical hit
+       counts (per-slot pointer equality is the fuzzer's job). */
+    if (have_mg) {
+        unsigned long gr = (reps < 200000) ? reps : 200000;
+        unsigned long hs = kern_serial(J, probe, gr);
+        unsigned long hm = kern_mg(J, probe, gr, 256);
+        unsigned long hm2 = kern_mg(J, probe, gr, 1024);
+        int ok = (hs == hm && hs == hm2);
+        printf("GATE,%s,%lu,%lu,%lu,%lu,%s\n", corpus, n, gr, hs, hm,
+               ok ? "PASS" : "FAIL");
+        if (!ok) return 1;
+    }
+
+    unsigned long h;
+    h = kern_serial(J, probe, reps/4 + 1);                /* warmup */
+    for (int ps = 1; ps <= passes; ps++) {
+        double a = now_ns();
+        h = kern_serial(J, probe, reps);
+        double b = now_ns();
+        printf("RES,%s,%lu,%lu,serial,%d,%.4f,%lu\n",
+               corpus, n, reps, ps, (b-a)/reps, h);
+    }
+    h = kern_serial_old(J, keys, n, reps/4 + 1);          /* warmup */
+    for (int ps = 1; ps <= passes; ps++) {
+        double a = now_ns();
+        h = kern_serial_old(J, keys, n, reps);
+        double b = now_ns();
+        printf("RES,%s,%lu,%lu,serialold,%d,%.4f,%lu\n",
+               corpus, n, reps, ps, (b-a)/reps, h);
+    }
+    if (have_mg) {
+        char bc[128]; strncpy(bc, blkcsv, sizeof bc - 1); bc[sizeof bc-1]=0;
+        for (char *tok = strtok(bc, ","); tok; tok = strtok(NULL, ",")) {
+            unsigned long blk = strtoul(tok, NULL, 10);
+            if (blk < 1 || blk > MAXBLK) continue;
+            h = kern_mg(J, probe, reps/4 + 1, blk);       /* warmup */
+            for (int ps = 1; ps <= passes; ps++) {
+                double a = now_ns();
+                h = kern_mg(J, probe, reps, blk);
+                double b = now_ns();
+                printf("RES,%s,%lu,%lu,mg%lu,%d,%.4f,%lu\n",
+                       corpus, n, reps, blk, ps, (b-a)/reps, h);
+            }
+        }
+    }
+    return 0;
+}

--- a/research/libjudy-modernization/o5p-harness/php4-driver.sh
+++ b/research/libjudy-modernization/o5p-harness/php4-driver.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# php4-driver.sh -- O5 REOPEN PHP-level A/B inside php-judy-bench image.
+# Arms: pre (origin/main serial getAll), ctl (archived unpartitioned
+# multiget), post (partitioned multiget + 4096-key gather).
+# Replication unit = PROCESS RUN (disclosed: weaker than the C gate's
+# build replication; the C gate carries the layout-noise-proofed claim).
+# EVERY raw invocation output is persisted under raw/ (the original drop
+# lost its "+10% sparse" cell to an unpersisted run).
+set -e
+
+. /var/tmp/jp113/o5p/o5p-lock.sh
+bench_lock_acquire "o5p-gate" "O5 reopen PHP-level A/B" || exit 3
+P=/var/tmp/jp113/o5p/php
+OUT=$P/php4-bench.csv
+mkdir -p $P/raw
+cd $P
+
+build() { # $1 = arm
+  docker run --rm -v $P/$1:/usr/src/php-judy -w /usr/src/php-judy php-judy-bench:latest \
+    sh -c 'find . -name "*.lo" -delete; find . -name "*.o" -delete; rm -f Makefile config.status; phpize >/dev/null && ./configure >/dev/null && make -j8 >/dev/null 2>&1 && echo built' \
+    > $P/$1-build.log 2>&1
+  grep -q built $P/$1-build.log || { echo "BUILD FAILED $1"; tail $P/$1-build.log; exit 1; }
+}
+
+for arm in pre ctl post; do
+  [ -f $P/$arm/modules/judy.so ] || build $arm
+done
+
+# feature checks: symbol present only in ctl/post; the loaded module is
+# the mounted one (stale-baked-in-extension hazard: clear PHP_INI_SCAN_DIR
+# and verify via /proc/self/maps).
+for arm in pre ctl post; do
+  SYM=$(docker run --rm -v $P:/p php-judy-bench:latest sh -c "nm -D /p/$arm/modules/judy.so 2>/dev/null | grep -c JudyLMultiGet || true")
+  MAP=$(docker run --rm -v $P:/p php-judy-bench:latest sh -c "PHP_INI_SCAN_DIR= php -d extension=/p/$arm/modules/judy.so -r 'echo (int)(strpos(file_get_contents(\"/proc/self/maps\"), \"/p/$arm/modules/judy.so\") !== false);'")
+  echo "featurecheck arm=$arm JudyLMultiGet-exports=$SYM mapped-from-mount=$MAP" | tee -a $P/php4-feature.log
+  [ "$MAP" = "1" ] || { echo "ARM $arm NOT MAPPED FROM MOUNT"; exit 1; }
+  case $arm in
+    pre)  [ "$SYM" = "0" ] || { echo "pre .so unexpectedly has JudyLMultiGet"; exit 1; } ;;
+    *)    [ "$SYM" != "0" ] || { echo "$arm .so lacks JudyLMultiGet"; exit 1; } ;;
+  esac
+done
+
+echo "arm,trial,op,shape,n,median_ms,cks" > $OUT
+echo "# loadavg_start=$(cut -d' ' -f1 /proc/loadavg)" >> $OUT
+for t in 1 2 3 4 5 6 7; do
+  for spec in getall:sparse:1000000:9 getall:mix:1000000:9 getall:dense:1000000:9 getall:dense90:1000000:9 getall:sparse:8000000:7 getall:mix:8000000:7 getall:dense:8000000:7 getall:dense90:8000000:7 getall:clust:1000000:9 getall:clust:8000000:7 foreach:clust:1000000:9 foreach:sparse:1000000:9 foreach:mix:1000000:9 foreach:dense:1000000:9 foreach:sparse:8000000:7; do
+    op=${spec%%:*}; r1=${spec#*:}; shape=${r1%%:*}; r2=${r1#*:}; n=${r2%%:*}; reps=${r2#*:}
+    for arm in pre ctl post; do
+      RAW=$P/raw/t${t}-${arm}-${op}-${shape}-${n}.out
+      docker run --rm --cpuset-cpus=2 -v $P:/p php-judy-bench:latest \
+        sh -c "PHP_INI_SCAN_DIR= php -d memory_limit=-1 -d extension=/p/$arm/modules/judy.so /p/phpbench4.php $op $shape $n $reps" > $RAW 2>&1
+      L=$(grep PHPRES4 $RAW)
+      IFS=, read -r _ oo ss nn med cks <<< "$L"
+      echo "$arm,$t,$oo,$ss,$nn,$med,$cks" >> $OUT
+    done
+  done
+  echo "# loadavg_t${t}=$(cut -d' ' -f1 /proc/loadavg)" >> $OUT
+done
+echo "# loadavg_end=$(cut -d' ' -f1 /proc/loadavg)" >> $OUT
+echo DONE > $P/php4-bench.done

--- a/research/libjudy-modernization/o5p-harness/phpbench4.php
+++ b/research/libjudy-modernization/o5p-harness/phpbench4.php
@@ -1,0 +1,61 @@
+<?php
+/* O5 REOPEN PHP-level A/B cells (#142).
+ * usage: php phpbench4.php <op> <shape> <n> <reps>
+ * ops:   getall  -- $a->getAll($probe), 200K random-order user keys
+ *        foreach -- foreach($probe) $a[$k] (offsetGet), same probes
+ * shape: sparse  (homogeneous xorshift)
+ *        mix     (half dense strided x3, half sparse -- the cell that
+ *                 killed the original O5 drop at n=1e6)
+ *        dense90 (90% dense strided x3, 10% sparse -- the partition's
+ *                 worst measured C-level ratio)
+ *        clust   (50% CLUSTERED dense: 1024-key runs at random 40-bit
+ *                 bases, + 50% sparse -- the PHP analog of the C gate's
+ *                 wmixc50, the worst measured cell for the batched path;
+ *                 clustering at random high-order bases is what defeats
+ *                 the partition's discriminating-byte heuristic)
+ *        dense   (100% dense strided x3 -- the cheap-descend tree where
+ *                 the C gate shows the BATCHED PATH ITSELF losing under
+ *                 the corrected serial baseline, archived impl included;
+ *                 the adoption's worst case, not the partition's)
+ * Emits: PHPRES4,<op>,<shape>,<n>,<median_ms>,<cks>
+ */
+$op = $argv[1]; $shape = $argv[2]; $n = (int)$argv[3]; $reps = (int)$argv[4];
+$dense = 0;
+if ($shape === 'mix') $dense = intdiv($n, 2);
+elseif ($shape === 'dense90') $dense = intdiv($n * 9, 10);
+elseif ($shape === 'dense') $dense = $n;
+elseif ($shape === 'clust') $dense = intdiv($n, 2);
+$keys = []; $x = 88172645463325252; $clustbase = 0;
+for ($i = 0; $i < $n; $i++) {
+    if ($i < $dense) {
+        if ($shape === 'clust') {
+            if (($i & 1023) === 0) {
+                $x = ($x ^ ($x << 13)) & PHP_INT_MAX; $x = $x ^ ($x >> 7); $x = ($x ^ ($x << 17)) & PHP_INT_MAX;
+                $clustbase = $x & ((1 << 40) - 1);
+            }
+            $keys[] = $clustbase + ($i & 1023);
+        } else {
+            $keys[] = $i * 3;
+        }
+        continue;
+    }
+    $x = ($x ^ ($x << 13)) & PHP_INT_MAX; $x = $x ^ ($x >> 7); $x = ($x ^ ($x << 17)) & PHP_INT_MAX;
+    $keys[] = $x;
+}
+$a = new Judy(Judy::INT_TO_INT);
+foreach ($keys as $i => $k) $a[$k] = $i + 1;
+$probe = []; $x = 12345; $m = min(200000, $n);
+for ($i = 0; $i < $m; $i++) {
+    $x = ($x ^ ($x << 13)) & PHP_INT_MAX; $x = $x ^ ($x >> 7); $x = ($x ^ ($x << 17)) & PHP_INT_MAX;
+    $probe[] = $keys[$x % $n];
+}
+unset($keys);
+$times = []; $cks = 0;
+for ($r = 0; $r < $reps; $r++) {
+    $t0 = hrtime(true);
+    if ($op === 'getall') { $res = $a->getAll($probe); $cks = count($res); unset($res); }
+    else { $s = 0; foreach ($probe as $k) { if ($a[$k] !== null) $s++; } $cks = $s; }
+    $times[] = (hrtime(true) - $t0) / 1e6;
+}
+sort($times);
+printf("PHPRES4,%s,%s,%d,%.4f,%d\n", $op, $shape, $n, $times[intdiv(count($times),2)], $cks);


### PR DESCRIPTION
Record-only PR for the #142 O5 reopen. **The implementation is deliberately not here** — it stays archived on [`vendor/stage3-o5-partition`](https://github.com/orieg/php-judy/tree/vendor/stage3-o5-partition). Supersedes #163, which mixed mergeable and unmergeable work; closed in favour of this.

Gate outcome and full evidence: [#142 comment](https://github.com/orieg/php-judy/issues/142#issuecomment-5337024637).

### What lands

| | |
| --- | --- |
| FINDINGS §11.11 | the gate record, two corrections to the existing record, and the structural finding that makes this a defensible permanent drop |
| `research/libjudy-modernization/o5p-harness/**` | the measurement harness — closes the standing FINDINGS item about uncommitted harnesses |
| `research/differential-fuzz/validation/build-stock.sh` | one-hunk fix, independent of O5 (see below) |

Nothing else. Verified mechanically: `JudyMultiGet.c`, `JudyMultiGet.h`, `JudyLMultiGet.c`, `php_judy.c`, `config.m4`, `config.w32`, `PATCHES.md`, `multiget_batched_paths_001.phpt`, `ci.yml`, `diffuzz.cpp` and the fuzzer `Makefile` are all byte-identical to `main` on this branch.

### The outcome in one line

The counting partition proposed by the §11.10 adversarial re-review **works** — ×1.25–×2.90 over the archived implementation on every heterogeneous cell, at no cost on unimodal ones — and the `getAll()` adoption **still fails its PHP-level gate**, so O5 stays dropped.

The dilemma is structural rather than a mistuned constant, which is what makes the drop permanent rather than "we didn't tune hard enough": **the composition analysis needs a large batch to amortise (13–15% at 256 keys), and a large batch pollutes the caller's cache (~10%).** No setting of that knob serves both. The repair was [pre-registered before the deciding probe ran](https://github.com/orieg/php-judy/commit/031362b), came out negative, and was refused rather than retried with a different knob.

### Two corrections to the existing record

1. **Part of §11.9's C-level headline was a serial-baseline artifact** — the original gate computed probe keys in a dependent chain *inside* the timed loop. Same corpora read ×0.7–×1.6 corrected, against ×1.4–×4.5 old-style.
2. **`cJL_MULTIGET_SERIAL_POP1 = 262144` is wrong**, and §11.9's claim that the threshold evidence was "upheld" does not survive. With the fallback compiled out the pipeline loses at *every* population up to 65536 and still loses at 262144 on `wdense` (×0.732) — the shipped cutoff switches the pipeline on exactly where it still loses.

### Reusable beyond O5

`o5p-stability.py` and `o5p-lock.sh` are called out in the harness README as general-purpose. During this round two php-judy benchmark campaigns ran concurrently on honeycomb and **corrupted each other while both satisfied the `loadavg < N/2` hygiene rule** (24 cores, peak 2.87) — two memory-bound benchmarks contend for LLC and memory bandwidth regardless of core pinning. The guard is the mechanical form of that rule and strictly stronger: it treats an untouched baseline arm as a canary and fails any cell whose baseline drifts, flagging the collided sweep at 116–142% and clearing the clean one at ≤3.7%. It also caught a 20% single-trial excursion that eyeballing the ratios had dismissed. Any future campaign should use both.

### The one code change, and why it is safe

`build-stock.sh` now compiles P7's `JudyNoInline.c` when present. It **is** in `libjudy/src` today and was being silently omitted from every fuzzed build. This hunk is independent of the dropped O5 work; the MULTIGET-specific fuzzer changes were deliberately left behind because they cannot even be compiled on `main` (the symbol does not exist — verified: `MULTIGET=1` fails to link), so merging them would leave untestable dead code.

Verified by running the CI job, not by reading the diff — full `differential-fuzz` path against this branch: `build-stock` OK with `JudyNoInline.o` compiled, smoke **48 cells** clean, soak **700 cells** clean, ASan+UBSan smoke **48 cells** clean.

### On the synthetic panel, in both directions

The reopen came from an **internal synthetic panel — adversarial brainstorming, not external peer review.** It was right to reopen and right about the mechanism: it predicted the 90%-dense cell would still lose at ×0.77, measured here at **×0.774** from an independent in-library implementation. That it survived falsification is worth recording *precisely because the optimization it rescued still failed* — the panel was right about the partition, and the adoption still does not pay. Neither half of that is safe to drop.

### Not included, deliberately

No `package.xml` entries: `research/` is not shipped in the PECL package (`research/differential-fuzz` has 7 tracked files and zero package.xml entries), and the only completeness gate in CI covers `tests/`. Adding entries would break that convention.
