### PR TITLE
fix(bench): make judy-bench.php's memory_limit a floor, not an override

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1537,6 +1537,25 @@ published number in this project.
 - **Three independent builds per arm, rotated across rounds.** A cell whose
   per-build spread exceeds its own delta is demoted to null: that is binary
   layout, not a library change.
+- **The suite's `memory_limit` is a floor, not a ceiling — and it was not
+  always.** `judy-bench.php` used to set a flat `ini_set('memory_limit', '2G')`
+  at the top of the file, which silently overrode the `-d memory_limit=-1` that
+  both `scripts/bench-compare.php` and `scripts/bench-threearm.php` pass every
+  child. That made the `core.str` group impossible to run at `--size 6000000`
+  under **any** arm: the group materialises four 6M-element PHP arrays before
+  the first Judy call and died inside its own fixture builder, so the failure
+  was a property of the harness and not a signal about either library. It is a
+  second, separate blocker on the out-of-cache row below — alongside the
+  memory-safety one that
+  [#162](https://github.com/orieg/php-judy/issues/162) closed — and the reason
+  an attempt at that row could only cover the integer and bitset paths. The
+  script now treats `2G` as a floor it raises a *lower* caller up to, leaves a
+  caller who already asked for more (including `-1`) alone, and honours an
+  explicit `--memory-limit` that wins outright. Which cap a run used is
+  recorded in its JSON as `metadata.memory_limit` and echoed in the console
+  banner — **read it there rather than assuming it**, because every run
+  published before this change used the unconditional `2G` no matter what its
+  driver asked for.
 - **Host hygiene gated at load N/2 *and* on co-tenancy.** Load is sampled before,
   between and after every phase; over threshold the run self-marks contaminated
   and every verdict is suppressed.
@@ -2108,9 +2127,12 @@ why it sits below the gating floor and is not in the headline table above.
   object in the GC root buffer; `judy-bench.php` does, via `count()` and the
   closures it hands the container to. macOS needed 6M to fault where linux/amd64
   faulted at 3M — an allocator difference, not a different bug. The `2G`
-  `memory_limit` that `judy-bench.php` sets was a candidate mechanism (a bailout
-  unwinding through an in-progress Judy write) and is ruled out: the post-fix 6M
-  runs complete under that same cap without a fatal.
+  `memory_limit` that `judy-bench.php` set unconditionally at the time was a
+  candidate mechanism (a bailout unwinding through an in-progress Judy write)
+  and is ruled out: the post-fix 6M runs complete under that same cap without a
+  fatal. Those runs are `core.int`, whose fixtures fit inside `2G`; the cap has
+  since become a floor rather than an override (methodology above), which does
+  not affect this result either way.
 
   **What this unblocks and what it does not.** The out-of-cache (>=6M) `core.int`
   cell now runs to completion, so the arm can be scheduled; the slot in the tier

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1540,8 +1540,10 @@ published number in this project.
 - **The suite's `memory_limit` is a floor, not a ceiling — and it was not
   always.** `judy-bench.php` used to set a flat `ini_set('memory_limit', '2G')`
   at the top of the file, which silently overrode the `-d memory_limit=-1` that
-  both `scripts/bench-compare.php` and `scripts/bench-threearm.php` pass every
-  child. That made the `core.str` group impossible to run at `--size 6000000`
+  every driver passes its children — `scripts/bench-compare.php` directly, and
+  `scripts/bench-threearm.php` and `scripts/bench-gate.php` through the shared
+  launcher in `scripts/bench-lib.php`. That made the `core.str` group
+  impossible to run at `--size 6000000`
   under **any** arm: the group materialises four 6M-element PHP arrays before
   the first Judy call and died inside its own fixture builder, so the failure
   was a property of the harness and not a signal about either library. It is a

--- a/examples/benchmarks/judy-bench.php
+++ b/examples/benchmarks/judy-bench.php
@@ -14,23 +14,95 @@
  *   all      — All of the above (default)
  *
  * Usage:
- *   php judy-bench.php [--json output.json] [--size N] [--iterations N] [--suite SUITE]
+ *   php judy-bench.php [--json output.json] [--size N] [--iterations N]
+ *                      [--suite SUITE] [--group A,B] [--memory-limit LIMIT]
  *
  * Examples:
  *   php judy-bench.php --size 100000 --iterations 3
  *   php judy-bench.php --json bench.json --suite core
  *   php judy-bench.php --json bench.json --size 500000 --iterations 5 --suite all
+ *   php judy-bench.php --group core.str --size 6000000 --memory-limit -1
  */
-
-ini_set('memory_limit', '2G');
 
 // ── CLI argument parsing ────────────────────────────────────────────────────
 
-$opts = getopt('', ['json:', 'size:', 'iterations:', 'suite:', 'group:', 'list-groups']);
+$opts = getopt('', ['json:', 'size:', 'iterations:', 'suite:', 'group:', 'list-groups',
+                    'memory-limit:']);
 $size       = isset($opts['size'])       ? (int)$opts['size']       : 500000;
 $iterations = isset($opts['iterations']) ? (int)$opts['iterations'] : 5;
 $suite      = isset($opts['suite'])      ? $opts['suite']           : 'all';
 $json_file  = isset($opts['json'])       ? $opts['json']            : null;
+
+// ── Memory limit ────────────────────────────────────────────────────────────
+//
+// Several groups build their PHP-array fixtures in full before any Judy work
+// starts, so the suite needs a cap well above the php.ini default. It used to
+// take that as a flat unconditional `2G`, which silently overrode the
+// `-d memory_limit=-1` that scripts/bench-compare.php and
+// scripts/bench-threearm.php pass every child, and made
+// `--group core.str --size 6000000` impossible to run at all: that group
+// materialises four 6M-element PHP arrays up front and dies in the fixture
+// builder, identically under every arm, before a single measurement is taken.
+// That is a second blocker on the out-of-cache three-arm row tracked by #169,
+// independent of the memory-safety one #162 closed, and the reason an attempt
+// at that row could only cover the integer and bitset paths.
+//
+// So 2G is a floor now, not a ceiling. --memory-limit wins outright; failing
+// that, a caller who already asked for more — including unlimited — keeps what
+// they asked for, and only a caller sitting below the floor is raised to it.
+// Nothing here changes what is measured: memory_limit is a ceiling PHP
+// enforces on demand, not an allocation.
+const BENCH_MEMORY_FLOOR = '2G';
+
+/**
+ * Bytes for a PHP ini shorthand size ("2G", "512M", "1073741824", "-1").
+ *
+ * Returns PHP_INT_MAX for an unlimited (negative) value, so limits compare
+ * with a plain `>=`, and null for anything this script should reject rather
+ * than silently reinterpret. A magnitude that would not survive the suffix
+ * multiply is rejected too: letting it overflow to float would trade a clean
+ * message for an uncaught TypeError on the return type.
+ */
+function bench_ini_bytes(string $value): ?int {
+    if (!preg_match('/^\s*(-?\d+)\s*([KMG]?)\s*$/i', $value, $m)) {
+        return null;
+    }
+    if (!is_int($n = filter_var($m[1], FILTER_VALIDATE_INT))) {
+        return null;
+    }
+    if ($n < 0) {
+        return PHP_INT_MAX; // unlimited
+    }
+    $mult = ['' => 1, 'K' => 1024, 'M' => 1024 * 1024, 'G' => 1024 * 1024 * 1024];
+    $f = $mult[strtoupper($m[2])];
+    return $n <= intdiv(PHP_INT_MAX, $f) ? $n * $f : null;
+}
+
+if (isset($opts['memory-limit'])) {
+    $mem_target = trim((string)$opts['memory-limit']);
+    if (bench_ini_bytes($mem_target) === null) {
+        fwrite(STDERR, "Invalid --memory-limit: $mem_target. "
+            . "Use a PHP ini size such as 4G, 512M, 1073741824, or -1 for unlimited.\n");
+        exit(1);
+    }
+} else {
+    // An inherited value this script cannot parse counts as "not raised": the
+    // floor still applies, rather than assuming the unknown value is generous.
+    $inherited = bench_ini_bytes((string)ini_get('memory_limit'));
+    $mem_target = ($inherited !== null && $inherited >= bench_ini_bytes(BENCH_MEMORY_FLOOR))
+        ? null
+        : BENCH_MEMORY_FLOOR;
+}
+
+// Loud rather than silent. A run that proceeds under a lower cap than it asked
+// for dies later inside a fixture builder, where the fatal names an allocation
+// size and this script's line number and says nothing about the real cause.
+if ($mem_target !== null && ini_set('memory_limit', $mem_target) === false) {
+    fwrite(STDERR, "Could not set memory_limit=$mem_target (currently "
+        . ini_get('memory_limit') . "). Pass -d memory_limit=... to the PHP binary instead.\n");
+    exit(1);
+}
+$memory_limit = (string)ini_get('memory_limit');
 
 // Groups are the finest unit the runner can execute on its own. Each one owns
 // its setup, so running a group in isolation costs only that group's work —
@@ -156,6 +228,7 @@ $json_results = [
         'iterations'   => $iterations,
         'suite'        => $suite,
         'groups'       => $active_groups,
+        'memory_limit' => $memory_limit,
     ],
     'benchmarks' => [],
 ];
@@ -234,6 +307,7 @@ echo "$div\n";
 echo "  php-judy Benchmark Suite — " . number_format($size) . " elements, $iterations iterations (median)\n";
 echo "  PHP " . phpversion() . " | Judy ext " . judy_version() . " | " . PHP_OS . " " . php_uname('m') . "\n";
 echo "  Suite: $suite | Groups: " . implode(',', $active_groups) . "\n";
+echo "  memory_limit: $memory_limit\n";
 echo "$div\n\n";
 
 // ╔═══════════════════════════════════════════════════════════════════════════╗

--- a/examples/benchmarks/judy-bench.php
+++ b/examples/benchmarks/judy-bench.php
@@ -59,22 +59,30 @@ const BENCH_MEMORY_FLOOR = '2G';
  *
  * Returns PHP_INT_MAX for an unlimited (negative) value, so limits compare
  * with a plain `>=`, and null for anything this script should reject rather
- * than silently reinterpret. A magnitude that would not survive the suffix
- * multiply is rejected too: letting it overflow to float would trade a clean
- * message for an uncaught TypeError on the return type.
+ * than silently reinterpret. A magnitude that does not fit an int, or that
+ * would not survive the suffix multiply, is rejected too: letting either
+ * overflow to float would trade a clean message for an uncaught TypeError on
+ * the return type.
+ *
+ * Deliberately core-only — no ext/filter, no ext/ctype. The debug CI job
+ * builds its PHP `--disable-all`, where json and pcre are the only extensions
+ * present, and this script has to parse its own arguments there.
  */
 function bench_ini_bytes(string $value): ?int {
-    if (!preg_match('/^\s*(-?\d+)\s*([KMG]?)\s*$/i', $value, $m)) {
+    if (!preg_match('/^\s*(-?)0*(\d+)\s*([KMG]?)\s*$/i', $value, $m)) {
         return null;
     }
-    if (!is_int($n = filter_var($m[1], FILTER_VALIDATE_INT))) {
+    // (int) saturates at PHP_INT_MAX rather than wrapping, so a magnitude that
+    // does not survive the round trip did not fit in the first place.
+    $n = (int)$m[2];
+    if ((string)$n !== $m[2]) {
         return null;
     }
-    if ($n < 0) {
+    if ($m[1] === '-') {
         return PHP_INT_MAX; // unlimited
     }
     $mult = ['' => 1, 'K' => 1024, 'M' => 1024 * 1024, 'G' => 1024 * 1024 * 1024];
-    $f = $mult[strtoupper($m[2])];
+    $f = $mult[strtoupper($m[3])];
     return $n <= intdiv(PHP_INT_MAX, $f) ? $n * $f : null;
 }
 

--- a/examples/benchmarks/judy-bench.php
+++ b/examples/benchmarks/judy-bench.php
@@ -38,9 +38,11 @@ $json_file  = isset($opts['json'])       ? $opts['json']            : null;
 // Several groups build their PHP-array fixtures in full before any Judy work
 // starts, so the suite needs a cap well above the php.ini default. It used to
 // take that as a flat unconditional `2G`, which silently overrode the
-// `-d memory_limit=-1` that scripts/bench-compare.php and
-// scripts/bench-threearm.php pass every child, and made
-// `--group core.str --size 6000000` impossible to run at all: that group
+// `-d memory_limit=-1` that every driver passes its children —
+// scripts/bench-compare.php directly, and scripts/bench-threearm.php and
+// scripts/bench-gate.php through the shared launcher in scripts/bench-lib.php
+// — and made `--group core.str --size 6000000` impossible to run at all: that
+// group
 // materialises four 6M-element PHP arrays up front and dies in the fixture
 // builder, identically under every arm, before a single measurement is taken.
 // That is a second blocker on the out-of-cache three-arm row tracked by #169,

--- a/package.xml
+++ b/package.xml
@@ -94,6 +94,7 @@
          <file name="tests/arrayaccess_void_return_001.phpt" role="test" />
          <file name="tests/bench_compare_drift_001.phpt" role="test" />
          <file name="tests/bench_compare_fake_bench.inc" role="test" />
+         <file name="tests/bench_memory_limit_001.phpt" role="test" />
          <file md5sum="43e01c2e189ff2523a83016559b80391" name="tests/bitset_001.phpt" role="test" />
          <file md5sum="9f3363cc4c6d15cb52184351cf710fd7" name="tests/bitset_002.phpt" role="test" />
          <file md5sum="e859b3b92086bc165b3ec98800920f03" name="tests/bitset_003.phpt" role="test" />

--- a/tests/bench_memory_limit_001.phpt
+++ b/tests/bench_memory_limit_001.phpt
@@ -65,7 +65,7 @@ run_bench('below floor      ', '128M');
 run_bench('at floor         ', '2G');
 // Above the floor stays put, rather than being silently lowered to 2G.
 run_bench('above floor      ', '4G');
-// The form both bench drivers actually pass. This is the regression.
+// The form every bench driver actually passes. This is the regression.
 run_bench('unlimited (-d -1)', '-1');
 // An explicit request wins outright, including downward against -1.
 run_bench('explicit wins    ', '-1', '--memory-limit 256M');

--- a/tests/bench_memory_limit_001.phpt
+++ b/tests/bench_memory_limit_001.phpt
@@ -1,0 +1,66 @@
+--TEST--
+judy-bench: memory_limit is a floor a caller can raise, not a cap that overrides them
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) === 'WIN') die('skip POSIX shell required');
+$root = dirname(__DIR__);
+if (!is_file("$root/examples/benchmarks/judy-bench.php")) die('skip judy-bench.php not present');
+if (!is_file("$root/modules/judy.so")) die('skip requires in-tree build (modules/judy.so)');
+?>
+--FILE--
+<?php
+/*
+ * The suite used to set a flat `ini_set('memory_limit', '2G')` before parsing
+ * argv, which silently overrode the `-d memory_limit=-1` that both bench
+ * drivers pass their children and made the large string groups impossible to
+ * run at all. What is pinned here is the precedence, not the number: a caller
+ * asking for MORE must keep what they asked for, a caller asking for LESS is
+ * still raised to the floor, and --memory-limit beats both.
+ */
+$root   = dirname(__DIR__);
+$so     = "$root/modules/judy.so";
+$script = "$root/examples/benchmarks/judy-bench.php";
+
+function run_bench(string $label, string $ini, string $extra = ''): void {
+    global $so, $script;
+
+    // A tiny core.int run: enough to reach the banner, cheap enough for CI.
+    $cmd = escapeshellarg(PHP_BINARY)
+        . ' -d extension=' . escapeshellarg($so)
+        . ' -d memory_limit=' . escapeshellarg($ini)
+        . ' ' . escapeshellarg($script)
+        . ' --group core.int --size 200 --iterations 1 ' . $extra
+        . ' 2>&1';
+    exec($cmd, $output, $status);
+
+    $seen = 'none';
+    foreach ($output as $line) {
+        if (preg_match('/^\s*memory_limit:\s*(\S+)/', $line, $m)) {
+            $seen = $m[1];
+        } elseif (preg_match('/^(Invalid --memory-limit:.*)$/', $line, $m)) {
+            $seen = $m[1];
+        }
+    }
+    echo "$label: exit=$status effective=$seen\n";
+}
+
+// A caller below the floor is raised to it — the historical default.
+run_bench('below floor      ', '128M');
+// Equal to the floor: unchanged either way.
+run_bench('at floor         ', '2G');
+// Above the floor stays put, rather than being silently lowered to 2G.
+run_bench('above floor      ', '4G');
+// The form both bench drivers actually pass. This is the regression.
+run_bench('unlimited (-d -1)', '-1');
+// An explicit request wins outright, including downward against -1.
+run_bench('explicit wins    ', '-1', '--memory-limit 256M');
+// ...and is rejected rather than silently reinterpreted when unparseable.
+run_bench('explicit invalid ', '-1', '--memory-limit 4gigs');
+?>
+--EXPECT--
+below floor      : exit=0 effective=2G
+at floor         : exit=0 effective=2G
+above floor      : exit=0 effective=4G
+unlimited (-d -1): exit=0 effective=-1
+explicit wins    : exit=0 effective=256M
+explicit invalid : exit=1 effective=Invalid --memory-limit: 4gigs. Use a PHP ini size such as 4G, 512M, 1073741824, or -1 for unlimited.

--- a/tests/bench_memory_limit_001.phpt
+++ b/tests/bench_memory_limit_001.phpt
@@ -21,25 +21,40 @@ $root   = dirname(__DIR__);
 $so     = "$root/modules/judy.so";
 $script = "$root/examples/benchmarks/judy-bench.php";
 
-function run_bench(string $label, string $ini, string $extra = ''): void {
+function run_bench(string $label, string $ini, string $extra = '', string $ini_extra = ''): void {
     global $so, $script;
 
     // A tiny core.int run: enough to reach the banner, cheap enough for CI.
     $cmd = escapeshellarg(PHP_BINARY)
         . ' -d extension=' . escapeshellarg($so)
         . ' -d memory_limit=' . escapeshellarg($ini)
+        . ' ' . $ini_extra
         . ' ' . escapeshellarg($script)
         . ' --group core.int --size 200 --iterations 1 ' . $extra
         . ' 2>&1';
     exec($cmd, $output, $status);
 
-    $seen = 'none';
+    $seen = null;
     foreach ($output as $line) {
         if (preg_match('/^\s*memory_limit:\s*(\S+)/', $line, $m)) {
             $seen = $m[1];
         } elseif (preg_match('/^(Invalid --memory-limit:.*)$/', $line, $m)) {
             $seen = $m[1];
         }
+    }
+    if ($seen === null) {
+        // Only reachable when the child never got as far as reporting a limit.
+        // Quote what it said instead of a bare "none": a fatal in the child
+        // would otherwise collapse every row to the same uninformative token
+        // and hide which dependency or path actually broke.
+        $err = 'no limit reported';
+        foreach ($output as $line) {
+            if (preg_match('/(Fatal error|Parse error|Warning|Error):.*/', $line, $m)) {
+                $err = $m[0];
+                break;
+            }
+        }
+        $seen = "NONE — $err";
     }
     echo "$label: exit=$status effective=$seen\n";
 }
@@ -56,6 +71,16 @@ run_bench('unlimited (-d -1)', '-1');
 run_bench('explicit wins    ', '-1', '--memory-limit 256M');
 // ...and is rejected rather than silently reinterpreted when unparseable.
 run_bench('explicit invalid ', '-1', '--memory-limit 4gigs');
+// A magnitude that cannot fit an int is rejected, not overflowed to float:
+// letting it through cost an uncaught TypeError on the parser's return type.
+run_bench('explicit overflow', '-1', '--memory-limit 99999999999999999G');
+
+// The suite must parse its own arguments using core + pcre only. The debug CI
+// job builds its PHP `--disable-all`, where ext/filter is absent; a
+// filter_var() call in the size parser made every row above fatal there while
+// passing everywhere else. disable_functions reproduces that here, and is a
+// no-op on a build where the function was never compiled in.
+run_bench('no ext/filter    ', '128M', '', '-d disable_functions=filter_var,ctype_digit');
 ?>
 --EXPECT--
 below floor      : exit=0 effective=2G
@@ -64,3 +89,5 @@ above floor      : exit=0 effective=4G
 unlimited (-d -1): exit=0 effective=-1
 explicit wins    : exit=0 effective=256M
 explicit invalid : exit=1 effective=Invalid --memory-limit: 4gigs. Use a PHP ini size such as 4G, 512M, 1073741824, or -1 for unlimited.
+explicit overflow: exit=1 effective=Invalid --memory-limit: 99999999999999999G. Use a PHP ini size such as 4G, 512M, 1073741824, or -1 for unlimited.
+no ext/filter    : exit=0 effective=2G


### PR DESCRIPTION
## Problem

`examples/benchmarks/judy-bench.php` set a flat `ini_set('memory_limit', '2G')`
before parsing argv, which silently overrode the `-d memory_limit=-1` that both
`scripts/bench-compare.php:165` and `scripts/bench-threearm.php:602,605` pass
every child.

That made the `core.str` group impossible to run at `--size 6000000` under
**any** arm — it dies identically in its own fixture builder, which materialises
four 6M-element PHP arrays before the first Judy call:

```
Fatal error: Allowed memory size of 2147483648 bytes exhausted
(tried to allocate 335544320 bytes) in examples/benchmarks/judy-bench.php
```

Observed on honeycomb (Debian 13, gcc 14.2.0, PHP 8.4.24) at `--size 6000000`:
`core.int`, `api.batch`, `api.setops` and `adv.iter` all rc=0; `core.str` rc=255.
The failure is a property of the harness, not a signal about either library. It
is a second blocker on the out-of-cache three-arm row tracked by #169,
independent of the memory-safety one #162 closed, and the reason an attempt at
that row could only cover the integer and bitset paths.

## Change

`2G` becomes a floor rather than a ceiling, applied after argv parsing:

| caller | effective |
| --- | --- |
| `-d memory_limit=128M` | `2G` (raised to floor — the historical default) |
| `-d memory_limit=2G` | `2G` |
| `-d memory_limit=4G` | `4G` (kept) |
| `-d memory_limit=-1` | `-1` (kept — **what both drivers pass**) |
| `--memory-limit 256M` over `-d -1` | `256M` (explicit wins, even downward) |
| `--memory-limit 4gigs` | exit 1 with a message, not a silent reinterpretation |

Both drivers already pass `-d memory_limit=-1`, so they work **unchanged** — no
driver edits, which also keeps this clear of #166 (it rewrites
`bench-threearm.php` and the confidence-tier table, but touches neither region
edited here).

The effective cap is recorded as `metadata.memory_limit` in the JSON and echoed
in the console banner, so run provenance is readable rather than assumed.

## Verification

- All six precedence cases, against the built extension.
- **The knob gates the reported path**: `--group core.str --size 2000000
  --memory-limit 256M` reproduces the exact signature (fixture-builder
  `Allowed memory size ... exhausted`, rc=255); the same run uncapped completes
  rc=0. 6M was not runnable on the laptop used, but it is the same code path.
- Override mechanism confirmed directly: `php -d memory_limit=512M -r
  'ini_set("memory_limit","2G")'` → `2G`.
- New `tests/bench_memory_limit_001.phpt` pins the precedence table (precedent:
  `bench_compare_drift_001.phpt` also tests a harness script). **Negative
  control run** — it fails against the pre-change script.
- Full suite 224/224 pass. `package.xml` updated; every `tests/*` entry checked
  as listed.
- Hardened one edge case found while probing: `--memory-limit 99999999999999999G`
  crashed with an uncaught `TypeError` from the size parser overflowing to
  float. Now a clean rejection.

## Docs

`BENCHMARK.md` gets a three-arm methodology bullet stating which runs used which
cap, and the #162 paragraph now says the `2G` there was *unconditional at the
time* and that those runs were `core.int` (fixtures fit inside `2G`), so that
result is unaffected either way.

Note on scope: this is documented as a *second blocker* on the #169 row, not as
a caveat on a published result — #169 is still open and that tier row still
reads `not measured`.

## Not addressed

Sibling scripts (`judy-bench-all-types.php`, `judy-bench-phase2-api.php`,
`judy-bench-phase3-advanced.php` at `2G`; others at 128M–512M) have the same
hardcoded pattern. They are standalone and not driven by the comparison drivers,
so they are left alone here.
