### PR TITLE
docs(benchmark): close the three-arm memory-safety signal as #162

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1761,7 +1761,7 @@ null automatically; none in the reported set were.
 | Linux x86-64, honeycomb | gcc 14.2.0, PHP 8.4.24, Debian 13 | measured | measured | **claim-grade** |
 | macOS arm64 | Apple clang 21, PHP 8.5.8, Homebrew | **not measured** | measured | **directional only** |
 | Alpine / musl x86-64 | gcc, PHP 8.4 | not measured | not measured | **not measured** |
-| Linux x86-64, out-of-cache (>=6M) | gcc 14.2.0 | not measured | measured (8M rows above) | **not measured** |
+| Linux x86-64, out-of-cache (>=6M) | gcc 14.2.0 | not measured (unblocked, not yet run) | measured (8M rows above) | **not measured** |
 | Windows | MSVC | not measured | not measured | **not measured** |
 
 - **macOS arm64 is directional, not claim-grade, and the hole is narrowed rather
@@ -1772,25 +1772,56 @@ null automatically; none in the reported set were.
   (`bitset` 30.2x vs 22.7x, `int_to_mixed` 0.79x vs 0.79x, `string_to_int` 3.09x
   vs 3.32x) and its B/C ratios are ~1.00, but they are reported as directional.
   **Apple clang / arm64 remains this project's acknowledged measurement gap.**
-- **Out-of-cache timing is not measured, and the reason is a memory-safety
-  signal that is still open.** The intended 6M run aborted when arm B terminated
-  with SIGSEGV in the `core.int` group. Triage so far:
+- **Out-of-cache timing is still not measured, but the memory-safety signal that
+  blocked it is resolved.** The intended 6M run aborted when arm B terminated
+  with SIGSEGV in the `core.int` group, and at the time this section could not
+  say whether the fault lay in the extension, the benchmark script, or libJudy.
+  It is now established: the fault is **php-judy's own PHP-facing layer**, not
+  libJudy and not the benchmark. `judy_free_array_internal()` walked the
+  container calling `zval_ptr_dtor()` + `efree()` on each stored zval while the
+  freed pointers stayed reachable in the container; once the GC root buffer
+  filled, `gc_collect_cycles()` ran synchronously inside that loop and
+  `judy_object_get_gc()` re-walked the half-freed container. Use-after-free,
+  surfacing as `zend_mm_heap corrupted` or SIGSEGV. Tracked as
+  [#162](https://github.com/orieg/php-judy/issues/162), fixed in `dcc368e`
+  (unlink the container before the destructive walk), covered by
+  `tests/regression_gc_teardown_reentrancy_001.phpt`.
 
-  | check | result |
-  | --- | --- |
-  | macOS arm64, plain 6M `INT_TO_INT` insert loop, both arms | clean, no fault, identical `memoryUsage()` |
-  | linux/amd64, `judy-bench.php --group core.int --size 3000000`, arm **B** | `zend_mm_heap corrupted` |
-  | linux/amd64, same cell, arm **C** (bundled) | `zend_mm_heap corrupted` |
+  That the crash reproduced under **both** arms was the correct reading and
+  remains so: it is explicitly **not** a bundled-versus-system robustness claim,
+  and nothing in this section should be read as one. The bundled-vs-system
+  comparison was never the variable.
 
-  **Both arms corrupt the heap**, so this is explicitly **not** a
-  bundled-versus-system robustness claim, and nothing in this section should be
-  read as one. A simple large insert loop is clean, so it is specific to what the
-  `core.int` group does at scale. Whether the fault lies in the extension, in the
-  benchmark script, or in libJudy below both is **not yet established**, and it is
-  being tracked as its own correctness investigation rather than resolved here —
-  a memory-safety bug is not a benchmark footnote. The 8M rows in the memory
-  table are unaffected: those run in their own child processes and complete
-  cleanly.
+  Post-fix verification, one tree per arm built from the two commits and driven
+  by the identical `judy-bench.php` (`--group core.int --iterations 1`). The
+  pre-fix column at 3M/6M on linux/amd64 also reproduces the original triage
+  above, which covered arms **B** and **C**; the post-fix runs below are arm
+  **C** (bundled) only.
+
+  | check | pre-fix (`172e489`) | post-fix (`dcc368e`) |
+  | --- | --- | --- |
+  | macOS arm64, plain 6M `INT_TO_INT` insert loop, both arms | clean | clean |
+  | linux/amd64 (`php:8.4-cli`, gcc 14.2.0), `core.int` n=3M | `zend_mm_heap corrupted` (rc=134) | clean (rc=0) |
+  | linux/amd64, `core.int` n=6M | `zend_mm_heap corrupted` (rc=134) | clean (rc=0) |
+  | linux/amd64, `regression_gc_teardown_reentrancy_001` body | `zend_mm_heap corrupted` (rc=134) | clean (rc=0) |
+  | macOS arm64 (PHP 8.5.8), `core.int` n=3M | clean | clean |
+  | macOS arm64, `core.int` n=6M | `zend_mm_heap corrupted` (rc=134) | clean (rc=0) |
+
+  The insert-only loop stayed clean throughout because it never puts the Judy
+  object in the GC root buffer; `judy-bench.php` does, via `count()` and the
+  closures it hands the container to. macOS needed 6M to fault where linux/amd64
+  faulted at 3M — an allocator difference, not a different bug. The `2G`
+  `memory_limit` that `judy-bench.php` sets was a candidate mechanism (a bailout
+  unwinding through an in-progress Judy write) and is ruled out: the post-fix 6M
+  runs complete under that same cap without a fatal.
+
+  **What this unblocks and what it does not.** The out-of-cache (>=6M) `core.int`
+  cell now runs to completion, so the arm can be scheduled; the slot in the tier
+  table stays `not measured` until it is actually run on an exclusively-held
+  honeycomb. Nothing above is a timing measurement — the runs in the table are
+  crash reproductions on a shared laptop and assert nothing about performance.
+  The 8M rows in the memory table were always unaffected: those run in their own
+  child processes and complete cleanly.
 - **Alpine / musl is not measured.** It matters — musl's allocator is not
   glibc's and Judy is allocation-heavy — and Alpine ships **pristine** 1.0.5, so
   its B-vs-C would also include P1. Deferred for host scheduling reasons only.

--- a/research/three-arm-benchmark/results/heap-corruption-triage.txt
+++ b/research/three-arm-benchmark/results/heap-corruption-triage.txt
@@ -1,5 +1,12 @@
 # Heap-corruption triage (surfaced by, not caused by, the three-arm benchmark)
 
+RESOLVED. Root cause is php-judy's own PHP-facing layer, not libJudy: GC
+re-entrancy during MIXED teardown (use-after-free in judy_free_array_internal).
+Tracked as issue #162, fixed in dcc368e, covered by
+tests/regression_gc_teardown_reentrancy_001.phpt. The readings below are the
+frozen pre-fix record; see the "Confidence tiers" section of BENCHMARK.md for
+the post-fix verification matrix.
+
 Both arms, both sizes. NOT a bundled-vs-system difference.
 
 ## linux/amd64 (Docker), judy-bench.php --group core.int --iterations 1


### PR DESCRIPTION
## Summary

`BENCHMARK.md`'s three-arm section still carried the `core.int` heap corruption
at n>=3M as an open question — "Whether the fault lies in the extension, in the
benchmark script, or in libJudy below both is **not yet established**" — and
parked the out-of-cache arm behind it. That is stale: the root cause was settled
and fixed in #162 / #165 (`dcc368e`), which landed after
`perf/three-arm-benchmark` was branched. No branch had corrected the section.

Docs only. No extension sources touched.

## Verification

Independent pre/post check rather than taking the fix on faith. Both commits
built from clean `git archive` exports, `--with-judy=bundled`, driven by the
identical `judy-bench.php --group core.int --iterations 1`:

| check | pre-fix `172e489` | post-fix `dcc368e` |
| --- | --- | --- |
| linux/amd64 (`php:8.4-cli`, gcc 14.2.0), n=3M | `zend_mm_heap corrupted` rc=134 | clean rc=0 |
| linux/amd64, n=6M | `zend_mm_heap corrupted` rc=134 | clean rc=0 |
| linux/amd64, `regression_gc_teardown_reentrancy_001` body | `zend_mm_heap corrupted` rc=134 | clean rc=0 |
| macOS arm64 (PHP 8.5.8), n=3M | clean | clean |
| macOS arm64, n=6M | `zend_mm_heap corrupted` rc=134 | clean rc=0 |

macOS needs 6M to fault where linux/amd64 faults at 3M — an allocator
difference, not a second bug.

Two hypotheses from the original triage brief are ruled out and recorded as
such:

- **P3 / `JudyLInsArray`**: not implicated. `core.int` never reaches the batch
  APIs; it only does `$j[$k] = $v`.
- **The `2G` `memory_limit`** (a bailout unwinding through an in-progress Judy
  write): the post-fix 6M runs complete under that same cap without a fatal.

## Changes

- Replace the open-signal bullet with the resolved account (GC re-entrancy in
  `judy_free_array_internal()`, #162, `dcc368e`,
  `tests/regression_gc_teardown_reentrancy_001.phpt`) plus the matrix above.
- Annotate `research/three-arm-benchmark/results/heap-corruption-triage.txt` so
  the frozen pre-fix record does not read as open.
- Tier table row -> `not measured (unblocked, not yet run)`.

The bundled-vs-system reading is unchanged and was always correct: both arms
corrupted, so nothing in the section is a robustness claim either way.

## What this does NOT claim

The out-of-cache arm is unblocked but **not run**. The runs above are crash
reproductions on a shared laptop and assert nothing about timing; a claim-grade
out-of-cache number needs honeycomb held exclusively. The slot stays
`not measured` and now says why.

Refs #162
