### PR TITLE
fix(gc): unlink MIXED containers before teardown frees their zvals

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -305,6 +305,7 @@
          <file name="tests/regression_bulk_exception_stop_001.phpt" role="test" />
          <file name="tests/regression_callback_reentrancy_001.phpt" role="test" />
          <file name="tests/regression_gc_cycle_001.phpt" role="test" />
+         <file name="tests/regression_gc_teardown_reentrancy_001.phpt" role="test" />
          <file name="tests/regression_int_keyed_string_key_001.phpt" role="test" />
          <file name="tests/regression_mixed_destructor_reentrancy_001.phpt" role="test" />
          <file name="tests/regression_packed_equals_001.phpt" role="test" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -63,6 +63,7 @@ static void php_judy_init_globals(zend_judy_globals *judy_globals)
 static Word_t judy_free_array_internal(judy_object *intern)
 {
 	Word_t Rc_word = 0;
+	Pvoid_t arr, hs, kidx;
 
 	/* Teardown is the one point every object reaches, whatever it was used
 	 * for, and it is already O(n) — so it is where the consistency check earns
@@ -76,44 +77,67 @@ static Word_t judy_free_array_internal(judy_object *intern)
 		return 0;
 	}
 
+	/* UNLINK BEFORE DESTROY. The MIXED branches below walk the container while
+	 * calling zval_ptr_dtor() on every stored value. That is a re-entrancy
+	 * point: dropping the last-but-one reference to a GC-collectable value
+	 * calls gc_possible_root(), and once the root buffer fills PHP runs
+	 * gc_collect_cycles() *synchronously, inside this loop*. If this object is
+	 * itself in the root buffer — which any refcount inc/dec puts it there,
+	 * e.g. count($j) or passing $j to a function — GC then calls
+	 * judy_object_get_gc() on it and walks the very container we are midway
+	 * through freeing, dereferencing zvals this loop has already efree()d.
+	 *
+	 * Detaching the roots first makes that walk see an empty container and add
+	 * nothing, so the re-entrant traversal is harmless. intern->type stays set
+	 * because the branches below still need it; the detach, not a type reset,
+	 * is what closes the hole. See issue #162. */
+	arr  = intern->array;
+	hs   = intern->hs_array;
+	kidx = intern->key_index;
+	intern->array = NULL;
+	intern->hs_array = NULL;
+	intern->key_index = NULL;
+	intern->counter = 0;
+	intern->approx_payload_bytes = 0;
+
 	if (intern->type == TYPE_INT_TO_MIXED) {
 		Word_t index = 0;
 		Word_t *PValue;
 
-		JLF(PValue, intern->array, index);
+		JLF(PValue, arr, index);
 		while (PValue != NULL && PValue != PJERR) {
 			zval *value = JUDY_MVAL_READ(PValue);
 			zval_ptr_dtor(value);
 			efree(value);
-			JLN(PValue, intern->array, index);
+			JLN(PValue, arr, index);
 		}
-		JLFA(Rc_word, intern->array);
+		JLFA(Rc_word, arr);
 	} else if (intern->type == TYPE_INT_TO_PACKED) {
 		Word_t index = 0;
 		Word_t *PValue;
 
-		JLF(PValue, intern->array, index);
+		JLF(PValue, arr, index);
 		while (PValue != NULL && PValue != PJERR) {
 			judy_packed_value *packed = JUDY_PVAL_READ(PValue);
 			if (packed) {
 				efree(packed);
 			}
-			JLN(PValue, intern->array, index);
+			JLN(PValue, arr, index);
 		}
-		JLFA(Rc_word, intern->array);
+		JLFA(Rc_word, arr);
 	} else if (intern->type == TYPE_STRING_TO_MIXED) {
 		uint8_t *kindex = intern->key_scratch;
 		Word_t *PValue;
 
 		kindex[0] = '\0';
-		JSLF(PValue, intern->array, kindex);
+		JSLF(PValue, arr, kindex);
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 			zval *value = JUDY_MVAL_READ(PValue);
 			zval_ptr_dtor(value);
 			efree(value);
-			JSLN(PValue, intern->array, kindex);
+			JSLN(PValue, arr, kindex);
 		}
-		JSLFA(Rc_word, intern->array);
+		JSLFA(Rc_word, arr);
 	} else if (intern->type == TYPE_STRING_TO_MIXED_HASH) {
 		uint8_t *kindex = intern->key_scratch;
 		Word_t *PValue;
@@ -121,69 +145,59 @@ static Word_t judy_free_array_internal(judy_object *intern)
 
 		/* Enumerate keys via key_index (JudySL), free zvals via JudyHS lookup */
 		kindex[0] = '\0';
-		JSLF(PValue, intern->key_index, kindex);
+		JSLF(PValue, kidx, kindex);
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
-			JHSG(HValue, intern->array, kindex, (Word_t)strlen((char *)kindex));
+			JHSG(HValue, arr, kindex, (Word_t)strlen((char *)kindex));
 			if (JUDY_LIKELY(HValue != NULL && HValue != PJERR)) {
 				zval *value = JUDY_MVAL_READ(HValue);
 				zval_ptr_dtor(value);
 				efree(value);
 			}
-			JSLN(PValue, intern->key_index, kindex);
+			JSLN(PValue, kidx, kindex);
 		}
-		JHSFA(Rc_word, intern->array);
-		JSLFA(Rc_word, intern->key_index);
-		intern->key_index = NULL;
+		JHSFA(Rc_word, arr);
+		JSLFA(Rc_word, kidx);
 	} else if (intern->type == TYPE_STRING_TO_INT_HASH) {
 		/* JudyHS stores Word_t values (no zval allocation), just free both arrays */
-		JHSFA(Rc_word, intern->array);
-		JSLFA(Rc_word, intern->key_index);
-		intern->key_index = NULL;
+		JHSFA(Rc_word, arr);
+		JSLFA(Rc_word, kidx);
 	} else if (intern->type == TYPE_STRING_TO_MIXED_ADAPTIVE) {
 		uint8_t *kindex = intern->key_scratch;
 		Word_t *PValue;
 		Pvoid_t *HValue;
 
 		kindex[0] = '\0';
-		JSLF(PValue, intern->key_index, kindex);
+		JSLF(PValue, kidx, kindex);
 		while (JUDY_LIKELY(PValue != NULL && PValue != PJERR)) {
 			Word_t klen = (Word_t)strlen((char *)kindex);
 			if (klen < 8) {
 				Word_t index = 0;
 				memcpy(&index, kindex, klen);
-				JLG(HValue, intern->array, index);
+				JLG(HValue, arr, index);
 			} else {
-				JHSG(HValue, intern->hs_array, kindex, klen);
+				JHSG(HValue, hs, kindex, klen);
 			}
 			if (JUDY_LIKELY(HValue != NULL && HValue != PJERR)) {
 				zval *value = JUDY_MVAL_READ(HValue);
 				zval_ptr_dtor(value);
 				efree(value);
 			}
-			JSLN(PValue, intern->key_index, kindex);
+			JSLN(PValue, kidx, kindex);
 		}
-		JLFA(Rc_word, intern->array);
-		JHSFA(Rc_word, intern->hs_array);
-		JSLFA(Rc_word, intern->key_index);
-		intern->key_index = NULL;
-		intern->hs_array = NULL;
+		JLFA(Rc_word, arr);
+		JHSFA(Rc_word, hs);
+		JSLFA(Rc_word, kidx);
 	} else if (intern->type == TYPE_STRING_TO_INT_ADAPTIVE) {
-		JLFA(Rc_word, intern->array);
-		JHSFA(Rc_word, intern->hs_array);
-		JSLFA(Rc_word, intern->key_index);
-		intern->key_index = NULL;
-		intern->hs_array = NULL;
+		JLFA(Rc_word, arr);
+		JHSFA(Rc_word, hs);
+		JSLFA(Rc_word, kidx);
 	} else if (intern->type == TYPE_BITSET) {
-		J1FA(Rc_word, intern->array);
+		J1FA(Rc_word, arr);
 	} else if (intern->type == TYPE_INT_TO_INT) {
-		JLFA(Rc_word, intern->array);
+		JLFA(Rc_word, arr);
 	} else if (intern->type == TYPE_STRING_TO_INT) {
-		JSLFA(Rc_word, intern->array);
+		JSLFA(Rc_word, arr);
 	}
-
-	intern->array = NULL;
-	intern->counter = 0;
-	intern->approx_payload_bytes = 0;
 
 	return Rc_word;
 }

--- a/tests/regression_gc_teardown_reentrancy_001.phpt
+++ b/tests/regression_gc_teardown_reentrancy_001.phpt
@@ -1,0 +1,77 @@
+--TEST--
+Regression #162: GC re-entrancy during MIXED teardown must not touch freed zvals
+--SKIPIF--
+<?php if (!extension_loaded("judy")) print "skip"; ?>
+--FILE--
+<?php
+// judy_free_array_internal() walks the container calling zval_ptr_dtor() on
+// every stored value. Dropping a GC-collectable value to a still-positive
+// refcount calls gc_possible_root(); once the root buffer fills, PHP runs
+// gc_collect_cycles() synchronously *inside* that loop. If the Judy object is
+// itself a GC root, the collector calls judy_object_get_gc(), which used to
+// re-walk the half-freed container and dereference zvals the loop had already
+// efree()d — a use-after-free that surfaced as "zend_mm_heap corrupted".
+//
+// Three conditions are needed and all three are reproduced below:
+//   1. the values are GC-collectable AND shared ($data holds a second
+//      reference), so zval_ptr_dtor roots them instead of freeing them;
+//   2. there are enough of them to fill the root buffer (default threshold is
+//      ~10000), so the collector actually runs inside teardown;
+//   3. the Judy object is itself in the root buffer — count() puts it there,
+//      as does passing it to any function.
+//
+// On an unfixed build the first type below aborts the process.
+
+const N = 20000;
+
+function churn(int $type, bool $string_keys): void {
+    $data = [];
+    for ($i = 0; $i < N; $i++) {
+        $data[$string_keys ? "k$i" : $i] = [$i, $i + 1];   // condition 1 + 2
+    }
+    for ($round = 0; $round < 3; $round++) {
+        $j = new Judy($type);
+        foreach ($data as $k => $v) {
+            $j[$k] = $v;
+        }
+        if (count($j) !== N) {                            // condition 3
+            echo "bad count\n";
+            return;
+        }
+        unset($j);
+    }
+}
+
+churn(Judy::INT_TO_MIXED, false);
+churn(Judy::STRING_TO_MIXED, true);
+churn(Judy::STRING_TO_MIXED_HASH, true);
+churn(Judy::STRING_TO_MIXED_ADAPTIVE, true);
+echo "teardown survived\n";
+
+// The same walk runs from the explicit Judy::free() entry point, on an object
+// that is still live and therefore trivially reachable by the collector.
+$data = [];
+$j = new Judy(Judy::INT_TO_MIXED);
+for ($i = 0; $i < N; $i++) {
+    $v = [$i, $i + 1];
+    $data[$i] = $v;
+    $j[$i] = $v;
+}
+count($j);
+$j->free();
+echo count($j) === 0 ? "free() survived\n" : "free() left state\n";
+unset($j, $data);
+
+// Detaching the container during teardown must not break get_gc for live
+// objects: a cycle through a MIXED value still has to be collectable.
+$j = new Judy(Judy::INT_TO_MIXED);
+$holder = new stdClass();
+$holder->j = $j;
+$j[0] = $holder;
+unset($j, $holder);
+echo gc_collect_cycles() >= 1 ? "cycles collected\n" : "cycle leaked\n";
+?>
+--EXPECT--
+teardown survived
+free() survived
+cycles collected


### PR DESCRIPTION
Fixes #162.

## Root cause

`judy_free_array_internal()` walked `intern->array` while calling
`zval_ptr_dtor(value); efree(value)` on each slot. The `efree`'d `zval*`
pointers stayed reachable in the container for the whole walk — the Judy roots
are only released by the closing `JLFA`/`JSLFA`/`JHSFA`.

`zval_ptr_dtor()` on a GC-collectable value whose refcount stays > 0 calls
`gc_possible_root()`. Once the root buffer fills (~10 000 roots), PHP runs
`gc_collect_cycles()` **synchronously, inside that loop**. If the Judy object is
itself a GC root — which any refcount inc/dec puts it there: `count($j)`,
passing `$j` to a function, `$b = $j` — the collector calls
`judy_object_get_gc()` on the half-destroyed object, which re-walks the same
container and dereferences the already-freed zvals.

```
==1== Invalid read of size 4
==1==    at 0x...: UnknownInlinedFun (zend_gc.h:130)
==1==    by 0x...: judy_object_get_gc (php_judy.c:353)
==1==    by 0x...: zend_gc_collect_cycles
==1==    by 0x...: judy_free_array_internal (php_judy.c:86)
==1==  Address ... is 8 bytes inside a block of size 16 free'd
==1==    by 0x...: judy_free_array_internal (php_judy.c:87)
==1==  Block was alloc'd at
==1==    by 0x...: judy_object_write_dimension_helper (php_judy.c:1061)
```

Affects `INT_TO_MIXED`, `STRING_TO_MIXED`, `STRING_TO_MIXED_HASH` and
`STRING_TO_MIXED_ADAPTIVE`, through both `Judy::free()` and object destruction.
Independent of which libJudy is linked — the dangling block is allocated by
php-judy, not libJudy.

## Fix

Unlink before destroy: detach `array` / `hs_array` / `key_index` into locals and
NULL the `intern` fields (plus `counter` / `approx_payload_bytes`) *before* the
destructive walk, so a re-entrant `judy_object_get_gc()` sees an empty container
and contributes nothing. `intern->type` stays set because the branches still
dispatch on it. Same shape as the existing
`regression_delete_range_destructor_reentrancy_001` fix.

## Verification

- `tests/regression_gc_teardown_reentrancy_001.phpt` aborts the process with
  `zend_mm_heap corrupted` on an unfixed build; passes after, in 0.076 s.
- `USE_ZEND_ALLOC=0 valgrind`: 119 994 invalid accesses before, **0** after;
  `--leak-check=full` reports all heap blocks freed.
- Full suite 223/223, zero compiler warnings.
- The original signal reproduces and is fixed:
  `judy-bench.php --group core.int --size 3000000` and `--size 6000000` both
  complete `rc=0` after the fix.
- Verified against **both** the bundled libJudy and `--with-judy=/usr` system
  libJudy (php:8.4-cli, Debian bookworm, linux/arm64; the original signal was
  seen on linux/amd64 and honeycomb x86-64).

## How it was found

`research/three-arm-benchmark/results/heap-corruption-triage.txt` recorded four
`zend_mm_heap corrupted` rows labelled `PHP array` with `rc=0`. The label is not
a data-structure attribution: it is the second line of the `INT_TO_MIXED`
`printf` pair — the last line flushed before the abort. The `rc=0` came from a
pipeline in the ad-hoc triage runner; a direct run exits 133. A `php -n` control
running the equivalent PHP-array workload at 3M elements with the extension not
loaded is clean.
