### PR TITLE
perf(bench): measure the out-of-cache (n=6M) three-arm cell

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1893,6 +1893,111 @@ already long job, so it runs one build per arm, `rebuild_control_available` read
 `false` in its run JSON, and its threshold falls back to the offline floor alone.
 That is recorded rather than quietly equated with the other platforms.
 
+### Out-of-cache (n=6M): what survives when the working set leaves L3
+
+Everything above is cache-resident at 300k. This section is the same apparatus
+at **n=6,000,000**, where the structures no longer fit the host's 30 MB L3 and
+every Judy descend is a DRAM round trip. **Claim-grade**, Linux x86-64 /
+gcc 14.2.0 / PHP 8.4.24 / Debian 13, exclusively-held pinned honeycomb
+(`/var/tmp/BENCH_LOCK` held for the whole campaign, `--cpuset-cpus=2`), 7
+interleaved ABBA rounds, 3 independently linked builds per arm rotated across
+rounds, **~1.3% out-of-cache claim floor** applied automatically because
+6M ≥ the driver's `--dram-size` of 4M. Raw JSON and console output:
+`research/three-arm-benchmark/results/run6-out-of-cache-6m.{json,txt}`,
+`run6-attribution-6m.{json,txt}`, `run6-cvsc-control-6m.{json,txt}`.
+
+Host hygiene held flat across all four phase boundaries of all three runs:
+load1 1.00-1.22 against a threshold of 12.0, **foreign CPU 0.0% at every
+snapshot**, no run self-marked `contaminated`.
+
+#### The delivered difference, and its decomposition
+
+| | delivered (B→C) | our patches alone (S→C) | share attributable to our patches |
+| --- | ---: | ---: | ---: |
+| integer / bitset | **-12.0%** (n=37) | **-12.8%** (n=35) | **98.7%** |
+| string | **-19.7%** (n=34) | **-7.2%** (n=32) | **40.3%** |
+
+B→C is **71 cells faster, 0 slower, 2 null**; S→C is **68 faster, 0 slower,
+5 null**. Share is the per-cell median of `ln(S→C) / ln(B→C)` over matched
+cells, the same statistic as the cache-resident decomposition.
+
+**The headline finding is that the split barely moves with residency.**
+Cache-resident it was 96.5% integer / 39.8% string; out-of-cache it is 98.7% /
+40.3%. The prediction on record — that leaving cache should *raise* the patch
+share, because PLT/linkage overhead is fixed per call while memory stalls grow
+with the working set — is **not supported**: the integer share was already
+within a couple of points of 100% and the string share did not move at all.
+Whatever makes string paths gain more from bundling than from our patches is
+therefore not a cache-residency effect; it survives a 20x working set.
+
+The magnitudes do shrink, which is the expected direction: integer/bitset
+B→C goes from -17.7% cache-resident to **-12.0%** out-of-cache, and string from
+-22.2% to **-19.7%**. Instruction-level wins (O1 popcount, O3 word-access
+metadata) buy less when the pipeline is waiting on DRAM. This is consistent with
+the C-level gates, where O3's win survived DRAM-bound intact while O1's shrank.
+
+#### Memory at the same working set
+
+Peak RSS over the per-arm empty-process floor, median of 3 runs, n=6M.
+
+| workload | A: PHP array | B: system | C: bundled | **A/C** | B/C |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `int_to_int` (dense) | 129.6 MB | 49.5 MB | 49.7 MB | **2.61x** | 1.00x |
+| `int_sparse` (stride 4099) | 290.5 MB | 74.6 MB | 74.8 MB | **3.88x** | 1.00x |
+| `int_to_mixed` | 192.0 MB | 232.5 MB | 232.9 MB | **0.83x** | 1.00x |
+| `string_to_int` | 477.2 MB | 138.2 MB | 138.4 MB | **3.45x** | 1.00x |
+| `bitset` | 290.5 MB | 10.1 MB | 10.3 MB | **28.17x** | 0.98x |
+
+Same story as the 8M rows: `bitset` is the strongest case in the library,
+`int_to_mixed` still **loses** at 0.83x (in line with 0.79x at 8M), and B/C is
+1.00 everywhere — the vendoring did not change memory at this residency either.
+
+#### Where the PHP array wins, out-of-cache
+
+The A-vs-C comparison changes character more than anything else here. At 300k
+the PHP array won **42 of 43** comparable cells at a median of 4.19x. At 6M it
+wins **17 of 21**, median **1.97x**, and php-judy takes four cells outright:
+
+| operation | PHP array | php-judy | judy/array | winner |
+| --- | ---: | ---: | ---: | --- |
+| `bitset` free | 5.01 ms | 0.02 ms | **0.00x** | **php-judy** |
+| `int_to_int` free | 5.45 ms | 2.09 ms | **0.38x** | **php-judy** |
+| `xor` (bitset) | 221.28 ms | 172.93 ms | **0.78x** | **php-judy** |
+| `intersect` (bitset) | 95.43 ms | 87.03 ms | **0.91x** | **php-judy** |
+| `int_to_int` write | 91.95 ms | 144.70 ms | 1.57x | PHP array |
+| `int_to_int` read | 22.22 ms | 66.98 ms | 3.01x | PHP array |
+| `int_to_int` iterate | 18.66 ms | 113.10 ms | 6.06x | PHP array |
+
+The mechanism is the one the 300k section already gives: php-judy's per-call
+cost is a roughly fixed ~16 ns PHP/C boundary crossing, so as the per-element
+work grows with the working set, that fixed cost amortizes and the ratio falls.
+It does not invert the advice — **the array still wins the majority of scalar
+cells** — but "adopt php-judy for memory and ordering, not speed" is a weaker
+statement at 6M than at 300k, and the set-operation and teardown cells cross
+over entirely.
+
+#### The control, and the floor this run actually measured
+
+The C-vs-C rebuild control was re-run at 6M with the three arm-C builds rotated
+one position, so no round compares a binary against itself:
+
+| control | result |
+| --- | --- |
+| C-vs-C rebuild control at 6M, 73 cells | **0 faster, 0 slower, 73 null** |
+| PHP-array-only rows, B→C run | **-0.04% [-0.11, +0.02]** over 21 rows |
+| PHP-array-only rows, S→C run | **+0.04% [+0.00, +0.07]** over 21 rows |
+| PHP-array-only rows, C-vs-C run | **+0.01% [-0.02, +0.08]** over 21 rows |
+
+**One honest caveat on the floor.** The driver also reports how far the control
+rows themselves scatter, and at this residency that scatter exceeded the assumed
+1.3% floor in two of the three runs: **1.26%** in the B→C run (inside), but
+**2.63%** in the S→C run and **1.62%** in the C-vs-C control. The 1.3%
+out-of-cache floor is therefore *optimistic for these runs*, and any cell moving
+by less than about **2.6%** should be read as null regardless of what its CI
+says. Every figure quoted above is between 7.2% and 19.7%, far outside that
+band, so none of the headline claims depend on the difference — but a reader
+mining the raw JSON for small cells should apply the wider floor.
+
 ### Confidence tiers, and what is NOT measured
 
 There are now three tiers on this page and they are not interchangeable.
@@ -1911,7 +2016,7 @@ There are now three tiers on this page and they are not interchangeable.
 | **macOS arm64**, GitHub runner | Apple clang 21.0.0, PHP 8.4.24 | measured | measured | measured | **ci-relative** |
 | macOS arm64, local workstation | Apple clang 21, PHP 8.5.8, Homebrew | directional | directional | measured | **directional** |
 | Windows x64 | MSVC | see below | see below | see below | see below |
-| Linux x86-64, **out-of-cache** (>=6M) | gcc 14.2.0 | not measured | not measured | measured (8M rows above) | **not measured** |
+| Linux x86-64, **out-of-cache** (n=6M), honeycomb (dedicated) | gcc 14.2.0, PHP 8.4.24, Debian 13 | measured | measured | measured | **claim-grade** (integer/bitset + string API paths; `core.str` not measured — see below) |
 
 #### What the gate measured on each platform
 
@@ -2067,10 +2172,27 @@ per-arm process-floor subtraction is comparing small differences of large
 numbers. It is exactly the kind of figure that would mislead if quoted, which is
 why it sits below the gating floor and is not in the headline table above.
 
-#### Still not measured
+#### Still not measured, and one slot recently closed
 
-- **Out-of-cache timing is still not measured, but the memory-safety signal that
-  blocked it is resolved.** The intended 6M run aborted when arm B terminated
+- **Out-of-cache timing is now MEASURED** — see the
+  [out-of-cache section](#out-of-cache-n6m-what-survives-when-the-working-set-leaves-l3)
+  above for the figures. What follows is the record of the memory-safety
+  blocker that held the slot empty, kept because it is the reason the cell sat
+  unmeasured for so long. **One hole remains inside the cell**: the `core.str`
+  group cannot run at 6M at all, for a reason that has nothing to do with
+  php-judy. `judy-bench.php` sets `ini_set('memory_limit', '2G')`, which
+  overrides any `-d memory_limit=-1` a caller passes, and that group's own
+  fixtures — two 6M-element string-keyed PHP arrays plus their key lists, built
+  before any Judy work starts — exhaust it. It fails identically under every
+  arm with `Allowed memory size of 2147483648 bytes exhausted` at
+  `judy-bench.php` line 494. The measured cell therefore covers `core.int`,
+  `api.batch`, `api.setops` and `adv.iter`; string **API** paths are well
+  represented there (34 of the 71 faster cells are string-keyed), but the
+  `core.str` per-element write/read/iterate table is absent. Lifting the cap is
+  a change to a published benchmark fixture and is deliberately not bundled
+  into this measurement.
+
+  The original blocker, for the record: the intended 6M run aborted when arm B terminated
   with SIGSEGV in the `core.int` group, and at the time this section could not
   say whether the fault lay in the extension, the benchmark script, or libJudy.
   It is now established: the fault is **php-judy's own PHP-facing layer**, not
@@ -2112,13 +2234,15 @@ why it sits below the gating floor and is not in the headline table above.
   unwinding through an in-progress Judy write) and is ruled out: the post-fix 6M
   runs complete under that same cap without a fatal.
 
-  **What this unblocks and what it does not.** The out-of-cache (>=6M) `core.int`
-  cell now runs to completion, so the arm can be scheduled; the slot in the tier
-  table stays `not measured` until it is actually run on an exclusively-held
-  honeycomb. Nothing above is a timing measurement — the runs in the table are
-  crash reproductions on a shared laptop and assert nothing about performance.
-  The 8M rows in the memory table were always unaffected: those run in their own
-  child processes and complete cleanly.
+  **What this unblocked.** The out-of-cache (>=6M) `core.int` cell runs to
+  completion, and the campaign was subsequently run on an exclusively-held
+  honeycomb — `core.int` at 6M completed `rc=0` under all three arms across 7
+  interleaved rounds, confirming on a third platform that the fix holds under
+  sustained load rather than in a single reproduction. Nothing in the table
+  above is a timing measurement: those runs are crash reproductions on a shared
+  laptop and assert nothing about performance. The 8M rows in the memory table
+  were always unaffected: those run in their own child processes and complete
+  cleanly.
 
   For the gate specifically: the slot is wired and needs no rework. Raise
   `BENCH_SIZE` past the driver's `--dram-size` in
@@ -2148,6 +2272,20 @@ php scripts/bench-threearm.php \
   --rounds 7 --size 300000 --assert-same-source \
   --system-provenance "$(. /etc/os-release; echo "$PRETTY_NAME") $(dpkg-query -W -f='${Version}' libjudy-dev 2>/dev/null)" \
   --out bench-threearm.json
+```
+
+For the **out-of-cache** cell, raise `--size` past the driver's `--dram-size`
+(default 4M) so the ~1.3% floor is selected, and drop `core.str` — its fixtures
+exceed the 2G cap `judy-bench.php` sets for itself and it cannot run at this
+size under any arm:
+
+```sh
+php scripts/bench-threearm.php \
+  --system-so judy-system.so --bundled-so judy-bundled.so \
+  --rounds 7 --size 6000000 --assert-same-source \
+  --groups core.int,api.batch,api.setops,adv.iter --mem-sizes 6000000 \
+  --system-provenance "$(. /etc/os-release; echo "$PRETTY_NAME") $(dpkg-query -W -f='${Version}' libjudy-dev 2>/dev/null)" \
+  --out research/three-arm-benchmark/results/run6-out-of-cache-6m.json
 ```
 
 Pass `--system-so` / `--bundled-so` more than once to rotate independent builds.

--- a/research/three-arm-benchmark/results/run6-attribution-6m.json
+++ b/research/three-arm-benchmark/results/run6-attribution-6m.json
@@ -1,0 +1,5831 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "linux-x86_64-gcc14.2-php8.4-out-of-cache-6M-ATTRIBUTION-S-vs-C",
+        "date": "2026-08-19T06:11:17+00:00",
+        "php_version": "8.4.24",
+        "platform": "Linux x86_64",
+        "uname": "Linux 9eda8be811ef 6.8.0-136-generic #136~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  3 16:29:11 UTC  x86_64",
+        "judy_version": "2.5.2",
+        "system_so": [
+            "/work/builds/judy-S-1.so",
+            "/work/builds/judy-S-2.so",
+            "/work/builds/judy-S-3.so"
+        ],
+        "bundled_so": [
+            "/work/builds/judy-C-1.so",
+            "/work/builds/judy-C-2.so",
+            "/work/builds/judy-C-3.so"
+        ],
+        "system_so_sha256": [
+            "2b2f9bac6f3f3d052e369669dfcae91b1740c7ada8588b76eb9df6b11a8baf79",
+            "13d184e9aa680da01a04d31883606ebe6a9e741d300a547b9b12f7065a900c83",
+            "2a598eca38b43b7fa15c327632bc20ae83cb817a1f9440e52b19e04e463c0fe4"
+        ],
+        "bundled_so_sha256": [
+            "df5d52bc39e6792a0838d911d816e44a3dbd9966347aa837cd5754aaf4fe0f2a",
+            "e045a13c7e649278937555e54798aa1296bda245cc7bad759770c3ebfab17b12",
+            "fb78079bf462da012789c29bef076168d23f50c47cb31ba47aa9299f481252d3"
+        ],
+        "system_provenance": "ARM S: PRISTINE Judy-1.0.5 (official tarball sha256 d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb), STATIC into the extension, IDENTICAL pinned CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt -fPIC. Isolates the php-judy source patches ALONE.",
+        "bundled_provenance": "bundled libjudy/ static into the extension (P1-P7, O1 popcount, O3 bswap, O4 string-layer); vendor CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt",
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 6000000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            100000,
+            1000000,
+            8000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "out-of-cache",
+        "claim_floor_pct": 1.3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 56,
+        "memory_children": 0,
+        "wall_seconds": 1804.5
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T05:41:12+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T06:11:17+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T06:11:17+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "note": "load average alone is necessary but not sufficient: a co-resident memory-bound benchmark contends for LLC and memory bandwidth at low load, and a PHP-array control does not detect it"
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 1.00042,
+            "delta_pct": 0.04,
+            "ci_delta_pct": [
+                0,
+                0.07
+            ],
+            "measured_spread_pct": 2.63,
+            "row_count": 21,
+            "eligibility": "genuine PHP-array rows only (TAM_ARM_A_ROWS); Judy-touching .php rows are excluded because they carry real signal",
+            "rows": {
+                "core.bitset.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99961,
+                    "delta_pct": -0.04,
+                    "ci_delta_pct": [
+                        -0.22,
+                        0.17
+                    ],
+                    "n": 7,
+                    "b_ms": 89,
+                    "c_ms": 89.0933
+                },
+                "core.bitset.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00992,
+                    "delta_pct": 0.99,
+                    "ci_delta_pct": [
+                        0.59,
+                        3.94
+                    ],
+                    "n": 7,
+                    "b_ms": 22.2717,
+                    "c_ms": 22.4613
+                },
+                "core.bitset.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00067,
+                    "delta_pct": 0.07,
+                    "ci_delta_pct": [
+                        -0.18,
+                        0.43
+                    ],
+                    "n": 7,
+                    "b_ms": 18.7367,
+                    "c_ms": 18.7337
+                },
+                "core.bitset.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.97372,
+                    "delta_pct": -2.63,
+                    "ci_delta_pct": [
+                        -9.86,
+                        1.08
+                    ],
+                    "n": 7,
+                    "b_ms": 5.3994,
+                    "c_ms": 4.9988
+                },
+                "core.int_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00042,
+                    "delta_pct": 0.04,
+                    "ci_delta_pct": [
+                        -0.26,
+                        0.17
+                    ],
+                    "n": 7,
+                    "b_ms": 91.9626,
+                    "c_ms": 91.968
+                },
+                "core.int_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.01427,
+                    "delta_pct": 1.43,
+                    "ci_delta_pct": [
+                        0.14,
+                        1.81
+                    ],
+                    "n": 7,
+                    "b_ms": 21.9824,
+                    "c_ms": 22.296
+                },
+                "core.int_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00118,
+                    "delta_pct": 0.12,
+                    "ci_delta_pct": [
+                        0.05,
+                        0.26
+                    ],
+                    "n": 7,
+                    "b_ms": 18.6342,
+                    "c_ms": 18.6534
+                },
+                "core.int_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00058,
+                    "delta_pct": 0.06,
+                    "ci_delta_pct": [
+                        -0.41,
+                        0.2
+                    ],
+                    "n": 7,
+                    "b_ms": 5.5022,
+                    "c_ms": 5.478
+                },
+                "core.int_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99967,
+                    "delta_pct": -0.03,
+                    "ci_delta_pct": [
+                        -0.1,
+                        0.17
+                    ],
+                    "n": 7,
+                    "b_ms": 264.7174,
+                    "c_ms": 264.5573
+                },
+                "core.int_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99778,
+                    "delta_pct": -0.22,
+                    "ci_delta_pct": [
+                        -0.43,
+                        0.2
+                    ],
+                    "n": 7,
+                    "b_ms": 121.0011,
+                    "c_ms": 120.7326
+                },
+                "core.int_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00115,
+                    "delta_pct": 0.12,
+                    "ci_delta_pct": [
+                        0.02,
+                        0.23
+                    ],
+                    "n": 7,
+                    "b_ms": 85.3543,
+                    "c_ms": 85.3762
+                },
+                "core.int_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1,
+                    "delta_pct": 0,
+                    "ci_delta_pct": [
+                        -0.18,
+                        0.13
+                    ],
+                    "n": 7,
+                    "b_ms": 46.108,
+                    "c_ms": 46.0982
+                },
+                "core.int_to_packed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99875,
+                    "delta_pct": -0.13,
+                    "ci_delta_pct": [
+                        -0.17,
+                        0.1
+                    ],
+                    "n": 7,
+                    "b_ms": 246.8753,
+                    "c_ms": 246.8084
+                },
+                "core.int_to_packed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00035,
+                    "delta_pct": 0.04,
+                    "ci_delta_pct": [
+                        -0.15,
+                        0.12
+                    ],
+                    "n": 7,
+                    "b_ms": 106.5824,
+                    "c_ms": 106.5287
+                },
+                "core.int_to_packed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00012,
+                    "delta_pct": 0.01,
+                    "ci_delta_pct": [
+                        -2.1,
+                        0.42
+                    ],
+                    "n": 7,
+                    "b_ms": 21.4418,
+                    "c_ms": 21.4357
+                },
+                "core.int_to_packed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00017,
+                    "delta_pct": 0.02,
+                    "ci_delta_pct": [
+                        -0.16,
+                        0.09
+                    ],
+                    "n": 7,
+                    "b_ms": 46.8885,
+                    "c_ms": 46.8966
+                },
+                "api.increment.int_to_int": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99857,
+                    "delta_pct": -0.14,
+                    "ci_delta_pct": [
+                        -0.35,
+                        0.04
+                    ],
+                    "n": 7,
+                    "b_ms": 57.4286,
+                    "c_ms": 57.3579
+                },
+                "api.setop.union.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00062,
+                    "delta_pct": 0.06,
+                    "ci_delta_pct": [
+                        0.05,
+                        0.21
+                    ],
+                    "n": 7,
+                    "b_ms": 92.2993,
+                    "c_ms": 92.3826
+                },
+                "api.setop.intersect.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00207,
+                    "delta_pct": 0.21,
+                    "ci_delta_pct": [
+                        0.04,
+                        0.3
+                    ],
+                    "n": 7,
+                    "b_ms": 95.2506,
+                    "c_ms": 95.4538
+                },
+                "api.setop.diff.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00073,
+                    "delta_pct": 0.07,
+                    "ci_delta_pct": [
+                        -0.24,
+                        0.37
+                    ],
+                    "n": 7,
+                    "b_ms": 43.0839,
+                    "c_ms": 43.0604
+                },
+                "api.setop.xor.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00091,
+                    "delta_pct": 0.09,
+                    "ci_delta_pct": [
+                        -0.17,
+                        0.36
+                    ],
+                    "n": 7,
+                    "b_ms": 221.3978,
+                    "c_ms": 221.307
+                }
+            }
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 68,
+        "slower": 0,
+        "null": 5
+    },
+    "a_counts": {
+        "php-judy": 4,
+        "php-array": 17,
+        "parity": 0
+    },
+    "bundled_vs_system": {
+        "core.bitset.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88436,
+            "delta_pct": -11.56,
+            "ci_delta_pct": [
+                -11.63,
+                -11.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.56,
+                "B2/C2": -11.39,
+                "B3/C3": -11.7
+            },
+            "build_spread_pct": 0.31,
+            "builds": 3,
+            "system_ms": 116.7094,
+            "bundled_ms": 103.2607,
+            "raw_delta_pct": -11.53,
+            "spread_pct": [
+                0.4,
+                1
+            ],
+            "system_runs_ms": [
+                116.6989,
+                116.356,
+                116.3779,
+                116.7094,
+                116.8053,
+                116.7872,
+                116.7733
+            ],
+            "bundled_runs_ms": [
+                103.7236,
+                103.4383,
+                103.3147,
+                103.2563,
+                103.2607,
+                102.6644,
+                103.2479
+            ],
+            "paired_ratios": [
+                0.88881,
+                0.88898,
+                0.88775,
+                0.88473,
+                0.88404,
+                0.87907,
+                0.88417
+            ]
+        },
+        "core.bitset.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.98624,
+            "delta_pct": -1.38,
+            "ci_delta_pct": [
+                -4.04,
+                -0.95
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.22,
+                "B2/C2": -0.87,
+                "B3/C3": -2.77
+            },
+            "build_spread_pct": 1.9,
+            "builds": 3,
+            "system_ms": 68.6761,
+            "bundled_ms": 67.5018,
+            "raw_delta_pct": -1.34,
+            "spread_pct": [
+                3.4,
+                2.4
+            ],
+            "system_runs_ms": [
+                68.0545,
+                68.4744,
+                70.1503,
+                68.1235,
+                68.9134,
+                68.6761,
+                70.3642
+            ],
+            "bundled_runs_ms": [
+                67.2506,
+                67.5601,
+                67.3458,
+                67.5018,
+                68.6909,
+                67.676,
+                67.0997
+            ],
+            "paired_ratios": [
+                0.98819,
+                0.98665,
+                0.96002,
+                0.99087,
+                0.99677,
+                0.98544,
+                0.95361
+            ]
+        },
+        "core.bitset.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.96607,
+            "delta_pct": -3.39,
+            "ci_delta_pct": [
+                -4.12,
+                -3.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.73,
+                "B2/C2": -3.33,
+                "B3/C3": -2.88
+            },
+            "build_spread_pct": 0.85,
+            "builds": 3,
+            "system_ms": 111.2202,
+            "bundled_ms": 107.5718,
+            "raw_delta_pct": -3.35,
+            "spread_pct": [
+                2.7,
+                3.6
+            ],
+            "system_runs_ms": [
+                111.9902,
+                111.3728,
+                110.6914,
+                111.2202,
+                111.0086,
+                112.4025,
+                109.348
+            ],
+            "bundled_runs_ms": [
+                107.4188,
+                107.7748,
+                109.152,
+                107.6062,
+                107.2866,
+                107.5718,
+                105.3171
+            ],
+            "paired_ratios": [
+                0.95918,
+                0.96769,
+                0.98609,
+                0.96751,
+                0.96647,
+                0.95702,
+                0.96314
+            ]
+        },
+        "core.int_to_int.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76251,
+            "delta_pct": -23.75,
+            "ci_delta_pct": [
+                -23.96,
+                -23.67
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.67,
+                "B2/C2": -24.03,
+                "B3/C3": -23.89
+            },
+            "build_spread_pct": 0.36,
+            "builds": 3,
+            "system_ms": 190.1016,
+            "bundled_ms": 144.8022,
+            "raw_delta_pct": -23.72,
+            "spread_pct": [
+                1,
+                0.6
+            ],
+            "system_runs_ms": [
+                189.6195,
+                190.1016,
+                190.8042,
+                189.5555,
+                190.9915,
+                190.8619,
+                189.1586
+            ],
+            "bundled_runs_ms": [
+                144.8022,
+                145.0155,
+                145.1418,
+                144.6792,
+                144.606,
+                145.4548,
+                144.6251
+            ],
+            "paired_ratios": [
+                0.76365,
+                0.76283,
+                0.76068,
+                0.76326,
+                0.75713,
+                0.76209,
+                0.76457
+            ]
+        },
+        "core.int_to_int.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83213,
+            "delta_pct": -16.79,
+            "ci_delta_pct": [
+                -17.45,
+                -16.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.93,
+                "B2/C2": -16.51,
+                "B3/C3": -17.17
+            },
+            "build_spread_pct": 0.66,
+            "builds": 3,
+            "system_ms": 80.8143,
+            "bundled_ms": 67.2861,
+            "raw_delta_pct": -16.75,
+            "spread_pct": [
+                0.8,
+                1.2
+            ],
+            "system_runs_ms": [
+                81.2185,
+                80.601,
+                80.7745,
+                81.1367,
+                80.8143,
+                81.1307,
+                80.7671
+            ],
+            "bundled_runs_ms": [
+                67.4966,
+                67.5535,
+                67.2861,
+                67.0098,
+                67.2759,
+                66.8699,
+                67.6566
+            ],
+            "paired_ratios": [
+                0.83105,
+                0.83812,
+                0.83301,
+                0.82589,
+                0.83248,
+                0.82422,
+                0.83768
+            ]
+        },
+        "core.int_to_int.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9151,
+            "delta_pct": -8.49,
+            "ci_delta_pct": [
+                -8.72,
+                -8.36
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.49,
+                "B2/C2": -8.55,
+                "B3/C3": -8.5
+            },
+            "build_spread_pct": 0.06,
+            "builds": 3,
+            "system_ms": 123.9027,
+            "bundled_ms": 113.459,
+            "raw_delta_pct": -8.45,
+            "spread_pct": [
+                0.4,
+                0.5
+            ],
+            "system_runs_ms": [
+                124.0959,
+                123.6854,
+                123.8209,
+                124.0395,
+                123.9027,
+                123.7467,
+                124.1796
+            ],
+            "bundled_runs_ms": [
+                113.6664,
+                113.459,
+                113.5153,
+                113.2667,
+                113.0614,
+                113.1023,
+                113.6843
+            ],
+            "paired_ratios": [
+                0.91596,
+                0.91732,
+                0.91677,
+                0.91315,
+                0.9125,
+                0.91398,
+                0.91548
+            ]
+        },
+        "core.int_to_int.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00055,
+            "delta_pct": 0.05,
+            "ci_delta_pct": [
+                -2.59,
+                1.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.05,
+                "B2/C2": -2.44,
+                "B3/C3": 2.48
+            },
+            "build_spread_pct": 4.92,
+            "builds": 3,
+            "system_ms": 2.1021,
+            "bundled_ms": 2.0815,
+            "raw_delta_pct": 0.1,
+            "spread_pct": [
+                4.7,
+                4.2
+            ],
+            "system_runs_ms": [
+                2.157,
+                2.1216,
+                2.0652,
+                2.1021,
+                2.1214,
+                2.0572,
+                2.0699
+            ],
+            "bundled_runs_ms": [
+                2.102,
+                2.0815,
+                2.1464,
+                2.1119,
+                2.0595,
+                2.0803,
+                2.0719
+            ],
+            "paired_ratios": [
+                0.9745,
+                0.9811,
+                1.03932,
+                1.00466,
+                0.97082,
+                1.01123,
+                1.00097
+            ]
+        },
+        "core.int_to_mixed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90292,
+            "delta_pct": -9.71,
+            "ci_delta_pct": [
+                -9.84,
+                -9.63
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.74,
+                "B2/C2": -10.13,
+                "B3/C3": -9.65
+            },
+            "build_spread_pct": 0.48,
+            "builds": 3,
+            "system_ms": 440.937,
+            "bundled_ms": 398.4521,
+            "raw_delta_pct": -9.67,
+            "spread_pct": [
+                0.6,
+                0.7
+            ],
+            "system_runs_ms": [
+                440.3473,
+                441.1104,
+                441.4226,
+                440.7375,
+                442.9053,
+                440.937,
+                440.2941
+            ],
+            "bundled_runs_ms": [
+                397.2043,
+                398.4521,
+                398.9033,
+                399.0756,
+                396.2992,
+                398.6234,
+                397.5951
+            ],
+            "paired_ratios": [
+                0.90203,
+                0.90329,
+                0.90368,
+                0.90547,
+                0.89477,
+                0.90404,
+                0.90302
+            ]
+        },
+        "core.int_to_mixed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87214,
+            "delta_pct": -12.79,
+            "ci_delta_pct": [
+                -12.96,
+                -12.5
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.68,
+                "B2/C2": -12.73,
+                "B3/C3": -13.03
+            },
+            "build_spread_pct": 0.35,
+            "builds": 3,
+            "system_ms": 317.9678,
+            "bundled_ms": 278.0552,
+            "raw_delta_pct": -12.75,
+            "spread_pct": [
+                1,
+                0.8
+            ],
+            "system_runs_ms": [
+                317.7682,
+                317.9678,
+                319.2464,
+                316.5535,
+                319.3214,
+                319.5919,
+                317.9081
+            ],
+            "bundled_runs_ms": [
+                278.2206,
+                278.3278,
+                276.9874,
+                276.5227,
+                278.0552,
+                278.8439,
+                277.2483
+            ],
+            "paired_ratios": [
+                0.87555,
+                0.87533,
+                0.86763,
+                0.87354,
+                0.87077,
+                0.8725,
+                0.8721
+            ]
+        },
+        "core.int_to_mixed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91808,
+            "delta_pct": -8.19,
+            "ci_delta_pct": [
+                -8.48,
+                -7.99
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.05,
+                "B2/C2": -8.09,
+                "B3/C3": -8.66
+            },
+            "build_spread_pct": 0.61,
+            "builds": 3,
+            "system_ms": 349.9261,
+            "bundled_ms": 321.7003,
+            "raw_delta_pct": -8.15,
+            "spread_pct": [
+                0.5,
+                0.9
+            ],
+            "system_runs_ms": [
+                348.6073,
+                349.4839,
+                349.9503,
+                350.4471,
+                350.4613,
+                349.9261,
+                349.8238
+            ],
+            "bundled_runs_ms": [
+                321.9084,
+                321.7003,
+                320.4087,
+                321.6528,
+                321.8872,
+                319.1058,
+                321.783
+            ],
+            "paired_ratios": [
+                0.92341,
+                0.9205,
+                0.91558,
+                0.91784,
+                0.91847,
+                0.91192,
+                0.91984
+            ]
+        },
+        "core.int_to_mixed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91457,
+            "delta_pct": -8.54,
+            "ci_delta_pct": [
+                -8.72,
+                -8.06
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.06,
+                "B2/C2": -8.51,
+                "B3/C3": -8.71
+            },
+            "build_spread_pct": 0.65,
+            "builds": 3,
+            "system_ms": 109.4854,
+            "bundled_ms": 100.2413,
+            "raw_delta_pct": -8.5,
+            "spread_pct": [
+                0.2,
+                1.5
+            ],
+            "system_runs_ms": [
+                109.4384,
+                109.5131,
+                109.4854,
+                109.3124,
+                109.5593,
+                109.4413,
+                109.5085
+            ],
+            "bundled_runs_ms": [
+                100.8982,
+                100.2732,
+                99.9818,
+                100.5485,
+                100.2413,
+                99.9545,
+                99.3706
+            ],
+            "paired_ratios": [
+                0.92196,
+                0.91563,
+                0.9132,
+                0.91983,
+                0.91495,
+                0.91332,
+                0.90742
+            ]
+        },
+        "core.int_to_packed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90552,
+            "delta_pct": -9.45,
+            "ci_delta_pct": [
+                -9.53,
+                -9.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.35,
+                "B2/C2": -9.49,
+                "B3/C3": -10.1
+            },
+            "build_spread_pct": 0.75,
+            "builds": 3,
+            "system_ms": 381.5501,
+            "bundled_ms": 346.002,
+            "raw_delta_pct": -9.41,
+            "spread_pct": [
+                2.7,
+                0.7
+            ],
+            "system_runs_ms": [
+                382.4956,
+                381.8043,
+                390.9751,
+                381.0207,
+                381.5501,
+                380.7185,
+                381.2124
+            ],
+            "bundled_runs_ms": [
+                346.3082,
+                345.5563,
+                347.9801,
+                346.7802,
+                345.6447,
+                346.002,
+                345.7044
+            ],
+            "paired_ratios": [
+                0.90539,
+                0.90506,
+                0.89003,
+                0.91013,
+                0.9059,
+                0.90881,
+                0.90686
+            ]
+        },
+        "core.int_to_packed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.97348,
+            "delta_pct": -2.65,
+            "ci_delta_pct": [
+                -2.88,
+                -2.39
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.65,
+                "B2/C2": -2.27,
+                "B3/C3": -4.86
+            },
+            "build_spread_pct": 2.59,
+            "builds": 3,
+            "system_ms": 210.7512,
+            "bundled_ms": 205.6329,
+            "raw_delta_pct": -2.61,
+            "spread_pct": [
+                4.6,
+                0.8
+            ],
+            "system_runs_ms": [
+                211.7757,
+                210.8931,
+                220.2335,
+                210.4548,
+                210.7512,
+                210.7355,
+                210.5715
+            ],
+            "bundled_runs_ms": [
+                205.7623,
+                205.7152,
+                205.197,
+                204.9601,
+                206.5195,
+                204.7886,
+                205.6329
+            ],
+            "paired_ratios": [
+                0.9716,
+                0.97545,
+                0.93172,
+                0.97389,
+                0.97992,
+                0.97178,
+                0.97655
+            ]
+        },
+        "core.int_to_packed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93646,
+            "delta_pct": -6.35,
+            "ci_delta_pct": [
+                -6.47,
+                -5.14
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.39,
+                "B2/C2": -6.29,
+                "B3/C3": -6.01
+            },
+            "build_spread_pct": 0.38,
+            "builds": 3,
+            "system_ms": 263.814,
+            "bundled_ms": 247.0961,
+            "raw_delta_pct": -6.31,
+            "spread_pct": [
+                0.2,
+                2.4
+            ],
+            "system_runs_ms": [
+                263.8435,
+                263.5097,
+                263.6586,
+                263.8651,
+                264.0308,
+                263.7736,
+                263.814
+            ],
+            "bundled_runs_ms": [
+                251.7421,
+                246.8707,
+                250.2072,
+                247.0961,
+                247.678,
+                245.7506,
+                246.8507
+            ],
+            "paired_ratios": [
+                0.95413,
+                0.93686,
+                0.94898,
+                0.93645,
+                0.93806,
+                0.93167,
+                0.9357
+            ]
+        },
+        "core.int_to_packed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84274,
+            "delta_pct": -15.73,
+            "ci_delta_pct": [
+                -15.83,
+                -15.59
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.74,
+                "B2/C2": -15.56,
+                "B3/C3": -15.66
+            },
+            "build_spread_pct": 0.18,
+            "builds": 3,
+            "system_ms": 61.7007,
+            "bundled_ms": 51.9577,
+            "raw_delta_pct": -15.69,
+            "spread_pct": [
+                0.6,
+                1.1
+            ],
+            "system_runs_ms": [
+                61.6412,
+                61.7007,
+                61.6203,
+                61.6402,
+                61.7229,
+                61.8878,
+                61.9818
+            ],
+            "bundled_runs_ms": [
+                51.9577,
+                52.4241,
+                51.9518,
+                51.9026,
+                51.8437,
+                52.2604,
+                52.2702
+            ],
+            "paired_ratios": [
+                0.84291,
+                0.84965,
+                0.8431,
+                0.84203,
+                0.83994,
+                0.84444,
+                0.84332
+            ]
+        },
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.73779,
+            "delta_pct": -26.22,
+            "ci_delta_pct": [
+                -26.26,
+                -26.2
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.2,
+                "B2/C2": -26.22,
+                "B3/C3": -26.24
+            },
+            "build_spread_pct": 0.04,
+            "builds": 3,
+            "system_ms": 171.1047,
+            "bundled_ms": 126.2926,
+            "raw_delta_pct": -26.19,
+            "spread_pct": [
+                0.4,
+                0.4
+            ],
+            "system_runs_ms": [
+                171.0966,
+                171.1047,
+                171.6289,
+                171.1606,
+                170.9891,
+                170.9108,
+                171.1235
+            ],
+            "bundled_runs_ms": [
+                126.3168,
+                126.2926,
+                126.6138,
+                126.2127,
+                126.2004,
+                126.162,
+                126.4078
+            ],
+            "paired_ratios": [
+                0.73828,
+                0.7381,
+                0.73772,
+                0.73739,
+                0.73806,
+                0.73817,
+                0.73869
+            ]
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.73771,
+            "delta_pct": -26.23,
+            "ci_delta_pct": [
+                -26.43,
+                -25.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.43,
+                "B2/C2": -26.04,
+                "B3/C3": -26.11
+            },
+            "build_spread_pct": 0.39,
+            "builds": 3,
+            "system_ms": 171.1284,
+            "bundled_ms": 126.3783,
+            "raw_delta_pct": -26.2,
+            "spread_pct": [
+                2.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                170.8487,
+                170.8582,
+                171.5372,
+                175.2273,
+                171.1284,
+                170.9154,
+                171.2548
+            ],
+            "bundled_runs_ms": [
+                126.3063,
+                126.738,
+                126.3783,
+                126.7041,
+                126.2959,
+                126.7733,
+                126.0389
+            ],
+            "paired_ratios": [
+                0.73929,
+                0.74177,
+                0.73674,
+                0.72308,
+                0.73802,
+                0.74173,
+                0.73597
+            ]
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.96741,
+            "delta_pct": -3.26,
+            "ci_delta_pct": [
+                -3.58,
+                -3.2
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.26,
+                "B2/C2": -3.34,
+                "B3/C3": -3.39
+            },
+            "build_spread_pct": 0.13,
+            "builds": 3,
+            "system_ms": 308.1087,
+            "bundled_ms": 298.4365,
+            "raw_delta_pct": -3.22,
+            "spread_pct": [
+                1.1,
+                0.9
+            ],
+            "system_runs_ms": [
+                309.5216,
+                310.7636,
+                308.181,
+                308.1087,
+                307.7504,
+                307.6396,
+                307.3691
+            ],
+            "bundled_runs_ms": [
+                299.0907,
+                299.4532,
+                298.4365,
+                298.3796,
+                298.6273,
+                296.7641,
+                297.4775
+            ],
+            "paired_ratios": [
+                0.9663,
+                0.9636,
+                0.96838,
+                0.96842,
+                0.97036,
+                0.96465,
+                0.96782
+            ]
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90103,
+            "delta_pct": -9.9,
+            "ci_delta_pct": [
+                -10.14,
+                -9.53
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.9,
+                "B2/C2": -9.79,
+                "B3/C3": -9.83
+            },
+            "build_spread_pct": 0.11,
+            "builds": 3,
+            "system_ms": 23.8056,
+            "bundled_ms": 21.4574,
+            "raw_delta_pct": -9.86,
+            "spread_pct": [
+                0.9,
+                0.7
+            ],
+            "system_runs_ms": [
+                23.9078,
+                23.8207,
+                23.7504,
+                23.9568,
+                23.7779,
+                23.8056,
+                23.76
+            ],
+            "bundled_runs_ms": [
+                21.5506,
+                21.4238,
+                21.4966,
+                21.4574,
+                21.5324,
+                21.401,
+                21.4531
+            ],
+            "paired_ratios": [
+                0.9014,
+                0.89938,
+                0.9051,
+                0.89567,
+                0.90556,
+                0.89899,
+                0.90291
+            ]
+        },
+        "api.increment.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94373,
+            "delta_pct": -5.63,
+            "ci_delta_pct": [
+                -6.28,
+                -5.03
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.63,
+                "B2/C2": -5.65,
+                "B3/C3": -7.06
+            },
+            "build_spread_pct": 1.43,
+            "builds": 3,
+            "system_ms": 153.0373,
+            "bundled_ms": 144.6556,
+            "raw_delta_pct": -5.59,
+            "spread_pct": [
+                2.3,
+                4
+            ],
+            "system_runs_ms": [
+                153.0373,
+                153.0973,
+                153.426,
+                152.2649,
+                155.7072,
+                152.8658,
+                152.2413
+            ],
+            "bundled_runs_ms": [
+                143.9944,
+                145.4631,
+                140.1361,
+                145.639,
+                145.9889,
+                144.6556,
+                143.735
+            ],
+            "paired_ratios": [
+                0.94091,
+                0.95013,
+                0.91338,
+                0.95648,
+                0.93759,
+                0.94629,
+                0.94413
+            ]
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91034,
+            "delta_pct": -8.97,
+            "ci_delta_pct": [
+                -9.15,
+                -8.71
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.71,
+                "B2/C2": -8.95,
+                "B3/C3": -9.15
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 127.7184,
+            "bundled_ms": 116.2482,
+            "raw_delta_pct": -8.93,
+            "spread_pct": [
+                0.8,
+                3.4
+            ],
+            "system_runs_ms": [
+                126.9398,
+                127.8058,
+                127.8978,
+                127.7184,
+                127.5595,
+                127.9381,
+                127.2534
+            ],
+            "bundled_runs_ms": [
+                120.0517,
+                116.395,
+                116.2482,
+                116.0699,
+                116.203,
+                116.285,
+                116.2196
+            ],
+            "paired_ratios": [
+                0.94574,
+                0.91072,
+                0.90891,
+                0.9088,
+                0.91097,
+                0.90892,
+                0.91329
+            ]
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91153,
+            "delta_pct": -8.85,
+            "ci_delta_pct": [
+                -8.98,
+                -8.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.79,
+                "B2/C2": -9.02,
+                "B3/C3": -8.17
+            },
+            "build_spread_pct": 0.85,
+            "builds": 3,
+            "system_ms": 132.6971,
+            "bundled_ms": 121.0078,
+            "raw_delta_pct": -8.81,
+            "spread_pct": [
+                0.6,
+                1.9
+            ],
+            "system_runs_ms": [
+                132.2226,
+                132.9079,
+                132.9793,
+                132.3731,
+                132.9457,
+                132.6971,
+                132.6638
+            ],
+            "bundled_runs_ms": [
+                121.2369,
+                121.0194,
+                123.0599,
+                120.7824,
+                120.9631,
+                121.0078,
+                120.8762
+            ],
+            "paired_ratios": [
+                0.91692,
+                0.91055,
+                0.92541,
+                0.91244,
+                0.90987,
+                0.91191,
+                0.91115
+            ]
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90218,
+            "delta_pct": -9.78,
+            "ci_delta_pct": [
+                -10.2,
+                -9.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.55,
+                "B2/C2": -10,
+                "B3/C3": -9.52
+            },
+            "build_spread_pct": 0.48,
+            "builds": 3,
+            "system_ms": 11.2121,
+            "bundled_ms": 10.106,
+            "raw_delta_pct": -9.74,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                11.1161,
+                11.2121,
+                11.1853,
+                11.2133,
+                11.2124,
+                11.14,
+                11.2399
+            ],
+            "bundled_runs_ms": [
+                10.106,
+                10.0727,
+                10.0954,
+                10.1468,
+                10.1188,
+                10.1134,
+                10.0914
+            ],
+            "paired_ratios": [
+                0.90913,
+                0.89838,
+                0.90256,
+                0.90489,
+                0.90247,
+                0.90785,
+                0.89782
+            ]
+        },
+        "api.range.size.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77138,
+            "delta_pct": -22.86,
+            "ci_delta_pct": [
+                -23.27,
+                -22.79
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.86,
+                "B2/C2": -23.13,
+                "B3/C3": -22.79
+            },
+            "build_spread_pct": 0.34,
+            "builds": 3,
+            "system_ms": 27.128,
+            "bundled_ms": 20.9037,
+            "raw_delta_pct": -22.83,
+            "spread_pct": [
+                2.5,
+                0.5
+            ],
+            "system_runs_ms": [
+                27.0444,
+                27.1817,
+                27.0604,
+                27.0756,
+                27.1701,
+                27.128,
+                27.7265
+            ],
+            "bundled_runs_ms": [
+                20.8703,
+                20.9378,
+                20.9037,
+                20.9125,
+                20.8573,
+                20.9529,
+                20.8759
+            ],
+            "paired_ratios": [
+                0.77171,
+                0.77029,
+                0.77248,
+                0.77237,
+                0.76766,
+                0.77237,
+                0.75292
+            ]
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79854,
+            "delta_pct": -20.15,
+            "ci_delta_pct": [
+                -20.56,
+                -19.78
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.56,
+                "B2/C2": -20.33,
+                "B3/C3": -19.24
+            },
+            "build_spread_pct": 1.32,
+            "builds": 3,
+            "system_ms": 60.7682,
+            "bundled_ms": 48.5746,
+            "raw_delta_pct": -20.11,
+            "spread_pct": [
+                2.4,
+                0.3
+            ],
+            "system_runs_ms": [
+                60.6918,
+                61.1056,
+                60.6149,
+                61.1971,
+                60.7682,
+                59.722,
+                61.0521
+            ],
+            "bundled_runs_ms": [
+                48.643,
+                48.5955,
+                48.6444,
+                48.5746,
+                48.546,
+                48.5721,
+                48.521
+            ],
+            "paired_ratios": [
+                0.80148,
+                0.79527,
+                0.80252,
+                0.79374,
+                0.79887,
+                0.8133,
+                0.79475
+            ]
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76018,
+            "delta_pct": -23.98,
+            "ci_delta_pct": [
+                -24.1,
+                -23.62
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.92,
+                "B2/C2": -23.81,
+                "B3/C3": -24.24
+            },
+            "build_spread_pct": 0.43,
+            "builds": 3,
+            "system_ms": 311.0293,
+            "bundled_ms": 236.6869,
+            "raw_delta_pct": -23.95,
+            "spread_pct": [
+                0.7,
+                1
+            ],
+            "system_runs_ms": [
+                311.0293,
+                310.9139,
+                311.7051,
+                310.9294,
+                311.2709,
+                312.7044,
+                310.4858
+            ],
+            "bundled_runs_ms": [
+                238.6328,
+                237.5777,
+                236.6869,
+                236.4605,
+                236.6893,
+                236.5546,
+                236.3189
+            ],
+            "paired_ratios": [
+                0.76724,
+                0.76413,
+                0.75933,
+                0.7605,
+                0.7604,
+                0.75648,
+                0.76113
+            ]
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74418,
+            "delta_pct": -25.58,
+            "ci_delta_pct": [
+                -25.83,
+                -25.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.78,
+                "B2/C2": -25.68,
+                "B3/C3": -25.37
+            },
+            "build_spread_pct": 0.41,
+            "builds": 3,
+            "system_ms": 95.819,
+            "bundled_ms": 71.2494,
+            "raw_delta_pct": -25.55,
+            "spread_pct": [
+                0.3,
+                0.7
+            ],
+            "system_runs_ms": [
+                95.8267,
+                95.9429,
+                95.7021,
+                95.9381,
+                95.819,
+                95.6645,
+                95.7711
+            ],
+            "bundled_runs_ms": [
+                71.4125,
+                71.116,
+                71.2494,
+                71.1892,
+                71.4548,
+                71.6264,
+                71.1099
+            ],
+            "paired_ratios": [
+                0.74523,
+                0.74123,
+                0.74449,
+                0.74203,
+                0.74573,
+                0.74872,
+                0.7425
+            ]
+        },
+        "api.setop.union.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77079,
+            "delta_pct": -22.92,
+            "ci_delta_pct": [
+                -23.21,
+                -22.39
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.43,
+                "B2/C2": -22.7,
+                "B3/C3": -23.3
+            },
+            "build_spread_pct": 0.87,
+            "builds": 3,
+            "system_ms": 236.1502,
+            "bundled_ms": 182.7258,
+            "raw_delta_pct": -22.89,
+            "spread_pct": [
+                0.9,
+                1.6
+            ],
+            "system_runs_ms": [
+                236.3747,
+                236.0339,
+                236.1502,
+                236.1613,
+                235.8315,
+                237.8479,
+                236.0748
+            ],
+            "bundled_runs_ms": [
+                183.8022,
+                183.2697,
+                180.9623,
+                183.2616,
+                181.6427,
+                182.7258,
+                182.0395
+            ],
+            "paired_ratios": [
+                0.77759,
+                0.77645,
+                0.7663,
+                0.776,
+                0.77022,
+                0.76825,
+                0.77111
+            ]
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79265,
+            "delta_pct": -20.73,
+            "ci_delta_pct": [
+                -20.91,
+                -20.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.27,
+                "B2/C2": -20.71,
+                "B3/C3": -20.83
+            },
+            "build_spread_pct": 0.56,
+            "builds": 3,
+            "system_ms": 109.4834,
+            "bundled_ms": 86.8299,
+            "raw_delta_pct": -20.7,
+            "spread_pct": [
+                0.6,
+                0.5
+            ],
+            "system_runs_ms": [
+                109.0783,
+                109.5347,
+                109.7716,
+                109.2829,
+                109.4079,
+                109.4834,
+                109.6367
+            ],
+            "bundled_runs_ms": [
+                87.033,
+                86.7078,
+                86.8299,
+                87.1718,
+                86.9628,
+                86.8187,
+                86.7426
+            ],
+            "paired_ratios": [
+                0.79789,
+                0.7916,
+                0.79101,
+                0.79767,
+                0.79485,
+                0.79299,
+                0.79118
+            ]
+        },
+        "api.setop.diff.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79779,
+            "delta_pct": -20.22,
+            "ci_delta_pct": [
+                -20.34,
+                -20.19
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.21,
+                "B2/C2": -20.27,
+                "B3/C3": -20.3
+            },
+            "build_spread_pct": 0.09,
+            "builds": 3,
+            "system_ms": 108.0241,
+            "bundled_ms": 86.1929,
+            "raw_delta_pct": -20.19,
+            "spread_pct": [
+                0.3,
+                0.2
+            ],
+            "system_runs_ms": [
+                107.9742,
+                108.1434,
+                107.9951,
+                108.2185,
+                107.8769,
+                108.0945,
+                108.0241
+            ],
+            "bundled_runs_ms": [
+                86.2876,
+                86.1802,
+                86.1929,
+                86.2417,
+                86.132,
+                86.1111,
+                86.233
+            ],
+            "paired_ratios": [
+                0.79915,
+                0.79691,
+                0.79812,
+                0.79692,
+                0.79843,
+                0.79663,
+                0.79828
+            ]
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.798,
+            "delta_pct": -20.2,
+            "ci_delta_pct": [
+                -20.28,
+                -20.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.09,
+                "B2/C2": -20.24,
+                "B3/C3": -20.29
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 216.3066,
+            "bundled_ms": 172.7226,
+            "raw_delta_pct": -20.17,
+            "spread_pct": [
+                0.2,
+                0.5
+            ],
+            "system_runs_ms": [
+                216.5941,
+                216.5749,
+                216.4323,
+                216.2137,
+                216.3066,
+                216.2891,
+                216.2951
+            ],
+            "bundled_runs_ms": [
+                173.1438,
+                172.7226,
+                172.7429,
+                173.1828,
+                172.684,
+                172.333,
+                172.6805
+            ],
+            "paired_ratios": [
+                0.79939,
+                0.79752,
+                0.79814,
+                0.80098,
+                0.79833,
+                0.79677,
+                0.79836
+            ]
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75443,
+            "delta_pct": -24.56,
+            "ci_delta_pct": [
+                -24.68,
+                -24.37
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.56,
+                "B2/C2": -24.54,
+                "B3/C3": -24.32
+            },
+            "build_spread_pct": 0.24,
+            "builds": 3,
+            "system_ms": 351.9178,
+            "bundled_ms": 265.6317,
+            "raw_delta_pct": -24.53,
+            "spread_pct": [
+                1.2,
+                1
+            ],
+            "system_runs_ms": [
+                350.7214,
+                352.4729,
+                351.2321,
+                351.9178,
+                352.7268,
+                354.8117,
+                351.0838
+            ],
+            "bundled_runs_ms": [
+                264.7046,
+                265.4723,
+                267.1522,
+                265.4749,
+                266.8806,
+                267.3621,
+                265.6317
+            ],
+            "paired_ratios": [
+                0.75474,
+                0.75317,
+                0.76061,
+                0.75437,
+                0.75662,
+                0.75353,
+                0.7566
+            ]
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74587,
+            "delta_pct": -25.41,
+            "ci_delta_pct": [
+                -25.75,
+                -25.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.08,
+                "B2/C2": -25.71,
+                "B3/C3": -25.63
+            },
+            "build_spread_pct": 0.63,
+            "builds": 3,
+            "system_ms": 146.5328,
+            "bundled_ms": 109.3399,
+            "raw_delta_pct": -25.38,
+            "spread_pct": [
+                0.5,
+                3.3
+            ],
+            "system_runs_ms": [
+                146.2576,
+                146.7841,
+                146.3743,
+                146.5328,
+                146.746,
+                146.896,
+                146.1993
+            ],
+            "bundled_runs_ms": [
+                112.2434,
+                109.1477,
+                109.5071,
+                109.3399,
+                109.0015,
+                108.6863,
+                109.5845
+            ],
+            "paired_ratios": [
+                0.76744,
+                0.74359,
+                0.74813,
+                0.74618,
+                0.74279,
+                0.73989,
+                0.74956
+            ]
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77703,
+            "delta_pct": -22.3,
+            "ci_delta_pct": [
+                -22.35,
+                -22.22
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.22,
+                "B2/C2": -22.28,
+                "B3/C3": -22.45
+            },
+            "build_spread_pct": 0.23,
+            "builds": 3,
+            "system_ms": 138.6345,
+            "bundled_ms": 107.7469,
+            "raw_delta_pct": -22.26,
+            "spread_pct": [
+                0.5,
+                0.4
+            ],
+            "system_runs_ms": [
+                138.3936,
+                138.8625,
+                138.6805,
+                138.3577,
+                138.3889,
+                139.0693,
+                138.6345
+            ],
+            "bundled_runs_ms": [
+                107.527,
+                107.9796,
+                107.735,
+                107.9002,
+                107.5774,
+                107.7469,
+                107.8809
+            ],
+            "paired_ratios": [
+                0.77697,
+                0.7776,
+                0.77686,
+                0.77986,
+                0.77736,
+                0.77477,
+                0.77817
+            ]
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7811,
+            "delta_pct": -21.89,
+            "ci_delta_pct": [
+                -22.13,
+                -21.77
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.05,
+                "B2/C2": -21.8,
+                "B3/C3": -22.03
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 277.3883,
+            "bundled_ms": 216.6338,
+            "raw_delta_pct": -21.86,
+            "spread_pct": [
+                0.4,
+                0.5
+            ],
+            "system_runs_ms": [
+                277.3883,
+                277.0487,
+                277.662,
+                277.4689,
+                277.167,
+                278.2238,
+                277.2643
+            ],
+            "bundled_runs_ms": [
+                216.7582,
+                216.6338,
+                217.3204,
+                216.1674,
+                216.9297,
+                216.3006,
+                216.2198
+            ],
+            "paired_ratios": [
+                0.78143,
+                0.78193,
+                0.78268,
+                0.77907,
+                0.78267,
+                0.77743,
+                0.77983
+            ]
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87799,
+            "delta_pct": -12.2,
+            "ci_delta_pct": [
+                -12.37,
+                -11.81
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.37,
+                "B2/C2": -12,
+                "B3/C3": -11.94
+            },
+            "build_spread_pct": 0.43,
+            "builds": 3,
+            "system_ms": 1655.0653,
+            "bundled_ms": 1453.7374,
+            "raw_delta_pct": -12.16,
+            "spread_pct": [
+                0.6,
+                0.7
+            ],
+            "system_runs_ms": [
+                1663.5162,
+                1653.5488,
+                1654.9624,
+                1655.0653,
+                1654.8828,
+                1655.3486,
+                1655.7939
+            ],
+            "bundled_runs_ms": [
+                1450.2892,
+                1460.9579,
+                1455.9115,
+                1453.7374,
+                1451.6237,
+                1460.3805,
+                1451.5874
+            ],
+            "paired_ratios": [
+                0.87182,
+                0.88353,
+                0.87972,
+                0.87836,
+                0.87718,
+                0.88222,
+                0.87667
+            ]
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86666,
+            "delta_pct": -13.33,
+            "ci_delta_pct": [
+                -13.46,
+                -12.81
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.81,
+                "B2/C2": -13.59,
+                "B3/C3": -13.4
+            },
+            "build_spread_pct": 0.78,
+            "builds": 3,
+            "system_ms": 753.942,
+            "bundled_ms": 653.7853,
+            "raw_delta_pct": -13.3,
+            "spread_pct": [
+                0.9,
+                0.7
+            ],
+            "system_runs_ms": [
+                751.3726,
+                755.7735,
+                753.942,
+                750.237,
+                756.1688,
+                756.2346,
+                749.4807
+            ],
+            "bundled_runs_ms": [
+                653.7853,
+                652.0027,
+                652.7389,
+                656.7347,
+                655.0068,
+                655.6697,
+                653.7601
+            ],
+            "paired_ratios": [
+                0.87012,
+                0.8627,
+                0.86577,
+                0.87537,
+                0.86622,
+                0.86702,
+                0.87228
+            ]
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86972,
+            "delta_pct": -13.03,
+            "ci_delta_pct": [
+                -13.38,
+                -12.96
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.28,
+                "B2/C2": -13.15,
+                "B3/C3": -12.98
+            },
+            "build_spread_pct": 0.3,
+            "builds": 3,
+            "system_ms": 777.7427,
+            "bundled_ms": 676.6999,
+            "raw_delta_pct": -12.99,
+            "spread_pct": [
+                0.4,
+                0.5
+            ],
+            "system_runs_ms": [
+                777.7427,
+                780.2871,
+                777.6219,
+                780.1352,
+                778.3493,
+                777.2311,
+                777.5672
+            ],
+            "bundled_runs_ms": [
+                676.6999,
+                676.1907,
+                676.8022,
+                674.6019,
+                677.9699,
+                676.7595,
+                674.6026
+            ],
+            "paired_ratios": [
+                0.87008,
+                0.86659,
+                0.87035,
+                0.86472,
+                0.87104,
+                0.87073,
+                0.86758
+            ]
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78695,
+            "delta_pct": -21.3,
+            "ci_delta_pct": [
+                -21.43,
+                -21.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.3,
+                "B2/C2": -21.34,
+                "B3/C3": -21.44
+            },
+            "build_spread_pct": 0.14,
+            "builds": 3,
+            "system_ms": 383.0558,
+            "bundled_ms": 301.6485,
+            "raw_delta_pct": -21.27,
+            "spread_pct": [
+                0.3,
+                0.6
+            ],
+            "system_runs_ms": [
+                383.0382,
+                382.9515,
+                383.0558,
+                383.4262,
+                383.3405,
+                383.9305,
+                382.9162
+            ],
+            "bundled_runs_ms": [
+                301.5598,
+                301.0196,
+                301.7287,
+                301.6485,
+                302.0204,
+                301.0493,
+                302.8482
+            ],
+            "paired_ratios": [
+                0.78728,
+                0.78605,
+                0.78769,
+                0.78672,
+                0.78786,
+                0.78412,
+                0.7909
+            ]
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88493,
+            "delta_pct": -11.51,
+            "ci_delta_pct": [
+                -11.92,
+                -10.61
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.51,
+                "B2/C2": -11.27,
+                "B3/C3": -11.57
+            },
+            "build_spread_pct": 0.3,
+            "builds": 3,
+            "system_ms": 1352.5243,
+            "bundled_ms": 1195.0593,
+            "raw_delta_pct": -11.47,
+            "spread_pct": [
+                0.8,
+                1.1
+            ],
+            "system_runs_ms": [
+                1356.071,
+                1348.8454,
+                1352.5243,
+                1349.2846,
+                1353.4919,
+                1357.576,
+                1346.2771
+            ],
+            "bundled_runs_ms": [
+                1194.6621,
+                1206.1705,
+                1195.0593,
+                1194.5239,
+                1192.6904,
+                1202.4585,
+                1206.0052
+            ],
+            "paired_ratios": [
+                0.88097,
+                0.89422,
+                0.88358,
+                0.8853,
+                0.8812,
+                0.88574,
+                0.89581
+            ]
+        },
+        "adv.forEach.int_to_int": {
+            "status": "null",
+            "reason": "per-build spread 8.63% exceeds the 4.93% delta \u2014 layout, not libJudy",
+            "ratio": 0.95068,
+            "delta_pct": -4.93,
+            "ci_delta_pct": [
+                -5.52,
+                -3.99
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.27,
+                "B2/C2": -3.89,
+                "B3/C3": -12.52
+            },
+            "build_spread_pct": 8.63,
+            "builds": 3,
+            "system_ms": 199.0694,
+            "bundled_ms": 190.2473,
+            "raw_delta_pct": -4.89,
+            "spread_pct": [
+                23,
+                1.1
+            ],
+            "system_runs_ms": [
+                198.1391,
+                200.2171,
+                239.4944,
+                199.4087,
+                193.7449,
+                199.0694,
+                198.9504
+            ],
+            "bundled_runs_ms": [
+                190.3034,
+                190.4218,
+                190.3267,
+                188.4831,
+                188.2997,
+                190.2473,
+                188.5476
+            ],
+            "paired_ratios": [
+                0.96045,
+                0.95108,
+                0.7947,
+                0.94521,
+                0.9719,
+                0.95568,
+                0.94771
+            ]
+        },
+        "adv.forEach.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88447,
+            "delta_pct": -11.55,
+            "ci_delta_pct": [
+                -11.8,
+                -11.45
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.47,
+                "B2/C2": -11.6,
+                "B3/C3": -15.77
+            },
+            "build_spread_pct": 4.3,
+            "builds": 3,
+            "system_ms": 401.0375,
+            "bundled_ms": 354.4885,
+            "raw_delta_pct": -11.52,
+            "spread_pct": [
+                10.2,
+                0.3
+            ],
+            "system_runs_ms": [
+                401.0375,
+                400.2711,
+                440.9082,
+                400.7991,
+                401.0659,
+                401.1657,
+                400.1112
+            ],
+            "bundled_runs_ms": [
+                354.8528,
+                354.6044,
+                354.0394,
+                354.9682,
+                354.054,
+                353.9866,
+                354.4885
+            ],
+            "paired_ratios": [
+                0.88484,
+                0.88591,
+                0.80298,
+                0.88565,
+                0.88278,
+                0.88239,
+                0.88597
+            ]
+        },
+        "adv.filter.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92839,
+            "delta_pct": -7.16,
+            "ci_delta_pct": [
+                -7.39,
+                -6.83
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.13,
+                "B2/C2": -7.2,
+                "B3/C3": -7.34
+            },
+            "build_spread_pct": 0.21,
+            "builds": 3,
+            "system_ms": 296.3717,
+            "bundled_ms": 275.123,
+            "raw_delta_pct": -7.12,
+            "spread_pct": [
+                0.7,
+                0.6
+            ],
+            "system_runs_ms": [
+                296.5616,
+                296.3717,
+                296.9385,
+                296.4669,
+                295.2403,
+                295.1664,
+                294.8648
+            ],
+            "bundled_runs_ms": [
+                274.7722,
+                275.2629,
+                273.743,
+                275.4355,
+                274.0039,
+                275.123,
+                275.3458
+            ],
+            "paired_ratios": [
+                0.92653,
+                0.92878,
+                0.92188,
+                0.92906,
+                0.92807,
+                0.93209,
+                0.9338
+            ]
+        },
+        "adv.filter.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87621,
+            "delta_pct": -12.38,
+            "ci_delta_pct": [
+                -12.55,
+                -12.3
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.49,
+                "B2/C2": -12.46,
+                "B3/C3": -12.24
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 890.1545,
+            "bundled_ms": 779.36,
+            "raw_delta_pct": -12.34,
+            "spread_pct": [
+                0.5,
+                0.4
+            ],
+            "system_runs_ms": [
+                891.8229,
+                890.8637,
+                887.6386,
+                890.2362,
+                890.1545,
+                887.9618,
+                889.6523
+            ],
+            "bundled_runs_ms": [
+                777.9625,
+                781.0278,
+                778.8069,
+                779.36,
+                778.7356,
+                780.1189,
+                779.8508
+            ],
+            "paired_ratios": [
+                0.87233,
+                0.87671,
+                0.87739,
+                0.87545,
+                0.87483,
+                0.87855,
+                0.87658
+            ]
+        },
+        "adv.map.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91912,
+            "delta_pct": -8.09,
+            "ci_delta_pct": [
+                -8.12,
+                -7.92
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.92,
+                "B2/C2": -8.11,
+                "B3/C3": -8.05
+            },
+            "build_spread_pct": 0.19,
+            "builds": 3,
+            "system_ms": 323.2217,
+            "bundled_ms": 297.2025,
+            "raw_delta_pct": -8.05,
+            "spread_pct": [
+                0.8,
+                1.1
+            ],
+            "system_runs_ms": [
+                325.5056,
+                323.1305,
+                323.2217,
+                322.798,
+                323.2639,
+                323.2199,
+                323.7301
+            ],
+            "bundled_runs_ms": [
+                295.9027,
+                297.0202,
+                297.4373,
+                297.3585,
+                297.2006,
+                297.2025,
+                299.175
+            ],
+            "paired_ratios": [
+                0.90906,
+                0.9192,
+                0.92023,
+                0.92119,
+                0.91937,
+                0.91951,
+                0.92415
+            ]
+        },
+        "adv.map.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87257,
+            "delta_pct": -12.74,
+            "ci_delta_pct": [
+                -12.82,
+                -12.61
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.74,
+                "B2/C2": -12.77,
+                "B3/C3": -12.73
+            },
+            "build_spread_pct": 0.04,
+            "builds": 3,
+            "system_ms": 1219.997,
+            "bundled_ms": 1064.972,
+            "raw_delta_pct": -12.71,
+            "spread_pct": [
+                0.4,
+                0.3
+            ],
+            "system_runs_ms": [
+                1221.9938,
+                1219.4111,
+                1216.8997,
+                1219.8217,
+                1221.164,
+                1221.3521,
+                1219.997
+            ],
+            "bundled_runs_ms": [
+                1066.0236,
+                1064.7525,
+                1063.8999,
+                1067.362,
+                1065.0326,
+                1064.7671,
+                1064.972
+            ],
+            "paired_ratios": [
+                0.87236,
+                0.87317,
+                0.87427,
+                0.87501,
+                0.87215,
+                0.87179,
+                0.87293
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91277,
+            "delta_pct": -8.72,
+            "ci_delta_pct": [
+                -9.16,
+                -8.68
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.72,
+                "B2/C2": -9.52,
+                "B3/C3": -8.93
+            },
+            "build_spread_pct": 0.8,
+            "builds": 3,
+            "system_ms": 24.1855,
+            "bundled_ms": 22.0851,
+            "raw_delta_pct": -8.68,
+            "spread_pct": [
+                2.5,
+                0.5
+            ],
+            "system_runs_ms": [
+                24.0787,
+                24.1082,
+                24.1795,
+                24.2319,
+                24.674,
+                24.299,
+                24.1855
+            ],
+            "bundled_runs_ms": [
+                21.9975,
+                22.1178,
+                22.0851,
+                22.0954,
+                22.0331,
+                22.0815,
+                22.0851
+            ],
+            "paired_ratios": [
+                0.91357,
+                0.91744,
+                0.91338,
+                0.91183,
+                0.89297,
+                0.90874,
+                0.91315
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87371,
+            "delta_pct": -12.63,
+            "ci_delta_pct": [
+                -13.28,
+                -12.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.16,
+                "B2/C2": -13.11,
+                "B3/C3": -13.23
+            },
+            "build_spread_pct": 1.07,
+            "builds": 3,
+            "system_ms": 14.6149,
+            "bundled_ms": 12.8032,
+            "raw_delta_pct": -12.59,
+            "spread_pct": [
+                2.4,
+                1.4
+            ],
+            "system_runs_ms": [
+                14.5692,
+                14.5762,
+                14.668,
+                14.6743,
+                14.9202,
+                14.6149,
+                14.592
+            ],
+            "bundled_runs_ms": [
+                12.8032,
+                12.7745,
+                12.7407,
+                12.8265,
+                12.8638,
+                12.6795,
+                12.8283
+            ],
+            "paired_ratios": [
+                0.87879,
+                0.87639,
+                0.86861,
+                0.87408,
+                0.86217,
+                0.86757,
+                0.87913
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9582,
+            "delta_pct": -4.18,
+            "ci_delta_pct": [
+                -4.57,
+                -3.77
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.85,
+                "B2/C2": -4,
+                "B3/C3": -4.76
+            },
+            "build_spread_pct": 0.91,
+            "builds": 3,
+            "system_ms": 60.4692,
+            "bundled_ms": 58.0507,
+            "raw_delta_pct": -4.14,
+            "spread_pct": [
+                0.9,
+                1.7
+            ],
+            "system_runs_ms": [
+                60.5068,
+                60.4616,
+                60.6629,
+                60.5579,
+                60.4692,
+                60.146,
+                60.3339
+            ],
+            "bundled_runs_ms": [
+                58.2031,
+                57.7566,
+                57.6892,
+                58.0507,
+                58.3842,
+                57.4213,
+                58.0858
+            ],
+            "paired_ratios": [
+                0.96193,
+                0.95526,
+                0.95098,
+                0.9586,
+                0.96552,
+                0.9547,
+                0.96274
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92533,
+            "delta_pct": -7.47,
+            "ci_delta_pct": [
+                -7.63,
+                -7.06
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.45,
+                "B2/C2": -7.25,
+                "B3/C3": -7.61
+            },
+            "build_spread_pct": 0.36,
+            "builds": 3,
+            "system_ms": 22.3243,
+            "bundled_ms": 20.6469,
+            "raw_delta_pct": -7.43,
+            "spread_pct": [
+                0.3,
+                0.6
+            ],
+            "system_runs_ms": [
+                22.2916,
+                22.3362,
+                22.3374,
+                22.3243,
+                22.3103,
+                22.3278,
+                22.275
+            ],
+            "bundled_runs_ms": [
+                20.6391,
+                20.6771,
+                20.6369,
+                20.6295,
+                20.7495,
+                20.6469,
+                20.712
+            ],
+            "paired_ratios": [
+                0.92587,
+                0.92572,
+                0.92387,
+                0.92408,
+                0.93004,
+                0.92472,
+                0.92983
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85841,
+            "delta_pct": -14.16,
+            "ci_delta_pct": [
+                -14.23,
+                -13.66
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.02,
+                "B2/C2": -14.19,
+                "B3/C3": -13.88
+            },
+            "build_spread_pct": 0.31,
+            "builds": 3,
+            "system_ms": 12.2801,
+            "bundled_ms": 10.5794,
+            "raw_delta_pct": -14.12,
+            "spread_pct": [
+                0.6,
+                0.7
+            ],
+            "system_runs_ms": [
+                12.3273,
+                12.2594,
+                12.2672,
+                12.2993,
+                12.2801,
+                12.3269,
+                12.2525
+            ],
+            "bundled_runs_ms": [
+                10.5452,
+                10.528,
+                10.6064,
+                10.5794,
+                10.5371,
+                10.5828,
+                10.5834
+            ],
+            "paired_ratios": [
+                0.85543,
+                0.85877,
+                0.86461,
+                0.86016,
+                0.85806,
+                0.85851,
+                0.86377
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92802,
+            "delta_pct": -7.2,
+            "ci_delta_pct": [
+                -7.65,
+                -6.96
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.14,
+                "B2/C2": -7.52,
+                "B3/C3": -6.83
+            },
+            "build_spread_pct": 0.69,
+            "builds": 3,
+            "system_ms": 55.0425,
+            "bundled_ms": 51.0978,
+            "raw_delta_pct": -7.16,
+            "spread_pct": [
+                0.8,
+                1.2
+            ],
+            "system_runs_ms": [
+                55.3,
+                54.8859,
+                54.918,
+                55.0938,
+                55.0425,
+                55.2085,
+                55.0058
+            ],
+            "bundled_runs_ms": [
+                51.0932,
+                50.9161,
+                51.3954,
+                51.2832,
+                50.7826,
+                51.2562,
+                51.0978
+            ],
+            "paired_ratios": [
+                0.92393,
+                0.92767,
+                0.93586,
+                0.93083,
+                0.92261,
+                0.92841,
+                0.92895
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94203,
+            "delta_pct": -5.8,
+            "ci_delta_pct": [
+                -6.05,
+                -5.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.49,
+                "B2/C2": -5.64,
+                "B3/C3": -5.92
+            },
+            "build_spread_pct": 0.43,
+            "builds": 3,
+            "system_ms": 31.058,
+            "bundled_ms": 29.2944,
+            "raw_delta_pct": -5.76,
+            "spread_pct": [
+                0.7,
+                0.8
+            ],
+            "system_runs_ms": [
+                31.1966,
+                31.0131,
+                31.1684,
+                30.9825,
+                31.139,
+                31.058,
+                31.0431
+            ],
+            "bundled_runs_ms": [
+                29.1571,
+                29.3893,
+                29.2944,
+                29.3434,
+                29.2808,
+                29.2699,
+                29.3526
+            ],
+            "paired_ratios": [
+                0.93462,
+                0.94764,
+                0.93988,
+                0.9471,
+                0.94033,
+                0.94243,
+                0.94554
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92798,
+            "delta_pct": -7.2,
+            "ci_delta_pct": [
+                -7.61,
+                -7.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.14,
+                "B2/C2": -7.15,
+                "B3/C3": -7.43
+            },
+            "build_spread_pct": 0.29,
+            "builds": 3,
+            "system_ms": 19.3439,
+            "bundled_ms": 17.9492,
+            "raw_delta_pct": -7.16,
+            "spread_pct": [
+                0.5,
+                0.4
+            ],
+            "system_runs_ms": [
+                19.4039,
+                19.337,
+                19.41,
+                19.3214,
+                19.3219,
+                19.3439,
+                19.3881
+            ],
+            "bundled_runs_ms": [
+                17.9317,
+                17.9739,
+                17.9401,
+                17.9886,
+                17.9378,
+                17.9492,
+                18.0108
+            ],
+            "paired_ratios": [
+                0.92413,
+                0.92951,
+                0.92427,
+                0.93102,
+                0.92837,
+                0.9279,
+                0.92896
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.98298,
+            "delta_pct": -1.7,
+            "ci_delta_pct": [
+                -1.79,
+                -1.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.74,
+                "B2/C2": -1.63,
+                "B3/C3": -1.64
+            },
+            "build_spread_pct": 0.11,
+            "builds": 3,
+            "system_ms": 62.2831,
+            "bundled_ms": 61.3036,
+            "raw_delta_pct": -1.66,
+            "spread_pct": [
+                0.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                62.1987,
+                62.351,
+                62.2747,
+                62.3623,
+                62.0506,
+                62.2831,
+                62.4554
+            ],
+            "bundled_runs_ms": [
+                61.5002,
+                61.1582,
+                61.2406,
+                61.3036,
+                61.2611,
+                61.3233,
+                61.3602
+            ],
+            "paired_ratios": [
+                0.98877,
+                0.98087,
+                0.98339,
+                0.98302,
+                0.98728,
+                0.98459,
+                0.98246
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.973,
+            "delta_pct": -2.7,
+            "ci_delta_pct": [
+                -2.92,
+                -2.42
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.42,
+                "B2/C2": -2.62,
+                "B3/C3": -2.89
+            },
+            "build_spread_pct": 0.47,
+            "builds": 3,
+            "system_ms": 16.7309,
+            "bundled_ms": 16.2782,
+            "raw_delta_pct": -2.66,
+            "spread_pct": [
+                1.2,
+                0.7
+            ],
+            "system_runs_ms": [
+                16.6754,
+                16.7159,
+                16.7528,
+                16.7995,
+                16.7309,
+                16.744,
+                16.5916
+            ],
+            "bundled_runs_ms": [
+                16.2782,
+                16.2713,
+                16.282,
+                16.2759,
+                16.3141,
+                16.2616,
+                16.3784
+            ],
+            "paired_ratios": [
+                0.97618,
+                0.9734,
+                0.9719,
+                0.96883,
+                0.97509,
+                0.97119,
+                0.98715
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.9515,
+            "delta_pct": -4.85,
+            "ci_delta_pct": [
+                -5.94,
+                -4.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.85,
+                "B2/C2": -4.8,
+                "B3/C3": -5.41
+            },
+            "build_spread_pct": 0.61,
+            "builds": 3,
+            "system_ms": 19.919,
+            "bundled_ms": 18.9735,
+            "raw_delta_pct": -4.81,
+            "spread_pct": [
+                1.5,
+                0.9
+            ],
+            "system_runs_ms": [
+                19.8462,
+                19.8808,
+                20.1406,
+                20.0684,
+                19.8918,
+                19.919,
+                20.0098
+            ],
+            "bundled_runs_ms": [
+                19.0084,
+                18.9735,
+                18.9268,
+                18.8841,
+                18.9075,
+                18.9787,
+                19.0473
+            ],
+            "paired_ratios": [
+                0.95779,
+                0.95436,
+                0.93973,
+                0.94099,
+                0.95052,
+                0.95279,
+                0.9519
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.97439,
+            "delta_pct": -2.56,
+            "ci_delta_pct": [
+                -3.35,
+                -1.94
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.92,
+                "B2/C2": -2.28,
+                "B3/C3": -2.64
+            },
+            "build_spread_pct": 0.64,
+            "builds": 3,
+            "system_ms": 119.0145,
+            "bundled_ms": 116.2953,
+            "raw_delta_pct": -2.52,
+            "spread_pct": [
+                1.4,
+                0.8
+            ],
+            "system_runs_ms": [
+                119.0145,
+                118.9336,
+                120.2226,
+                119.4586,
+                118.8931,
+                118.9623,
+                120.6017
+            ],
+            "bundled_runs_ms": [
+                116.7725,
+                116.6073,
+                116.2439,
+                116.0243,
+                115.8964,
+                116.709,
+                116.2953
+            ],
+            "paired_ratios": [
+                0.98116,
+                0.98044,
+                0.96691,
+                0.97125,
+                0.9748,
+                0.98106,
+                0.96429
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.97132,
+            "delta_pct": -2.87,
+            "ci_delta_pct": [
+                -3.11,
+                -2.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.86,
+                "B2/C2": -2.48,
+                "B3/C3": -3.24
+            },
+            "build_spread_pct": 0.76,
+            "builds": 3,
+            "system_ms": 16.7664,
+            "bundled_ms": 16.2924,
+            "raw_delta_pct": -2.83,
+            "spread_pct": [
+                0.8,
+                0.9
+            ],
+            "system_runs_ms": [
+                16.6983,
+                16.7664,
+                16.7739,
+                16.832,
+                16.698,
+                16.7733,
+                16.6971
+            ],
+            "bundled_runs_ms": [
+                16.2267,
+                16.2924,
+                16.2167,
+                16.3258,
+                16.3564,
+                16.258,
+                16.2959
+            ],
+            "paired_ratios": [
+                0.97176,
+                0.97173,
+                0.96678,
+                0.96993,
+                0.97954,
+                0.96928,
+                0.97597
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94927,
+            "delta_pct": -5.07,
+            "ci_delta_pct": [
+                -5.27,
+                -4.59
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.74,
+                "B2/C2": -4.7,
+                "B3/C3": -5.24
+            },
+            "build_spread_pct": 0.54,
+            "builds": 3,
+            "system_ms": 20.1037,
+            "bundled_ms": 19.0994,
+            "raw_delta_pct": -5.03,
+            "spread_pct": [
+                0.7,
+                0.9
+            ],
+            "system_runs_ms": [
+                20.0314,
+                20.1117,
+                20.1085,
+                20.1037,
+                20.0941,
+                20.1715,
+                20.0462
+            ],
+            "bundled_runs_ms": [
+                19.0907,
+                19.0994,
+                19.0699,
+                19.0517,
+                19.2321,
+                19.1172,
+                19.1348
+            ],
+            "paired_ratios": [
+                0.95304,
+                0.94967,
+                0.94835,
+                0.94767,
+                0.9571,
+                0.94773,
+                0.95454
+            ]
+        },
+        "adv.optiter.ratio.increment.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.97737,
+            "delta_pct": -2.26,
+            "ci_delta_pct": [
+                -2.33,
+                -1.97
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.24,
+                "B2/C2": -2.32,
+                "B3/C3": -2.11
+            },
+            "build_spread_pct": 0.21,
+            "builds": 3,
+            "system_ms": 119.9601,
+            "bundled_ms": 117.5813,
+            "raw_delta_pct": -2.22,
+            "spread_pct": [
+                0.8,
+                0.8
+            ],
+            "system_runs_ms": [
+                119.9601,
+                119.9524,
+                119.8796,
+                119.4373,
+                120.3381,
+                120.259,
+                120.0578
+            ],
+            "bundled_runs_ms": [
+                117.6502,
+                117.2289,
+                117.5946,
+                116.6969,
+                117.5813,
+                117.5865,
+                117.4213
+            ],
+            "paired_ratios": [
+                0.98074,
+                0.9773,
+                0.98094,
+                0.97706,
+                0.97709,
+                0.97778,
+                0.97804
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93325,
+            "delta_pct": -6.67,
+            "ci_delta_pct": [
+                -7.5,
+                -6.47
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.64,
+                "B2/C2": -7.78,
+                "B3/C3": -6.47
+            },
+            "build_spread_pct": 1.31,
+            "builds": 3,
+            "system_ms": 32.2521,
+            "bundled_ms": 30.1156,
+            "raw_delta_pct": -6.64,
+            "spread_pct": [
+                1.5,
+                0.4
+            ],
+            "system_runs_ms": [
+                32.2146,
+                32.5623,
+                32.1923,
+                32.2521,
+                32.6832,
+                32.2671,
+                32.185
+            ],
+            "bundled_runs_ms": [
+                30.0869,
+                30.1338,
+                30.1868,
+                30.1091,
+                30.0602,
+                30.1259,
+                30.1156
+            ],
+            "paired_ratios": [
+                0.93395,
+                0.92542,
+                0.9377,
+                0.93355,
+                0.91974,
+                0.93364,
+                0.9357
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87267,
+            "delta_pct": -12.73,
+            "ci_delta_pct": [
+                -12.96,
+                -12.38
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.72,
+                "B2/C2": -14.74,
+                "B3/C3": -12.67
+            },
+            "build_spread_pct": 2.07,
+            "builds": 3,
+            "system_ms": 16.0051,
+            "bundled_ms": 13.9679,
+            "raw_delta_pct": -12.7,
+            "spread_pct": [
+                4.6,
+                1.3
+            ],
+            "system_runs_ms": [
+                16.0042,
+                16.1456,
+                16.0408,
+                16.0023,
+                16.7152,
+                16.0051,
+                15.9806
+            ],
+            "bundled_runs_ms": [
+                13.9497,
+                14.0957,
+                13.9679,
+                14.0433,
+                13.9209,
+                14.0293,
+                13.954
+            ],
+            "paired_ratios": [
+                0.87163,
+                0.87304,
+                0.87077,
+                0.87758,
+                0.83283,
+                0.87655,
+                0.87318
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93288,
+            "delta_pct": -6.71,
+            "ci_delta_pct": [
+                -7.18,
+                -6.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.71,
+                "B2/C2": -7.59,
+                "B3/C3": -6.66
+            },
+            "build_spread_pct": 0.93,
+            "builds": 3,
+            "system_ms": 49.6524,
+            "bundled_ms": 46.3649,
+            "raw_delta_pct": -6.67,
+            "spread_pct": [
+                3.1,
+                1.1
+            ],
+            "system_runs_ms": [
+                49.6799,
+                49.5839,
+                49.828,
+                49.6162,
+                51.143,
+                49.6019,
+                49.6524
+            ],
+            "bundled_runs_ms": [
+                46.3649,
+                46.7771,
+                46.2715,
+                46.6413,
+                46.3101,
+                46.5691,
+                46.3348
+            ],
+            "paired_ratios": [
+                0.93327,
+                0.94339,
+                0.92862,
+                0.94004,
+                0.9055,
+                0.93886,
+                0.93318
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94024,
+            "delta_pct": -5.98,
+            "ci_delta_pct": [
+                -6.08,
+                -5.89
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.89,
+                "B2/C2": -6.06,
+                "B3/C3": -5.95
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 31.0705,
+            "bundled_ms": 29.226,
+            "raw_delta_pct": -5.94,
+            "spread_pct": [
+                0.3,
+                0.6
+            ],
+            "system_runs_ms": [
+                31.1075,
+                31.1177,
+                31.0705,
+                31.1041,
+                31.054,
+                31.0465,
+                31.0329
+            ],
+            "bundled_runs_ms": [
+                29.2885,
+                29.2528,
+                29.226,
+                29.1766,
+                29.1776,
+                29.2174,
+                29.3378
+            ],
+            "paired_ratios": [
+                0.94153,
+                0.94007,
+                0.94064,
+                0.93803,
+                0.93958,
+                0.94109,
+                0.94538
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87173,
+            "delta_pct": -12.83,
+            "ci_delta_pct": [
+                -13.13,
+                -12.78
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.81,
+                "B2/C2": -12.35,
+                "B3/C3": -12.98
+            },
+            "build_spread_pct": 0.63,
+            "builds": 3,
+            "system_ms": 14.2456,
+            "bundled_ms": 12.4009,
+            "raw_delta_pct": -12.79,
+            "spread_pct": [
+                1.4,
+                1.5
+            ],
+            "system_runs_ms": [
+                14.4092,
+                14.2299,
+                14.2069,
+                14.2114,
+                14.246,
+                14.2593,
+                14.2456
+            ],
+            "bundled_runs_ms": [
+                12.3816,
+                12.4051,
+                12.3898,
+                12.4009,
+                12.5656,
+                12.3927,
+                12.426
+            ],
+            "paired_ratios": [
+                0.85928,
+                0.87176,
+                0.8721,
+                0.8726,
+                0.88204,
+                0.8691,
+                0.87227
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92675,
+            "delta_pct": -7.33,
+            "ci_delta_pct": [
+                -7.77,
+                -7.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.77,
+                "B2/C2": -6.73,
+                "B3/C3": -7.51
+            },
+            "build_spread_pct": 1.04,
+            "builds": 3,
+            "system_ms": 45.8748,
+            "bundled_ms": 42.4065,
+            "raw_delta_pct": -7.29,
+            "spread_pct": [
+                1.4,
+                1.9
+            ],
+            "system_runs_ms": [
+                46.3207,
+                45.7295,
+                45.7248,
+                45.6897,
+                45.8748,
+                45.929,
+                45.9048
+            ],
+            "bundled_runs_ms": [
+                42.2745,
+                42.4065,
+                42.393,
+                42.503,
+                43.0659,
+                42.4153,
+                42.3549
+            ],
+            "paired_ratios": [
+                0.91265,
+                0.92733,
+                0.92713,
+                0.93025,
+                0.93877,
+                0.9235,
+                0.92267
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94322,
+            "delta_pct": -5.68,
+            "ci_delta_pct": [
+                -5.76,
+                -5.59
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.59,
+                "B2/C2": -5.87,
+                "B3/C3": -5.72
+            },
+            "build_spread_pct": 0.28,
+            "builds": 3,
+            "system_ms": 41.8676,
+            "bundled_ms": 39.4996,
+            "raw_delta_pct": -5.64,
+            "spread_pct": [
+                0.4,
+                0.6
+            ],
+            "system_runs_ms": [
+                41.8676,
+                41.8988,
+                41.8574,
+                41.77,
+                41.8735,
+                41.7411,
+                41.87
+            ],
+            "bundled_runs_ms": [
+                39.5423,
+                39.3895,
+                39.4974,
+                39.5833,
+                39.4996,
+                39.3533,
+                39.5328
+            ],
+            "paired_ratios": [
+                0.94446,
+                0.94011,
+                0.94362,
+                0.94765,
+                0.94331,
+                0.94279,
+                0.94418
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93455,
+            "delta_pct": -6.54,
+            "ci_delta_pct": [
+                -7.08,
+                -6.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.31,
+                "B2/C2": -6.79,
+                "B3/C3": -6.7
+            },
+            "build_spread_pct": 0.48,
+            "builds": 3,
+            "system_ms": 23.2176,
+            "bundled_ms": 21.6369,
+            "raw_delta_pct": -6.51,
+            "spread_pct": [
+                0.8,
+                0.8
+            ],
+            "system_runs_ms": [
+                23.3225,
+                23.2528,
+                23.134,
+                23.2364,
+                23.176,
+                23.2176,
+                23.1621
+            ],
+            "bundled_runs_ms": [
+                21.6086,
+                21.6161,
+                21.629,
+                21.7787,
+                21.6765,
+                21.6369,
+                21.7778
+            ],
+            "paired_ratios": [
+                0.92651,
+                0.92961,
+                0.93494,
+                0.93727,
+                0.9353,
+                0.93192,
+                0.94023
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.98863,
+            "delta_pct": -1.14,
+            "ci_delta_pct": [
+                -1.19,
+                -0.89
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.14,
+                "B2/C2": -1.02,
+                "B3/C3": -1.08
+            },
+            "build_spread_pct": 0.12,
+            "builds": 3,
+            "system_ms": 55.4974,
+            "bundled_ms": 54.878,
+            "raw_delta_pct": -1.1,
+            "spread_pct": [
+                0.8,
+                0.8
+            ],
+            "system_runs_ms": [
+                55.7055,
+                55.4974,
+                55.2687,
+                55.6294,
+                55.3477,
+                55.6229,
+                55.3191
+            ],
+            "bundled_runs_ms": [
+                54.6469,
+                54.878,
+                54.7607,
+                55.0198,
+                54.8777,
+                54.9812,
+                55.0878
+            ],
+            "paired_ratios": [
+                0.981,
+                0.98884,
+                0.99081,
+                0.98904,
+                0.99151,
+                0.98846,
+                0.99582
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.98249,
+            "delta_pct": -1.75,
+            "ci_delta_pct": [
+                -2.05,
+                -1.43
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -2.03,
+                "B2/C2": -1.37,
+                "B3/C3": -1.9
+            },
+            "build_spread_pct": 0.66,
+            "builds": 3,
+            "system_ms": 24.9468,
+            "bundled_ms": 24.5443,
+            "raw_delta_pct": -1.71,
+            "spread_pct": [
+                0.4,
+                0.7
+            ],
+            "system_runs_ms": [
+                25.0055,
+                24.9468,
+                24.9714,
+                24.9343,
+                24.9113,
+                24.9259,
+                24.9693
+            ],
+            "bundled_runs_ms": [
+                24.4847,
+                24.5997,
+                24.5443,
+                24.5808,
+                24.5967,
+                24.424,
+                24.472
+            ],
+            "paired_ratios": [
+                0.97917,
+                0.98609,
+                0.9829,
+                0.98582,
+                0.98737,
+                0.97986,
+                0.98008
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.96556,
+            "delta_pct": -3.44,
+            "ci_delta_pct": [
+                -3.56,
+                -3.22
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.44,
+                "B2/C2": -3.47,
+                "B3/C3": -3.3
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 27.1394,
+            "bundled_ms": 26.2156,
+            "raw_delta_pct": -3.4,
+            "spread_pct": [
+                0.3,
+                0.5
+            ],
+            "system_runs_ms": [
+                27.1394,
+                27.126,
+                27.1665,
+                27.1732,
+                27.1022,
+                27.0792,
+                27.1508
+            ],
+            "bundled_runs_ms": [
+                26.2156,
+                26.2027,
+                26.1684,
+                26.2165,
+                26.1644,
+                26.3071,
+                26.288
+            ],
+            "paired_ratios": [
+                0.96596,
+                0.96596,
+                0.96326,
+                0.96479,
+                0.9654,
+                0.97149,
+                0.96822
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.97961,
+            "delta_pct": -2.04,
+            "ci_delta_pct": [
+                -2.17,
+                -1.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.39,
+                "B2/C2": -2.17,
+                "B3/C3": -1.47
+            },
+            "build_spread_pct": 0.78,
+            "builds": 3,
+            "system_ms": 108.7366,
+            "bundled_ms": 106.6545,
+            "raw_delta_pct": -2,
+            "spread_pct": [
+                0.4,
+                1.3
+            ],
+            "system_runs_ms": [
+                108.5335,
+                108.7352,
+                108.7904,
+                108.9794,
+                108.7949,
+                108.6386,
+                108.7366
+            ],
+            "bundled_runs_ms": [
+                107.0694,
+                106.5162,
+                106.6171,
+                106.6545,
+                106.3735,
+                107.71,
+                107.4206
+            ],
+            "paired_ratios": [
+                0.98651,
+                0.97959,
+                0.98002,
+                0.97867,
+                0.97774,
+                0.99145,
+                0.9879
+            ]
+        }
+    },
+    "array_vs_bundled": {
+        "core.bitset.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.15922,
+            "delta_pct": 15.92,
+            "ci_delta_pct": [
+                15.58,
+                15.99
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                89.8177,
+                89.1866,
+                89.1241,
+                89.0933,
+                89.0254,
+                88.828,
+                88.8024
+            ],
+            "judy_runs_ms": [
+                103.7236,
+                103.4383,
+                103.3147,
+                103.2563,
+                103.2607,
+                102.6644,
+                103.2479
+            ],
+            "array_ms": 89.0933,
+            "judy_ms": 103.2607,
+            "judy_over_array": 1.159,
+            "winner": "php-array"
+        },
+        "core.bitset.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.00904,
+            "delta_pct": 200.9,
+            "ci_delta_pct": [
+                196.91,
+                203.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.4613,
+                22.3915,
+                23.2549,
+                22.433,
+                22.5298,
+                22.7937,
+                22.1345
+            ],
+            "judy_runs_ms": [
+                67.2506,
+                67.5601,
+                67.3458,
+                67.5018,
+                68.6909,
+                67.676,
+                67.0997
+            ],
+            "array_ms": 22.4613,
+            "judy_ms": 67.5018,
+            "judy_over_array": 3.005,
+            "winner": "php-array"
+        },
+        "core.bitset.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.73505,
+            "delta_pct": 473.51,
+            "ci_delta_pct": [
+                467.93,
+                475.01
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.6841,
+                18.6764,
+                19.2193,
+                18.7629,
+                18.7493,
+                18.7078,
+                18.7337
+            ],
+            "judy_runs_ms": [
+                107.4188,
+                107.7748,
+                109.152,
+                107.6062,
+                107.2866,
+                107.5718,
+                105.3171
+            ],
+            "array_ms": 18.7337,
+            "judy_ms": 107.5718,
+            "judy_over_array": 5.742,
+            "winner": "php-array"
+        },
+        "core.bitset.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.00366,
+            "delta_pct": -99.63,
+            "ci_delta_pct": [
+                -99.64,
+                -99.62
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.1497,
+                4.9988,
+                5.4602,
+                5.4579,
+                4.8647,
+                4.9908,
+                4.9682
+            ],
+            "judy_runs_ms": [
+                0.0184,
+                0.0185,
+                0.025,
+                0.0184,
+                0.0183,
+                0.0182,
+                0.0182
+            ],
+            "array_ms": 4.9988,
+            "judy_ms": 0.0184,
+            "judy_over_array": 0.004,
+            "winner": "php-judy"
+        },
+        "core.int_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.57435,
+            "delta_pct": 57.44,
+            "ci_delta_pct": [
+                57.39,
+                57.79
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.1923,
+                91.968,
+                91.9852,
+                91.8976,
+                91.8782,
+                92.118,
+                91.8726
+            ],
+            "judy_runs_ms": [
+                144.8022,
+                145.0155,
+                145.1418,
+                144.6792,
+                144.606,
+                145.4548,
+                144.6251
+            ],
+            "array_ms": 91.968,
+            "judy_ms": 144.8022,
+            "judy_over_array": 1.574,
+            "winner": "php-array"
+        },
+        "core.int_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.0174,
+            "delta_pct": 201.74,
+            "ci_delta_pct": [
+                199.14,
+                206.83
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.1182,
+                22.5013,
+                21.9294,
+                22.8019,
+                22.296,
+                22.3539,
+                21.8472
+            ],
+            "judy_runs_ms": [
+                67.4966,
+                67.5535,
+                67.2861,
+                67.0098,
+                67.2759,
+                66.8699,
+                67.6566
+            ],
+            "array_ms": 22.296,
+            "judy_ms": 67.2861,
+            "judy_over_array": 3.018,
+            "winner": "php-array"
+        },
+        "core.int_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.07283,
+            "delta_pct": 507.28,
+            "ci_delta_pct": [
+                506.12,
+                510.1
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.6182,
+                18.5968,
+                18.7157,
+                18.6514,
+                18.6534,
+                18.6985,
+                18.6546
+            ],
+            "judy_runs_ms": [
+                113.6664,
+                113.459,
+                113.5153,
+                113.2667,
+                113.0614,
+                113.1023,
+                113.6843
+            ],
+            "array_ms": 18.6534,
+            "judy_ms": 113.459,
+            "judy_over_array": 6.082,
+            "winner": "php-array"
+        },
+        "core.int_to_int.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.37997,
+            "delta_pct": -62,
+            "ci_delta_pct": [
+                -62.45,
+                -61.36
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.4679,
+                5.478,
+                5.4477,
+                5.4657,
+                5.5054,
+                5.5236,
+                5.5176
+            ],
+            "judy_runs_ms": [
+                2.102,
+                2.0815,
+                2.1464,
+                2.1119,
+                2.0595,
+                2.0803,
+                2.0719
+            ],
+            "array_ms": 5.478,
+            "judy_ms": 2.0815,
+            "judy_over_array": 0.38,
+            "winner": "php-judy"
+        },
+        "core.int_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.50308,
+            "delta_pct": 50.31,
+            "ci_delta_pct": [
+                49.8,
+                50.66
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                264.5573,
+                265.0902,
+                264.3785,
+                267.0939,
+                264.5495,
+                264.5842,
+                264.3564
+            ],
+            "judy_runs_ms": [
+                397.2043,
+                398.4521,
+                398.9033,
+                399.0756,
+                396.2992,
+                398.6234,
+                397.5951
+            ],
+            "array_ms": 264.5573,
+            "judy_ms": 398.4521,
+            "judy_over_array": 1.506,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.29942,
+            "delta_pct": 129.94,
+            "ci_delta_pct": [
+                129.12,
+                130.48
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                120.9129,
+                121.4747,
+                120.4596,
+                120.971,
+                120.6422,
+                120.7326,
+                120.6988
+            ],
+            "judy_runs_ms": [
+                278.2206,
+                278.3278,
+                276.9874,
+                276.5227,
+                278.0552,
+                278.8439,
+                277.2483
+            ],
+            "array_ms": 120.7326,
+            "judy_ms": 278.0552,
+            "judy_over_array": 2.303,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.76696,
+            "delta_pct": 276.7,
+            "ci_delta_pct": [
+                275.75,
+                277.43
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                85.4955,
+                85.4005,
+                85.2725,
+                85.3762,
+                85.2843,
+                85.69,
+                85.2447
+            ],
+            "judy_runs_ms": [
+                321.9084,
+                321.7003,
+                320.4087,
+                321.6528,
+                321.8872,
+                319.1058,
+                321.783
+            ],
+            "array_ms": 85.3762,
+            "judy_ms": 321.7003,
+            "judy_over_array": 3.768,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.17446,
+            "delta_pct": 117.45,
+            "ci_delta_pct": [
+                115.66,
+                117.85
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                46.0769,
+                46.1679,
+                45.98,
+                46.1743,
+                46.0143,
+                46.3473,
+                46.0982
+            ],
+            "judy_runs_ms": [
+                100.8982,
+                100.2732,
+                99.9818,
+                100.5485,
+                100.2413,
+                99.9545,
+                99.3706
+            ],
+            "array_ms": 46.0982,
+            "judy_ms": 100.2413,
+            "judy_over_array": 2.175,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.40265,
+            "delta_pct": 40.26,
+            "ci_delta_pct": [
+                40.12,
+                40.51
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                246.4737,
+                247.5506,
+                246.8084,
+                246.9203,
+                246.5076,
+                246.9269,
+                246.4656
+            ],
+            "judy_runs_ms": [
+                346.3082,
+                345.5563,
+                347.9801,
+                346.7802,
+                345.6447,
+                346.002,
+                345.7044
+            ],
+            "array_ms": 246.8084,
+            "judy_ms": 346.002,
+            "judy_over_array": 1.402,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.92674,
+            "delta_pct": 92.67,
+            "ci_delta_pct": [
+                92.41,
+                93.03
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                106.853,
+                106.9161,
+                106.4017,
+                106.3766,
+                106.4077,
+                106.6233,
+                106.5287
+            ],
+            "judy_runs_ms": [
+                205.7623,
+                205.7152,
+                205.197,
+                204.9601,
+                206.5195,
+                204.7886,
+                205.6329
+            ],
+            "array_ms": 106.5287,
+            "judy_ms": 205.6329,
+            "judy_over_array": 1.93,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 11.52269,
+            "delta_pct": 1052.27,
+            "ci_delta_pct": [
+                1048.8,
+                1071.5
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                21.266,
+                21.6861,
+                21.3579,
+                21.4443,
+                21.4357,
+                21.3513,
+                21.4877
+            ],
+            "judy_runs_ms": [
+                251.7421,
+                246.8707,
+                250.2072,
+                247.0961,
+                247.678,
+                245.7506,
+                246.8507
+            ],
+            "array_ms": 21.4357,
+            "judy_ms": 247.0961,
+            "judy_over_array": 11.527,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.10954,
+            "delta_pct": 10.95,
+            "ci_delta_pct": [
+                10.79,
+                11.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                46.8966,
+                47.0404,
+                46.8229,
+                46.7907,
+                46.8611,
+                46.9213,
+                46.9604
+            ],
+            "judy_runs_ms": [
+                51.9577,
+                52.4241,
+                51.9518,
+                51.9026,
+                51.8437,
+                52.2604,
+                52.2702
+            ],
+            "array_ms": 46.8966,
+            "judy_ms": 51.9577,
+            "judy_over_array": 1.108,
+            "winner": "php-array"
+        },
+        "api.increment.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.52198,
+            "delta_pct": 152.2,
+            "ci_delta_pct": [
+                150.58,
+                154.06
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                57.3084,
+                57.2552,
+                57.3678,
+                57.488,
+                57.1354,
+                57.3579,
+                57.3607
+            ],
+            "judy_runs_ms": [
+                143.9944,
+                145.4631,
+                140.1361,
+                145.639,
+                145.9889,
+                144.6556,
+                143.735
+            ],
+            "array_ms": 57.3579,
+            "judy_ms": 144.6556,
+            "judy_over_array": 2.522,
+            "winner": "php-array"
+        },
+        "api.setop.union.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.98233,
+            "delta_pct": 98.23,
+            "ci_delta_pct": [
+                96.38,
+                98.49
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.4041,
+                92.3826,
+                92.3598,
+                92.3294,
+                92.4969,
+                92.1774,
+                92.4317
+            ],
+            "judy_runs_ms": [
+                183.8022,
+                183.2697,
+                180.9623,
+                183.2616,
+                181.6427,
+                182.7258,
+                182.0395
+            ],
+            "array_ms": 92.3826,
+            "judy_ms": 182.7258,
+            "judy_over_array": 1.978,
+            "winner": "php-array"
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90954,
+            "delta_pct": -9.05,
+            "ci_delta_pct": [
+                -9.13,
+                -8.91
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                95.5674,
+                95.4203,
+                95.3255,
+                95.3236,
+                95.6344,
+                95.4538,
+                95.539
+            ],
+            "judy_runs_ms": [
+                87.033,
+                86.7078,
+                86.8299,
+                87.1718,
+                86.9628,
+                86.8187,
+                86.7426
+            ],
+            "array_ms": 95.4538,
+            "judy_ms": 86.8299,
+            "judy_over_array": 0.91,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.00281,
+            "delta_pct": 100.28,
+            "ci_delta_pct": [
+                99.77,
+                100.39
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                42.9867,
+                43.0196,
+                43.1159,
+                43.0604,
+                43.1149,
+                43.1561,
+                43.0321
+            ],
+            "judy_runs_ms": [
+                86.2876,
+                86.1802,
+                86.1929,
+                86.2417,
+                86.132,
+                86.1111,
+                86.233
+            ],
+            "array_ms": 43.0604,
+            "judy_ms": 86.1929,
+            "judy_over_array": 2.002,
+            "winner": "php-array"
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78047,
+            "delta_pct": -21.95,
+            "ci_delta_pct": [
+                -22.23,
+                -21.74
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                221.2304,
+                221.307,
+                221.3707,
+                221.0729,
+                226.6843,
+                221.6039,
+                221.2044
+            ],
+            "judy_runs_ms": [
+                173.1438,
+                172.7226,
+                172.7429,
+                173.1828,
+                172.684,
+                172.333,
+                172.6805
+            ],
+            "array_ms": 221.307,
+            "judy_ms": 172.7226,
+            "judy_over_array": 0.78,
+            "winner": "php-judy"
+        }
+    },
+    "judy_vs_phploop": {
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69532,
+            "delta_pct": -30.47,
+            "ci_delta_pct": [
+                -30.92,
+                -30.36
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                183.0842,
+                181.3482,
+                181.0982,
+                181.5162,
+                181.2586,
+                181.4852,
+                182.9818
+            ],
+            "judy_runs_ms": [
+                126.3168,
+                126.2926,
+                126.6138,
+                126.2127,
+                126.2004,
+                126.162,
+                126.4078
+            ],
+            "array_ms": 181.4852,
+            "judy_ms": 126.2926,
+            "judy_over_array": 0.696,
+            "winner": "php-judy"
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69784,
+            "delta_pct": -30.22,
+            "ci_delta_pct": [
+                -31.01,
+                -30.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                183.0842,
+                181.3482,
+                181.0982,
+                181.5162,
+                181.2586,
+                181.4852,
+                182.9818
+            ],
+            "judy_runs_ms": [
+                126.3063,
+                126.738,
+                126.3783,
+                126.7041,
+                126.2959,
+                126.7733,
+                126.0389
+            ],
+            "array_ms": 181.4852,
+            "judy_ms": 126.3783,
+            "judy_over_array": 0.696,
+            "winner": "php-judy"
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.81775,
+            "delta_pct": -18.23,
+            "ci_delta_pct": [
+                -18.57,
+                -17.34
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                361.8467,
+                361.6558,
+                365.9548,
+                366.41,
+                361.3906,
+                362.9053,
+                369.1025
+            ],
+            "judy_runs_ms": [
+                299.0907,
+                299.4532,
+                298.4365,
+                298.3796,
+                298.6273,
+                296.7641,
+                297.4775
+            ],
+            "array_ms": 362.9053,
+            "judy_ms": 298.4365,
+            "judy_over_array": 0.822,
+            "winner": "php-judy"
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78295,
+            "delta_pct": -21.71,
+            "ci_delta_pct": [
+                -21.83,
+                -21.55
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                27.4493,
+                27.4078,
+                27.4026,
+                27.368,
+                27.5072,
+                27.4168,
+                27.4004
+            ],
+            "judy_runs_ms": [
+                21.5506,
+                21.4238,
+                21.4966,
+                21.4574,
+                21.5324,
+                21.401,
+                21.4531
+            ],
+            "array_ms": 27.4078,
+            "judy_ms": 21.4574,
+            "judy_over_array": 0.783,
+            "winner": "php-judy"
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.59752,
+            "delta_pct": -40.25,
+            "ci_delta_pct": [
+                -40.47,
+                -40.14
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.885,
+                194.4388,
+                194.5513,
+                194.0561,
+                195.3263,
+                195.3414,
+                195.0355
+            ],
+            "judy_runs_ms": [
+                120.0517,
+                116.395,
+                116.2482,
+                116.0699,
+                116.203,
+                116.285,
+                116.2196
+            ],
+            "array_ms": 194.885,
+            "judy_ms": 116.2482,
+            "judy_over_array": 0.596,
+            "winner": "php-judy"
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.62251,
+            "delta_pct": -37.75,
+            "ci_delta_pct": [
+                -37.77,
+                -37.69
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.6147,
+                194.2282,
+                195.5891,
+                194.025,
+                195.0822,
+                194.396,
+                194.2483
+            ],
+            "judy_runs_ms": [
+                121.2369,
+                121.0194,
+                123.0599,
+                120.7824,
+                120.9631,
+                121.0078,
+                120.8762
+            ],
+            "array_ms": 194.396,
+            "judy_ms": 121.0078,
+            "judy_over_array": 0.622,
+            "winner": "php-judy"
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.06846,
+            "delta_pct": -93.15,
+            "ci_delta_pct": [
+                -93.18,
+                -93.14
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                147.2665,
+                147.7674,
+                147.4749,
+                147.3352,
+                147.6763,
+                147.9221,
+                148.4206
+            ],
+            "judy_runs_ms": [
+                10.106,
+                10.0727,
+                10.0954,
+                10.1468,
+                10.1188,
+                10.1134,
+                10.0914
+            ],
+            "array_ms": 147.6763,
+            "judy_ms": 10.106,
+            "judy_over_array": 0.068,
+            "winner": "php-judy"
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41214,
+            "delta_pct": -58.79,
+            "ci_delta_pct": [
+                -58.87,
+                -58.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                117.0725,
+                117.3451,
+                118.2783,
+                117.8778,
+                117.7913,
+                118.1554,
+                117.5957
+            ],
+            "judy_runs_ms": [
+                48.643,
+                48.5955,
+                48.6444,
+                48.5746,
+                48.546,
+                48.5721,
+                48.521
+            ],
+            "array_ms": 117.7913,
+            "judy_ms": 48.5746,
+            "judy_over_array": 0.412,
+            "winner": "php-judy"
+        },
+        "api.populationCount.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0,
+            "delta_pct": -100,
+            "ci_delta_pct": [
+                -100,
+                -100
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                118.3283,
+                119.0532,
+                118.2275,
+                117.6048,
+                118.006,
+                118.4056,
+                118.8202
+            ],
+            "judy_runs_ms": [
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001
+            ],
+            "array_ms": 118.3283,
+            "judy_ms": 0.0001,
+            "judy_over_array": 0,
+            "winner": "php-judy"
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69945,
+            "delta_pct": -30.05,
+            "ci_delta_pct": [
+                -30.33,
+                -29.99
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                339.2977,
+                339.3476,
+                339.1888,
+                339.5792,
+                338.3921,
+                338.1232,
+                339.1918
+            ],
+            "judy_runs_ms": [
+                238.6328,
+                237.5777,
+                236.6869,
+                236.4605,
+                236.6893,
+                236.5546,
+                236.3189
+            ],
+            "array_ms": 339.1918,
+            "judy_ms": 236.6869,
+            "judy_over_array": 0.698,
+            "winner": "php-judy"
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.25748,
+            "delta_pct": -74.25,
+            "ci_delta_pct": [
+                -74.62,
+                -74.06
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                275.3096,
+                275.4604,
+                280.7585,
+                282.4317,
+                277.5186,
+                276.0469,
+                276.8352
+            ],
+            "judy_runs_ms": [
+                71.4125,
+                71.116,
+                71.2494,
+                71.1892,
+                71.4548,
+                71.6264,
+                71.1099
+            ],
+            "array_ms": 276.8352,
+            "judy_ms": 71.2494,
+            "judy_over_array": 0.257,
+            "winner": "php-judy"
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.52373,
+            "delta_pct": -47.63,
+            "ci_delta_pct": [
+                -47.75,
+                -47.57
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                506.6065,
+                506.4657,
+                512.0695,
+                508.0672,
+                508.0042,
+                509.9272,
+                507.1889
+            ],
+            "judy_runs_ms": [
+                264.7046,
+                265.4723,
+                267.1522,
+                265.4749,
+                266.8806,
+                267.3621,
+                265.6317
+            ],
+            "array_ms": 508.0042,
+            "judy_ms": 265.6317,
+            "judy_over_array": 0.523,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.44015,
+            "delta_pct": -55.98,
+            "ci_delta_pct": [
+                -56.16,
+                -55.67
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                247.3873,
+                247.9758,
+                249.395,
+                246.8761,
+                248.9583,
+                247.9148,
+                247.2243
+            ],
+            "judy_runs_ms": [
+                112.2434,
+                109.1477,
+                109.5071,
+                109.3399,
+                109.0015,
+                108.6863,
+                109.5845
+            ],
+            "array_ms": 247.9148,
+            "judy_ms": 109.3399,
+            "judy_over_array": 0.441,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42089,
+            "delta_pct": -57.91,
+            "ci_delta_pct": [
+                -58.27,
+                -57.84
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                257.6856,
+                256.1124,
+                256.5458,
+                256.365,
+                255.4601,
+                258.8574,
+                255.3743
+            ],
+            "judy_runs_ms": [
+                107.527,
+                107.9796,
+                107.735,
+                107.9002,
+                107.5774,
+                107.7469,
+                107.8809
+            ],
+            "array_ms": 256.365,
+            "judy_ms": 107.7469,
+            "judy_over_array": 0.42,
+            "winner": "php-judy"
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42197,
+            "delta_pct": -57.8,
+            "ci_delta_pct": [
+                -57.94,
+                -57.64
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                513.6825,
+                512.792,
+                513.0008,
+                513.9752,
+                512.1262,
+                519.8813,
+                512.6214
+            ],
+            "judy_runs_ms": [
+                216.7582,
+                216.6338,
+                217.3204,
+                216.1674,
+                216.9297,
+                216.3006,
+                216.2198
+            ],
+            "array_ms": 513.0008,
+            "judy_ms": 216.6338,
+            "judy_over_array": 0.422,
+            "winner": "php-judy"
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85931,
+            "delta_pct": -14.07,
+            "ci_delta_pct": [
+                -14.37,
+                -13.73
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1693.7249,
+                1693.5146,
+                1688.1284,
+                1691.75,
+                1689.3368,
+                1692.0933,
+                1698.0511
+            ],
+            "judy_runs_ms": [
+                1450.2892,
+                1460.9579,
+                1455.9115,
+                1453.7374,
+                1451.6237,
+                1460.3805,
+                1451.5874
+            ],
+            "array_ms": 1692.0933,
+            "judy_ms": 1453.7374,
+            "judy_over_array": 0.859,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83865,
+            "delta_pct": -16.14,
+            "ci_delta_pct": [
+                -16.18,
+                -15.74
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                779.5693,
+                777.5224,
+                774.6553,
+                778.6654,
+                780.5316,
+                782.2495,
+                781.4304
+            ],
+            "judy_runs_ms": [
+                653.7853,
+                652.0027,
+                652.7389,
+                656.7347,
+                655.0068,
+                655.6697,
+                653.7601
+            ],
+            "array_ms": 779.5693,
+            "judy_ms": 653.7853,
+            "judy_over_array": 0.839,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86592,
+            "delta_pct": -13.41,
+            "ci_delta_pct": [
+                -13.77,
+                -13.26
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                780.8537,
+                775.9856,
+                784.9937,
+                782.288,
+                781.6122,
+                781.5495,
+                779.982
+            ],
+            "judy_runs_ms": [
+                676.6999,
+                676.1907,
+                676.8022,
+                674.6019,
+                677.9699,
+                676.7595,
+                674.6026
+            ],
+            "array_ms": 781.5495,
+            "judy_ms": 676.6999,
+            "judy_over_array": 0.866,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78332,
+            "delta_pct": -21.67,
+            "ci_delta_pct": [
+                -22.1,
+                -21.47
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                384.3606,
+                384.286,
+                387.3463,
+                384.1372,
+                384.4768,
+                393.3183,
+                387.4606
+            ],
+            "judy_runs_ms": [
+                301.5598,
+                301.0196,
+                301.7287,
+                301.6485,
+                302.0204,
+                301.0493,
+                302.8482
+            ],
+            "array_ms": 384.4768,
+            "judy_ms": 301.6485,
+            "judy_over_array": 0.785,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90552,
+            "delta_pct": -9.45,
+            "ci_delta_pct": [
+                -9.45,
+                -8.9
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1319.348,
+                1323.9351,
+                1320.0009,
+                1315.9853,
+                1317.2119,
+                1327.9249,
+                1314.8516
+            ],
+            "judy_runs_ms": [
+                1194.6621,
+                1206.1705,
+                1195.0593,
+                1194.5239,
+                1192.6904,
+                1202.4585,
+                1206.0052
+            ],
+            "array_ms": 1319.348,
+            "judy_ms": 1195.0593,
+            "judy_over_array": 0.906,
+            "winner": "php-judy"
+        },
+        "adv.forEach.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.4904,
+            "delta_pct": 49.04,
+            "ci_delta_pct": [
+                48.21,
+                49.65
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                127.6862,
+                127.0176,
+                127.3175,
+                127.2881,
+                127.0487,
+                127.1312,
+                127.0278
+            ],
+            "judy_runs_ms": [
+                190.3034,
+                190.4218,
+                190.3267,
+                188.4831,
+                188.2997,
+                190.2473,
+                188.5476
+            ],
+            "array_ms": 127.1312,
+            "judy_ms": 190.2473,
+            "judy_over_array": 1.496,
+            "winner": "php-array"
+        },
+        "adv.forEach.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.16524,
+            "delta_pct": 16.52,
+            "ci_delta_pct": [
+                16.45,
+                16.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                304.5314,
+                305.4448,
+                303.6963,
+                304.8241,
+                303.2876,
+                303.9805,
+                303.7345
+            ],
+            "judy_runs_ms": [
+                354.8528,
+                354.6044,
+                354.0394,
+                354.9682,
+                354.054,
+                353.9866,
+                354.4885
+            ],
+            "array_ms": 303.9805,
+            "judy_ms": 354.4885,
+            "judy_over_array": 1.166,
+            "winner": "php-array"
+        },
+        "adv.filter.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.22299,
+            "delta_pct": 22.3,
+            "ci_delta_pct": [
+                21.88,
+                23.08
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                226.0447,
+                223.6453,
+                224.0161,
+                225.0071,
+                224.0438,
+                223.3429,
+                225.9073
+            ],
+            "judy_runs_ms": [
+                274.7722,
+                275.2629,
+                273.743,
+                275.4355,
+                274.0039,
+                275.123,
+                275.3458
+            ],
+            "array_ms": 224.0438,
+            "judy_ms": 275.123,
+            "judy_over_array": 1.228,
+            "winner": "php-array"
+        },
+        "adv.filter.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.05593,
+            "delta_pct": 5.59,
+            "ci_delta_pct": [
+                5.51,
+                5.92
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                737.3188,
+                737.0029,
+                738.5282,
+                738.5884,
+                735.5074,
+                738.8001,
+                736.2893
+            ],
+            "judy_runs_ms": [
+                777.9625,
+                781.0278,
+                778.8069,
+                779.36,
+                778.7356,
+                780.1189,
+                779.8508
+            ],
+            "array_ms": 737.3188,
+            "judy_ms": 779.36,
+            "judy_over_array": 1.057,
+            "winner": "php-array"
+        },
+        "adv.map.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.09018,
+            "delta_pct": 9.02,
+            "ci_delta_pct": [
+                8.99,
+                9.34
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                273.6529,
+                272.5249,
+                271.8326,
+                272.7711,
+                271.8127,
+                272.6186,
+                274.3656
+            ],
+            "judy_runs_ms": [
+                295.9027,
+                297.0202,
+                297.4373,
+                297.3585,
+                297.2006,
+                297.2025,
+                299.175
+            ],
+            "array_ms": 272.6186,
+            "judy_ms": 297.2025,
+            "judy_over_array": 1.09,
+            "winner": "php-array"
+        },
+        "adv.map.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.02209,
+            "delta_pct": 2.21,
+            "ci_delta_pct": [
+                2.01,
+                2.29
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1044.1579,
+                1040.7347,
+                1040.9081,
+                1044.2679,
+                1044.4122,
+                1040.9757,
+                1043.9672
+            ],
+            "judy_runs_ms": [
+                1066.0236,
+                1064.7525,
+                1063.8999,
+                1067.362,
+                1065.0326,
+                1064.7671,
+                1064.972
+            ],
+            "array_ms": 1043.9672,
+            "judy_ms": 1064.972,
+            "judy_over_array": 1.02,
+            "winner": "php-array"
+        }
+    },
+    "memory": [],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-S-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-254/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-S-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-254/B2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-S-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-254/B3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-254/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-254/C2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-254/C3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/run6-attribution-6m.txt
+++ b/research/three-arm-benchmark/results/run6-attribution-6m.txt
@@ -1,0 +1,137 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /work/builds/judy-S-1.so, /work/builds/judy-S-2.so, /work/builds/judy-S-3.so
+  C  php-judy + bundled libJudy : /work/builds/judy-C-1.so, /work/builds/judy-C-2.so, /work/builds/judy-C-3.so
+  timing core.int     round 1/7  timing core.int     round 2/7  timing core.int     round 3/7  timing core.int     round 4/7  timing core.int     round 5/7  timing core.int     round 6/7  timing core.int     round 7/7  timing core.int     done          
+  timing api.batch    round 1/7  timing api.batch    round 2/7  timing api.batch    round 3/7  timing api.batch    round 4/7  timing api.batch    round 5/7  timing api.batch    round 6/7  timing api.batch    round 7/7  timing api.batch    done          
+  timing api.setops   round 1/7  timing api.setops   round 2/7  timing api.setops   round 3/7  timing api.setops   round 4/7  timing api.setops   round 5/7  timing api.setops   round 6/7  timing api.setops   round 7/7  timing api.setops   done          
+  timing adv.iter     round 1/7  timing adv.iter     round 2/7  timing adv.iter     round 3/7  timing adv.iter     round 4/7  timing adv.iter     round 5/7  timing adv.iter     round 6/7  timing adv.iter     round 7/7  timing adv.iter     done          
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — linux-x86_64-gcc14.2-php8.4-out-of-cache-6M-ATTRIBUTION-S-vs-C
+------------------------------------------------------------------------------------------------
+  PHP 8.4.24, Linux x86_64
+  arm B system libJudy : ARM S: PRISTINE Judy-1.0.5 (official tarball sha256 d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb), STATIC into the extension, IDENTICAL pinned CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt -fPIC. Isolates the php-judy source patches ALONE.
+  arm C bundled libJudy: bundled libjudy/ static into the extension (P1-P7, O1 popcount, O3 bswap, O4 string-layer); vendor CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt
+  size 6000000 (out-of-cache), 7 rounds, 3 iterations, floor 1.3%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-timing   load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    end            load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+
+  control (PHP-only rows, touch no libJudy): +0.04% [+0.00, +0.07] over 21 rows
+  measured control scatter: 2.63%  (assumed floor 1.3%)
+
+------------------------------------------------------------------------------------------------
+  B vs C — bundled libJudy against system libJudy (this project's contribution)
+  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears
+  the 1.3% floor assert anything; everything else is null.
+------------------------------------------------------------------------------------------------
+  benchmark                                     system   bundled    delta CI                 verdict
+  api.fromArray.int_to_int                      171.13    126.38  -26.23% [-26.43,-25.86] FASTER
+  api.putAll.int_to_int                         171.10    126.29  -26.22% [-26.26,-26.20] FASTER
+  api.equals.int_to_int                          95.82     71.25  -25.58% [-25.83,-25.46] FASTER
+  api.setop.intersect.int_to_int                146.53    109.34  -25.41% [-25.75,-25.08] FASTER
+  api.setop.union.int_to_int                    351.92    265.63  -24.56% [-24.68,-24.37] FASTER
+  api.deleteRange.int_to_int                    311.03    236.69  -23.98% [-24.10,-23.62] FASTER
+  core.int_to_int.write                         190.10    144.80  -23.75% [-23.96,-23.67] FASTER
+  api.setop.union.bitset                        236.15    182.73  -22.92% [-23.21,-22.39] FASTER
+  api.range.size.string_to_int                   27.13     20.90  -22.86% [-23.27,-22.79] FASTER
+  api.setop.diff.int_to_int                     138.63    107.75  -22.30% [-22.35,-22.22] FASTER
+  api.setop.xor.int_to_int                      277.39    216.63  -21.89% [-22.13,-21.77] FASTER
+  api.mergeWith.int_to_int                      383.06    301.65  -21.30% [-21.43,-21.25] FASTER
+  api.setop.intersect.bitset                    109.48     86.83  -20.73% [-20.91,-20.27] FASTER
+  api.setop.diff.bitset                         108.02     86.19  -20.22% [-20.34,-20.19] FASTER
+  api.setop.xor.bitset                          216.31    172.72  -20.20% [-20.28,-20.09] FASTER
+  api.sumValues.int_to_int                       60.77     48.57  -20.15% [-20.56,-19.78] FASTER
+  core.int_to_int.read                           80.81     67.29  -16.79% [-17.45,-16.27] FASTER
+  core.int_to_packed.free                        61.70     51.96  -15.73% [-15.83,-15.59] FASTER
+  adv.optiter.values.string_to_int_hash.optimized     12.28     10.58  -14.16% [-14.23,-13.66] FASTER
+  api.setop.intersect.string_to_int             753.94    653.79  -13.33% [-13.46,-12.81] FASTER
+  api.setop.diff.string_to_int                  777.74    676.70  -13.03% [-13.38,-12.96] FASTER
+  adv.optiter.values.string_to_int_adaptive.optimized     14.25     12.40  -12.83% [-13.13,-12.78] FASTER
+  core.int_to_mixed.read                        317.97    278.06  -12.79% [-12.96,-12.50] FASTER
+  adv.map.string_to_int                        1220.00   1064.97  -12.74% [-12.82,-12.61] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.optimized     16.01     13.97  -12.73% [-12.96,-12.38] FASTER
+  adv.optiter.foreach.string_to_int_hash.optimized     14.61     12.80  -12.63% [-13.28,-12.16] FASTER
+  adv.filter.string_to_int                      890.15    779.36  -12.38% [-12.55,-12.30] FASTER
+  api.setop.union.string_to_int                1655.07   1453.74  -12.20% [-12.37,-11.81] FASTER
+  core.bitset.write                             116.71    103.26  -11.56% [-11.63,-11.16] FASTER
+  adv.forEach.string_to_int                     401.04    354.49  -11.55% [-11.80,-11.45] FASTER
+  api.mergeWith.string_to_int                  1352.52   1195.06  -11.51% [-11.92,-10.61] FASTER
+  api.getAll.int_to_int                          23.81     21.46   -9.90% [-10.14, -9.53] FASTER
+  api.range.keys.int_to_int                      11.21     10.11   -9.78% [-10.20, -9.25] FASTER
+  core.int_to_mixed.write                       440.94    398.45   -9.71% [ -9.84, -9.63] FASTER
+  core.int_to_packed.write                      381.55    346.00   -9.45% [ -9.53, -9.16] FASTER
+  api.keys.int_to_int                           127.72    116.25   -8.97% [ -9.15, -8.71] FASTER
+  api.values.int_to_int                         132.70    121.01   -8.85% [ -8.98, -8.35] FASTER
+  adv.optiter.foreach.string_to_int_hash.default     24.19     22.09   -8.72% [ -9.16, -8.68] FASTER
+  core.int_to_mixed.free                        109.49    100.24   -8.54% [ -8.72, -8.06] FASTER
+  core.int_to_int.iter                          123.90    113.46   -8.49% [ -8.72, -8.36] FASTER
+  core.int_to_mixed.iter                        349.93    321.70   -8.19% [ -8.48, -7.99] FASTER
+  adv.map.int_to_int                            323.22    297.20   -8.09% [ -8.12, -7.92] FASTER
+  adv.optiter.values.string_to_int_hash.default     22.32     20.65   -7.47% [ -7.63, -7.06] FASTER
+  adv.optiter.ratio.values.string_to_int_adaptive     45.87     42.41   -7.33% [ -7.77, -7.01] FASTER
+  adv.optiter.ratio.values.string_to_int_hash     55.04     51.10   -7.20% [ -7.65, -6.96] FASTER
+  adv.optiter.toArray.string_to_int_hash.optimized     19.34     17.95   -7.20% [ -7.61, -7.09] FASTER
+  adv.filter.int_to_int                         296.37    275.12   -7.16% [ -7.39, -6.83] FASTER
+  adv.optiter.ratio.foreach.string_to_int_adaptive     49.65     46.36   -6.71% [ -7.18, -6.04] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.default     32.25     30.12   -6.67% [ -7.50, -6.47] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.optimized     23.22     21.64   -6.54% [ -7.08, -6.31] FASTER
+  core.int_to_packed.iter                       263.81    247.10   -6.35% [ -6.47, -5.14] FASTER
+  adv.optiter.values.string_to_int_adaptive.default     31.07     29.23   -5.98% [ -6.08, -5.89] FASTER
+  adv.optiter.toArray.string_to_int_hash.default     31.06     29.29   -5.80% [ -6.05, -5.33] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.default     41.87     39.50   -5.68% [ -5.76, -5.59] FASTER
+  api.increment.int_to_int                      153.04    144.66   -5.63% [ -6.28, -5.03] FASTER
+  adv.optiter.increment.string_to_int_hash.optimized     20.10     19.10   -5.07% [ -5.27, -4.59] FASTER
+  adv.forEach.int_to_int                        199.07    190.25   -4.93% [ -5.52, -3.99] null
+  adv.optiter.overwrite.string_to_int_hash.optimized     19.92     18.97   -4.85% [ -5.94, -4.60] FASTER
+  adv.optiter.ratio.foreach.string_to_int_hash     60.47     58.05   -4.18% [ -4.57, -3.77] FASTER
+  adv.optiter.overwrite.string_to_int_adaptive.optimized     27.14     26.22   -3.44% [ -3.56, -3.22] FASTER
+  core.bitset.iter                              111.22    107.57   -3.39% [ -4.12, -3.27] FASTER
+  api.toArray.int_to_int                        308.11    298.44   -3.26% [ -3.58, -3.20] FASTER
+  adv.optiter.increment.string_to_int_hash.default     16.77     16.29   -2.87% [ -3.11, -2.44] FASTER
+  adv.optiter.overwrite.string_to_int_hash.default     16.73     16.28   -2.70% [ -2.92, -2.42] FASTER
+  core.int_to_packed.read                       210.75    205.63   -2.65% [ -2.88, -2.39] FASTER
+  adv.optiter.ratio.overwrite.string_to_int_hash    119.01    116.30   -2.56% [ -3.35, -1.94] FASTER
+  adv.optiter.ratio.increment.string_to_int_hash    119.96    117.58   -2.26% [ -2.33, -1.97] FASTER
+  adv.optiter.ratio.overwrite.string_to_int_adaptive    108.74    106.65   -2.04% [ -2.17, -1.25] null
+  adv.optiter.overwrite.string_to_int_adaptive.default     24.95     24.54   -1.75% [ -2.05, -1.43] FASTER
+  adv.optiter.ratio.toArray.string_to_int_hash     62.28     61.30   -1.70% [ -1.79, -1.31] FASTER
+  core.bitset.read                               68.68     67.50   -1.38% [ -4.04, -0.95] null
+  adv.optiter.ratio.toArray.string_to_int_adaptive     55.50     54.88   -1.14% [ -1.19, -0.89] null
+  core.int_to_int.free                            2.10      2.08    0.05% [ -2.59, +1.08] null
+  totals: 68 faster, 0 slower, 5 null
+
+------------------------------------------------------------------------------------------------
+  A vs C — PHP native array against php-judy (bundled)
+  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means
+  the PHP array is FASTER — publish these, they are the honest half of the story.
+------------------------------------------------------------------------------------------------
+  benchmark                                   array ms   judy ms  judy/arr winner
+  core.bitset.free                                5.00      0.02     0.00x php-judy
+  core.int_to_int.free                            5.48      2.08     0.38x php-judy
+  api.setop.xor.bitset                          221.31    172.72     0.78x php-judy
+  api.setop.intersect.bitset                     95.45     86.83     0.91x php-judy
+  core.int_to_packed.free                        46.90     51.96     1.11x php-array
+  core.bitset.write                              89.09    103.26     1.16x php-array
+  core.int_to_packed.write                      246.81    346.00     1.40x php-array
+  core.int_to_mixed.write                       264.56    398.45     1.51x php-array
+  core.int_to_int.write                          91.97    144.80     1.57x php-array
+  core.int_to_packed.read                       106.53    205.63     1.93x php-array
+  api.setop.union.bitset                         92.38    182.73     1.98x php-array
+  api.setop.diff.bitset                          43.06     86.19     2.00x php-array
+  core.int_to_mixed.free                         46.10    100.24     2.17x php-array
+  core.int_to_mixed.read                        120.73    278.06     2.30x php-array
+  api.increment.int_to_int                       57.36    144.66     2.52x php-array
+  core.bitset.read                               22.46     67.50     3.00x php-array
+  core.int_to_int.read                           22.30     67.29     3.02x php-array
+  core.int_to_mixed.iter                         85.38    321.70     3.77x php-array
+  core.bitset.iter                               18.73    107.57     5.74x php-array
+  core.int_to_int.iter                           18.65    113.46     6.08x php-array
+  core.int_to_packed.iter                        21.44    247.10    11.53x php-array
+  totals: php-judy wins 4, PHP array wins 17, parity 0
+
+Wrote /work/results/run6-attribution-6m.json

--- a/research/three-arm-benchmark/results/run6-cvsc-control-6m.json
+++ b/research/three-arm-benchmark/results/run6-cvsc-control-6m.json
@@ -1,0 +1,5831 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "linux-x86_64-gcc14.2-php8.4-out-of-cache-6M-CvsC-REBUILD-CONTROL",
+        "date": "2026-08-19T06:39:40+00:00",
+        "php_version": "8.4.24",
+        "platform": "Linux x86_64",
+        "uname": "Linux 9eda8be811ef 6.8.0-136-generic #136~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  3 16:29:11 UTC  x86_64",
+        "judy_version": "2.5.2",
+        "system_so": [
+            "/work/builds/judy-C-2.so",
+            "/work/builds/judy-C-3.so",
+            "/work/builds/judy-C-1.so"
+        ],
+        "bundled_so": [
+            "/work/builds/judy-C-1.so",
+            "/work/builds/judy-C-2.so",
+            "/work/builds/judy-C-3.so"
+        ],
+        "system_so_sha256": [
+            "e045a13c7e649278937555e54798aa1296bda245cc7bad759770c3ebfab17b12",
+            "fb78079bf462da012789c29bef076168d23f50c47cb31ba47aa9299f481252d3",
+            "df5d52bc39e6792a0838d911d816e44a3dbd9966347aa837cd5754aaf4fe0f2a"
+        ],
+        "bundled_so_sha256": [
+            "df5d52bc39e6792a0838d911d816e44a3dbd9966347aa837cd5754aaf4fe0f2a",
+            "e045a13c7e649278937555e54798aa1296bda245cc7bad759770c3ebfab17b12",
+            "fb78079bf462da012789c29bef076168d23f50c47cb31ba47aa9299f481252d3"
+        ],
+        "system_provenance": "CONTROL: arm C builds rotated one position, so no round compares a binary against itself",
+        "bundled_provenance": "bundled libjudy/ static into the extension (P1-P7, O1 popcount, O3 bswap, O4 string-layer); vendor CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt",
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 6000000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            100000,
+            1000000,
+            8000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "out-of-cache",
+        "claim_floor_pct": 1.3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 56,
+        "memory_children": 0,
+        "wall_seconds": 1702.9
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T06:11:17+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T06:39:40+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T06:39:40+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "note": "load average alone is necessary but not sufficient: a co-resident memory-bound benchmark contends for LLC and memory bandwidth at low load, and a PHP-array control does not detect it"
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 1.00007,
+            "delta_pct": 0.01,
+            "ci_delta_pct": [
+                -0.02,
+                0.08
+            ],
+            "measured_spread_pct": 1.62,
+            "row_count": 21,
+            "eligibility": "genuine PHP-array rows only (TAM_ARM_A_ROWS); Judy-touching .php rows are excluded because they carry real signal",
+            "rows": {
+                "core.bitset.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00085,
+                    "delta_pct": 0.08,
+                    "ci_delta_pct": [
+                        -0.36,
+                        0.12
+                    ],
+                    "n": 7,
+                    "b_ms": 89.0391,
+                    "c_ms": 89.0926
+                },
+                "core.bitset.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00756,
+                    "delta_pct": 0.76,
+                    "ci_delta_pct": [
+                        -1.95,
+                        2
+                    ],
+                    "n": 7,
+                    "b_ms": 22.2928,
+                    "c_ms": 22.4005
+                },
+                "core.bitset.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00146,
+                    "delta_pct": 0.15,
+                    "ci_delta_pct": [
+                        -0.35,
+                        0.24
+                    ],
+                    "n": 7,
+                    "b_ms": 18.7383,
+                    "c_ms": 18.7474
+                },
+                "core.bitset.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99173,
+                    "delta_pct": -0.83,
+                    "ci_delta_pct": [
+                        -1.99,
+                        0.16
+                    ],
+                    "n": 7,
+                    "b_ms": 5.4383,
+                    "c_ms": 5.4037
+                },
+                "core.int_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00101,
+                    "delta_pct": 0.1,
+                    "ci_delta_pct": [
+                        -0.09,
+                        0.21
+                    ],
+                    "n": 7,
+                    "b_ms": 91.9746,
+                    "c_ms": 91.9396
+                },
+                "core.int_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.01624,
+                    "delta_pct": 1.62,
+                    "ci_delta_pct": [
+                        -0.31,
+                        4.39
+                    ],
+                    "n": 7,
+                    "b_ms": 22.1334,
+                    "c_ms": 22.5936
+                },
+                "core.int_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99932,
+                    "delta_pct": -0.07,
+                    "ci_delta_pct": [
+                        -0.35,
+                        0.15
+                    ],
+                    "n": 7,
+                    "b_ms": 18.646,
+                    "c_ms": 18.6304
+                },
+                "core.int_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00016,
+                    "delta_pct": 0.02,
+                    "ci_delta_pct": [
+                        -0.23,
+                        0.25
+                    ],
+                    "n": 7,
+                    "b_ms": 5.5033,
+                    "c_ms": 5.4909
+                },
+                "core.int_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00053,
+                    "delta_pct": 0.05,
+                    "ci_delta_pct": [
+                        -0.35,
+                        0.11
+                    ],
+                    "n": 7,
+                    "b_ms": 264.5723,
+                    "c_ms": 264.6131
+                },
+                "core.int_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99979,
+                    "delta_pct": -0.02,
+                    "ci_delta_pct": [
+                        -0.76,
+                        0.08
+                    ],
+                    "n": 7,
+                    "b_ms": 120.5508,
+                    "c_ms": 120.4712
+                },
+                "core.int_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99991,
+                    "delta_pct": -0.01,
+                    "ci_delta_pct": [
+                        -0.13,
+                        0.19
+                    ],
+                    "n": 7,
+                    "b_ms": 85.2117,
+                    "c_ms": 85.2443
+                },
+                "core.int_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00335,
+                    "delta_pct": 0.33,
+                    "ci_delta_pct": [
+                        -0.39,
+                        0.47
+                    ],
+                    "n": 7,
+                    "b_ms": 45.9523,
+                    "c_ms": 46.0045
+                },
+                "core.int_to_packed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99953,
+                    "delta_pct": -0.05,
+                    "ci_delta_pct": [
+                        -0.2,
+                        0.09
+                    ],
+                    "n": 7,
+                    "b_ms": 246.9171,
+                    "c_ms": 246.7087
+                },
+                "core.int_to_packed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00007,
+                    "delta_pct": 0.01,
+                    "ci_delta_pct": [
+                        -0.08,
+                        0.15
+                    ],
+                    "n": 7,
+                    "b_ms": 106.508,
+                    "c_ms": 106.565
+                },
+                "core.int_to_packed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00561,
+                    "delta_pct": 0.56,
+                    "ci_delta_pct": [
+                        -1.08,
+                        0.81
+                    ],
+                    "n": 7,
+                    "b_ms": 21.2987,
+                    "c_ms": 21.4491
+                },
+                "core.int_to_packed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99943,
+                    "delta_pct": -0.06,
+                    "ci_delta_pct": [
+                        -0.36,
+                        0.13
+                    ],
+                    "n": 7,
+                    "b_ms": 46.8813,
+                    "c_ms": 46.9316
+                },
+                "api.increment.int_to_int": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00034,
+                    "delta_pct": 0.03,
+                    "ci_delta_pct": [
+                        -0.36,
+                        0.2
+                    ],
+                    "n": 7,
+                    "b_ms": 57.3449,
+                    "c_ms": 57.3308
+                },
+                "api.setop.union.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99977,
+                    "delta_pct": -0.02,
+                    "ci_delta_pct": [
+                        -0.13,
+                        0.1
+                    ],
+                    "n": 7,
+                    "b_ms": 92.3327,
+                    "c_ms": 92.3199
+                },
+                "api.setop.intersect.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99941,
+                    "delta_pct": -0.06,
+                    "ci_delta_pct": [
+                        -0.21,
+                        0.19
+                    ],
+                    "n": 7,
+                    "b_ms": 95.4238,
+                    "c_ms": 95.3282
+                },
+                "api.setop.diff.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99984,
+                    "delta_pct": -0.02,
+                    "ci_delta_pct": [
+                        -0.67,
+                        0.42
+                    ],
+                    "n": 7,
+                    "b_ms": 42.968,
+                    "c_ms": 43.0712
+                },
+                "api.setop.xor.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99953,
+                    "delta_pct": -0.05,
+                    "ci_delta_pct": [
+                        -0.15,
+                        0.07
+                    ],
+                    "n": 7,
+                    "b_ms": 221.0534,
+                    "c_ms": 220.9355
+                }
+            }
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 0,
+        "slower": 0,
+        "null": 73
+    },
+    "a_counts": {
+        "php-judy": 4,
+        "php-array": 17,
+        "parity": 0
+    },
+    "bundled_vs_system": {
+        "core.bitset.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00535,
+            "delta_pct": 0.54,
+            "ci_delta_pct": [
+                -0.19,
+                0.86
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.12,
+                "B2/C2": 0.76,
+                "B3/C3": 0.34
+            },
+            "build_spread_pct": 0.64,
+            "builds": 3,
+            "system_ms": 102.9144,
+            "bundled_ms": 103.2904,
+            "raw_delta_pct": 0.54,
+            "spread_pct": [
+                1,
+                1.6
+            ],
+            "system_runs_ms": [
+                102.9709,
+                102.621,
+                103.3654,
+                103.6089,
+                102.6955,
+                102.7792,
+                102.9144
+            ],
+            "bundled_runs_ms": [
+                103.5291,
+                103.6014,
+                104.2582,
+                102.9388,
+                103.2904,
+                102.5941,
+                103.042
+            ],
+            "paired_ratios": [
+                1.00542,
+                1.00955,
+                1.00864,
+                0.99353,
+                1.00579,
+                0.9982,
+                1.00124
+            ]
+        },
+        "core.bitset.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00583,
+            "delta_pct": 0.58,
+            "ci_delta_pct": [
+                -0.11,
+                0.64
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.31,
+                "B2/C2": -0.07,
+                "B3/C3": 0.6
+            },
+            "build_spread_pct": 0.67,
+            "builds": 3,
+            "system_ms": 67.2114,
+            "bundled_ms": 67.4609,
+            "raw_delta_pct": 0.59,
+            "spread_pct": [
+                2.7,
+                1.4
+            ],
+            "system_runs_ms": [
+                66.2346,
+                66.7491,
+                67.2114,
+                67.2502,
+                68.0768,
+                67.1686,
+                67.5875
+            ],
+            "bundled_runs_ms": [
+                66.6627,
+                67.2739,
+                67.6274,
+                67.4609,
+                67.4508,
+                67.5643,
+                67.5195
+            ],
+            "paired_ratios": [
+                1.00646,
+                1.00786,
+                1.00619,
+                1.00313,
+                0.9908,
+                1.00589,
+                0.99899
+            ]
+        },
+        "core.bitset.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99954,
+            "delta_pct": -0.05,
+            "ci_delta_pct": [
+                -0.82,
+                0.63
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.82,
+                "B2/C2": 0.11,
+                "B3/C3": 0.29
+            },
+            "build_spread_pct": 1.11,
+            "builds": 3,
+            "system_ms": 107.3852,
+            "bundled_ms": 107.3283,
+            "raw_delta_pct": -0.04,
+            "spread_pct": [
+                2.1,
+                1.9
+            ],
+            "system_runs_ms": [
+                105.7724,
+                106.8999,
+                106.6841,
+                108.017,
+                107.3852,
+                107.7069,
+                107.7048
+            ],
+            "bundled_runs_ms": [
+                107.4569,
+                107.3283,
+                107.3677,
+                105.5746,
+                107.1974,
+                107.6647,
+                106.8242
+            ],
+            "paired_ratios": [
+                1.01593,
+                1.00401,
+                1.00641,
+                0.97739,
+                0.99825,
+                0.99961,
+                0.99182
+            ]
+        },
+        "core.int_to_int.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99956,
+            "delta_pct": -0.04,
+            "ci_delta_pct": [
+                -0.47,
+                0.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.22,
+                "B2/C2": 0.23,
+                "B3/C3": -0.26
+            },
+            "build_spread_pct": 0.49,
+            "builds": 3,
+            "system_ms": 144.758,
+            "bundled_ms": 144.6974,
+            "raw_delta_pct": -0.04,
+            "spread_pct": [
+                0.9,
+                0.6
+            ],
+            "system_runs_ms": [
+                145.0621,
+                144.607,
+                144.8585,
+                144.3932,
+                144.35,
+                144.758,
+                145.6105
+            ],
+            "bundled_runs_ms": [
+                144.7552,
+                144.6974,
+                144.8036,
+                144.537,
+                144.9315,
+                144.092,
+                144.625
+            ],
+            "paired_ratios": [
+                0.99788,
+                1.00063,
+                0.99962,
+                1.001,
+                1.00403,
+                0.9954,
+                0.99323
+            ]
+        },
+        "core.int_to_int.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99603,
+            "delta_pct": -0.4,
+            "ci_delta_pct": [
+                -0.45,
+                0.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.09,
+                "B2/C2": -0.45,
+                "B3/C3": -0.03
+            },
+            "build_spread_pct": 0.42,
+            "builds": 3,
+            "system_ms": 67.0556,
+            "bundled_ms": 66.9204,
+            "raw_delta_pct": -0.39,
+            "spread_pct": [
+                0.7,
+                0.7
+            ],
+            "system_runs_ms": [
+                67.0556,
+                67.2172,
+                66.9681,
+                66.8398,
+                67.1988,
+                67.287,
+                66.9313
+            ],
+            "bundled_runs_ms": [
+                66.7937,
+                66.9204,
+                67.2474,
+                67.191,
+                66.9043,
+                66.9698,
+                66.8778
+            ],
+            "paired_ratios": [
+                0.99609,
+                0.99558,
+                1.00417,
+                1.00525,
+                0.99562,
+                0.99529,
+                0.9992
+            ]
+        },
+        "core.int_to_int.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99795,
+            "delta_pct": -0.21,
+            "ci_delta_pct": [
+                -0.31,
+                -0.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.3,
+                "B2/C2": -0.5,
+                "B3/C3": -0.17
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 113.4553,
+            "bundled_ms": 113.1879,
+            "raw_delta_pct": -0.2,
+            "spread_pct": [
+                1.6,
+                1.4
+            ],
+            "system_runs_ms": [
+                113.8752,
+                114.0793,
+                112.2169,
+                113.4553,
+                113.0713,
+                113.1876,
+                113.8098
+            ],
+            "bundled_runs_ms": [
+                113.5414,
+                113.1879,
+                112.0413,
+                113.6168,
+                112.8464,
+                113.0049,
+                113.4669
+            ],
+            "paired_ratios": [
+                0.99707,
+                0.99219,
+                0.99844,
+                1.00142,
+                0.99801,
+                0.99839,
+                0.99699
+            ]
+        },
+        "core.int_to_int.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9994,
+            "delta_pct": -0.06,
+            "ci_delta_pct": [
+                -1.62,
+                3.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 3.15,
+                "B2/C2": -0.46,
+                "B3/C3": -1.06
+            },
+            "build_spread_pct": 4.21,
+            "builds": 3,
+            "system_ms": 2.0749,
+            "bundled_ms": 2.0924,
+            "raw_delta_pct": -0.05,
+            "spread_pct": [
+                6.2,
+                3.6
+            ],
+            "system_runs_ms": [
+                2.0071,
+                2.1155,
+                2.1359,
+                2.0668,
+                2.0744,
+                2.0896,
+                2.0749
+            ],
+            "bundled_runs_ms": [
+                2.1029,
+                2.0778,
+                2.1252,
+                2.1321,
+                2.0924,
+                2.0559,
+                2.0738
+            ],
+            "paired_ratios": [
+                1.04773,
+                0.98218,
+                0.99499,
+                1.03159,
+                1.00868,
+                0.98387,
+                0.99947
+            ]
+        },
+        "core.int_to_mixed.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00177,
+            "delta_pct": 0.18,
+            "ci_delta_pct": [
+                -0.62,
+                0.37
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.37,
+                "B2/C2": -0.74,
+                "B3/C3": 0.17
+            },
+            "build_spread_pct": 1.11,
+            "builds": 3,
+            "system_ms": 397.6057,
+            "bundled_ms": 397.5835,
+            "raw_delta_pct": 0.18,
+            "spread_pct": [
+                0.9,
+                0.7
+            ],
+            "system_runs_ms": [
+                396.3929,
+                398.7679,
+                397.4722,
+                397.6057,
+                399.9715,
+                397.7987,
+                397.2006
+            ],
+            "bundled_runs_ms": [
+                397.121,
+                396.3035,
+                397.5835,
+                399.0877,
+                396.5925,
+                399.1289,
+                399.282
+            ],
+            "paired_ratios": [
+                1.00184,
+                0.99382,
+                1.00028,
+                1.00373,
+                0.99155,
+                1.00334,
+                1.00524
+            ]
+        },
+        "core.int_to_mixed.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99804,
+            "delta_pct": -0.2,
+            "ci_delta_pct": [
+                -0.57,
+                0.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.3,
+                "B2/C2": 0.03,
+                "B3/C3": -0.17
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 277.7887,
+            "bundled_ms": 277.4582,
+            "raw_delta_pct": -0.19,
+            "spread_pct": [
+                0.7,
+                0.3
+            ],
+            "system_runs_ms": [
+                278.8838,
+                277.4417,
+                277.1235,
+                278.0082,
+                277.594,
+                278.9359,
+                277.7887
+            ],
+            "bundled_runs_ms": [
+                277.0008,
+                277.4582,
+                277.8098,
+                277.4817,
+                277.7968,
+                277.3524,
+                276.9828
+            ],
+            "paired_ratios": [
+                0.99325,
+                1.00006,
+                1.00248,
+                0.99811,
+                1.00073,
+                0.99432,
+                0.9971
+            ]
+        },
+        "core.int_to_mixed.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00384,
+            "delta_pct": 0.38,
+            "ci_delta_pct": [
+                -0.16,
+                0.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.41,
+                "B2/C2": -0.18,
+                "B3/C3": 0.4
+            },
+            "build_spread_pct": 0.59,
+            "builds": 3,
+            "system_ms": 320.3281,
+            "bundled_ms": 321.3676,
+            "raw_delta_pct": 0.39,
+            "spread_pct": [
+                0.7,
+                1.2
+            ],
+            "system_runs_ms": [
+                319.6088,
+                320.3281,
+                320.2208,
+                319.5294,
+                321.7809,
+                321.4847,
+                320.3649
+            ],
+            "bundled_runs_ms": [
+                319.1305,
+                320.5377,
+                321.4704,
+                321.3676,
+                320.4675,
+                322.8354,
+                321.692
+            ],
+            "paired_ratios": [
+                0.9985,
+                1.00065,
+                1.0039,
+                1.00575,
+                0.99592,
+                1.0042,
+                1.00414
+            ]
+        },
+        "core.int_to_mixed.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00243,
+            "delta_pct": 0.24,
+            "ci_delta_pct": [
+                -0.2,
+                0.94
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.2,
+                "B2/C2": 0.19,
+                "B3/C3": 0.66
+            },
+            "build_spread_pct": 0.86,
+            "builds": 3,
+            "system_ms": 100.0649,
+            "bundled_ms": 100.2224,
+            "raw_delta_pct": 0.25,
+            "spread_pct": [
+                1.5,
+                0.7
+            ],
+            "system_runs_ms": [
+                99.2867,
+                100.149,
+                99.5175,
+                100.7777,
+                100.0649,
+                99.9783,
+                100.1627
+            ],
+            "bundled_runs_ms": [
+                100.2224,
+                100.3994,
+                100.5065,
+                99.8373,
+                100.2094,
+                100.3138,
+                99.9715
+            ],
+            "paired_ratios": [
+                1.00942,
+                1.0025,
+                1.00994,
+                0.99067,
+                1.00144,
+                1.00336,
+                0.99809
+            ]
+        },
+        "core.int_to_packed.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00175,
+            "delta_pct": 0.17,
+            "ci_delta_pct": [
+                -0.4,
+                0.52
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.52,
+                "B2/C2": -0.66,
+                "B3/C3": 0.27
+            },
+            "build_spread_pct": 1.18,
+            "builds": 3,
+            "system_ms": 345.2271,
+            "bundled_ms": 346.499,
+            "raw_delta_pct": 0.18,
+            "spread_pct": [
+                0.9,
+                0.7
+            ],
+            "system_runs_ms": [
+                347.849,
+                347.8936,
+                345.1473,
+                344.7629,
+                346.9026,
+                345.2271,
+                345.1974
+            ],
+            "bundled_runs_ms": [
+                346.8016,
+                344.7244,
+                345.7733,
+                347.1362,
+                345.5332,
+                346.499,
+                347.0186
+            ],
+            "paired_ratios": [
+                0.99699,
+                0.99089,
+                1.00181,
+                1.00688,
+                0.99605,
+                1.00368,
+                1.00528
+            ]
+        },
+        "core.int_to_packed.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99924,
+            "delta_pct": -0.08,
+            "ci_delta_pct": [
+                -0.38,
+                0.24
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.08,
+                "B2/C2": 0.39,
+                "B3/C3": -0.35
+            },
+            "build_spread_pct": 0.74,
+            "builds": 3,
+            "system_ms": 205.9561,
+            "bundled_ms": 205.7159,
+            "raw_delta_pct": -0.07,
+            "spread_pct": [
+                0.8,
+                0.6
+            ],
+            "system_runs_ms": [
+                206.2003,
+                204.6103,
+                206.353,
+                205.9561,
+                205.2407,
+                205.9938,
+                205.8597
+            ],
+            "bundled_runs_ms": [
+                206.1502,
+                205.1234,
+                205.7526,
+                205.1955,
+                206.3378,
+                205.1923,
+                205.7159
+            ],
+            "paired_ratios": [
+                0.99976,
+                1.00251,
+                0.99709,
+                0.99631,
+                1.00535,
+                0.99611,
+                0.9993
+            ]
+        },
+        "core.int_to_packed.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99909,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.52,
+                0.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.52,
+                "B2/C2": -0.27,
+                "B3/C3": 1.62
+            },
+            "build_spread_pct": 2.14,
+            "builds": 3,
+            "system_ms": 247.6756,
+            "bundled_ms": 247.529,
+            "raw_delta_pct": -0.08,
+            "spread_pct": [
+                2,
+                2
+            ],
+            "system_runs_ms": [
+                248.9333,
+                248.1972,
+                244.072,
+                247.6756,
+                247.7376,
+                247.2267,
+                247.5348
+            ],
+            "bundled_runs_ms": [
+                246.7407,
+                247.0867,
+                251.1994,
+                247.9423,
+                247.529,
+                248.0531,
+                246.2668
+            ],
+            "paired_ratios": [
+                0.99119,
+                0.99553,
+                1.0292,
+                1.00108,
+                0.99916,
+                1.00334,
+                0.99488
+            ]
+        },
+        "core.int_to_packed.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00423,
+            "delta_pct": 0.42,
+            "ci_delta_pct": [
+                0.19,
+                0.67
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.45,
+                "B2/C2": 0.2,
+                "B3/C3": 0.31
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 51.9124,
+            "bundled_ms": 52.086,
+            "raw_delta_pct": 0.43,
+            "spread_pct": [
+                0.5,
+                0.7
+            ],
+            "system_runs_ms": [
+                51.8424,
+                51.9358,
+                52.032,
+                51.8482,
+                52.0935,
+                51.9124,
+                51.8373
+            ],
+            "bundled_runs_ms": [
+                52.2361,
+                52.2872,
+                52.2554,
+                52.086,
+                51.9538,
+                52.0205,
+                51.9369
+            ],
+            "paired_ratios": [
+                1.00759,
+                1.00677,
+                1.00429,
+                1.00459,
+                0.99732,
+                1.00208,
+                1.00192
+            ]
+        },
+        "api.putAll.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00216,
+            "delta_pct": 0.22,
+            "ci_delta_pct": [
+                0.04,
+                0.66
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.16,
+                "B2/C2": 0.88,
+                "B3/C3": 0.41
+            },
+            "build_spread_pct": 0.72,
+            "builds": 3,
+            "system_ms": 126.5184,
+            "bundled_ms": 126.9472,
+            "raw_delta_pct": 0.22,
+            "spread_pct": [
+                0.4,
+                2
+            ],
+            "system_runs_ms": [
+                126.3793,
+                126.5929,
+                126.1661,
+                126.5184,
+                126.4242,
+                126.6768,
+                126.5621
+            ],
+            "bundled_runs_ms": [
+                127.219,
+                128.8889,
+                126.9472,
+                126.7272,
+                126.3701,
+                126.959,
+                126.6164
+            ],
+            "paired_ratios": [
+                1.00664,
+                1.01814,
+                1.00619,
+                1.00165,
+                0.99957,
+                1.00223,
+                1.00043
+            ]
+        },
+        "api.fromArray.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00388,
+            "delta_pct": 0.39,
+            "ci_delta_pct": [
+                0.11,
+                1.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.39,
+                "B2/C2": 0.8,
+                "B3/C3": -0.64
+            },
+            "build_spread_pct": 1.44,
+            "builds": 3,
+            "system_ms": 126.1438,
+            "bundled_ms": 126.6569,
+            "raw_delta_pct": 0.39,
+            "spread_pct": [
+                1.9,
+                1.7
+            ],
+            "system_runs_ms": [
+                126.1438,
+                125.8171,
+                128.2657,
+                126.4876,
+                126.0251,
+                126.0753,
+                126.3344
+            ],
+            "bundled_runs_ms": [
+                128.1859,
+                127.7053,
+                126.0614,
+                126.9866,
+                126.1725,
+                126.6569,
+                126.5282
+            ],
+            "paired_ratios": [
+                1.01619,
+                1.01501,
+                0.98281,
+                1.00395,
+                1.00117,
+                1.00461,
+                1.00153
+            ]
+        },
+        "api.toArray.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00197,
+            "delta_pct": 0.2,
+            "ci_delta_pct": [
+                0.03,
+                0.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.28,
+                "B2/C2": 0.44,
+                "B3/C3": -0.39
+            },
+            "build_spread_pct": 0.83,
+            "builds": 3,
+            "system_ms": 297.4057,
+            "bundled_ms": 297.8087,
+            "raw_delta_pct": 0.2,
+            "spread_pct": [
+                0.8,
+                1.3
+            ],
+            "system_runs_ms": [
+                298.7236,
+                297.9641,
+                297.4057,
+                297.1905,
+                296.7652,
+                299.0686,
+                296.968
+            ],
+            "bundled_runs_ms": [
+                299.3329,
+                300.5306,
+                297.5337,
+                298.0638,
+                296.8624,
+                296.6292,
+                297.8087
+            ],
+            "paired_ratios": [
+                1.00204,
+                1.00861,
+                1.00043,
+                1.00294,
+                1.00033,
+                0.99184,
+                1.00283
+            ]
+        },
+        "api.getAll.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99829,
+            "delta_pct": -0.17,
+            "ci_delta_pct": [
+                -0.86,
+                0.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.45,
+                "B2/C2": -0.87,
+                "B3/C3": 0.21
+            },
+            "build_spread_pct": 1.08,
+            "builds": 3,
+            "system_ms": 21.5246,
+            "bundled_ms": 21.4602,
+            "raw_delta_pct": -0.16,
+            "spread_pct": [
+                1.6,
+                0.9
+            ],
+            "system_runs_ms": [
+                21.6389,
+                21.7276,
+                21.4552,
+                21.3793,
+                21.5371,
+                21.5246,
+                21.4514
+            ],
+            "bundled_runs_ms": [
+                21.4534,
+                21.3874,
+                21.5188,
+                21.4602,
+                21.5017,
+                21.5554,
+                21.3573
+            ],
+            "paired_ratios": [
+                0.99143,
+                0.98434,
+                1.00296,
+                1.00378,
+                0.99836,
+                1.00143,
+                0.99561
+            ]
+        },
+        "api.increment.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99867,
+            "delta_pct": -0.13,
+            "ci_delta_pct": [
+                -0.46,
+                1.9
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.13,
+                "B2/C2": -0.05,
+                "B3/C3": 0.77
+            },
+            "build_spread_pct": 0.9,
+            "builds": 3,
+            "system_ms": 144.4002,
+            "bundled_ms": 144.84,
+            "raw_delta_pct": -0.13,
+            "spread_pct": [
+                3.1,
+                1
+            ],
+            "system_runs_ms": [
+                142.336,
+                144.2946,
+                141.8544,
+                145.2703,
+                146.2739,
+                145.3289,
+                144.4002
+            ],
+            "bundled_runs_ms": [
+                145.046,
+                144.8236,
+                144.84,
+                145.0326,
+                145.6087,
+                144.5177,
+                144.2171
+            ],
+            "paired_ratios": [
+                1.01904,
+                1.00367,
+                1.02105,
+                0.99836,
+                0.99545,
+                0.99442,
+                0.99873
+            ]
+        },
+        "api.keys.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00143,
+            "delta_pct": 0.14,
+            "ci_delta_pct": [
+                -0.01,
+                0.4
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.22,
+                "B2/C2": 0.03,
+                "B3/C3": 0.27
+            },
+            "build_spread_pct": 0.24,
+            "builds": 3,
+            "system_ms": 116.2315,
+            "bundled_ms": 116.3709,
+            "raw_delta_pct": 0.15,
+            "spread_pct": [
+                0.3,
+                0.8
+            ],
+            "system_runs_ms": [
+                116.3154,
+                116.3747,
+                116.2315,
+                116.3155,
+                116.0615,
+                116.0038,
+                116.11
+            ],
+            "bundled_runs_ms": [
+                117.0656,
+                116.3723,
+                116.7021,
+                116.3037,
+                116.1396,
+                116.1776,
+                116.3709
+            ],
+            "paired_ratios": [
+                1.00645,
+                0.99998,
+                1.00405,
+                0.9999,
+                1.00067,
+                1.0015,
+                1.00225
+            ]
+        },
+        "api.values.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00236,
+            "delta_pct": 0.24,
+            "ci_delta_pct": [
+                -0.49,
+                0.48
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.48,
+                "B2/C2": -0.21,
+                "B3/C3": 0.27
+            },
+            "build_spread_pct": 0.69,
+            "builds": 3,
+            "system_ms": 121.0197,
+            "bundled_ms": 121.1518,
+            "raw_delta_pct": 0.24,
+            "spread_pct": [
+                0.8,
+                0.9
+            ],
+            "system_runs_ms": [
+                121.1737,
+                121.0197,
+                120.9931,
+                120.7229,
+                121.3399,
+                120.4291,
+                121.2855
+            ],
+            "bundled_runs_ms": [
+                121.7607,
+                121.1518,
+                121.2863,
+                121.3113,
+                120.7021,
+                120.796,
+                120.7032
+            ],
+            "paired_ratios": [
+                1.00484,
+                1.00109,
+                1.00242,
+                1.00487,
+                0.99474,
+                1.00305,
+                0.9952
+            ]
+        },
+        "api.range.keys.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00151,
+            "delta_pct": 0.15,
+            "ci_delta_pct": [
+                -0.29,
+                0.24
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.24,
+                "B2/C2": -0.08,
+                "B3/C3": -0.07
+            },
+            "build_spread_pct": 0.32,
+            "builds": 3,
+            "system_ms": 10.1027,
+            "bundled_ms": 10.1029,
+            "raw_delta_pct": 0.16,
+            "spread_pct": [
+                0.5,
+                1.2
+            ],
+            "system_runs_ms": [
+                10.0747,
+                10.1034,
+                10.1027,
+                10.0782,
+                10.1295,
+                10.1144,
+                10.0865
+            ],
+            "bundled_runs_ms": [
+                10.1942,
+                10.1241,
+                10.0738,
+                10.1029,
+                10.0945,
+                10.1303,
+                10.071
+            ],
+            "paired_ratios": [
+                1.01186,
+                1.00205,
+                0.99714,
+                1.00245,
+                0.99654,
+                1.00157,
+                0.99846
+            ]
+        },
+        "api.range.size.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9981,
+            "delta_pct": -0.19,
+            "ci_delta_pct": [
+                -0.28,
+                0.03
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.25,
+                "B2/C2": -10.09,
+                "B3/C3": 0.01
+            },
+            "build_spread_pct": 10.1,
+            "builds": 3,
+            "system_ms": 20.927,
+            "bundled_ms": 20.895,
+            "raw_delta_pct": -0.18,
+            "spread_pct": [
+                25,
+                0.1
+            ],
+            "system_runs_ms": [
+                20.9474,
+                20.927,
+                20.8606,
+                20.9584,
+                26.0971,
+                20.9069,
+                20.8919
+            ],
+            "bundled_runs_ms": [
+                20.8964,
+                20.8887,
+                20.879,
+                20.902,
+                20.8812,
+                20.895,
+                20.8997
+            ],
+            "paired_ratios": [
+                0.99757,
+                0.99817,
+                1.00088,
+                0.99731,
+                0.80013,
+                0.99943,
+                1.00037
+            ]
+        },
+        "api.sumValues.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99975,
+            "delta_pct": -0.02,
+            "ci_delta_pct": [
+                -0.74,
+                0.95
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.15,
+                "B2/C2": 0.11,
+                "B3/C3": 0.31
+            },
+            "build_spread_pct": 0.46,
+            "builds": 3,
+            "system_ms": 48.6313,
+            "bundled_ms": 48.5704,
+            "raw_delta_pct": -0.02,
+            "spread_pct": [
+                2.6,
+                0.9
+            ],
+            "system_runs_ms": [
+                48.6417,
+                48.6465,
+                48.3698,
+                47.4517,
+                48.1893,
+                48.6313,
+                48.7304
+            ],
+            "bundled_runs_ms": [
+                48.5704,
+                48.2895,
+                48.6883,
+                48.5117,
+                48.6519,
+                48.6224,
+                48.2631
+            ],
+            "paired_ratios": [
+                0.99853,
+                0.99266,
+                1.00658,
+                1.02234,
+                1.0096,
+                0.99982,
+                0.99041
+            ]
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00042,
+            "delta_pct": 0.04,
+            "ci_delta_pct": [
+                -0.17,
+                0.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.04,
+                "B2/C2": 0.17,
+                "B3/C3": -0.13
+            },
+            "build_spread_pct": 0.3,
+            "builds": 3,
+            "system_ms": 236.426,
+            "bundled_ms": 236.4386,
+            "raw_delta_pct": 0.05,
+            "spread_pct": [
+                0.7,
+                0.5
+            ],
+            "system_runs_ms": [
+                237.3937,
+                236.7105,
+                236.7605,
+                236.1082,
+                236.2796,
+                236.426,
+                235.7333
+            ],
+            "bundled_runs_ms": [
+                236.6848,
+                237.4078,
+                236.367,
+                236.223,
+                236.4386,
+                236.2426,
+                237.1241
+            ],
+            "paired_ratios": [
+                0.99701,
+                1.00295,
+                0.99834,
+                1.00049,
+                1.00067,
+                0.99922,
+                1.0059
+            ]
+        },
+        "api.equals.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99876,
+            "delta_pct": -0.12,
+            "ci_delta_pct": [
+                -0.47,
+                0.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.12,
+                "B2/C2": -0.04,
+                "B3/C3": -0.43
+            },
+            "build_spread_pct": 0.55,
+            "builds": 3,
+            "system_ms": 71.2589,
+            "bundled_ms": 71.2299,
+            "raw_delta_pct": -0.12,
+            "spread_pct": [
+                1.4,
+                1.1
+            ],
+            "system_runs_ms": [
+                70.8172,
+                71.7951,
+                71.5073,
+                71.7927,
+                71.0613,
+                71.2589,
+                71.1478
+            ],
+            "bundled_runs_ms": [
+                70.9041,
+                71.5733,
+                70.9815,
+                71.4606,
+                71.2299,
+                71.1751,
+                71.6533
+            ],
+            "paired_ratios": [
+                1.00123,
+                0.99691,
+                0.99265,
+                0.99537,
+                1.00237,
+                0.99882,
+                1.0071
+            ]
+        },
+        "api.setop.union.bitset": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99613,
+            "delta_pct": -0.39,
+            "ci_delta_pct": [
+                -0.73,
+                0
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.39,
+                "B2/C2": -0.48,
+                "B3/C3": -0.17
+            },
+            "build_spread_pct": 0.31,
+            "builds": 3,
+            "system_ms": 182.7569,
+            "bundled_ms": 182.2432,
+            "raw_delta_pct": -0.38,
+            "spread_pct": [
+                0.4,
+                1.4
+            ],
+            "system_runs_ms": [
+                182.6022,
+                182.4288,
+                183.2332,
+                182.7569,
+                182.63,
+                182.7932,
+                183.1247
+            ],
+            "bundled_runs_ms": [
+                181.5513,
+                182.4452,
+                181.9018,
+                182.2432,
+                180.8925,
+                183.5307,
+                182.4286
+            ],
+            "paired_ratios": [
+                0.99424,
+                1.00009,
+                0.99273,
+                0.99719,
+                0.99049,
+                1.00403,
+                0.9962
+            ]
+        },
+        "api.setop.intersect.bitset": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00018,
+            "delta_pct": 0.02,
+            "ci_delta_pct": [
+                -0.24,
+                0.26
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.24,
+                "B2/C2": 0.21,
+                "B3/C3": 0.1
+            },
+            "build_spread_pct": 0.45,
+            "builds": 3,
+            "system_ms": 86.9386,
+            "bundled_ms": 87.023,
+            "raw_delta_pct": 0.02,
+            "spread_pct": [
+                0.3,
+                0.7
+            ],
+            "system_runs_ms": [
+                86.9883,
+                86.9296,
+                86.7526,
+                87.0255,
+                87.002,
+                86.8614,
+                86.9386
+            ],
+            "bundled_runs_ms": [
+                87.0823,
+                87.2857,
+                86.7014,
+                86.6387,
+                87.023,
+                87.0973,
+                86.739
+            ],
+            "paired_ratios": [
+                1.00108,
+                1.0041,
+                0.99941,
+                0.99556,
+                1.00024,
+                1.00272,
+                0.9977
+            ]
+        },
+        "api.setop.diff.bitset": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99724,
+            "delta_pct": -0.28,
+            "ci_delta_pct": [
+                -0.47,
+                -0.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.29,
+                "B2/C2": -0.24,
+                "B3/C3": -0.46
+            },
+            "build_spread_pct": 0.22,
+            "builds": 3,
+            "system_ms": 86.4064,
+            "bundled_ms": 86.1807,
+            "raw_delta_pct": -0.27,
+            "spread_pct": [
+                0.6,
+                0.3
+            ],
+            "system_runs_ms": [
+                86.0957,
+                86.3675,
+                86.624,
+                86.2303,
+                86.4205,
+                86.4064,
+                86.5852
+            ],
+            "bundled_runs_ms": [
+                85.9068,
+                86.1973,
+                86.0446,
+                85.9896,
+                86.188,
+                86.203,
+                86.1807
+            ],
+            "paired_ratios": [
+                0.99781,
+                0.99803,
+                0.99331,
+                0.99721,
+                0.99731,
+                0.99765,
+                0.99533
+            ]
+        },
+        "api.setop.xor.bitset": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99972,
+            "delta_pct": -0.03,
+            "ci_delta_pct": [
+                -0.36,
+                0.02
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.03,
+                "B2/C2": -0.13,
+                "B3/C3": -0.94
+            },
+            "build_spread_pct": 0.91,
+            "builds": 3,
+            "system_ms": 172.6795,
+            "bundled_ms": 172.6333,
+            "raw_delta_pct": -0.02,
+            "spread_pct": [
+                2,
+                0.4
+            ],
+            "system_runs_ms": [
+                173.2381,
+                172.5698,
+                172.5142,
+                172.6105,
+                172.6795,
+                176.0435,
+                172.7901
+            ],
+            "bundled_runs_ms": [
+                172.6333,
+                172.1726,
+                172.7222,
+                172.573,
+                172.658,
+                172.5479,
+                172.8364
+            ],
+            "paired_ratios": [
+                0.99651,
+                0.9977,
+                1.00121,
+                0.99978,
+                0.99988,
+                0.98014,
+                1.00027
+            ]
+        },
+        "api.setop.union.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00018,
+            "delta_pct": 0.02,
+            "ci_delta_pct": [
+                -0.06,
+                0.39
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.06,
+                "B2/C2": 0.12,
+                "B3/C3": 0.18
+            },
+            "build_spread_pct": 0.24,
+            "builds": 3,
+            "system_ms": 266.6844,
+            "bundled_ms": 266.542,
+            "raw_delta_pct": 0.02,
+            "spread_pct": [
+                1.4,
+                1.2
+            ],
+            "system_runs_ms": [
+                269.2462,
+                265.7668,
+                267.3203,
+                265.6889,
+                265.45,
+                267.5818,
+                266.6844
+            ],
+            "bundled_runs_ms": [
+                266.0118,
+                266.3595,
+                267.2503,
+                266.9231,
+                265.5157,
+                268.6401,
+                266.542
+            ],
+            "paired_ratios": [
+                0.98799,
+                1.00223,
+                0.99974,
+                1.00465,
+                1.00025,
+                1.00396,
+                0.99947
+            ]
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.0019,
+            "delta_pct": 0.19,
+            "ci_delta_pct": [
+                -0.08,
+                0.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.19,
+                "B2/C2": 0.24,
+                "B3/C3": 0
+            },
+            "build_spread_pct": 0.24,
+            "builds": 3,
+            "system_ms": 108.7621,
+            "bundled_ms": 109.1786,
+            "raw_delta_pct": 0.2,
+            "spread_pct": [
+                1.4,
+                0.7
+            ],
+            "system_runs_ms": [
+                109.162,
+                108.7293,
+                108.5825,
+                108.7621,
+                109.0094,
+                110.1331,
+                108.7188
+            ],
+            "bundled_runs_ms": [
+                109.3792,
+                109.0966,
+                109.2716,
+                108.9758,
+                109.1786,
+                109.4491,
+                108.6421
+            ],
+            "paired_ratios": [
+                1.00199,
+                1.00338,
+                1.00635,
+                1.00196,
+                1.00155,
+                0.99379,
+                0.99929
+            ]
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00241,
+            "delta_pct": 0.24,
+            "ci_delta_pct": [
+                0.02,
+                0.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.02,
+                "B2/C2": 0.42,
+                "B3/C3": 0.27
+            },
+            "build_spread_pct": 0.4,
+            "builds": 3,
+            "system_ms": 107.5162,
+            "bundled_ms": 107.7468,
+            "raw_delta_pct": 0.25,
+            "spread_pct": [
+                0.5,
+                0.3
+            ],
+            "system_runs_ms": [
+                107.7868,
+                107.5228,
+                107.5162,
+                107.7197,
+                107.2462,
+                107.4633,
+                107.4065
+            ],
+            "bundled_runs_ms": [
+                107.6443,
+                107.7892,
+                107.8352,
+                107.7468,
+                107.8966,
+                107.7316,
+                107.6231
+            ],
+            "paired_ratios": [
+                0.99868,
+                1.00248,
+                1.00297,
+                1.00025,
+                1.00606,
+                1.0025,
+                1.00202
+            ]
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99959,
+            "delta_pct": -0.04,
+            "ci_delta_pct": [
+                -0.16,
+                0.03
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.01,
+                "B2/C2": -0.07,
+                "B3/C3": 0.03
+            },
+            "build_spread_pct": 0.1,
+            "builds": 3,
+            "system_ms": 216.5268,
+            "bundled_ms": 216.5292,
+            "raw_delta_pct": -0.03,
+            "spread_pct": [
+                0.5,
+                0.6
+            ],
+            "system_runs_ms": [
+                216.5008,
+                217.3201,
+                216.3875,
+                216.5268,
+                217.248,
+                216.6472,
+                216.1735
+            ],
+            "bundled_runs_ms": [
+                215.9122,
+                217.2443,
+                216.8814,
+                216.5292,
+                217.0656,
+                216.3146,
+                216.2607
+            ],
+            "paired_ratios": [
+                0.99728,
+                0.99965,
+                1.00228,
+                1.00001,
+                0.99916,
+                0.99846,
+                1.0004
+            ]
+        },
+        "api.setop.union.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99666,
+            "delta_pct": -0.33,
+            "ci_delta_pct": [
+                -0.68,
+                0.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.48,
+                "B2/C2": -0.34,
+                "B3/C3": -0.11
+            },
+            "build_spread_pct": 0.37,
+            "builds": 3,
+            "system_ms": 1457.8843,
+            "bundled_ms": 1451.6506,
+            "raw_delta_pct": -0.33,
+            "spread_pct": [
+                1.2,
+                0.8
+            ],
+            "system_runs_ms": [
+                1443.3674,
+                1443.3199,
+                1455.0393,
+                1457.8843,
+                1461.2859,
+                1457.9058,
+                1461.5286
+            ],
+            "bundled_runs_ms": [
+                1456.186,
+                1445.5295,
+                1456.8962,
+                1451.0049,
+                1449.1989,
+                1453.1372,
+                1451.6506
+            ],
+            "paired_ratios": [
+                1.00888,
+                1.00153,
+                1.00128,
+                0.99528,
+                0.99173,
+                0.99673,
+                0.99324
+            ]
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99461,
+            "delta_pct": -0.54,
+            "ci_delta_pct": [
+                -0.85,
+                0.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.54,
+                "B2/C2": 0.16,
+                "B3/C3": -0.93
+            },
+            "build_spread_pct": 1.09,
+            "builds": 3,
+            "system_ms": 658.0594,
+            "bundled_ms": 654.4146,
+            "raw_delta_pct": -0.53,
+            "spread_pct": [
+                1.3,
+                1
+            ],
+            "system_runs_ms": [
+                658.0594,
+                656.4065,
+                658.0793,
+                660.0128,
+                656.279,
+                658.6609,
+                651.7415
+            ],
+            "bundled_runs_ms": [
+                654.5555,
+                657.4986,
+                653.7523,
+                654.4146,
+                657.3599,
+                650.8018,
+                652.5005
+            ],
+            "paired_ratios": [
+                0.99468,
+                1.00166,
+                0.99342,
+                0.99152,
+                1.00165,
+                0.98807,
+                1.00116
+            ]
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99752,
+            "delta_pct": -0.25,
+            "ci_delta_pct": [
+                -0.3,
+                -0.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.06,
+                "B2/C2": -0.28,
+                "B3/C3": -0.17
+            },
+            "build_spread_pct": 0.22,
+            "builds": 3,
+            "system_ms": 676.7769,
+            "bundled_ms": 675.8546,
+            "raw_delta_pct": -0.24,
+            "spread_pct": [
+                0.3,
+                0.2
+            ],
+            "system_runs_ms": [
+                676.3714,
+                676.7769,
+                676.1229,
+                676.9902,
+                677.0647,
+                678.1581,
+                675.9835
+            ],
+            "bundled_runs_ms": [
+                676.0118,
+                674.7658,
+                675.8546,
+                674.7686,
+                675.4309,
+                676.2063,
+                676.0883
+            ],
+            "paired_ratios": [
+                0.99947,
+                0.99703,
+                0.9996,
+                0.99672,
+                0.99759,
+                0.99712,
+                1.00016
+            ]
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99979,
+            "delta_pct": -0.02,
+            "ci_delta_pct": [
+                -0.21,
+                0.17
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.02,
+                "B2/C2": -0.12,
+                "B3/C3": 0.21
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 302.4911,
+            "bundled_ms": 302.2706,
+            "raw_delta_pct": -0.01,
+            "spread_pct": [
+                0.4,
+                0.6
+            ],
+            "system_runs_ms": [
+                301.7267,
+                302.3116,
+                302.7712,
+                303.0522,
+                302.4911,
+                302.2172,
+                302.7623
+            ],
+            "bundled_runs_ms": [
+                302.2706,
+                302.2591,
+                303.6292,
+                301.877,
+                301.8856,
+                302.6785,
+                302.7196
+            ],
+            "paired_ratios": [
+                1.0018,
+                0.99983,
+                1.00283,
+                0.99612,
+                0.998,
+                1.00153,
+                0.99986
+            ]
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00158,
+            "delta_pct": 0.16,
+            "ci_delta_pct": [
+                -0.69,
+                0.55
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.55,
+                "B2/C2": -0.32,
+                "B3/C3": -0.28
+            },
+            "build_spread_pct": 0.87,
+            "builds": 3,
+            "system_ms": 1196.7711,
+            "bundled_ms": 1199.1589,
+            "raw_delta_pct": 0.16,
+            "spread_pct": [
+                1.1,
+                0.6
+            ],
+            "system_runs_ms": [
+                1196.4882,
+                1196.7711,
+                1204.3852,
+                1196.7252,
+                1207.8295,
+                1197.4384,
+                1195.1656
+            ],
+            "bundled_runs_ms": [
+                1203.1333,
+                1198.7457,
+                1196.1815,
+                1199.4586,
+                1198.2235,
+                1199.1589,
+                1203.8539
+            ],
+            "paired_ratios": [
+                1.00555,
+                1.00165,
+                0.99319,
+                1.00228,
+                0.99205,
+                1.00144,
+                1.00727
+            ]
+        },
+        "adv.forEach.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99341,
+            "delta_pct": -0.66,
+            "ci_delta_pct": [
+                -1.57,
+                0.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.16,
+                "B2/C2": -0.92,
+                "B3/C3": -1.24
+            },
+            "build_spread_pct": 1.4,
+            "builds": 3,
+            "system_ms": 191.4913,
+            "bundled_ms": 189.2088,
+            "raw_delta_pct": -0.65,
+            "spread_pct": [
+                2.2,
+                1.9
+            ],
+            "system_runs_ms": [
+                188.3301,
+                192.5708,
+                191.736,
+                191.7793,
+                191.4913,
+                189.4968,
+                188.8488
+            ],
+            "bundled_runs_ms": [
+                188.6499,
+                189.2088,
+                188.7412,
+                190.5277,
+                191.341,
+                187.7841,
+                191.4331
+            ],
+            "paired_ratios": [
+                1.0017,
+                0.98254,
+                0.98438,
+                0.99347,
+                0.99922,
+                0.99096,
+                1.01368
+            ]
+        },
+        "adv.forEach.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00279,
+            "delta_pct": 0.28,
+            "ci_delta_pct": [
+                -0.3,
+                0.74
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.3,
+                "B2/C2": 0.33,
+                "B3/C3": 0.46
+            },
+            "build_spread_pct": 0.76,
+            "builds": 3,
+            "system_ms": 354.2718,
+            "bundled_ms": 355.2179,
+            "raw_delta_pct": 0.29,
+            "spread_pct": [
+                0.3,
+                1.3
+            ],
+            "system_runs_ms": [
+                354.4656,
+                354.2718,
+                353.7296,
+                354.5587,
+                354.2062,
+                353.5141,
+                354.2804
+            ],
+            "bundled_runs_ms": [
+                353.317,
+                355.6096,
+                354.3725,
+                357.7588,
+                355.2179,
+                356.1392,
+                353.2424
+            ],
+            "paired_ratios": [
+                0.99676,
+                1.00378,
+                1.00182,
+                1.00903,
+                1.00286,
+                1.00743,
+                0.99707
+            ]
+        },
+        "adv.filter.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00144,
+            "delta_pct": 0.14,
+            "ci_delta_pct": [
+                -0.09,
+                0.3
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.3,
+                "B2/C2": 0.1,
+                "B3/C3": -0.08
+            },
+            "build_spread_pct": 0.38,
+            "builds": 3,
+            "system_ms": 273.3363,
+            "bundled_ms": 274.1818,
+            "raw_delta_pct": 0.15,
+            "spread_pct": [
+                1,
+                1.2
+            ],
+            "system_runs_ms": [
+                273.9368,
+                273.1097,
+                274.3544,
+                273.042,
+                275.9008,
+                273.2449,
+                273.3363
+            ],
+            "bundled_runs_ms": [
+                275.162,
+                273.8894,
+                274.7684,
+                272.8304,
+                275.6815,
+                272.4508,
+                274.1818
+            ],
+            "paired_ratios": [
+                1.00447,
+                1.00285,
+                1.00151,
+                0.99923,
+                0.99921,
+                0.99709,
+                1.00309
+            ]
+        },
+        "adv.filter.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00133,
+            "delta_pct": 0.13,
+            "ci_delta_pct": [
+                -0.13,
+                0.3
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.13,
+                "B2/C2": 0.03,
+                "B3/C3": 0.06
+            },
+            "build_spread_pct": 0.1,
+            "builds": 3,
+            "system_ms": 778.1213,
+            "bundled_ms": 779.4167,
+            "raw_delta_pct": 0.14,
+            "spread_pct": [
+                0.5,
+                1.3
+            ],
+            "system_runs_ms": [
+                781.3189,
+                778.2183,
+                777.5153,
+                778.1213,
+                779.6352,
+                778.088,
+                777.8136
+            ],
+            "bundled_runs_ms": [
+                780.3714,
+                779.4167,
+                776.1055,
+                786.174,
+                779.0178,
+                780.5108,
+                778.9007
+            ],
+            "paired_ratios": [
+                0.99879,
+                1.00154,
+                0.99819,
+                1.01035,
+                0.99921,
+                1.00311,
+                1.0014
+            ]
+        },
+        "adv.map.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99878,
+            "delta_pct": -0.12,
+            "ci_delta_pct": [
+                -0.31,
+                0.4
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.12,
+                "B2/C2": 0.16,
+                "B3/C3": -0.17
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 297.3932,
+            "bundled_ms": 297.005,
+            "raw_delta_pct": -0.12,
+            "spread_pct": [
+                0.6,
+                0.7
+            ],
+            "system_runs_ms": [
+                297.3932,
+                296.4656,
+                298.2774,
+                297.3481,
+                297.9866,
+                297.7154,
+                296.5485
+            ],
+            "bundled_runs_ms": [
+                297.0022,
+                298.7797,
+                298.1878,
+                297.005,
+                296.6816,
+                296.811,
+                297.7556
+            ],
+            "paired_ratios": [
+                0.99869,
+                1.00781,
+                0.9997,
+                0.99885,
+                0.99562,
+                0.99696,
+                1.00407
+            ]
+        },
+        "adv.map.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00176,
+            "delta_pct": 0.18,
+            "ci_delta_pct": [
+                -0.31,
+                0.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.06,
+                "B2/C2": -0.06,
+                "B3/C3": 0.25
+            },
+            "build_spread_pct": 0.31,
+            "builds": 3,
+            "system_ms": 1063.0113,
+            "bundled_ms": 1065.0726,
+            "raw_delta_pct": 0.18,
+            "spread_pct": [
+                0.4,
+                1.1
+            ],
+            "system_runs_ms": [
+                1063.0113,
+                1062.9835,
+                1064.7338,
+                1062.6359,
+                1066.0454,
+                1061.5137,
+                1065.2237
+            ],
+            "bundled_runs_ms": [
+                1062.4053,
+                1065.4901,
+                1066.6828,
+                1073.6319,
+                1062.3904,
+                1065.0726,
+                1061.943
+            ],
+            "paired_ratios": [
+                0.99943,
+                1.00236,
+                1.00183,
+                1.01035,
+                0.99657,
+                1.00335,
+                0.99692
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00466,
+            "delta_pct": 0.47,
+            "ci_delta_pct": [
+                -0.35,
+                1.4
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 1.21,
+                "B2/C2": 3.8,
+                "B3/C3": 0.06
+            },
+            "build_spread_pct": 3.74,
+            "builds": 3,
+            "system_ms": 22.0149,
+            "bundled_ms": 22.0996,
+            "raw_delta_pct": 0.47,
+            "spread_pct": [
+                0.6,
+                7.6
+            ],
+            "system_runs_ms": [
+                22.1188,
+                22.0176,
+                21.9957,
+                22.0094,
+                22.0149,
+                22.0844,
+                22.0149
+            ],
+            "bundled_runs_ms": [
+                21.9717,
+                23.6439,
+                22.0996,
+                22.2762,
+                22.0638,
+                22.0076,
+                22.325
+            ],
+            "paired_ratios": [
+                0.99335,
+                1.07386,
+                1.00472,
+                1.01212,
+                1.00222,
+                0.99652,
+                1.01409
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99814,
+            "delta_pct": -0.19,
+            "ci_delta_pct": [
+                -0.82,
+                0.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.01,
+                "B2/C2": -0.64,
+                "B3/C3": -0
+            },
+            "build_spread_pct": 0.64,
+            "builds": 3,
+            "system_ms": 12.8394,
+            "bundled_ms": 12.7521,
+            "raw_delta_pct": -0.18,
+            "spread_pct": [
+                1.1,
+                1.3
+            ],
+            "system_runs_ms": [
+                12.8572,
+                12.7916,
+                12.8249,
+                12.878,
+                12.8394,
+                12.7516,
+                12.89
+            ],
+            "bundled_runs_ms": [
+                12.7521,
+                12.743,
+                12.8487,
+                12.8777,
+                12.7244,
+                12.7287,
+                12.8962
+            ],
+            "paired_ratios": [
+                0.99183,
+                0.9962,
+                1.00186,
+                0.99998,
+                0.99104,
+                0.9982,
+                1.00048
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.98878,
+            "delta_pct": -1.12,
+            "ci_delta_pct": [
+                -1.35,
+                -0.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.21,
+                "B2/C2": -4.18,
+                "B3/C3": -0.06
+            },
+            "build_spread_pct": 4.12,
+            "builds": 3,
+            "system_ms": 58.3064,
+            "bundled_ms": 57.8093,
+            "raw_delta_pct": -1.12,
+            "spread_pct": [
+                1.4,
+                7.3
+            ],
+            "system_runs_ms": [
+                58.1278,
+                58.0972,
+                58.3064,
+                58.5114,
+                58.3214,
+                57.7402,
+                58.5514
+            ],
+            "bundled_runs_ms": [
+                58.0386,
+                53.8956,
+                58.1399,
+                57.8093,
+                57.6708,
+                57.8378,
+                57.766
+            ],
+            "paired_ratios": [
+                0.99847,
+                0.92768,
+                0.99714,
+                0.988,
+                0.98884,
+                1.00169,
+                0.98659
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99996,
+            "delta_pct": -0,
+            "ci_delta_pct": [
+                -0.27,
+                0.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.09,
+                "B2/C2": 4.08,
+                "B3/C3": -0.53
+            },
+            "build_spread_pct": 4.61,
+            "builds": 3,
+            "system_ms": 20.6024,
+            "bundled_ms": 20.5994,
+            "raw_delta_pct": 0,
+            "spread_pct": [
+                0.9,
+                8.9
+            ],
+            "system_runs_ms": [
+                20.6023,
+                20.6506,
+                20.7791,
+                20.5985,
+                20.6024,
+                20.6096,
+                20.5993
+            ],
+            "bundled_runs_ms": [
+                20.6214,
+                22.3911,
+                20.5994,
+                20.5991,
+                20.5485,
+                20.5707,
+                20.6475
+            ],
+            "paired_ratios": [
+                1.00093,
+                1.08428,
+                0.99135,
+                1.00003,
+                0.99738,
+                0.99811,
+                1.00234
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00028,
+            "delta_pct": 0.03,
+            "ci_delta_pct": [
+                -0.44,
+                0.06
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.05,
+                "B2/C2": -0.12,
+                "B3/C3": -0.02
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 10.5601,
+            "bundled_ms": 10.5611,
+            "raw_delta_pct": 0.03,
+            "spread_pct": [
+                4,
+                0.6
+            ],
+            "system_runs_ms": [
+                10.5601,
+                10.5595,
+                10.5617,
+                10.9719,
+                10.5622,
+                10.5575,
+                10.5488
+            ],
+            "bundled_runs_ms": [
+                10.5662,
+                10.5807,
+                10.5563,
+                10.5761,
+                10.5164,
+                10.5611,
+                10.5563
+            ],
+            "paired_ratios": [
+                1.00058,
+                1.00201,
+                0.99949,
+                0.96393,
+                0.99566,
+                1.00034,
+                1.00071
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99831,
+            "delta_pct": -0.17,
+            "ci_delta_pct": [
+                -3.62,
+                0.22
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.17,
+                "B2/C2": -3.89,
+                "B3/C3": 0.52
+            },
+            "build_spread_pct": 4.41,
+            "builds": 3,
+            "system_ms": 51.226,
+            "bundled_ms": 51.239,
+            "raw_delta_pct": -0.16,
+            "spread_pct": [
+                4.8,
+                8
+            ],
+            "system_runs_ms": [
+                51.2568,
+                51.1343,
+                50.8285,
+                53.2656,
+                51.267,
+                51.226,
+                51.2097
+            ],
+            "bundled_runs_ms": [
+                51.239,
+                47.2543,
+                51.2456,
+                51.3424,
+                51.1782,
+                51.3404,
+                51.1263
+            ],
+            "paired_ratios": [
+                0.99965,
+                0.92412,
+                1.00821,
+                0.96389,
+                0.99827,
+                1.00223,
+                0.99837
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99904,
+            "delta_pct": -0.1,
+            "ci_delta_pct": [
+                -0.5,
+                1.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.1,
+                "B2/C2": 3.21,
+                "B3/C3": -0.35
+            },
+            "build_spread_pct": 3.56,
+            "builds": 3,
+            "system_ms": 29.2795,
+            "bundled_ms": 29.2533,
+            "raw_delta_pct": -0.09,
+            "spread_pct": [
+                1,
+                7.1
+            ],
+            "system_runs_ms": [
+                29.2795,
+                29.23,
+                29.4601,
+                29.1595,
+                29.3255,
+                29.1591,
+                29.2937
+            ],
+            "bundled_runs_ms": [
+                29.2533,
+                31.2548,
+                29.2506,
+                29.4573,
+                29.1812,
+                29.1681,
+                29.2539
+            ],
+            "paired_ratios": [
+                0.99911,
+                1.06927,
+                0.99289,
+                1.01021,
+                0.99508,
+                1.00031,
+                0.99864
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99949,
+            "delta_pct": -0.05,
+            "ci_delta_pct": [
+                -0.58,
+                0.3
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.05,
+                "B2/C2": 0.36,
+                "B3/C3": -0.35
+            },
+            "build_spread_pct": 0.71,
+            "builds": 3,
+            "system_ms": 17.9729,
+            "bundled_ms": 17.9527,
+            "raw_delta_pct": -0.04,
+            "spread_pct": [
+                0.8,
+                1.4
+            ],
+            "system_runs_ms": [
+                18.0305,
+                17.8862,
+                17.9989,
+                17.9249,
+                18.0209,
+                17.9284,
+                17.9729
+            ],
+            "bundled_runs_ms": [
+                18.0224,
+                18.1197,
+                17.8625,
+                17.9792,
+                17.9182,
+                17.9409,
+                17.9527
+            ],
+            "paired_ratios": [
+                0.99955,
+                1.01305,
+                0.99242,
+                1.00303,
+                0.9943,
+                1.0007,
+                0.99888
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99947,
+            "delta_pct": -0.05,
+            "ci_delta_pct": [
+                -0.72,
+                0.03
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.02,
+                "B2/C2": -2.67,
+                "B3/C3": -0.01
+            },
+            "build_spread_pct": 2.69,
+            "builds": 3,
+            "system_ms": 61.4514,
+            "bundled_ms": 61.3687,
+            "raw_delta_pct": -0.05,
+            "spread_pct": [
+                0.8,
+                5.9
+            ],
+            "system_runs_ms": [
+                61.5807,
+                61.1912,
+                61.0959,
+                61.4719,
+                61.4514,
+                61.4846,
+                61.3542
+            ],
+            "bundled_runs_ms": [
+                61.6079,
+                57.9743,
+                61.0673,
+                61.0346,
+                61.403,
+                61.5084,
+                61.3687
+            ],
+            "paired_ratios": [
+                1.00044,
+                0.94743,
+                0.99953,
+                0.99289,
+                0.99921,
+                1.00039,
+                1.00024
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00003,
+            "delta_pct": 0,
+            "ci_delta_pct": [
+                -0.06,
+                0.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.14,
+                "B2/C2": 0.1,
+                "B3/C3": -0.03
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 16.3043,
+            "bundled_ms": 16.3088,
+            "raw_delta_pct": 0.01,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                16.367,
+                16.2671,
+                16.3199,
+                16.3279,
+                16.3043,
+                16.2846,
+                16.1946
+            ],
+            "bundled_runs_ms": [
+                16.3911,
+                16.3088,
+                16.3116,
+                16.2704,
+                16.2982,
+                16.2861,
+                16.3283
+            ],
+            "paired_ratios": [
+                1.00147,
+                1.00256,
+                0.99949,
+                0.99648,
+                0.99963,
+                1.00009,
+                1.00826
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99969,
+            "delta_pct": -0.03,
+            "ci_delta_pct": [
+                -0.18,
+                0.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.31,
+                "B2/C2": -0.32,
+                "B3/C3": -0.1
+            },
+            "build_spread_pct": 0.63,
+            "builds": 3,
+            "system_ms": 18.928,
+            "bundled_ms": 18.9258,
+            "raw_delta_pct": -0.02,
+            "spread_pct": [
+                0.8,
+                0.8
+            ],
+            "system_runs_ms": [
+                18.928,
+                19.0237,
+                19.0034,
+                18.8764,
+                18.9162,
+                18.9545,
+                18.8653
+            ],
+            "bundled_runs_ms": [
+                19.0429,
+                18.9207,
+                18.9708,
+                18.9175,
+                18.8988,
+                18.9498,
+                18.9258
+            ],
+            "paired_ratios": [
+                1.00607,
+                0.99459,
+                0.99828,
+                1.00218,
+                0.99908,
+                0.99975,
+                1.00321
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99939,
+            "delta_pct": -0.06,
+            "ci_delta_pct": [
+                -0.51,
+                0.45
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.45,
+                "B2/C2": -0.43,
+                "B3/C3": -0.08
+            },
+            "build_spread_pct": 0.88,
+            "builds": 3,
+            "system_ms": 116.3955,
+            "bundled_ms": 116.1784,
+            "raw_delta_pct": -0.05,
+            "spread_pct": [
+                1.1,
+                0.4
+            ],
+            "system_runs_ms": [
+                115.6471,
+                116.9458,
+                116.4428,
+                115.6084,
+                116.0193,
+                116.3955,
+                116.4908
+            ],
+            "bundled_runs_ms": [
+                116.1784,
+                116.0153,
+                116.3028,
+                116.269,
+                115.9565,
+                116.3559,
+                115.9085
+            ],
+            "paired_ratios": [
+                1.00459,
+                0.99204,
+                0.9988,
+                1.00571,
+                0.99946,
+                0.99966,
+                0.995
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99704,
+            "delta_pct": -0.3,
+            "ci_delta_pct": [
+                -0.52,
+                0.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.23,
+                "B2/C2": -0.45,
+                "B3/C3": -0.15
+            },
+            "build_spread_pct": 0.3,
+            "builds": 3,
+            "system_ms": 16.2649,
+            "bundled_ms": 16.2288,
+            "raw_delta_pct": -0.29,
+            "spread_pct": [
+                0.8,
+                0.6
+            ],
+            "system_runs_ms": [
+                16.2649,
+                16.2686,
+                16.2495,
+                16.25,
+                16.346,
+                16.3008,
+                16.2163
+            ],
+            "bundled_runs_ms": [
+                16.2288,
+                16.2057,
+                16.2928,
+                16.2029,
+                16.2628,
+                16.212,
+                16.2437
+            ],
+            "paired_ratios": [
+                0.99778,
+                0.99613,
+                1.00266,
+                0.9971,
+                0.99491,
+                0.99455,
+                1.00169
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00261,
+            "delta_pct": 0.26,
+            "ci_delta_pct": [
+                -0.29,
+                0.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.27,
+                "B2/C2": -0.01,
+                "B3/C3": -0.02
+            },
+            "build_spread_pct": 0.29,
+            "builds": 3,
+            "system_ms": 19.0357,
+            "bundled_ms": 19.0481,
+            "raw_delta_pct": 0.27,
+            "spread_pct": [
+                0.7,
+                0.9
+            ],
+            "system_runs_ms": [
+                19.0553,
+                19.0829,
+                19.0288,
+                19.0306,
+                19.0357,
+                19.108,
+                18.9787
+            ],
+            "bundled_runs_ms": [
+                19.0478,
+                19.0297,
+                19.0819,
+                19.209,
+                19.0866,
+                19.0481,
+                19.0306
+            ],
+            "paired_ratios": [
+                0.99961,
+                0.99721,
+                1.00279,
+                1.00937,
+                1.00267,
+                0.99687,
+                1.00273
+            ]
+        },
+        "adv.optiter.ratio.increment.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00177,
+            "delta_pct": 0.18,
+            "ci_delta_pct": [
+                0.1,
+                0.77
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.18,
+                "B2/C2": 0.44,
+                "B3/C3": 0.12
+            },
+            "build_spread_pct": 0.32,
+            "builds": 3,
+            "system_ms": 117.1117,
+            "bundled_ms": 117.3705,
+            "raw_delta_pct": 0.18,
+            "spread_pct": [
+                0.7,
+                1.2
+            ],
+            "system_runs_ms": [
+                117.156,
+                117.2993,
+                117.1038,
+                117.1117,
+                116.4549,
+                117.2215,
+                117.0348
+            ],
+            "bundled_runs_ms": [
+                117.3705,
+                117.4263,
+                117.1184,
+                118.5524,
+                117.3636,
+                117.4939,
+                117.1568
+            ],
+            "paired_ratios": [
+                1.00183,
+                1.00108,
+                1.00012,
+                1.0123,
+                1.0078,
+                1.00232,
+                1.00104
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00159,
+            "delta_pct": 0.16,
+            "ci_delta_pct": [
+                -0.13,
+                0.81
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.31,
+                "B2/C2": 0.55,
+                "B3/C3": -0.08
+            },
+            "build_spread_pct": 0.63,
+            "builds": 3,
+            "system_ms": 30.1553,
+            "bundled_ms": 30.164,
+            "raw_delta_pct": 0.17,
+            "spread_pct": [
+                0.4,
+                1.5
+            ],
+            "system_runs_ms": [
+                30.0805,
+                30.1748,
+                30.1659,
+                30.1553,
+                30.2024,
+                30.1118,
+                30.075
+            ],
+            "bundled_runs_ms": [
+                30.1302,
+                30.5504,
+                30.0964,
+                30.403,
+                30.164,
+                30.139,
+                30.1697
+            ],
+            "paired_ratios": [
+                1.00165,
+                1.01245,
+                0.9977,
+                1.00821,
+                0.99873,
+                1.0009,
+                1.00315
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00405,
+            "delta_pct": 0.41,
+            "ci_delta_pct": [
+                0.04,
+                1.58
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 1.01,
+                "B2/C2": 0.26,
+                "B3/C3": 0.82
+            },
+            "build_spread_pct": 0.75,
+            "builds": 3,
+            "system_ms": 13.9597,
+            "bundled_ms": 14.0233,
+            "raw_delta_pct": 0.41,
+            "spread_pct": [
+                0.8,
+                1.7
+            ],
+            "system_runs_ms": [
+                13.9597,
+                13.9658,
+                13.9112,
+                13.9564,
+                13.9926,
+                13.9583,
+                14.026
+            ],
+            "bundled_runs_ms": [
+                13.9662,
+                14.0233,
+                14.1589,
+                14.1774,
+                14.01,
+                13.9405,
+                14.1685
+            ],
+            "paired_ratios": [
+                1.00047,
+                1.00412,
+                1.01781,
+                1.01584,
+                1.00124,
+                0.99872,
+                1.01016
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00246,
+            "delta_pct": 0.25,
+            "ci_delta_pct": [
+                -0.22,
+                0.75
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.69,
+                "B2/C2": -0.29,
+                "B3/C3": 0.89
+            },
+            "build_spread_pct": 1.18,
+            "builds": 3,
+            "system_ms": 46.3295,
+            "bundled_ms": 46.4463,
+            "raw_delta_pct": 0.25,
+            "spread_pct": [
+                1.1,
+                2.5
+            ],
+            "system_runs_ms": [
+                46.4079,
+                46.2831,
+                46.1156,
+                46.2817,
+                46.3295,
+                46.355,
+                46.6367
+            ],
+            "bundled_runs_ms": [
+                46.3528,
+                45.9022,
+                47.0453,
+                46.6316,
+                46.4463,
+                46.254,
+                46.9627
+            ],
+            "paired_ratios": [
+                0.99881,
+                0.99177,
+                1.02016,
+                1.00756,
+                1.00252,
+                0.99782,
+                1.00699
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00164,
+            "delta_pct": 0.16,
+            "ci_delta_pct": [
+                0.08,
+                0.61
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.12,
+                "B2/C2": 1.16,
+                "B3/C3": 0.35
+            },
+            "build_spread_pct": 1.04,
+            "builds": 3,
+            "system_ms": 29.2235,
+            "bundled_ms": 29.2602,
+            "raw_delta_pct": 0.17,
+            "spread_pct": [
+                0.8,
+                2.5
+            ],
+            "system_runs_ms": [
+                29.2235,
+                29.2662,
+                29.243,
+                29.0767,
+                29.2083,
+                29.1914,
+                29.3105
+            ],
+            "bundled_runs_ms": [
+                29.2602,
+                29.8669,
+                29.4247,
+                29.1264,
+                29.29,
+                29.2168,
+                29.1898
+            ],
+            "paired_ratios": [
+                1.00126,
+                1.02053,
+                1.00621,
+                1.00171,
+                1.0028,
+                1.00087,
+                0.99588
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00068,
+            "delta_pct": 0.07,
+            "ci_delta_pct": [
+                -0.18,
+                0.43
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.16,
+                "B2/C2": 0.48,
+                "B3/C3": -0.12
+            },
+            "build_spread_pct": 0.64,
+            "builds": 3,
+            "system_ms": 12.3768,
+            "bundled_ms": 12.4109,
+            "raw_delta_pct": 0.07,
+            "spread_pct": [
+                0.5,
+                1.4
+            ],
+            "system_runs_ms": [
+                12.4321,
+                12.3754,
+                12.3788,
+                12.3745,
+                12.3768,
+                12.3746,
+                12.3967
+            ],
+            "bundled_runs_ms": [
+                12.4109,
+                12.3846,
+                12.4134,
+                12.429,
+                12.4886,
+                12.3116,
+                12.3778
+            ],
+            "paired_ratios": [
+                0.99829,
+                1.00074,
+                1.0028,
+                1.0044,
+                1.00903,
+                0.99491,
+                0.99848
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99698,
+            "delta_pct": -0.3,
+            "ci_delta_pct": [
+                -0.6,
+                0.26
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.25,
+                "B2/C2": -0.66,
+                "B3/C3": -0.47
+            },
+            "build_spread_pct": 0.91,
+            "builds": 3,
+            "system_ms": 42.3743,
+            "bundled_ms": 42.4046,
+            "raw_delta_pct": -0.3,
+            "spread_pct": [
+                0.6,
+                2.8
+            ],
+            "system_runs_ms": [
+                42.5414,
+                42.2856,
+                42.3309,
+                42.5582,
+                42.3743,
+                42.3913,
+                42.2944
+            ],
+            "bundled_runs_ms": [
+                42.4157,
+                41.4659,
+                42.1871,
+                42.6727,
+                42.6377,
+                42.1387,
+                42.4046
+            ],
+            "paired_ratios": [
+                0.99705,
+                0.98062,
+                0.9966,
+                1.00269,
+                1.00622,
+                0.99404,
+                1.00261
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99844,
+            "delta_pct": -0.16,
+            "ci_delta_pct": [
+                -0.36,
+                -0.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.2,
+                "B2/C2": 0.36,
+                "B3/C3": -0.23
+            },
+            "build_spread_pct": 0.59,
+            "builds": 3,
+            "system_ms": 39.5282,
+            "bundled_ms": 39.4543,
+            "raw_delta_pct": -0.15,
+            "spread_pct": [
+                0.5,
+                1.4
+            ],
+            "system_runs_ms": [
+                39.5506,
+                39.5282,
+                39.4945,
+                39.3549,
+                39.5391,
+                39.4846,
+                39.5628
+            ],
+            "bundled_runs_ms": [
+                39.4732,
+                39.8585,
+                39.4543,
+                39.2959,
+                39.5012,
+                39.3467,
+                39.3645
+            ],
+            "paired_ratios": [
+                0.99804,
+                1.00836,
+                0.99898,
+                0.9985,
+                0.99904,
+                0.99651,
+                0.99499
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99681,
+            "delta_pct": -0.32,
+            "ci_delta_pct": [
+                -0.48,
+                0.62
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.48,
+                "B2/C2": 0.28,
+                "B3/C3": -0.32
+            },
+            "build_spread_pct": 0.76,
+            "builds": 3,
+            "system_ms": 21.6917,
+            "bundled_ms": 21.6275,
+            "raw_delta_pct": -0.31,
+            "spread_pct": [
+                1,
+                1
+            ],
+            "system_runs_ms": [
+                21.7157,
+                21.7347,
+                21.6306,
+                21.6441,
+                21.5074,
+                21.6917,
+                21.7205
+            ],
+            "bundled_runs_ms": [
+                21.6121,
+                21.6667,
+                21.5598,
+                21.7793,
+                21.6988,
+                21.6275,
+                21.5714
+            ],
+            "paired_ratios": [
+                0.99523,
+                0.99687,
+                0.99673,
+                1.00625,
+                1.0089,
+                0.99704,
+                0.99314
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99807,
+            "delta_pct": -0.19,
+            "ci_delta_pct": [
+                -0.29,
+                0.77
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.19,
+                "B2/C2": -0.08,
+                "B3/C3": -0.09
+            },
+            "build_spread_pct": 0.11,
+            "builds": 3,
+            "system_ms": 54.9061,
+            "bundled_ms": 54.7991,
+            "raw_delta_pct": -0.19,
+            "spread_pct": [
+                1.1,
+                1.9
+            ],
+            "system_runs_ms": [
+                54.9061,
+                54.9851,
+                54.7687,
+                54.9973,
+                54.3954,
+                54.9372,
+                54.9013
+            ],
+            "bundled_runs_ms": [
+                54.7512,
+                54.359,
+                54.645,
+                55.4239,
+                54.932,
+                54.9663,
+                54.7991
+            ],
+            "paired_ratios": [
+                0.99718,
+                0.98861,
+                0.99774,
+                1.00776,
+                1.00986,
+                1.00053,
+                0.99814
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00018,
+            "delta_pct": 0.02,
+            "ci_delta_pct": [
+                -0.12,
+                0.19
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.02,
+                "B2/C2": 0.09,
+                "B3/C3": -0.17
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 24.5312,
+            "bundled_ms": 24.4643,
+            "raw_delta_pct": 0.02,
+            "spread_pct": [
+                1.1,
+                1.2
+            ],
+            "system_runs_ms": [
+                24.4004,
+                24.4885,
+                24.5345,
+                24.5662,
+                24.5312,
+                24.4441,
+                24.6614
+            ],
+            "bundled_runs_ms": [
+                24.4063,
+                24.4643,
+                24.4403,
+                24.5384,
+                24.6019,
+                24.4558,
+                24.7088
+            ],
+            "paired_ratios": [
+                1.00024,
+                0.99901,
+                0.99616,
+                0.99887,
+                1.00288,
+                1.00048,
+                1.00192
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99877,
+            "delta_pct": -0.12,
+            "ci_delta_pct": [
+                -0.26,
+                0.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.12,
+                "B2/C2": -0.03,
+                "B3/C3": -0.12
+            },
+            "build_spread_pct": 0.09,
+            "builds": 3,
+            "system_ms": 26.2319,
+            "bundled_ms": 26.2199,
+            "raw_delta_pct": -0.12,
+            "spread_pct": [
+                0.4,
+                0.5
+            ],
+            "system_runs_ms": [
+                26.1625,
+                26.1964,
+                26.2382,
+                26.2687,
+                26.271,
+                26.2319,
+                26.2065
+            ],
+            "bundled_runs_ms": [
+                26.2199,
+                26.2612,
+                26.1729,
+                26.2381,
+                26.1958,
+                26.2396,
+                26.1409
+            ],
+            "paired_ratios": [
+                1.00219,
+                1.00247,
+                0.99751,
+                0.99884,
+                0.99714,
+                1.00029,
+                0.9975
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9999,
+            "delta_pct": -0.01,
+            "ci_delta_pct": [
+                -0.45,
+                0.19
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.01,
+                "B2/C2": -0.12,
+                "B3/C3": 0.05
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 106.9745,
+            "bundled_ms": 107.089,
+            "raw_delta_pct": -0,
+            "spread_pct": [
+                1,
+                1.5
+            ],
+            "system_runs_ms": [
+                107.2214,
+                106.9745,
+                106.944,
+                106.9303,
+                107.0922,
+                107.3141,
+                106.2653
+            ],
+            "bundled_runs_ms": [
+                107.4311,
+                107.345,
+                107.089,
+                106.9264,
+                106.4788,
+                107.2943,
+                105.7959
+            ],
+            "paired_ratios": [
+                1.00196,
+                1.00346,
+                1.00136,
+                0.99996,
+                0.99427,
+                0.99982,
+                0.99558
+            ]
+        }
+    },
+    "array_vs_bundled": {
+        "core.bitset.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.15657,
+            "delta_pct": 15.66,
+            "ci_delta_pct": [
+                15.29,
+                16.37
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                89.6848,
+                89.0306,
+                89.096,
+                89.2851,
+                88.8262,
+                89.0783,
+                89.0926
+            ],
+            "judy_runs_ms": [
+                103.5291,
+                103.6014,
+                104.2582,
+                102.9388,
+                103.2904,
+                102.5941,
+                103.042
+            ],
+            "array_ms": 89.0926,
+            "judy_ms": 103.2904,
+            "judy_over_array": 1.159,
+            "winner": "php-array"
+        },
+        "core.bitset.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.00323,
+            "delta_pct": 200.32,
+            "ci_delta_pct": [
+                200.14,
+                206.58
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                23.3201,
+                22.4005,
+                21.9358,
+                22.1006,
+                22.4613,
+                22.511,
+                22.0234
+            ],
+            "judy_runs_ms": [
+                66.6627,
+                67.2739,
+                67.6274,
+                67.4609,
+                67.4508,
+                67.5643,
+                67.5195
+            ],
+            "array_ms": 22.4005,
+            "judy_ms": 67.4609,
+            "judy_over_array": 3.012,
+            "winner": "php-array"
+        },
+        "core.bitset.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.72311,
+            "delta_pct": 472.31,
+            "ci_delta_pct": [
+                468.74,
+                473.69
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.7309,
+                18.7535,
+                18.7155,
+                18.7883,
+                18.7474,
+                18.7237,
+                18.7827
+            ],
+            "judy_runs_ms": [
+                107.4569,
+                107.3283,
+                107.3677,
+                105.5746,
+                107.1974,
+                107.6647,
+                106.8242
+            ],
+            "array_ms": 18.7474,
+            "judy_ms": 107.3283,
+            "judy_over_array": 5.725,
+            "winner": "php-array"
+        },
+        "core.bitset.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.0034,
+            "delta_pct": -99.66,
+            "ci_delta_pct": [
+                -99.67,
+                -99.65
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.3832,
+                5.442,
+                5.4037,
+                5.4495,
+                5.3465,
+                5.2573,
+                5.5001
+            ],
+            "judy_runs_ms": [
+                0.0183,
+                0.0181,
+                0.0181,
+                0.019,
+                0.0187,
+                0.0181,
+                0.0187
+            ],
+            "array_ms": 5.4037,
+            "judy_ms": 0.0183,
+            "judy_over_array": 0.003,
+            "winner": "php-judy"
+        },
+        "core.int_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.57273,
+            "delta_pct": 57.27,
+            "ci_delta_pct": [
+                57.07,
+                57.64
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                91.7713,
+                92.1225,
+                92.0658,
+                91.9022,
+                91.9396,
+                91.933,
+                91.9924
+            ],
+            "judy_runs_ms": [
+                144.7552,
+                144.6974,
+                144.8036,
+                144.537,
+                144.9315,
+                144.092,
+                144.625
+            ],
+            "array_ms": 91.9396,
+            "judy_ms": 144.6974,
+            "judy_over_array": 1.574,
+            "winner": "php-array"
+        },
+        "core.int_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.9739,
+            "delta_pct": 197.39,
+            "ci_delta_pct": [
+                190.07,
+                204.14
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                23.17,
+                22.0034,
+                22.6295,
+                22.5936,
+                22.147,
+                23.0878,
+                21.8186
+            ],
+            "judy_runs_ms": [
+                66.7937,
+                66.9204,
+                67.2474,
+                67.191,
+                66.9043,
+                66.9698,
+                66.8778
+            ],
+            "array_ms": 22.5936,
+            "judy_ms": 66.9204,
+            "judy_over_array": 2.962,
+            "winner": "php-array"
+        },
+        "core.int_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.07345,
+            "delta_pct": 507.35,
+            "ci_delta_pct": [
+                506.12,
+                509.04
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.6947,
+                18.6743,
+                18.624,
+                18.6386,
+                18.6031,
+                18.5909,
+                18.6304
+            ],
+            "judy_runs_ms": [
+                113.5414,
+                113.1879,
+                112.0413,
+                113.6168,
+                112.8464,
+                113.0049,
+                113.4669
+            ],
+            "array_ms": 18.6304,
+            "judy_ms": 113.1879,
+            "judy_over_array": 6.075,
+            "winner": "php-array"
+        },
+        "core.int_to_int.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.38332,
+            "delta_pct": -61.67,
+            "ci_delta_pct": [
+                -62.34,
+                -61.17
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.3387,
+                5.4205,
+                5.4738,
+                5.4909,
+                5.4927,
+                5.5058,
+                5.5071
+            ],
+            "judy_runs_ms": [
+                2.1029,
+                2.0778,
+                2.1252,
+                2.1321,
+                2.0924,
+                2.0559,
+                2.0738
+            ],
+            "array_ms": 5.4909,
+            "judy_ms": 2.0924,
+            "judy_over_array": 0.381,
+            "winner": "php-judy"
+        },
+        "core.int_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.50535,
+            "delta_pct": 50.54,
+            "ci_delta_pct": [
+                50.22,
+                50.89
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                263.0329,
+                263.7963,
+                264.6691,
+                265.1122,
+                264.3359,
+                264.674,
+                264.6131
+            ],
+            "judy_runs_ms": [
+                397.121,
+                396.3035,
+                397.5835,
+                399.0877,
+                396.5925,
+                399.1289,
+                399.282
+            ],
+            "array_ms": 264.6131,
+            "judy_ms": 397.5835,
+            "judy_over_array": 1.503,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.30475,
+            "delta_pct": 130.48,
+            "ci_delta_pct": [
+                129.05,
+                130.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                119.6728,
+                120.3852,
+                120.4545,
+                120.5556,
+                120.4712,
+                121.0885,
+                120.9403
+            ],
+            "judy_runs_ms": [
+                277.0008,
+                277.4582,
+                277.8098,
+                277.4817,
+                277.7968,
+                277.3524,
+                276.9828
+            ],
+            "array_ms": 120.4712,
+            "judy_ms": 277.4582,
+            "judy_over_array": 2.303,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.7691,
+            "delta_pct": 276.91,
+            "ci_delta_pct": [
+                276.02,
+                277.6
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                84.716,
+                85.2443,
+                85.277,
+                85.2637,
+                85.2912,
+                85.1529,
+                85.1937
+            ],
+            "judy_runs_ms": [
+                319.1305,
+                320.5377,
+                321.4704,
+                321.3676,
+                320.4675,
+                322.8354,
+                321.692
+            ],
+            "array_ms": 85.2443,
+            "judy_ms": 321.3676,
+            "judy_over_array": 3.77,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.17558,
+            "delta_pct": 117.56,
+            "ci_delta_pct": [
+                117.31,
+                118.35
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                45.5028,
+                46.0041,
+                46.1975,
+                46.3683,
+                45.8931,
+                46.1491,
+                46.0045
+            ],
+            "judy_runs_ms": [
+                100.2224,
+                100.3994,
+                100.5065,
+                99.8373,
+                100.2094,
+                100.3138,
+                99.9715
+            ],
+            "array_ms": 46.0045,
+            "judy_ms": 100.2224,
+            "judy_over_array": 2.179,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.40497,
+            "delta_pct": 40.5,
+            "ci_delta_pct": [
+                40.15,
+                40.62
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                246.5169,
+                246.8007,
+                246.7087,
+                246.8698,
+                246.3533,
+                246.6245,
+                246.8507
+            ],
+            "judy_runs_ms": [
+                346.8016,
+                344.7244,
+                345.7733,
+                347.1362,
+                345.5332,
+                346.499,
+                347.0186
+            ],
+            "array_ms": 246.7087,
+            "judy_ms": 346.499,
+            "judy_over_array": 1.404,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.93013,
+            "delta_pct": 93.01,
+            "ci_delta_pct": [
+                92.31,
+                93.72
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                106.0976,
+                106.4081,
+                106.565,
+                106.6997,
+                106.515,
+                106.8346,
+                106.5811
+            ],
+            "judy_runs_ms": [
+                206.1502,
+                205.1234,
+                205.7526,
+                205.1955,
+                206.3378,
+                205.1923,
+                205.7159
+            ],
+            "array_ms": 106.565,
+            "judy_ms": 205.7159,
+            "judy_over_array": 1.93,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 11.5403,
+            "delta_pct": 1054.03,
+            "ci_delta_pct": [
+                1046.01,
+                1056.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                21.3681,
+                21.4118,
+                21.4557,
+                21.4356,
+                21.4491,
+                21.6486,
+                21.4891
+            ],
+            "judy_runs_ms": [
+                246.7407,
+                247.0867,
+                251.1994,
+                247.9423,
+                247.529,
+                248.0531,
+                246.2668
+            ],
+            "array_ms": 21.4491,
+            "judy_ms": 247.529,
+            "judy_over_array": 11.54,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.10956,
+            "delta_pct": 10.96,
+            "ci_delta_pct": [
+                10.82,
+                12.02
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                46.5067,
+                46.6748,
+                46.9316,
+                46.943,
+                46.8586,
+                46.9425,
+                46.9365
+            ],
+            "judy_runs_ms": [
+                52.2361,
+                52.2872,
+                52.2554,
+                52.086,
+                51.9538,
+                52.0205,
+                51.9369
+            ],
+            "array_ms": 46.9316,
+            "judy_ms": 52.086,
+            "judy_over_array": 1.11,
+            "winner": "php-array"
+        },
+        "api.increment.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.52622,
+            "delta_pct": 152.62,
+            "ci_delta_pct": [
+                151.29,
+                153.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                57.4264,
+                57.3282,
+                57.1079,
+                57.2335,
+                57.3308,
+                57.5099,
+                57.4161
+            ],
+            "judy_runs_ms": [
+                145.046,
+                144.8236,
+                144.84,
+                145.0326,
+                145.6087,
+                144.5177,
+                144.2171
+            ],
+            "array_ms": 57.3308,
+            "judy_ms": 144.84,
+            "judy_over_array": 2.526,
+            "winner": "php-array"
+        },
+        "api.setop.union.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.97392,
+            "delta_pct": 97.39,
+            "ci_delta_pct": [
+                97.03,
+                97.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.084,
+                92.3861,
+                92.3199,
+                92.2163,
+                92.2997,
+                92.4636,
+                92.4196
+            ],
+            "judy_runs_ms": [
+                181.5513,
+                182.4452,
+                181.9018,
+                182.2432,
+                180.8925,
+                183.5307,
+                182.4286
+            ],
+            "array_ms": 92.3199,
+            "judy_ms": 182.2432,
+            "judy_over_array": 1.974,
+            "winner": "php-array"
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91316,
+            "delta_pct": -8.68,
+            "ci_delta_pct": [
+                -9,
+                -8.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                95.3642,
+                95.5221,
+                95.2784,
+                95.3289,
+                95.2379,
+                95.3282,
+                95.2779
+            ],
+            "judy_runs_ms": [
+                87.0823,
+                87.2857,
+                86.7014,
+                86.6387,
+                87.023,
+                87.0973,
+                86.739
+            ],
+            "array_ms": 95.3282,
+            "judy_ms": 87.023,
+            "judy_over_array": 0.913,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.00127,
+            "delta_pct": 100.13,
+            "ci_delta_pct": [
+                99.13,
+                100.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                43.0903,
+                43.0712,
+                42.8964,
+                43.1818,
+                42.9419,
+                43.0001,
+                43.3038
+            ],
+            "judy_runs_ms": [
+                85.9068,
+                86.1973,
+                86.0446,
+                85.9896,
+                86.188,
+                86.203,
+                86.1807
+            ],
+            "array_ms": 43.0712,
+            "judy_ms": 86.1807,
+            "judy_over_array": 2.001,
+            "winner": "php-array"
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78097,
+            "delta_pct": -21.9,
+            "ci_delta_pct": [
+                -21.99,
+                -21.85
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                221.2381,
+                220.7149,
+                220.3835,
+                221.5829,
+                220.9355,
+                220.8733,
+                221.3108
+            ],
+            "judy_runs_ms": [
+                172.6333,
+                172.1726,
+                172.7222,
+                172.573,
+                172.658,
+                172.5479,
+                172.8364
+            ],
+            "array_ms": 220.9355,
+            "judy_ms": 172.6333,
+            "judy_over_array": 0.781,
+            "winner": "php-judy"
+        }
+    },
+    "judy_vs_phploop": {
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69163,
+            "delta_pct": -30.84,
+            "ci_delta_pct": [
+                -31.2,
+                -30.13
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                183.9409,
+                182.564,
+                184.1205,
+                184.2078,
+                181.0401,
+                181.7061,
+                184.2404
+            ],
+            "judy_runs_ms": [
+                127.219,
+                128.8889,
+                126.9472,
+                126.7272,
+                126.3701,
+                126.959,
+                126.6164
+            ],
+            "array_ms": 183.9409,
+            "judy_ms": 126.9472,
+            "judy_over_array": 0.69,
+            "winner": "php-judy"
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69689,
+            "delta_pct": -30.31,
+            "ci_delta_pct": [
+                -31.32,
+                -30.3
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                183.9409,
+                182.564,
+                184.1205,
+                184.2078,
+                181.0401,
+                181.7061,
+                184.2404
+            ],
+            "judy_runs_ms": [
+                128.1859,
+                127.7053,
+                126.0614,
+                126.9866,
+                126.1725,
+                126.6569,
+                126.5282
+            ],
+            "array_ms": 183.9409,
+            "judy_ms": 126.6569,
+            "judy_over_array": 0.689,
+            "winner": "php-judy"
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.81922,
+            "delta_pct": -18.08,
+            "ci_delta_pct": [
+                -19.43,
+                -17.28
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                361.8582,
+                361.0163,
+                369.6339,
+                369.9241,
+                362.8758,
+                361.3363,
+                363.5289
+            ],
+            "judy_runs_ms": [
+                299.3329,
+                300.5306,
+                297.5337,
+                298.0638,
+                296.8624,
+                296.6292,
+                297.8087
+            ],
+            "array_ms": 362.8758,
+            "judy_ms": 297.8087,
+            "judy_over_array": 0.821,
+            "winner": "php-judy"
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78267,
+            "delta_pct": -21.73,
+            "ci_delta_pct": [
+                -21.98,
+                -21.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                27.5093,
+                27.3961,
+                27.448,
+                27.3589,
+                27.4722,
+                27.3908,
+                27.3727
+            ],
+            "judy_runs_ms": [
+                21.4534,
+                21.3874,
+                21.5188,
+                21.4602,
+                21.5017,
+                21.5554,
+                21.3573
+            ],
+            "array_ms": 27.3961,
+            "judy_ms": 21.4602,
+            "judy_over_array": 0.783,
+            "winner": "php-judy"
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.59766,
+            "delta_pct": -40.23,
+            "ci_delta_pct": [
+                -40.33,
+                -39.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.608,
+                195.1364,
+                194.4017,
+                194.9093,
+                194.3223,
+                194.386,
+                194.0352
+            ],
+            "judy_runs_ms": [
+                117.0656,
+                116.3723,
+                116.7021,
+                116.3037,
+                116.1396,
+                116.1776,
+                116.3709
+            ],
+            "array_ms": 194.4017,
+            "judy_ms": 116.3709,
+            "judy_over_array": 0.599,
+            "winner": "php-judy"
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.62243,
+            "delta_pct": -37.76,
+            "ci_delta_pct": [
+                -37.89,
+                -37.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.7043,
+                195.0539,
+                194.6364,
+                194.2798,
+                195.0228,
+                194.0706,
+                194.0993
+            ],
+            "judy_runs_ms": [
+                121.7607,
+                121.1518,
+                121.2863,
+                121.3113,
+                120.7021,
+                120.796,
+                120.7032
+            ],
+            "array_ms": 194.6364,
+            "judy_ms": 121.1518,
+            "judy_over_array": 0.622,
+            "winner": "php-judy"
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.06833,
+            "delta_pct": -93.17,
+            "ci_delta_pct": [
+                -93.18,
+                -93.13
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                147.3523,
+                147.6245,
+                147.799,
+                148.2483,
+                147.7981,
+                147.5425,
+                147.3843
+            ],
+            "judy_runs_ms": [
+                10.1942,
+                10.1241,
+                10.0738,
+                10.1029,
+                10.0945,
+                10.1303,
+                10.071
+            ],
+            "array_ms": 147.6245,
+            "judy_ms": 10.1029,
+            "judy_over_array": 0.068,
+            "winner": "php-judy"
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41371,
+            "delta_pct": -58.63,
+            "ci_delta_pct": [
+                -58.92,
+                -58.52
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                117.2445,
+                117.7887,
+                117.2657,
+                117.8513,
+                117.5985,
+                117.2197,
+                117.4874
+            ],
+            "judy_runs_ms": [
+                48.5704,
+                48.2895,
+                48.6883,
+                48.5117,
+                48.6519,
+                48.6224,
+                48.2631
+            ],
+            "array_ms": 117.4874,
+            "judy_ms": 48.5704,
+            "judy_over_array": 0.413,
+            "winner": "php-judy"
+        },
+        "api.populationCount.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0,
+            "delta_pct": -100,
+            "ci_delta_pct": [
+                -100,
+                -100
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                118.5981,
+                118.5139,
+                118.8917,
+                118.5017,
+                118.7512,
+                118.5495,
+                118.9009
+            ],
+            "judy_runs_ms": [
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001
+            ],
+            "array_ms": 118.5981,
+            "judy_ms": 0.0001,
+            "judy_over_array": 0,
+            "winner": "php-judy"
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69731,
+            "delta_pct": -30.27,
+            "ci_delta_pct": [
+                -30.28,
+                -30.2
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                339.0827,
+                340.4971,
+                339.026,
+                338.7645,
+                339.0726,
+                340.6048,
+                338.4292
+            ],
+            "judy_runs_ms": [
+                236.6848,
+                237.4078,
+                236.367,
+                236.223,
+                236.4386,
+                236.2426,
+                237.1241
+            ],
+            "array_ms": 339.0726,
+            "judy_ms": 236.4386,
+            "judy_over_array": 0.697,
+            "winner": "php-judy"
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.25836,
+            "delta_pct": -74.16,
+            "ci_delta_pct": [
+                -74.24,
+                -74.02
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                275.2826,
+                274.3383,
+                275.0185,
+                275.4818,
+                275.6951,
+                279.0331,
+                275.7982
+            ],
+            "judy_runs_ms": [
+                70.9041,
+                71.5733,
+                70.9815,
+                71.4606,
+                71.2299,
+                71.1751,
+                71.6533
+            ],
+            "array_ms": 275.4818,
+            "judy_ms": 71.2299,
+            "judy_over_array": 0.259,
+            "winner": "php-judy"
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.52522,
+            "delta_pct": -47.48,
+            "ci_delta_pct": [
+                -48.04,
+                -47.42
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                511.7407,
+                512.6343,
+                508.2764,
+                508.1559,
+                512.1782,
+                510.8513,
+                507.4871
+            ],
+            "judy_runs_ms": [
+                266.0118,
+                266.3595,
+                267.2503,
+                266.9231,
+                265.5157,
+                268.6401,
+                266.542
+            ],
+            "array_ms": 510.8513,
+            "judy_ms": 266.542,
+            "judy_over_array": 0.522,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.4397,
+            "delta_pct": -56.03,
+            "ci_delta_pct": [
+                -56.17,
+                -55.95
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                248.2874,
+                248.9242,
+                247.4937,
+                247.8431,
+                250.7527,
+                248.6994,
+                247.4147
+            ],
+            "judy_runs_ms": [
+                109.3792,
+                109.0966,
+                109.2716,
+                108.9758,
+                109.1786,
+                109.4491,
+                108.6421
+            ],
+            "array_ms": 248.2874,
+            "judy_ms": 109.1786,
+            "judy_over_array": 0.44,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42062,
+            "delta_pct": -57.94,
+            "ci_delta_pct": [
+                -58.13,
+                -57.83
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                257.0943,
+                255.5964,
+                255.6251,
+                255.5157,
+                256.5155,
+                256.7289,
+                258.0161
+            ],
+            "judy_runs_ms": [
+                107.6443,
+                107.7892,
+                107.8352,
+                107.7468,
+                107.8966,
+                107.7316,
+                107.6231
+            ],
+            "array_ms": 256.5155,
+            "judy_ms": 107.7468,
+            "judy_over_array": 0.42,
+            "winner": "php-judy"
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.4223,
+            "delta_pct": -57.77,
+            "ci_delta_pct": [
+                -57.96,
+                -57.75
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                513.6419,
+                514.1964,
+                512.6318,
+                512.4351,
+                514.0115,
+                513.703,
+                518.191
+            ],
+            "judy_runs_ms": [
+                215.9122,
+                217.2443,
+                216.8814,
+                216.5292,
+                217.0656,
+                216.3146,
+                216.2607
+            ],
+            "array_ms": 513.703,
+            "judy_ms": 216.5292,
+            "judy_over_array": 0.422,
+            "winner": "php-judy"
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85484,
+            "delta_pct": -14.52,
+            "ci_delta_pct": [
+                -14.61,
+                -14.4
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1705.4141,
+                1695.7374,
+                1691.987,
+                1695.1918,
+                1695.2818,
+                1698.897,
+                1698.5351
+            ],
+            "judy_runs_ms": [
+                1456.186,
+                1445.5295,
+                1456.8962,
+                1451.0049,
+                1449.1989,
+                1453.1372,
+                1451.6506
+            ],
+            "array_ms": 1695.7374,
+            "judy_ms": 1451.6506,
+            "judy_over_array": 0.856,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83607,
+            "delta_pct": -16.39,
+            "ci_delta_pct": [
+                -16.52,
+                -16.02
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                782.895,
+                778.9871,
+                780.6602,
+                783.3191,
+                782.7751,
+                779.5563,
+                781.885
+            ],
+            "judy_runs_ms": [
+                654.5555,
+                657.4986,
+                653.7523,
+                654.4146,
+                657.3599,
+                650.8018,
+                652.5005
+            ],
+            "array_ms": 781.885,
+            "judy_ms": 654.4146,
+            "judy_over_array": 0.837,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86328,
+            "delta_pct": -13.67,
+            "ci_delta_pct": [
+                -13.73,
+                -13.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                785.428,
+                781.721,
+                782.7709,
+                781.2465,
+                782.4031,
+                781.2483,
+                783.7065
+            ],
+            "judy_runs_ms": [
+                676.0118,
+                674.7658,
+                675.8546,
+                674.7686,
+                675.4309,
+                676.2063,
+                676.0883
+            ],
+            "array_ms": 782.4031,
+            "judy_ms": 675.8546,
+            "judy_over_array": 0.864,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77802,
+            "delta_pct": -22.2,
+            "ci_delta_pct": [
+                -22.27,
+                -21.45
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                389.1072,
+                388.7147,
+                387.5015,
+                388.0063,
+                388.4021,
+                384.6571,
+                385.4086
+            ],
+            "judy_runs_ms": [
+                302.2706,
+                302.2591,
+                303.6292,
+                301.877,
+                301.8856,
+                302.6785,
+                302.7196
+            ],
+            "array_ms": 388.0063,
+            "judy_ms": 302.2706,
+            "judy_over_array": 0.779,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90797,
+            "delta_pct": -9.2,
+            "ci_delta_pct": [
+                -9.42,
+                -9.03
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1324.5522,
+                1333.7724,
+                1317.4222,
+                1322.1221,
+                1322.8413,
+                1318.1872,
+                1320.7195
+            ],
+            "judy_runs_ms": [
+                1203.1333,
+                1198.7457,
+                1196.1815,
+                1199.4586,
+                1198.2235,
+                1199.1589,
+                1203.8539
+            ],
+            "array_ms": 1322.1221,
+            "judy_ms": 1199.1589,
+            "judy_over_array": 0.907,
+            "winner": "php-judy"
+        },
+        "adv.forEach.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.48851,
+            "delta_pct": 48.85,
+            "ci_delta_pct": [
+                47.79,
+                50.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                126.9255,
+                127.1133,
+                127.7099,
+                127.041,
+                127.2395,
+                127.5299,
+                127.1751
+            ],
+            "judy_runs_ms": [
+                188.6499,
+                189.2088,
+                188.7412,
+                190.5277,
+                191.341,
+                187.7841,
+                191.4331
+            ],
+            "array_ms": 127.1751,
+            "judy_ms": 189.2088,
+            "judy_over_array": 1.488,
+            "winner": "php-array"
+        },
+        "adv.forEach.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.17079,
+            "delta_pct": 17.08,
+            "ci_delta_pct": [
+                16.29,
+                17.34
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                303.9356,
+                303.2739,
+                303.0868,
+                304.4504,
+                303.3989,
+                303.5143,
+                303.7525
+            ],
+            "judy_runs_ms": [
+                353.317,
+                355.6096,
+                354.3725,
+                357.7588,
+                355.2179,
+                356.1392,
+                353.2424
+            ],
+            "array_ms": 303.5143,
+            "judy_ms": 355.2179,
+            "judy_over_array": 1.17,
+            "winner": "php-array"
+        },
+        "adv.filter.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.21774,
+            "delta_pct": 21.77,
+            "ci_delta_pct": [
+                21.17,
+                22.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                225.1427,
+                225.5612,
+                223.9135,
+                225.1673,
+                223.7512,
+                224.8918,
+                225.157
+            ],
+            "judy_runs_ms": [
+                275.162,
+                273.8894,
+                274.7684,
+                272.8304,
+                275.6815,
+                272.4508,
+                274.1818
+            ],
+            "array_ms": 225.1427,
+            "judy_ms": 274.1818,
+            "judy_over_array": 1.218,
+            "winner": "php-array"
+        },
+        "adv.filter.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.05729,
+            "delta_pct": 5.73,
+            "ci_delta_pct": [
+                5.57,
+                5.83
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                738.089,
+                738.2657,
+                736.4677,
+                742.7815,
+                736.1121,
+                737.8964,
+                737.6048
+            ],
+            "judy_runs_ms": [
+                780.3714,
+                779.4167,
+                776.1055,
+                786.174,
+                779.0178,
+                780.5108,
+                778.9007
+            ],
+            "array_ms": 737.8964,
+            "judy_ms": 779.4167,
+            "judy_over_array": 1.056,
+            "winner": "php-array"
+        },
+        "adv.map.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.08708,
+            "delta_pct": 8.71,
+            "ci_delta_pct": [
+                8.29,
+                9.26
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                273.6264,
+                274.8468,
+                272.5881,
+                274.6765,
+                271.535,
+                274.0795,
+                272.6637
+            ],
+            "judy_runs_ms": [
+                297.0022,
+                298.7797,
+                298.1878,
+                297.005,
+                296.6816,
+                296.811,
+                297.7556
+            ],
+            "array_ms": 273.6264,
+            "judy_ms": 297.005,
+            "judy_over_array": 1.085,
+            "winner": "php-array"
+        },
+        "adv.map.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.02215,
+            "delta_pct": 2.21,
+            "ci_delta_pct": [
+                1.84,
+                2.28
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1044.7553,
+                1046.2459,
+                1042.6354,
+                1049.7296,
+                1039.3689,
+                1041.5016,
+                1039.352
+            ],
+            "judy_runs_ms": [
+                1062.4053,
+                1065.4901,
+                1066.6828,
+                1073.6319,
+                1062.3904,
+                1065.0726,
+                1061.943
+            ],
+            "array_ms": 1042.6354,
+            "judy_ms": 1065.0726,
+            "judy_over_array": 1.022,
+            "winner": "php-array"
+        }
+    },
+    "memory": [],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-390/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-390/B2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-390/B3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-390/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-390/C2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-390/C3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/run6-cvsc-control-6m.txt
+++ b/research/three-arm-benchmark/results/run6-cvsc-control-6m.txt
@@ -1,0 +1,137 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /work/builds/judy-C-2.so, /work/builds/judy-C-3.so, /work/builds/judy-C-1.so
+  C  php-judy + bundled libJudy : /work/builds/judy-C-1.so, /work/builds/judy-C-2.so, /work/builds/judy-C-3.so
+  timing core.int     round 1/7  timing core.int     round 2/7  timing core.int     round 3/7  timing core.int     round 4/7  timing core.int     round 5/7  timing core.int     round 6/7  timing core.int     round 7/7  timing core.int     done          
+  timing api.batch    round 1/7  timing api.batch    round 2/7  timing api.batch    round 3/7  timing api.batch    round 4/7  timing api.batch    round 5/7  timing api.batch    round 6/7  timing api.batch    round 7/7  timing api.batch    done          
+  timing api.setops   round 1/7  timing api.setops   round 2/7  timing api.setops   round 3/7  timing api.setops   round 4/7  timing api.setops   round 5/7  timing api.setops   round 6/7  timing api.setops   round 7/7  timing api.setops   done          
+  timing adv.iter     round 1/7  timing adv.iter     round 2/7  timing adv.iter     round 3/7  timing adv.iter     round 4/7  timing adv.iter     round 5/7  timing adv.iter     round 6/7  timing adv.iter     round 7/7  timing adv.iter     done          
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — linux-x86_64-gcc14.2-php8.4-out-of-cache-6M-CvsC-REBUILD-CONTROL
+------------------------------------------------------------------------------------------------
+  PHP 8.4.24, Linux x86_64
+  arm B system libJudy : CONTROL: arm C builds rotated one position, so no round compares a binary against itself
+  arm C bundled libJudy: bundled libjudy/ static into the extension (P1-P7, O1 popcount, O3 bswap, O4 string-layer); vendor CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt
+  size 6000000 (out-of-cache), 7 rounds, 3 iterations, floor 1.3%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-timing   load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    end            load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+
+  control (PHP-only rows, touch no libJudy): +0.01% [-0.02, +0.08] over 21 rows
+  measured control scatter: 1.62%  (assumed floor 1.3%)
+
+------------------------------------------------------------------------------------------------
+  B vs C — bundled libJudy against system libJudy (this project's contribution)
+  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears
+  the 1.3% floor assert anything; everything else is null.
+------------------------------------------------------------------------------------------------
+  benchmark                                     system   bundled    delta CI                 verdict
+  adv.optiter.ratio.foreach.string_to_int_hash     58.31     57.81   -1.12% [ -1.35, -0.16] null
+  adv.forEach.int_to_int                        191.49    189.21   -0.66% [ -1.57, +0.16] null
+  api.setop.intersect.string_to_int             658.06    654.41   -0.54% [ -0.85, +0.16] null
+  core.int_to_int.read                           67.06     66.92   -0.40% [ -0.45, +0.41] null
+  api.setop.union.bitset                        182.76    182.24   -0.39% [ -0.73, +0.00] null
+  api.setop.union.string_to_int                1457.88   1451.65   -0.33% [ -0.68, +0.15] null
+  adv.optiter.toArray.string_to_int_adaptive.optimized     21.69     21.63   -0.32% [ -0.48, +0.62] null
+  adv.optiter.increment.string_to_int_hash.default     16.26     16.23   -0.30% [ -0.52, +0.16] null
+  adv.optiter.ratio.values.string_to_int_adaptive     42.37     42.40   -0.30% [ -0.60, +0.26] null
+  api.setop.diff.bitset                          86.41     86.18   -0.28% [ -0.47, -0.23] null
+  api.setop.diff.string_to_int                  676.78    675.85   -0.25% [ -0.30, -0.05] null
+  core.int_to_int.iter                          113.46    113.19   -0.21% [ -0.31, -0.16] null
+  core.int_to_mixed.read                        277.79    277.46   -0.20% [ -0.57, +0.07] null
+  api.range.size.string_to_int                   20.93     20.89   -0.19% [ -0.28, +0.03] null
+  adv.optiter.foreach.string_to_int_hash.optimized     12.84     12.75   -0.19% [ -0.82, +0.04] null
+  adv.optiter.ratio.toArray.string_to_int_adaptive     54.91     54.80   -0.19% [ -0.29, +0.77] null
+  api.getAll.int_to_int                          21.52     21.46   -0.17% [ -0.86, +0.29] null
+  adv.optiter.ratio.values.string_to_int_hash     51.23     51.24   -0.17% [ -3.62, +0.22] null
+  adv.optiter.toArray.string_to_int_adaptive.default     39.53     39.45   -0.16% [ -0.36, -0.10] null
+  api.increment.int_to_int                      144.40    144.84   -0.13% [ -0.46, +1.90] null
+  api.equals.int_to_int                          71.26     71.23   -0.12% [ -0.47, +0.23] null
+  adv.map.int_to_int                            297.39    297.00   -0.12% [ -0.31, +0.40] null
+  adv.optiter.overwrite.string_to_int_adaptive.optimized     26.23     26.22   -0.12% [ -0.26, +0.21] null
+  adv.optiter.toArray.string_to_int_hash.default     29.28     29.25   -0.10% [ -0.50, +1.01] null
+  core.int_to_packed.iter                       247.68    247.53   -0.09% [ -0.52, +0.33] null
+  core.int_to_packed.read                       205.96    205.72   -0.08% [ -0.38, +0.24] null
+  core.int_to_int.free                            2.07      2.09   -0.06% [ -1.62, +3.15] null
+  adv.optiter.ratio.overwrite.string_to_int_hash    116.40    116.18   -0.06% [ -0.51, +0.45] null
+  core.bitset.iter                              107.39    107.33   -0.05% [ -0.82, +0.63] null
+  adv.optiter.toArray.string_to_int_hash.optimized     17.97     17.95   -0.05% [ -0.58, +0.30] null
+  adv.optiter.ratio.toArray.string_to_int_hash     61.45     61.37   -0.05% [ -0.72, +0.03] null
+  core.int_to_int.write                         144.76    144.70   -0.04% [ -0.47, +0.09] null
+  api.setop.xor.int_to_int                      216.53    216.53   -0.04% [ -0.16, +0.03] null
+  api.setop.xor.bitset                          172.68    172.63   -0.03% [ -0.36, +0.02] null
+  adv.optiter.overwrite.string_to_int_hash.optimized     18.93     18.93   -0.03% [ -0.18, +0.31] null
+  api.sumValues.int_to_int                       48.63     48.57   -0.02% [ -0.74, +0.95] null
+  api.mergeWith.int_to_int                      302.49    302.27   -0.02% [ -0.21, +0.17] null
+  adv.optiter.ratio.overwrite.string_to_int_adaptive    106.97    107.09   -0.01% [ -0.45, +0.19] null
+  adv.optiter.values.string_to_int_hash.default     20.60     20.60    0.00% [ -0.27, +0.23] null
+  adv.optiter.overwrite.string_to_int_hash.default     16.30     16.31    0.00% [ -0.06, +0.25] null
+  api.setop.intersect.bitset                     86.94     87.02    0.02% [ -0.24, +0.26] null
+  api.setop.union.int_to_int                    266.68    266.54    0.02% [ -0.06, +0.39] null
+  adv.optiter.overwrite.string_to_int_adaptive.default     24.53     24.46    0.02% [ -0.12, +0.19] null
+  adv.optiter.values.string_to_int_hash.optimized     10.56     10.56    0.03% [ -0.44, +0.06] null
+  api.deleteRange.int_to_int                    236.43    236.44    0.04% [ -0.17, +0.29] null
+  adv.optiter.values.string_to_int_adaptive.optimized     12.38     12.41    0.07% [ -0.18, +0.43] null
+  adv.filter.string_to_int                      778.12    779.42    0.13% [ -0.13, +0.30] null
+  api.keys.int_to_int                           116.23    116.37    0.14% [ -0.01, +0.40] null
+  adv.filter.int_to_int                         273.34    274.18    0.14% [ -0.09, +0.30] null
+  api.range.keys.int_to_int                      10.10     10.10    0.15% [ -0.29, +0.24] null
+  api.mergeWith.string_to_int                  1196.77   1199.16    0.16% [ -0.69, +0.55] null
+  adv.optiter.foreach.string_to_int_adaptive.default     30.16     30.16    0.16% [ -0.13, +0.81] null
+  adv.optiter.values.string_to_int_adaptive.default     29.22     29.26    0.16% [ +0.08, +0.61] null
+  core.int_to_packed.write                      345.23    346.50    0.17% [ -0.40, +0.52] null
+  core.int_to_mixed.write                       397.61    397.58    0.18% [ -0.62, +0.37] null
+  adv.map.string_to_int                        1063.01   1065.07    0.18% [ -0.31, +0.33] null
+  adv.optiter.ratio.increment.string_to_int_hash    117.11    117.37    0.18% [ +0.10, +0.77] null
+  api.setop.intersect.int_to_int                108.76    109.18    0.19% [ -0.08, +0.33] null
+  api.toArray.int_to_int                        297.41    297.81    0.20% [ +0.03, +0.29] null
+  api.putAll.int_to_int                         126.52    126.95    0.22% [ +0.04, +0.66] null
+  core.int_to_mixed.free                        100.06    100.22    0.24% [ -0.20, +0.94] null
+  api.values.int_to_int                         121.02    121.15    0.24% [ -0.49, +0.48] null
+  api.setop.diff.int_to_int                     107.52    107.75    0.24% [ +0.02, +0.29] null
+  adv.optiter.ratio.foreach.string_to_int_adaptive     46.33     46.45    0.25% [ -0.22, +0.75] null
+  adv.optiter.increment.string_to_int_hash.optimized     19.04     19.05    0.26% [ -0.29, +0.27] null
+  adv.forEach.string_to_int                     354.27    355.22    0.28% [ -0.30, +0.74] null
+  core.int_to_mixed.iter                        320.33    321.37    0.38% [ -0.16, +0.41] null
+  api.fromArray.int_to_int                      126.14    126.66    0.39% [ +0.11, +1.49] null
+  adv.optiter.foreach.string_to_int_adaptive.optimized     13.96     14.02    0.41% [ +0.04, +1.58] null
+  core.int_to_packed.free                        51.91     52.09    0.42% [ +0.19, +0.67] null
+  adv.optiter.foreach.string_to_int_hash.default     22.01     22.10    0.47% [ -0.35, +1.40] null
+  core.bitset.write                             102.91    103.29    0.54% [ -0.19, +0.86] null
+  core.bitset.read                               67.21     67.46    0.58% [ -0.11, +0.64] null
+  totals: 0 faster, 0 slower, 73 null
+
+------------------------------------------------------------------------------------------------
+  A vs C — PHP native array against php-judy (bundled)
+  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means
+  the PHP array is FASTER — publish these, they are the honest half of the story.
+------------------------------------------------------------------------------------------------
+  benchmark                                   array ms   judy ms  judy/arr winner
+  core.bitset.free                                5.40      0.02     0.00x php-judy
+  core.int_to_int.free                            5.49      2.09     0.38x php-judy
+  api.setop.xor.bitset                          220.94    172.63     0.78x php-judy
+  api.setop.intersect.bitset                     95.33     87.02     0.91x php-judy
+  core.int_to_packed.free                        46.93     52.09     1.11x php-array
+  core.bitset.write                              89.09    103.29     1.16x php-array
+  core.int_to_packed.write                      246.71    346.50     1.40x php-array
+  core.int_to_mixed.write                       264.61    397.58     1.50x php-array
+  core.int_to_int.write                          91.94    144.70     1.57x php-array
+  core.int_to_packed.read                       106.56    205.72     1.93x php-array
+  api.setop.union.bitset                         92.32    182.24     1.97x php-array
+  api.setop.diff.bitset                          43.07     86.18     2.00x php-array
+  core.int_to_mixed.free                         46.00    100.22     2.18x php-array
+  core.int_to_mixed.read                        120.47    277.46     2.30x php-array
+  api.increment.int_to_int                       57.33    144.84     2.53x php-array
+  core.int_to_int.read                           22.59     66.92     2.96x php-array
+  core.bitset.read                               22.40     67.46     3.01x php-array
+  core.int_to_mixed.iter                         85.24    321.37     3.77x php-array
+  core.bitset.iter                               18.75    107.33     5.72x php-array
+  core.int_to_int.iter                           18.63    113.19     6.08x php-array
+  core.int_to_packed.iter                        21.45    247.53    11.54x php-array
+  totals: php-judy wins 4, PHP array wins 17, parity 0
+
+Wrote /work/results/run6-cvsc-control-6m.json

--- a/research/three-arm-benchmark/results/run6-out-of-cache-6m.json
+++ b/research/three-arm-benchmark/results/run6-out-of-cache-6m.json
@@ -1,0 +1,6077 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "linux-x86_64-gcc14.2-php8.4-out-of-cache-6M",
+        "date": "2026-08-19T05:41:12+00:00",
+        "php_version": "8.4.24",
+        "platform": "Linux x86_64",
+        "uname": "Linux 9eda8be811ef 6.8.0-136-generic #136~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  3 16:29:11 UTC  x86_64",
+        "judy_version": "2.5.2",
+        "system_so": [
+            "/work/builds/judy-B-1.so",
+            "/work/builds/judy-B-2.so",
+            "/work/builds/judy-B-3.so"
+        ],
+        "bundled_so": [
+            "/work/builds/judy-C-1.so",
+            "/work/builds/judy-C-2.so",
+            "/work/builds/judy-C-3.so"
+        ],
+        "system_so_sha256": [
+            "9ac0777128b5a41fe630d4ed4c54443d811d14dfe25123edfc714412d4e42f5e",
+            "29e565ef4d29da017a78816a9ad4840b3957d83483411c6185e909654f4f6368",
+            "4e5df47016e87917dff105ed563d42da1300e82954069948453232816199f2f8"
+        ],
+        "bundled_so_sha256": [
+            "df5d52bc39e6792a0838d911d816e44a3dbd9966347aa837cd5754aaf4fe0f2a",
+            "e045a13c7e649278937555e54798aa1296bda245cc7bad759770c3ebfab17b12",
+            "fb78079bf462da012789c29bef076168d23f50c47cb31ba47aa9299f481252d3"
+        ],
+        "system_provenance": "Debian 13 trixie (Debian GNU/Linux 13), libjudy-dev 1.0.5-5.1 SHARED lib; Baskins jp_1Index fix APPLIED (debian patch 04); dpkg hardening CFLAGS",
+        "bundled_provenance": "bundled libjudy/ static into the extension (P1-P7, O1 popcount, O3 bswap, O4 string-layer); vendor CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt",
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 6000000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            6000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "out-of-cache",
+        "claim_floor_pct": 1.3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 56,
+        "memory_children": 54,
+        "wall_seconds": 1874.8
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T05:09:57+00:00",
+                "load1": 1.22,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T05:40:57+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-memory",
+                "at": "2026-08-19T05:41:12+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T05:41:12+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "note": "load average alone is necessary but not sufficient: a co-resident memory-bound benchmark contends for LLC and memory bandwidth at low load, and a PHP-array control does not detect it"
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 0.99955,
+            "delta_pct": -0.04,
+            "ci_delta_pct": [
+                -0.11,
+                0.02
+            ],
+            "measured_spread_pct": 1.26,
+            "row_count": 21,
+            "eligibility": "genuine PHP-array rows only (TAM_ARM_A_ROWS); Judy-touching .php rows are excluded because they carry real signal",
+            "rows": {
+                "core.bitset.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99792,
+                    "delta_pct": -0.21,
+                    "ci_delta_pct": [
+                        -0.48,
+                        0.27
+                    ],
+                    "n": 7,
+                    "b_ms": 88.9571,
+                    "c_ms": 88.9549
+                },
+                "core.bitset.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99891,
+                    "delta_pct": -0.11,
+                    "ci_delta_pct": [
+                        -1.26,
+                        0.07
+                    ],
+                    "n": 7,
+                    "b_ms": 22.1754,
+                    "c_ms": 21.9194
+                },
+                "core.bitset.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00019,
+                    "delta_pct": 0.02,
+                    "ci_delta_pct": [
+                        -0.15,
+                        0.03
+                    ],
+                    "n": 7,
+                    "b_ms": 18.7424,
+                    "c_ms": 18.7423
+                },
+                "core.bitset.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00449,
+                    "delta_pct": 0.45,
+                    "ci_delta_pct": [
+                        -0.56,
+                        0.62
+                    ],
+                    "n": 7,
+                    "b_ms": 5.0127,
+                    "c_ms": 5.0107
+                },
+                "core.int_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99896,
+                    "delta_pct": -0.1,
+                    "ci_delta_pct": [
+                        -0.48,
+                        0.18
+                    ],
+                    "n": 7,
+                    "b_ms": 92.0342,
+                    "c_ms": 91.9472
+                },
+                "core.int_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.0126,
+                    "delta_pct": 1.26,
+                    "ci_delta_pct": [
+                        -0.04,
+                        1.7
+                    ],
+                    "n": 7,
+                    "b_ms": 21.9077,
+                    "c_ms": 22.2218
+                },
+                "core.int_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00027,
+                    "delta_pct": 0.03,
+                    "ci_delta_pct": [
+                        -0.11,
+                        0.31
+                    ],
+                    "n": 7,
+                    "b_ms": 18.646,
+                    "c_ms": 18.6636
+                },
+                "core.int_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99747,
+                    "delta_pct": -0.25,
+                    "ci_delta_pct": [
+                        -0.62,
+                        0.81
+                    ],
+                    "n": 7,
+                    "b_ms": 5.4696,
+                    "c_ms": 5.4547
+                },
+                "core.int_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00015,
+                    "delta_pct": 0.01,
+                    "ci_delta_pct": [
+                        -0.32,
+                        0.3
+                    ],
+                    "n": 7,
+                    "b_ms": 264.7421,
+                    "c_ms": 264.2683
+                },
+                "core.int_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99811,
+                    "delta_pct": -0.19,
+                    "ci_delta_pct": [
+                        -0.73,
+                        0.17
+                    ],
+                    "n": 7,
+                    "b_ms": 120.9177,
+                    "c_ms": 120.967
+                },
+                "core.int_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99928,
+                    "delta_pct": -0.07,
+                    "ci_delta_pct": [
+                        -0.26,
+                        0.35
+                    ],
+                    "n": 7,
+                    "b_ms": 85.1887,
+                    "c_ms": 85.3689
+                },
+                "core.int_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99887,
+                    "delta_pct": -0.11,
+                    "ci_delta_pct": [
+                        -0.45,
+                        0.12
+                    ],
+                    "n": 7,
+                    "b_ms": 46.0842,
+                    "c_ms": 46.0144
+                },
+                "core.int_to_packed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99693,
+                    "delta_pct": -0.31,
+                    "ci_delta_pct": [
+                        -0.46,
+                        0.12
+                    ],
+                    "n": 7,
+                    "b_ms": 246.8611,
+                    "c_ms": 246.6513
+                },
+                "core.int_to_packed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99955,
+                    "delta_pct": -0.04,
+                    "ci_delta_pct": [
+                        -0.06,
+                        0.01
+                    ],
+                    "n": 7,
+                    "b_ms": 106.5389,
+                    "c_ms": 106.6393
+                },
+                "core.int_to_packed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00199,
+                    "delta_pct": 0.2,
+                    "ci_delta_pct": [
+                        -0.46,
+                        0.3
+                    ],
+                    "n": 7,
+                    "b_ms": 21.4068,
+                    "c_ms": 21.4014
+                },
+                "core.int_to_packed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99991,
+                    "delta_pct": -0.01,
+                    "ci_delta_pct": [
+                        -0.21,
+                        0.12
+                    ],
+                    "n": 7,
+                    "b_ms": 46.8427,
+                    "c_ms": 46.8177
+                },
+                "api.increment.int_to_int": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00058,
+                    "delta_pct": 0.06,
+                    "ci_delta_pct": [
+                        -0.12,
+                        0.16
+                    ],
+                    "n": 7,
+                    "b_ms": 57.4342,
+                    "c_ms": 57.4234
+                },
+                "api.setop.union.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.0024,
+                    "delta_pct": 0.24,
+                    "ci_delta_pct": [
+                        -0.24,
+                        3.18
+                    ],
+                    "n": 7,
+                    "b_ms": 92.2815,
+                    "c_ms": 92.2909
+                },
+                "api.setop.intersect.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00021,
+                    "delta_pct": 0.02,
+                    "ci_delta_pct": [
+                        -0.34,
+                        0.4
+                    ],
+                    "n": 7,
+                    "b_ms": 95.385,
+                    "c_ms": 95.4341
+                },
+                "api.setop.diff.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99768,
+                    "delta_pct": -0.23,
+                    "ci_delta_pct": [
+                        -0.49,
+                        0.1
+                    ],
+                    "n": 7,
+                    "b_ms": 43.0322,
+                    "c_ms": 42.953
+                },
+                "api.setop.xor.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99866,
+                    "delta_pct": -0.13,
+                    "ci_delta_pct": [
+                        -0.17,
+                        0.1
+                    ],
+                    "n": 7,
+                    "b_ms": 221.1346,
+                    "c_ms": 221.284
+                }
+            }
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 71,
+        "slower": 0,
+        "null": 2
+    },
+    "a_counts": {
+        "php-judy": 4,
+        "php-array": 17,
+        "parity": 0
+    },
+    "bundled_vs_system": {
+        "core.bitset.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87966,
+            "delta_pct": -12.03,
+            "ci_delta_pct": [
+                -12.12,
+                -11.79
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.02,
+                "B2/C2": -11.96,
+                "B3/C3": -12.05
+            },
+            "build_spread_pct": 0.09,
+            "builds": 3,
+            "system_ms": 116.8293,
+            "bundled_ms": 103.0792,
+            "raw_delta_pct": -12.07,
+            "spread_pct": [
+                0.7,
+                1.6
+            ],
+            "system_runs_ms": [
+                117.5675,
+                116.7252,
+                117.2328,
+                116.8293,
+                116.7278,
+                117.2857,
+                116.7843
+            ],
+            "bundled_runs_ms": [
+                103.2649,
+                102.913,
+                103.0792,
+                104.1501,
+                102.5332,
+                103.0818,
+                102.7061
+            ],
+            "paired_ratios": [
+                0.87835,
+                0.88167,
+                0.87927,
+                0.89147,
+                0.8784,
+                0.87889,
+                0.87945
+            ]
+        },
+        "core.bitset.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95271,
+            "delta_pct": -4.73,
+            "ci_delta_pct": [
+                -5.58,
+                -4.68
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.41,
+                "B2/C2": -4.46,
+                "B3/C3": -5.13
+            },
+            "build_spread_pct": 0.95,
+            "builds": 3,
+            "system_ms": 71.0576,
+            "bundled_ms": 67.5641,
+            "raw_delta_pct": -4.77,
+            "spread_pct": [
+                6.4,
+                3.9
+            ],
+            "system_runs_ms": [
+                70.8948,
+                71.0576,
+                71.0669,
+                75.1664,
+                70.6393,
+                70.9142,
+                71.1384
+            ],
+            "bundled_runs_ms": [
+                67.5387,
+                67.6669,
+                67.0739,
+                69.6825,
+                67.6501,
+                67.5641,
+                67.258
+            ],
+            "paired_ratios": [
+                0.95266,
+                0.95228,
+                0.94381,
+                0.92704,
+                0.95768,
+                0.95276,
+                0.94545
+            ]
+        },
+        "core.bitset.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92673,
+            "delta_pct": -7.33,
+            "ci_delta_pct": [
+                -8.58,
+                -6.75
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.18,
+                "B2/C2": -7.71,
+                "B3/C3": -8.32
+            },
+            "build_spread_pct": 1.14,
+            "builds": 3,
+            "system_ms": 115.9297,
+            "bundled_ms": 107.2986,
+            "raw_delta_pct": -7.37,
+            "spread_pct": [
+                3,
+                2.3
+            ],
+            "system_runs_ms": [
+                116.2779,
+                115.0718,
+                116.9614,
+                115.9297,
+                118.0704,
+                114.559,
+                114.7925
+            ],
+            "bundled_runs_ms": [
+                107.7099,
+                107.2559,
+                106.8819,
+                107.555,
+                107.7743,
+                105.2689,
+                107.2986
+            ],
+            "paired_ratios": [
+                0.92631,
+                0.93208,
+                0.91382,
+                0.92776,
+                0.9128,
+                0.91891,
+                0.93472
+            ]
+        },
+        "core.int_to_int.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76129,
+            "delta_pct": -23.87,
+            "ci_delta_pct": [
+                -23.93,
+                -23.47
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.76,
+                "B2/C2": -23.89,
+                "B3/C3": -23.87
+            },
+            "build_spread_pct": 0.13,
+            "builds": 3,
+            "system_ms": 190.2438,
+            "bundled_ms": 144.6998,
+            "raw_delta_pct": -23.9,
+            "spread_pct": [
+                0.4,
+                5.2
+            ],
+            "system_runs_ms": [
+                190.8265,
+                190.1173,
+                190.3377,
+                190.2438,
+                190.2333,
+                190.2018,
+                190.2841
+            ],
+            "bundled_runs_ms": [
+                151.4656,
+                144.67,
+                145.605,
+                144.6566,
+                144.6998,
+                143.9862,
+                144.9997
+            ],
+            "paired_ratios": [
+                0.79373,
+                0.76095,
+                0.76498,
+                0.76037,
+                0.76064,
+                0.75702,
+                0.76202
+            ]
+        },
+        "core.int_to_int.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84031,
+            "delta_pct": -15.97,
+            "ci_delta_pct": [
+                -16.2,
+                -15.89
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.97,
+                "B2/C2": -15.97,
+                "B3/C3": -16.07
+            },
+            "build_spread_pct": 0.1,
+            "builds": 3,
+            "system_ms": 79.7683,
+            "bundled_ms": 66.979,
+            "raw_delta_pct": -16.01,
+            "spread_pct": [
+                0.5,
+                0.5
+            ],
+            "system_runs_ms": [
+                79.7228,
+                79.9788,
+                79.8299,
+                79.9205,
+                79.7683,
+                79.7208,
+                79.5821
+            ],
+            "bundled_runs_ms": [
+                66.9616,
+                67.1916,
+                66.8235,
+                66.9407,
+                66.979,
+                67.0256,
+                67.0986
+            ],
+            "paired_ratios": [
+                0.83993,
+                0.84012,
+                0.83707,
+                0.83759,
+                0.83967,
+                0.84075,
+                0.84314
+            ]
+        },
+        "core.int_to_int.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92861,
+            "delta_pct": -7.14,
+            "ci_delta_pct": [
+                -7.82,
+                -6.66
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.66,
+                "B2/C2": -7.2,
+                "B3/C3": -7.84
+            },
+            "build_spread_pct": 1.18,
+            "builds": 3,
+            "system_ms": 122.0098,
+            "bundled_ms": 113.1007,
+            "raw_delta_pct": -7.18,
+            "spread_pct": [
+                0.7,
+                1.5
+            ],
+            "system_runs_ms": [
+                121.9825,
+                122.0098,
+                122.1037,
+                121.7296,
+                122.0281,
+                122.6075,
+                121.9756
+            ],
+            "bundled_runs_ms": [
+                113.8123,
+                113.1007,
+                112.4526,
+                112.9984,
+                113.2658,
+                112.9747,
+                114.1268
+            ],
+            "paired_ratios": [
+                0.93302,
+                0.92698,
+                0.92096,
+                0.92827,
+                0.92819,
+                0.92143,
+                0.93565
+            ]
+        },
+        "core.int_to_int.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.01086,
+            "delta_pct": 1.09,
+            "ci_delta_pct": [
+                -0.3,
+                2.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 2.04,
+                "B2/C2": 0.24,
+                "B3/C3": 0.36
+            },
+            "build_spread_pct": 1.8,
+            "builds": 3,
+            "system_ms": 2.0965,
+            "bundled_ms": 2.0892,
+            "raw_delta_pct": 1.04,
+            "spread_pct": [
+                4,
+                14
+            ],
+            "system_runs_ms": [
+                2.121,
+                2.0767,
+                2.0576,
+                2.1127,
+                2.1185,
+                2.0965,
+                2.0379
+            ],
+            "bundled_runs_ms": [
+                2.3516,
+                2.0581,
+                2.0779,
+                2.1549,
+                2.1459,
+                2.0892,
+                2.0591
+            ],
+            "paired_ratios": [
+                1.10872,
+                0.99104,
+                1.00987,
+                1.01997,
+                1.01293,
+                0.99652,
+                1.0104
+            ]
+        },
+        "core.int_to_mixed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90965,
+            "delta_pct": -9.03,
+            "ci_delta_pct": [
+                -9.3,
+                -8.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.08,
+                "B2/C2": -8.71,
+                "B3/C3": -9.23
+            },
+            "build_spread_pct": 0.52,
+            "builds": 3,
+            "system_ms": 438.4369,
+            "bundled_ms": 398.6465,
+            "raw_delta_pct": -9.08,
+            "spread_pct": [
+                0.4,
+                3
+            ],
+            "system_runs_ms": [
+                438.5517,
+                438.2092,
+                438.4369,
+                439.5964,
+                437.9731,
+                438.202,
+                439.0578
+            ],
+            "bundled_runs_ms": [
+                408.5959,
+                401.034,
+                398.6465,
+                398.5561,
+                398.5101,
+                396.7595,
+                399.0295
+            ],
+            "paired_ratios": [
+                0.93169,
+                0.91517,
+                0.90924,
+                0.90664,
+                0.9099,
+                0.90543,
+                0.90883
+            ]
+        },
+        "core.int_to_mixed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88112,
+            "delta_pct": -11.89,
+            "ci_delta_pct": [
+                -12.73,
+                -11.48
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.09,
+                "B2/C2": -11.52,
+                "B3/C3": -11.95
+            },
+            "build_spread_pct": 0.57,
+            "builds": 3,
+            "system_ms": 314.7923,
+            "bundled_ms": 278.2761,
+            "raw_delta_pct": -11.93,
+            "spread_pct": [
+                12.8,
+                0.6
+            ],
+            "system_runs_ms": [
+                353.6208,
+                314.7923,
+                317.3131,
+                314.7511,
+                314.1382,
+                313.4348,
+                316.0173
+            ],
+            "bundled_runs_ms": [
+                278.3241,
+                278.2761,
+                276.802,
+                276.564,
+                277.9477,
+                278.2997,
+                278.3239
+            ],
+            "paired_ratios": [
+                0.78707,
+                0.884,
+                0.87233,
+                0.87868,
+                0.88479,
+                0.8879,
+                0.88072
+            ]
+        },
+        "core.int_to_mixed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93115,
+            "delta_pct": -6.89,
+            "ci_delta_pct": [
+                -7.27,
+                -6.59
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.92,
+                "B2/C2": -6.55,
+                "B3/C3": -7.08
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 344.9145,
+            "bundled_ms": 321.0226,
+            "raw_delta_pct": -6.93,
+            "spread_pct": [
+                0.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                345.7158,
+                344.0634,
+                345.1926,
+                344.9145,
+                344.318,
+                343.6483,
+                345.0508
+            ],
+            "bundled_runs_ms": [
+                320.2334,
+                321.2499,
+                319.9505,
+                321.0226,
+                321.727,
+                319.8619,
+                321.023
+            ],
+            "paired_ratios": [
+                0.92629,
+                0.93369,
+                0.92688,
+                0.93073,
+                0.93439,
+                0.93078,
+                0.93036
+            ]
+        },
+        "core.int_to_mixed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92877,
+            "delta_pct": -7.12,
+            "ci_delta_pct": [
+                -7.66,
+                -6.64
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.64,
+                "B2/C2": -6.97,
+                "B3/C3": -7.54
+            },
+            "build_spread_pct": 0.9,
+            "builds": 3,
+            "system_ms": 107.9293,
+            "bundled_ms": 100.2023,
+            "raw_delta_pct": -7.16,
+            "spread_pct": [
+                0.4,
+                1.6
+            ],
+            "system_runs_ms": [
+                107.9293,
+                107.946,
+                108.0392,
+                107.6334,
+                107.9356,
+                107.5663,
+                107.8203
+            ],
+            "bundled_runs_ms": [
+                100.9147,
+                100.5394,
+                99.7148,
+                99.307,
+                100.2023,
+                99.5427,
+                100.6201
+            ],
+            "paired_ratios": [
+                0.93501,
+                0.93139,
+                0.92295,
+                0.92264,
+                0.92835,
+                0.92541,
+                0.93322
+            ]
+        },
+        "core.int_to_packed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91516,
+            "delta_pct": -8.48,
+            "ci_delta_pct": [
+                -8.5,
+                -8.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.45,
+                "B2/C2": -8.37,
+                "B3/C3": -8.77
+            },
+            "build_spread_pct": 0.4,
+            "builds": 3,
+            "system_ms": 379.4397,
+            "bundled_ms": 347.0224,
+            "raw_delta_pct": -8.52,
+            "spread_pct": [
+                0.3,
+                3.4
+            ],
+            "system_runs_ms": [
+                380.0246,
+                379.2952,
+                379.0748,
+                379.4397,
+                379.8023,
+                379.062,
+                379.807
+            ],
+            "bundled_runs_ms": [
+                356.3076,
+                346.9518,
+                346.7595,
+                347.0224,
+                348.2966,
+                344.6043,
+                347.5518
+            ],
+            "paired_ratios": [
+                0.93759,
+                0.91473,
+                0.91475,
+                0.91457,
+                0.91705,
+                0.9091,
+                0.91507
+            ]
+        },
+        "core.int_to_packed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95428,
+            "delta_pct": -4.57,
+            "ci_delta_pct": [
+                -4.94,
+                -4.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.57,
+                "B2/C2": -4.56,
+                "B3/C3": -4.45
+            },
+            "build_spread_pct": 0.12,
+            "builds": 3,
+            "system_ms": 215.2051,
+            "bundled_ms": 205.4948,
+            "raw_delta_pct": -4.61,
+            "spread_pct": [
+                6.6,
+                0.5
+            ],
+            "system_runs_ms": [
+                229.0567,
+                215.4512,
+                215.0407,
+                215.2051,
+                214.9174,
+                214.9699,
+                215.4368
+            ],
+            "bundled_runs_ms": [
+                205.6957,
+                204.7107,
+                204.9991,
+                205.4319,
+                205.8392,
+                205.7007,
+                205.4948
+            ],
+            "paired_ratios": [
+                0.89801,
+                0.95015,
+                0.9533,
+                0.95459,
+                0.95776,
+                0.95688,
+                0.95385
+            ]
+        },
+        "core.int_to_packed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94539,
+            "delta_pct": -5.46,
+            "ci_delta_pct": [
+                -5.48,
+                -5.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.46,
+                "B2/C2": -5.26,
+                "B3/C3": -5.13
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 261.496,
+            "bundled_ms": 247.7162,
+            "raw_delta_pct": -5.5,
+            "spread_pct": [
+                0.5,
+                0.9
+            ],
+            "system_runs_ms": [
+                260.9291,
+                261.2183,
+                261.3923,
+                261.496,
+                261.9804,
+                262.1457,
+                261.9568
+            ],
+            "bundled_runs_ms": [
+                246.569,
+                247.9505,
+                248.7612,
+                246.4768,
+                247.5042,
+                247.7162,
+                248.3553
+            ],
+            "paired_ratios": [
+                0.94497,
+                0.94921,
+                0.95168,
+                0.94256,
+                0.94474,
+                0.94496,
+                0.94808
+            ]
+        },
+        "core.int_to_packed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85316,
+            "delta_pct": -14.68,
+            "ci_delta_pct": [
+                -15.18,
+                -14.42
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.68,
+                "B2/C2": -14.51,
+                "B3/C3": -14.82
+            },
+            "build_spread_pct": 0.31,
+            "builds": 3,
+            "system_ms": 61.0423,
+            "bundled_ms": 52.0836,
+            "raw_delta_pct": -14.72,
+            "spread_pct": [
+                1.2,
+                0.9
+            ],
+            "system_runs_ms": [
+                60.8958,
+                61.4547,
+                61.0423,
+                61.0294,
+                60.7245,
+                61.1339,
+                61.0631
+            ],
+            "bundled_runs_ms": [
+                51.9304,
+                52.0836,
+                52.1941,
+                52.2038,
+                52.3138,
+                51.8302,
+                51.9977
+            ],
+            "paired_ratios": [
+                0.85277,
+                0.84751,
+                0.85505,
+                0.85539,
+                0.86149,
+                0.84781,
+                0.85154
+            ]
+        },
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74114,
+            "delta_pct": -25.89,
+            "ci_delta_pct": [
+                -26.46,
+                -25.56
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.21,
+                "B2/C2": -25.56,
+                "B3/C3": -26.01
+            },
+            "build_spread_pct": 0.65,
+            "builds": 3,
+            "system_ms": 170.9387,
+            "bundled_ms": 126.6613,
+            "raw_delta_pct": -25.92,
+            "spread_pct": [
+                1.4,
+                1.1
+            ],
+            "system_runs_ms": [
+                170.926,
+                170.6366,
+                172.8321,
+                170.9464,
+                170.9387,
+                170.7882,
+                173.0695
+            ],
+            "bundled_runs_ms": [
+                126.0764,
+                127.5117,
+                127.0511,
+                126.6613,
+                126.632,
+                127.0809,
+                126.2268
+            ],
+            "paired_ratios": [
+                0.73761,
+                0.74727,
+                0.73511,
+                0.74094,
+                0.7408,
+                0.74408,
+                0.72934
+            ]
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.73904,
+            "delta_pct": -26.1,
+            "ci_delta_pct": [
+                -26.6,
+                -25.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.6,
+                "B2/C2": -25.72,
+                "B3/C3": -26.02
+            },
+            "build_spread_pct": 0.88,
+            "builds": 3,
+            "system_ms": 170.8527,
+            "bundled_ms": 126.8967,
+            "raw_delta_pct": -26.13,
+            "spread_pct": [
+                1.2,
+                1.2
+            ],
+            "system_runs_ms": [
+                170.7319,
+                170.7904,
+                172.7785,
+                171.7162,
+                170.8527,
+                170.7037,
+                172.6298
+            ],
+            "bundled_runs_ms": [
+                127.2111,
+                127.4474,
+                127.0895,
+                125.975,
+                126.2108,
+                126.8967,
+                126.1443
+            ],
+            "paired_ratios": [
+                0.74509,
+                0.74622,
+                0.73556,
+                0.73362,
+                0.73871,
+                0.74337,
+                0.73072
+            ]
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93282,
+            "delta_pct": -6.72,
+            "ci_delta_pct": [
+                -6.93,
+                -6.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.93,
+                "B2/C2": -6.21,
+                "B3/C3": -6.41
+            },
+            "build_spread_pct": 0.72,
+            "builds": 3,
+            "system_ms": 317.9289,
+            "bundled_ms": 297.5814,
+            "raw_delta_pct": -6.76,
+            "spread_pct": [
+                1.6,
+                0.8
+            ],
+            "system_runs_ms": [
+                322.3522,
+                317.4846,
+                317.2626,
+                317.9289,
+                317.747,
+                320.0997,
+                319.879
+            ],
+            "bundled_runs_ms": [
+                296.8466,
+                298.7747,
+                298.057,
+                296.4381,
+                296.7137,
+                298.1665,
+                297.5814
+            ],
+            "paired_ratios": [
+                0.92088,
+                0.94107,
+                0.93946,
+                0.9324,
+                0.9338,
+                0.93148,
+                0.93029
+            ]
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8997,
+            "delta_pct": -10.03,
+            "ci_delta_pct": [
+                -10.19,
+                -9.56
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.19,
+                "B2/C2": -9.65,
+                "B3/C3": -9.71
+            },
+            "build_spread_pct": 0.54,
+            "builds": 3,
+            "system_ms": 23.7122,
+            "bundled_ms": 21.3593,
+            "raw_delta_pct": -10.07,
+            "spread_pct": [
+                0.8,
+                1.1
+            ],
+            "system_runs_ms": [
+                23.8179,
+                23.7002,
+                23.7185,
+                23.6599,
+                23.8208,
+                23.6269,
+                23.7122
+            ],
+            "bundled_runs_ms": [
+                21.3412,
+                21.5102,
+                21.37,
+                21.2773,
+                21.4035,
+                21.3593,
+                21.2871
+            ],
+            "paired_ratios": [
+                0.89602,
+                0.9076,
+                0.90098,
+                0.8993,
+                0.89852,
+                0.90402,
+                0.89773
+            ]
+        },
+        "api.increment.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.80165,
+            "delta_pct": -19.84,
+            "ci_delta_pct": [
+                -20.78,
+                -18.96
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -19.2,
+                "B2/C2": -19.36,
+                "B3/C3": -21
+            },
+            "build_spread_pct": 1.8,
+            "builds": 3,
+            "system_ms": 179.2488,
+            "bundled_ms": 144.7937,
+            "raw_delta_pct": -19.87,
+            "spread_pct": [
+                1.5,
+                2.8
+            ],
+            "system_runs_ms": [
+                179.2488,
+                179.1257,
+                179.1181,
+                179.2709,
+                181.6815,
+                181.7632,
+                179.1642
+            ],
+            "bundled_runs_ms": [
+                145.2034,
+                145.9268,
+                141.8263,
+                144.7937,
+                144.8887,
+                143.1506,
+                143.5616
+            ],
+            "paired_ratios": [
+                0.81007,
+                0.81466,
+                0.7918,
+                0.80768,
+                0.79749,
+                0.78757,
+                0.80129
+            ]
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92465,
+            "delta_pct": -7.54,
+            "ci_delta_pct": [
+                -7.66,
+                -7.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.65,
+                "B2/C2": -7.44,
+                "B3/C3": -7.69
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 125.5219,
+            "bundled_ms": 115.8915,
+            "raw_delta_pct": -7.58,
+            "spread_pct": [
+                0.4,
+                0.5
+            ],
+            "system_runs_ms": [
+                125.283,
+                125.6173,
+                125.7258,
+                125.484,
+                125.5219,
+                125.1764,
+                125.5564
+            ],
+            "bundled_runs_ms": [
+                116.3136,
+                116.0998,
+                115.777,
+                115.8362,
+                116.2483,
+                115.7271,
+                115.8915
+            ],
+            "paired_ratios": [
+                0.92841,
+                0.92423,
+                0.92087,
+                0.92312,
+                0.92612,
+                0.92451,
+                0.92302
+            ]
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92645,
+            "delta_pct": -7.36,
+            "ci_delta_pct": [
+                -7.7,
+                -7.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.36,
+                "B2/C2": -7.25,
+                "B3/C3": -7.52
+            },
+            "build_spread_pct": 0.27,
+            "builds": 3,
+            "system_ms": 130.3475,
+            "bundled_ms": 120.8106,
+            "raw_delta_pct": -7.4,
+            "spread_pct": [
+                0.6,
+                0.7
+            ],
+            "system_runs_ms": [
+                130.2117,
+                130.4658,
+                130.6934,
+                130.3475,
+                130.2157,
+                129.9168,
+                130.4633
+            ],
+            "bundled_runs_ms": [
+                121.1408,
+                120.8156,
+                120.5279,
+                120.2569,
+                120.8527,
+                120.3642,
+                120.8106
+            ],
+            "paired_ratios": [
+                0.93034,
+                0.92603,
+                0.92222,
+                0.92259,
+                0.9281,
+                0.92647,
+                0.92601
+            ]
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91699,
+            "delta_pct": -8.3,
+            "ci_delta_pct": [
+                -8.83,
+                -7.89
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.3,
+                "B2/C2": -8.63,
+                "B3/C3": -8.1
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 10.9753,
+            "bundled_ms": 10.0399,
+            "raw_delta_pct": -8.34,
+            "spread_pct": [
+                1.2,
+                0.9
+            ],
+            "system_runs_ms": [
+                10.9753,
+                11.0371,
+                10.9395,
+                10.987,
+                10.9042,
+                10.9153,
+                11.0175
+            ],
+            "bundled_runs_ms": [
+                10.0597,
+                9.9982,
+                10.0147,
+                10.0913,
+                10.0396,
+                10.0597,
+                10.0399
+            ],
+            "paired_ratios": [
+                0.91658,
+                0.90587,
+                0.91546,
+                0.91848,
+                0.92071,
+                0.92161,
+                0.91127
+            ]
+        },
+        "api.range.size.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.57128,
+            "delta_pct": -42.87,
+            "ci_delta_pct": [
+                -44.56,
+                -42.62
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -42.62,
+                "B2/C2": -45.43,
+                "B3/C3": -43.73
+            },
+            "build_spread_pct": 2.81,
+            "builds": 3,
+            "system_ms": 36.5265,
+            "bundled_ms": 20.8886,
+            "raw_delta_pct": -42.9,
+            "spread_pct": [
+                10.3,
+                0.4
+            ],
+            "system_runs_ms": [
+                36.4924,
+                40.2478,
+                37.6958,
+                36.5113,
+                36.5283,
+                36.5265,
+                36.5039
+            ],
+            "bundled_runs_ms": [
+                20.9306,
+                20.8453,
+                20.8886,
+                20.8488,
+                20.9297,
+                20.8492,
+                20.938
+            ],
+            "paired_ratios": [
+                0.57356,
+                0.51792,
+                0.55414,
+                0.57102,
+                0.57297,
+                0.5708,
+                0.57358
+            ]
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.82762,
+            "delta_pct": -17.24,
+            "ci_delta_pct": [
+                -17.95,
+                -17.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -17.24,
+                "B2/C2": -17.12,
+                "B3/C3": -17.73
+            },
+            "build_spread_pct": 0.61,
+            "builds": 3,
+            "system_ms": 58.7581,
+            "bundled_ms": 48.5617,
+            "raw_delta_pct": -17.28,
+            "spread_pct": [
+                1.9,
+                0.9
+            ],
+            "system_runs_ms": [
+                58.7581,
+                58.3645,
+                59.4824,
+                58.8246,
+                58.8282,
+                58.4848,
+                58.7029
+            ],
+            "bundled_runs_ms": [
+                48.7058,
+                48.5673,
+                48.6201,
+                48.245,
+                48.5152,
+                48.3835,
+                48.5617
+            ],
+            "paired_ratios": [
+                0.82892,
+                0.83214,
+                0.81739,
+                0.82015,
+                0.82469,
+                0.82728,
+                0.82725
+            ]
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74927,
+            "delta_pct": -25.07,
+            "ci_delta_pct": [
+                -25.2,
+                -24.98
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.07,
+                "B2/C2": -25.12,
+                "B3/C3": -25.12
+            },
+            "build_spread_pct": 0.05,
+            "builds": 3,
+            "system_ms": 316.0299,
+            "bundled_ms": 236.6241,
+            "raw_delta_pct": -25.11,
+            "spread_pct": [
+                0.3,
+                2.1
+            ],
+            "system_runs_ms": [
+                316.0299,
+                315.9942,
+                316.7304,
+                316.2871,
+                315.834,
+                316.1207,
+                315.8155
+            ],
+            "bundled_runs_ms": [
+                236.3584,
+                236.2621,
+                236.6343,
+                241.1298,
+                236.6241,
+                237.0482,
+                236.5233
+            ],
+            "paired_ratios": [
+                0.7479,
+                0.74768,
+                0.74712,
+                0.76238,
+                0.7492,
+                0.74987,
+                0.74893
+            ]
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7296,
+            "delta_pct": -27.04,
+            "ci_delta_pct": [
+                -27.6,
+                -26.78
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -27.33,
+                "B2/C2": -26.91,
+                "B3/C3": -27.11
+            },
+            "build_spread_pct": 0.42,
+            "builds": 3,
+            "system_ms": 97.9059,
+            "bundled_ms": 71.4746,
+            "raw_delta_pct": -27.07,
+            "spread_pct": [
+                0.3,
+                2.1
+            ],
+            "system_runs_ms": [
+                98.1136,
+                98.0179,
+                97.9089,
+                97.8221,
+                97.7867,
+                97.9059,
+                97.8299
+            ],
+            "bundled_runs_ms": [
+                71.0026,
+                71.4816,
+                72.0942,
+                71.0596,
+                71.5702,
+                70.5614,
+                71.4746
+            ],
+            "paired_ratios": [
+                0.72368,
+                0.72927,
+                0.73634,
+                0.72642,
+                0.7319,
+                0.72071,
+                0.7306
+            ]
+        },
+        "api.setop.union.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75317,
+            "delta_pct": -24.68,
+            "ci_delta_pct": [
+                -24.73,
+                -24.28
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.71,
+                "B2/C2": -24.71,
+                "B3/C3": -23.63
+            },
+            "build_spread_pct": 1.08,
+            "builds": 3,
+            "system_ms": 242.2786,
+            "bundled_ms": 182.3807,
+            "raw_delta_pct": -24.72,
+            "spread_pct": [
+                0.4,
+                2.6
+            ],
+            "system_runs_ms": [
+                242.3478,
+                242.2786,
+                242.0145,
+                242.3056,
+                242.2257,
+                242.7304,
+                241.7888
+            ],
+            "bundled_runs_ms": [
+                182.3807,
+                182.394,
+                186.3256,
+                181.5828,
+                182.2349,
+                183.7177,
+                182.0284
+            ],
+            "paired_ratios": [
+                0.75256,
+                0.75283,
+                0.76989,
+                0.7494,
+                0.75234,
+                0.75688,
+                0.75284
+            ]
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74653,
+            "delta_pct": -25.35,
+            "ci_delta_pct": [
+                -25.68,
+                -25.21
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.59,
+                "B2/C2": -24.67,
+                "B3/C3": -25.52
+            },
+            "build_spread_pct": 0.92,
+            "builds": 3,
+            "system_ms": 116.7903,
+            "bundled_ms": 87.0292,
+            "raw_delta_pct": -25.38,
+            "spread_pct": [
+                0.5,
+                2.3
+            ],
+            "system_runs_ms": [
+                116.7903,
+                116.5991,
+                116.6637,
+                117.1611,
+                116.8015,
+                116.7965,
+                116.6118
+            ],
+            "bundled_runs_ms": [
+                86.8661,
+                88.5066,
+                86.4986,
+                87.0292,
+                87.2437,
+                87.3123,
+                87.0147
+            ],
+            "paired_ratios": [
+                0.74378,
+                0.75907,
+                0.74144,
+                0.74282,
+                0.74694,
+                0.74756,
+                0.74619
+            ]
+        },
+        "api.setop.diff.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76395,
+            "delta_pct": -23.6,
+            "ci_delta_pct": [
+                -23.88,
+                -23.54
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.6,
+                "B2/C2": -23.74,
+                "B3/C3": -23.56
+            },
+            "build_spread_pct": 0.18,
+            "builds": 3,
+            "system_ms": 113.0273,
+            "bundled_ms": 86.2032,
+            "raw_delta_pct": -23.64,
+            "spread_pct": [
+                0.6,
+                0.7
+            ],
+            "system_runs_ms": [
+                113.1211,
+                113.0239,
+                113.0478,
+                113.3237,
+                113.0273,
+                112.8559,
+                112.6386
+            ],
+            "bundled_runs_ms": [
+                85.9227,
+                86.3063,
+                86.2032,
+                86.5453,
+                85.996,
+                86.394,
+                86.0899
+            ],
+            "paired_ratios": [
+                0.75956,
+                0.76361,
+                0.76254,
+                0.7637,
+                0.76084,
+                0.76552,
+                0.7643
+            ]
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76954,
+            "delta_pct": -23.05,
+            "ci_delta_pct": [
+                -23.37,
+                -22.83
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.37,
+                "B2/C2": -22.94,
+                "B3/C3": -23.09
+            },
+            "build_spread_pct": 0.43,
+            "builds": 3,
+            "system_ms": 225.0456,
+            "bundled_ms": 172.9268,
+            "raw_delta_pct": -23.08,
+            "spread_pct": [
+                0.2,
+                1.3
+            ],
+            "system_runs_ms": [
+                225.0808,
+                225.0476,
+                225.0456,
+                224.9218,
+                225.1866,
+                224.7507,
+                224.8369
+            ],
+            "bundled_runs_ms": [
+                172.1419,
+                173.5926,
+                172.9268,
+                174.3812,
+                173.2124,
+                172.8768,
+                172.215
+            ],
+            "paired_ratios": [
+                0.7648,
+                0.77136,
+                0.76841,
+                0.7753,
+                0.76919,
+                0.76919,
+                0.76596
+            ]
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75163,
+            "delta_pct": -24.84,
+            "ci_delta_pct": [
+                -24.99,
+                -24.73
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.77,
+                "B2/C2": -24.86,
+                "B3/C3": -24.86
+            },
+            "build_spread_pct": 0.09,
+            "builds": 3,
+            "system_ms": 354.0532,
+            "bundled_ms": 266.2446,
+            "raw_delta_pct": -24.87,
+            "spread_pct": [
+                0.5,
+                0.5
+            ],
+            "system_runs_ms": [
+                353.8628,
+                355.2156,
+                355.445,
+                354.0532,
+                353.8936,
+                353.8253,
+                355.2346
+            ],
+            "bundled_runs_ms": [
+                266.0821,
+                266.3311,
+                266.9089,
+                267.1694,
+                266.2446,
+                265.8266,
+                265.7204
+            ],
+            "paired_ratios": [
+                0.75194,
+                0.74977,
+                0.75091,
+                0.7546,
+                0.75233,
+                0.75129,
+                0.74801
+            ]
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.73709,
+            "delta_pct": -26.29,
+            "ci_delta_pct": [
+                -26.37,
+                -26.2
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.2,
+                "B2/C2": -26.32,
+                "B3/C3": -26.47
+            },
+            "build_spread_pct": 0.27,
+            "builds": 3,
+            "system_ms": 147.868,
+            "bundled_ms": 109.0185,
+            "raw_delta_pct": -26.32,
+            "spread_pct": [
+                0.1,
+                1
+            ],
+            "system_runs_ms": [
+                147.8451,
+                147.9342,
+                147.9969,
+                147.868,
+                147.7845,
+                147.8642,
+                147.9677
+            ],
+            "bundled_runs_ms": [
+                109.0543,
+                109.0185,
+                109.0381,
+                108.824,
+                108.768,
+                108.4024,
+                109.4495
+            ],
+            "paired_ratios": [
+                0.73763,
+                0.73694,
+                0.73676,
+                0.73595,
+                0.73599,
+                0.73312,
+                0.73969
+            ]
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77017,
+            "delta_pct": -22.98,
+            "ci_delta_pct": [
+                -23.08,
+                -22.96
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.03,
+                "B2/C2": -24.07,
+                "B3/C3": -22.9
+            },
+            "build_spread_pct": 1.17,
+            "builds": 3,
+            "system_ms": 140.1112,
+            "bundled_ms": 107.8578,
+            "raw_delta_pct": -23.02,
+            "spread_pct": [
+                3,
+                0.2
+            ],
+            "system_runs_ms": [
+                140.1983,
+                140.035,
+                140.1112,
+                140.0621,
+                144.236,
+                139.9816,
+                140.1222
+            ],
+            "bundled_runs_ms": [
+                107.8578,
+                107.8351,
+                107.8609,
+                107.8433,
+                107.8635,
+                107.9877,
+                107.7324
+            ],
+            "paired_ratios": [
+                0.76932,
+                0.77006,
+                0.76982,
+                0.76997,
+                0.74783,
+                0.77144,
+                0.76885
+            ]
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77296,
+            "delta_pct": -22.7,
+            "ci_delta_pct": [
+                -22.77,
+                -22.62
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.73,
+                "B2/C2": -22.62,
+                "B3/C3": -22.74
+            },
+            "build_spread_pct": 0.12,
+            "builds": 3,
+            "system_ms": 280.2623,
+            "bundled_ms": 216.4144,
+            "raw_delta_pct": -22.74,
+            "spread_pct": [
+                0.3,
+                0.4
+            ],
+            "system_runs_ms": [
+                279.9721,
+                280.4256,
+                280.2623,
+                280.7026,
+                280.2944,
+                279.9777,
+                279.9351
+            ],
+            "bundled_runs_ms": [
+                216.4144,
+                216.8926,
+                216.354,
+                216.7878,
+                216.808,
+                216.3133,
+                215.9537
+            ],
+            "paired_ratios": [
+                0.77299,
+                0.77344,
+                0.77197,
+                0.7723,
+                0.7735,
+                0.77261,
+                0.77144
+            ]
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.80981,
+            "delta_pct": -19.02,
+            "ci_delta_pct": [
+                -19.38,
+                -18.84
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -18.94,
+                "B2/C2": -19.21,
+                "B3/C3": -19.05
+            },
+            "build_spread_pct": 0.27,
+            "builds": 3,
+            "system_ms": 1797.4378,
+            "bundled_ms": 1455.969,
+            "raw_delta_pct": -19.06,
+            "spread_pct": [
+                0.8,
+                0.9
+            ],
+            "system_runs_ms": [
+                1801.0801,
+                1797.4378,
+                1794.7688,
+                1800.1128,
+                1796.4739,
+                1808.2571,
+                1795.9446
+            ],
+            "bundled_runs_ms": [
+                1461.0663,
+                1448.1811,
+                1458.1417,
+                1455.969,
+                1454.1508,
+                1457.1604,
+                1455.1902
+            ],
+            "paired_ratios": [
+                0.81122,
+                0.80569,
+                0.81244,
+                0.80882,
+                0.80945,
+                0.80584,
+                0.81026
+            ]
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77559,
+            "delta_pct": -22.44,
+            "ci_delta_pct": [
+                -22.62,
+                -22.24
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.44,
+                "B2/C2": -22.43,
+                "B3/C3": -22.87
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 845.9873,
+            "bundled_ms": 655.0906,
+            "raw_delta_pct": -22.48,
+            "spread_pct": [
+                1,
+                1
+            ],
+            "system_runs_ms": [
+                845.9873,
+                846.9652,
+                845.331,
+                843.9127,
+                844.3859,
+                852.4758,
+                846.3414
+            ],
+            "bundled_runs_ms": [
+                657.9992,
+                655.0906,
+                657.0572,
+                654.2357,
+                656.2936,
+                651.7597,
+                654.7588
+            ],
+            "paired_ratios": [
+                0.77779,
+                0.77346,
+                0.77728,
+                0.77524,
+                0.77724,
+                0.76455,
+                0.77363
+            ]
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79346,
+            "delta_pct": -20.65,
+            "ci_delta_pct": [
+                -20.96,
+                -20.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.46,
+                "B2/C2": -20.73,
+                "B3/C3": -20.71
+            },
+            "build_spread_pct": 0.27,
+            "builds": 3,
+            "system_ms": 853.448,
+            "bundled_ms": 676.5314,
+            "raw_delta_pct": -20.69,
+            "spread_pct": [
+                0.5,
+                0.6
+            ],
+            "system_runs_ms": [
+                854.3539,
+                853.4897,
+                853.448,
+                850.9028,
+                852.6544,
+                855.4585,
+                853.2888
+            ],
+            "bundled_runs_ms": [
+                674.6552,
+                676.9053,
+                678.4353,
+                676.5314,
+                674.8668,
+                675.8782,
+                679.0286
+            ],
+            "paired_ratios": [
+                0.78967,
+                0.7931,
+                0.79493,
+                0.79507,
+                0.79149,
+                0.79008,
+                0.79578
+            ]
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78698,
+            "delta_pct": -21.3,
+            "ci_delta_pct": [
+                -21.79,
+                -21.11
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.11,
+                "B2/C2": -21.25,
+                "B3/C3": -21.64
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 384.3726,
+            "bundled_ms": 302.6263,
+            "raw_delta_pct": -21.34,
+            "spread_pct": [
+                1.6,
+                1
+            ],
+            "system_runs_ms": [
+                384.3374,
+                385.2407,
+                384.9825,
+                384.3726,
+                384.2217,
+                384.1899,
+                390.4736
+            ],
+            "bundled_runs_ms": [
+                303.056,
+                303.0421,
+                302.1062,
+                303.4521,
+                302.6263,
+                300.3413,
+                302.2349
+            ],
+            "paired_ratios": [
+                0.78852,
+                0.78663,
+                0.78473,
+                0.78947,
+                0.78763,
+                0.78175,
+                0.77402
+            ]
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79656,
+            "delta_pct": -20.34,
+            "ci_delta_pct": [
+                -20.77,
+                -20.22
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.22,
+                "B2/C2": -20.6,
+                "B3/C3": -20.56
+            },
+            "build_spread_pct": 0.38,
+            "builds": 3,
+            "system_ms": 1500.228,
+            "bundled_ms": 1191.5984,
+            "raw_delta_pct": -20.38,
+            "spread_pct": [
+                0.8,
+                0.9
+            ],
+            "system_runs_ms": [
+                1498.8207,
+                1506.4698,
+                1500.228,
+                1501.2019,
+                1495.466,
+                1503.0174,
+                1495.1567
+            ],
+            "bundled_runs_ms": [
+                1199.9779,
+                1191.5984,
+                1194.4826,
+                1197.0864,
+                1190.944,
+                1190.309,
+                1189.277
+            ],
+            "paired_ratios": [
+                0.80061,
+                0.79099,
+                0.7962,
+                0.79742,
+                0.79637,
+                0.79195,
+                0.79542
+            ]
+        },
+        "adv.forEach.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94858,
+            "delta_pct": -5.14,
+            "ci_delta_pct": [
+                -5.84,
+                -4.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.84,
+                "B2/C2": -5.33,
+                "B3/C3": -4.38
+            },
+            "build_spread_pct": 1.46,
+            "builds": 3,
+            "system_ms": 198.6679,
+            "bundled_ms": 188.4844,
+            "raw_delta_pct": -5.18,
+            "spread_pct": [
+                3.5,
+                4
+            ],
+            "system_runs_ms": [
+                197.7234,
+                199.9356,
+                198.6679,
+                203.9723,
+                197.088,
+                198.4305,
+                199.81
+            ],
+            "bundled_runs_ms": [
+                186.0957,
+                188.837,
+                191.0394,
+                184.0067,
+                186.8692,
+                188.4844,
+                191.5767
+            ],
+            "paired_ratios": [
+                0.94119,
+                0.94449,
+                0.9616,
+                0.90212,
+                0.94815,
+                0.94988,
+                0.95879
+            ]
+        },
+        "adv.forEach.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.70133,
+            "delta_pct": -29.87,
+            "ci_delta_pct": [
+                -30.12,
+                -29.78
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -29.78,
+                "B2/C2": -30,
+                "B3/C3": -29.87
+            },
+            "build_spread_pct": 0.22,
+            "builds": 3,
+            "system_ms": 505.8657,
+            "bundled_ms": 354.2639,
+            "raw_delta_pct": -29.9,
+            "spread_pct": [
+                0.6,
+                0.9
+            ],
+            "system_runs_ms": [
+                505.8657,
+                507.7856,
+                504.8768,
+                507.2635,
+                504.9695,
+                504.7632,
+                506.9427
+            ],
+            "bundled_runs_ms": [
+                355.0661,
+                354.3444,
+                353.9241,
+                357.0129,
+                354.2639,
+                353.8297,
+                354.0886
+            ],
+            "paired_ratios": [
+                0.7019,
+                0.69782,
+                0.70101,
+                0.7038,
+                0.70156,
+                0.70098,
+                0.69848
+            ]
+        },
+        "adv.filter.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90995,
+            "delta_pct": -9.01,
+            "ci_delta_pct": [
+                -9.59,
+                -8.72
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.1,
+                "B2/C2": -8.99,
+                "B3/C3": -9.15
+            },
+            "build_spread_pct": 0.16,
+            "builds": 3,
+            "system_ms": 301.2822,
+            "bundled_ms": 274.7759,
+            "raw_delta_pct": -9.05,
+            "spread_pct": [
+                1.3,
+                0.8
+            ],
+            "system_runs_ms": [
+                302.5955,
+                300.4669,
+                302.3545,
+                300.996,
+                301.2822,
+                301.1479,
+                304.4411
+            ],
+            "bundled_runs_ms": [
+                274.9265,
+                273.2858,
+                273.2443,
+                275.4757,
+                274.1438,
+                274.7759,
+                275.1003
+            ],
+            "paired_ratios": [
+                0.90856,
+                0.90954,
+                0.90372,
+                0.91521,
+                0.90992,
+                0.91243,
+                0.90362
+            ]
+        },
+        "adv.filter.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7696,
+            "delta_pct": -23.04,
+            "ci_delta_pct": [
+                -23.25,
+                -22.88
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.02,
+                "B2/C2": -23.15,
+                "B3/C3": -23.08
+            },
+            "build_spread_pct": 0.13,
+            "builds": 3,
+            "system_ms": 1012.6351,
+            "bundled_ms": 778.8982,
+            "raw_delta_pct": -23.08,
+            "spread_pct": [
+                0.2,
+                1
+            ],
+            "system_runs_ms": [
+                1012.1191,
+                1012.5434,
+                1012.7941,
+                1012.0555,
+                1012.702,
+                1012.6351,
+                1013.9446
+            ],
+            "bundled_runs_ms": [
+                776.7947,
+                778.8982,
+                776.6947,
+                784.272,
+                776.8801,
+                780.6225,
+                780.1906
+            ],
+            "paired_ratios": [
+                0.76749,
+                0.76925,
+                0.76688,
+                0.77493,
+                0.76714,
+                0.77088,
+                0.76946
+            ]
+        },
+        "adv.map.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90627,
+            "delta_pct": -9.37,
+            "ci_delta_pct": [
+                -9.77,
+                -8.77
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.37,
+                "B2/C2": -8.9,
+                "B3/C3": -9.83
+            },
+            "build_spread_pct": 0.93,
+            "builds": 3,
+            "system_ms": 327.9575,
+            "bundled_ms": 297.3636,
+            "raw_delta_pct": -9.41,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                327.9575,
+                327.4312,
+                330.4747,
+                326.8065,
+                327.5964,
+                329.1496,
+                329.0176
+            ],
+            "bundled_runs_ms": [
+                297.0857,
+                297.3636,
+                297.6621,
+                298.0044,
+                299.0706,
+                296.8497,
+                296.9707
+            ],
+            "paired_ratios": [
+                0.90587,
+                0.90817,
+                0.90071,
+                0.91187,
+                0.91292,
+                0.90187,
+                0.9026
+            ]
+        },
+        "adv.map.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75106,
+            "delta_pct": -24.89,
+            "ci_delta_pct": [
+                -25.03,
+                -24.77
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.89,
+                "B2/C2": -25.06,
+                "B3/C3": -24.9
+            },
+            "build_spread_pct": 0.17,
+            "builds": 3,
+            "system_ms": 1419.4181,
+            "bundled_ms": 1065.5867,
+            "raw_delta_pct": -24.93,
+            "spread_pct": [
+                0.5,
+                0.8
+            ],
+            "system_runs_ms": [
+                1424.0537,
+                1421.1565,
+                1421.8981,
+                1416.808,
+                1418.257,
+                1417.6037,
+                1419.4181
+            ],
+            "bundled_runs_ms": [
+                1067.9528,
+                1061.658,
+                1065.5112,
+                1069.8636,
+                1065.3642,
+                1066.029,
+                1065.5867
+            ],
+            "paired_ratios": [
+                0.74994,
+                0.74704,
+                0.74936,
+                0.75512,
+                0.75118,
+                0.75199,
+                0.75072
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79706,
+            "delta_pct": -20.29,
+            "ci_delta_pct": [
+                -20.36,
+                -20.06
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.29,
+                "B2/C2": -20.21,
+                "B3/C3": -19.79
+            },
+            "build_spread_pct": 0.5,
+            "builds": 3,
+            "system_ms": 27.6729,
+            "bundled_ms": 22.0488,
+            "raw_delta_pct": -20.33,
+            "spread_pct": [
+                0.7,
+                2.1
+            ],
+            "system_runs_ms": [
+                27.6474,
+                27.7156,
+                27.6729,
+                27.7199,
+                27.6472,
+                27.8169,
+                27.626
+            ],
+            "bundled_runs_ms": [
+                22.0488,
+                22.0642,
+                22.029,
+                21.9906,
+                22.0925,
+                22.4619,
+                22.0098
+            ],
+            "paired_ratios": [
+                0.7975,
+                0.79609,
+                0.79605,
+                0.79331,
+                0.79909,
+                0.80749,
+                0.79671
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.67387,
+            "delta_pct": -32.61,
+            "ci_delta_pct": [
+                -33.27,
+                -30.82
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -33.27,
+                "B2/C2": -32.6,
+                "B3/C3": -30.52
+            },
+            "build_spread_pct": 2.75,
+            "builds": 3,
+            "system_ms": 19.1261,
+            "bundled_ms": 12.8888,
+            "raw_delta_pct": -32.64,
+            "spread_pct": [
+                1.4,
+                4.6
+            ],
+            "system_runs_ms": [
+                19.1242,
+                19.1261,
+                19.1352,
+                19.3318,
+                19.106,
+                19.0663,
+                19.1714
+            ],
+            "bundled_runs_ms": [
+                12.7565,
+                12.8888,
+                13.3461,
+                12.8966,
+                12.8692,
+                13.1845,
+                12.7504
+            ],
+            "paired_ratios": [
+                0.66703,
+                0.67389,
+                0.69746,
+                0.66712,
+                0.67357,
+                0.69151,
+                0.66507
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8433,
+            "delta_pct": -15.67,
+            "ci_delta_pct": [
+                -16.32,
+                -14.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.32,
+                "B2/C2": -15.49,
+                "B3/C3": -13.33
+            },
+            "build_spread_pct": 2.99,
+            "builds": 3,
+            "system_ms": 69.1478,
+            "bundled_ms": 58.415,
+            "raw_delta_pct": -15.71,
+            "spread_pct": [
+                1.7,
+                4.7
+            ],
+            "system_runs_ms": [
+                69.1718,
+                69.0083,
+                69.1478,
+                69.74,
+                69.1064,
+                68.5419,
+                69.3962
+            ],
+            "bundled_runs_ms": [
+                57.8558,
+                58.415,
+                60.5845,
+                58.6458,
+                58.2512,
+                58.697,
+                57.9306
+            ],
+            "paired_ratios": [
+                0.83641,
+                0.84649,
+                0.87616,
+                0.84092,
+                0.84292,
+                0.85637,
+                0.83478
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78777,
+            "delta_pct": -21.22,
+            "ci_delta_pct": [
+                -21.44,
+                -21.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.44,
+                "B2/C2": -21.23,
+                "B3/C3": -21.19
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 26.2198,
+            "bundled_ms": 20.6203,
+            "raw_delta_pct": -21.26,
+            "spread_pct": [
+                0.5,
+                0.8
+            ],
+            "system_runs_ms": [
+                26.1999,
+                26.2783,
+                26.2382,
+                26.2022,
+                26.2198,
+                26.1492,
+                26.2585
+            ],
+            "bundled_runs_ms": [
+                20.664,
+                20.7411,
+                20.6767,
+                20.569,
+                20.595,
+                20.5902,
+                20.6203
+            ],
+            "paired_ratios": [
+                0.78871,
+                0.78929,
+                0.78804,
+                0.78501,
+                0.78548,
+                0.78741,
+                0.78528
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.65415,
+            "delta_pct": -34.58,
+            "ci_delta_pct": [
+                -34.83,
+                -34.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -34.58,
+                "B2/C2": -34.7,
+                "B3/C3": -34.54
+            },
+            "build_spread_pct": 0.16,
+            "builds": 3,
+            "system_ms": 16.141,
+            "bundled_ms": 10.5554,
+            "raw_delta_pct": -34.61,
+            "spread_pct": [
+                0.7,
+                0.5
+            ],
+            "system_runs_ms": [
+                16.2333,
+                16.141,
+                16.1315,
+                16.1267,
+                16.238,
+                16.1447,
+                16.1256
+            ],
+            "bundled_runs_ms": [
+                10.5747,
+                10.5919,
+                10.5634,
+                10.5446,
+                10.5433,
+                10.5554,
+                10.5455
+            ],
+            "paired_ratios": [
+                0.65142,
+                0.65621,
+                0.65483,
+                0.65386,
+                0.6493,
+                0.6538,
+                0.65396
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83133,
+            "delta_pct": -16.87,
+            "ci_delta_pct": [
+                -17.3,
+                -16.69
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -16.69,
+                "B2/C2": -17.06,
+                "B3/C3": -16.9
+            },
+            "build_spread_pct": 0.37,
+            "builds": 3,
+            "system_ms": 61.5471,
+            "bundled_ms": 51.1745,
+            "raw_delta_pct": -16.9,
+            "spread_pct": [
+                0.9,
+                0.4
+            ],
+            "system_runs_ms": [
+                61.9593,
+                61.4235,
+                61.4812,
+                61.5471,
+                61.9301,
+                61.7407,
+                61.4112
+            ],
+            "bundled_runs_ms": [
+                51.1745,
+                51.0674,
+                51.0884,
+                51.2644,
+                51.1937,
+                51.264,
+                51.1412
+            ],
+            "paired_ratios": [
+                0.82594,
+                0.8314,
+                0.83096,
+                0.83293,
+                0.82664,
+                0.83031,
+                0.83277
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85311,
+            "delta_pct": -14.69,
+            "ci_delta_pct": [
+                -15.01,
+                -14.42
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.69,
+                "B2/C2": -14.31,
+                "B3/C3": -15.2
+            },
+            "build_spread_pct": 0.89,
+            "builds": 3,
+            "system_ms": 34.4138,
+            "bundled_ms": 29.3372,
+            "raw_delta_pct": -14.73,
+            "spread_pct": [
+                0.8,
+                0.9
+            ],
+            "system_runs_ms": [
+                34.5781,
+                34.348,
+                34.4138,
+                34.308,
+                34.4292,
+                34.6001,
+                34.4039
+            ],
+            "bundled_runs_ms": [
+                29.373,
+                29.4566,
+                29.2905,
+                29.2818,
+                29.4524,
+                29.2062,
+                29.3372
+            ],
+            "paired_ratios": [
+                0.84947,
+                0.85759,
+                0.85113,
+                0.8535,
+                0.85545,
+                0.84411,
+                0.85273
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78912,
+            "delta_pct": -21.09,
+            "ci_delta_pct": [
+                -21.24,
+                -20.75
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.17,
+                "B2/C2": -21.11,
+                "B3/C3": -20.91
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 22.7776,
+            "bundled_ms": 17.9893,
+            "raw_delta_pct": -21.12,
+            "spread_pct": [
+                0.9,
+                0.6
+            ],
+            "system_runs_ms": [
+                22.8929,
+                22.9369,
+                22.7944,
+                22.7243,
+                22.7655,
+                22.7586,
+                22.7776
+            ],
+            "bundled_runs_ms": [
+                17.9893,
+                18.0568,
+                17.9795,
+                17.9998,
+                17.981,
+                18.0303,
+                17.9469
+            ],
+            "paired_ratios": [
+                0.7858,
+                0.78724,
+                0.78877,
+                0.79209,
+                0.78984,
+                0.79224,
+                0.78792
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92547,
+            "delta_pct": -7.45,
+            "ci_delta_pct": [
+                -7.63,
+                -7.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.45,
+                "B2/C2": -7.9,
+                "B3/C3": -6.69
+            },
+            "build_spread_pct": 1.21,
+            "builds": 3,
+            "system_ms": 66.2064,
+            "bundled_ms": 61.2996,
+            "raw_delta_pct": -7.49,
+            "spread_pct": [
+                1.5,
+                1.1
+            ],
+            "system_runs_ms": [
+                66.2064,
+                66.778,
+                66.2364,
+                66.2361,
+                66.1227,
+                65.776,
+                66.2064
+            ],
+            "bundled_runs_ms": [
+                61.2444,
+                61.2996,
+                61.3832,
+                61.4708,
+                61.0511,
+                61.7346,
+                61.1746
+            ],
+            "paired_ratios": [
+                0.92505,
+                0.91796,
+                0.92673,
+                0.92806,
+                0.9233,
+                0.93856,
+                0.924
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.96761,
+            "delta_pct": -3.24,
+            "ci_delta_pct": [
+                -3.87,
+                -2.98
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.36,
+                "B2/C2": -2.82,
+                "B3/C3": -3.73
+            },
+            "build_spread_pct": 0.91,
+            "builds": 3,
+            "system_ms": 16.8341,
+            "bundled_ms": 16.2588,
+            "raw_delta_pct": -3.28,
+            "spread_pct": [
+                0.9,
+                1.2
+            ],
+            "system_runs_ms": [
+                16.9058,
+                16.8341,
+                16.8022,
+                16.8174,
+                16.8517,
+                16.9596,
+                16.8106
+            ],
+            "bundled_runs_ms": [
+                16.244,
+                16.3921,
+                16.2942,
+                16.2445,
+                16.3277,
+                16.1911,
+                16.2588
+            ],
+            "paired_ratios": [
+                0.96085,
+                0.97374,
+                0.96977,
+                0.96593,
+                0.96891,
+                0.95469,
+                0.96718
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89256,
+            "delta_pct": -10.74,
+            "ci_delta_pct": [
+                -11.07,
+                -10.56
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.74,
+                "B2/C2": -11.24,
+                "B3/C3": -7.85
+            },
+            "build_spread_pct": 3.39,
+            "builds": 3,
+            "system_ms": 21.1952,
+            "bundled_ms": 18.9152,
+            "raw_delta_pct": -10.78,
+            "spread_pct": [
+                1,
+                6.4
+            ],
+            "system_runs_ms": [
+                21.2423,
+                21.3616,
+                21.1792,
+                21.1741,
+                21.2802,
+                21.149,
+                21.1952
+            ],
+            "bundled_runs_ms": [
+                18.9682,
+                18.9175,
+                20.0836,
+                18.8907,
+                18.9152,
+                18.9066,
+                18.8782
+            ],
+            "paired_ratios": [
+                0.89294,
+                0.88558,
+                0.94827,
+                0.89216,
+                0.88886,
+                0.89397,
+                0.89068
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92404,
+            "delta_pct": -7.6,
+            "ci_delta_pct": [
+                -8.22,
+                -6.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.6,
+                "B2/C2": -8.62,
+                "B3/C3": -4.24
+            },
+            "build_spread_pct": 4.38,
+            "builds": 3,
+            "system_ms": 126.0497,
+            "bundled_ms": 116.2903,
+            "raw_delta_pct": -7.64,
+            "spread_pct": [
+                1.7,
+                6.8
+            ],
+            "system_runs_ms": [
+                125.6512,
+                126.8948,
+                126.0497,
+                125.9061,
+                126.2787,
+                124.7018,
+                126.0818
+            ],
+            "bundled_runs_ms": [
+                116.7709,
+                115.4059,
+                123.2562,
+                116.2903,
+                115.8474,
+                116.7717,
+                116.1107
+            ],
+            "paired_ratios": [
+                0.92933,
+                0.90946,
+                0.97784,
+                0.92363,
+                0.91739,
+                0.93641,
+                0.92092
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95756,
+            "delta_pct": -4.24,
+            "ci_delta_pct": [
+                -4.51,
+                -4.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.24,
+                "B2/C2": -4.31,
+                "B3/C3": -4.45
+            },
+            "build_spread_pct": 0.21,
+            "builds": 3,
+            "system_ms": 16.9487,
+            "bundled_ms": 16.2191,
+            "raw_delta_pct": -4.29,
+            "spread_pct": [
+                0.7,
+                0.5
+            ],
+            "system_runs_ms": [
+                16.9519,
+                16.9448,
+                16.9487,
+                16.9724,
+                16.9005,
+                17.0245,
+                16.9046
+            ],
+            "bundled_runs_ms": [
+                16.2578,
+                16.1727,
+                16.2271,
+                16.2204,
+                16.2,
+                16.2191,
+                16.1799
+            ],
+            "paired_ratios": [
+                0.95905,
+                0.95443,
+                0.95742,
+                0.95569,
+                0.95855,
+                0.95269,
+                0.95713
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88783,
+            "delta_pct": -11.22,
+            "ci_delta_pct": [
+                -11.74,
+                -10.99
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.41,
+                "B2/C2": -11.04,
+                "B3/C3": -8.93
+            },
+            "build_spread_pct": 2.48,
+            "builds": 3,
+            "system_ms": 21.4924,
+            "bundled_ms": 19.0584,
+            "raw_delta_pct": -11.26,
+            "spread_pct": [
+                1.4,
+                7
+            ],
+            "system_runs_ms": [
+                21.5589,
+                21.3863,
+                21.4766,
+                21.5215,
+                21.4874,
+                21.6791,
+                21.4924
+            ],
+            "bundled_runs_ms": [
+                19.0193,
+                19.0265,
+                20.305,
+                19.0584,
+                19.0966,
+                18.9706,
+                19.073
+            ],
+            "paired_ratios": [
+                0.8822,
+                0.88966,
+                0.94545,
+                0.88555,
+                0.88873,
+                0.87506,
+                0.88743
+            ]
+        },
+        "adv.optiter.ratio.increment.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92758,
+            "delta_pct": -7.24,
+            "ci_delta_pct": [
+                -7.97,
+                -6.74
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.3,
+                "B2/C2": -6.99,
+                "B3/C3": -4.66
+            },
+            "build_spread_pct": 2.64,
+            "builds": 3,
+            "system_ms": 127.139,
+            "bundled_ms": 117.6457,
+            "raw_delta_pct": -7.28,
+            "spread_pct": [
+                0.9,
+                6.9
+            ],
+            "system_runs_ms": [
+                127.1764,
+                126.2113,
+                126.7157,
+                126.8034,
+                127.1403,
+                127.3408,
+                127.139
+            ],
+            "bundled_runs_ms": [
+                116.9862,
+                117.6457,
+                125.1297,
+                117.4961,
+                117.8799,
+                116.9647,
+                117.8809
+            ],
+            "paired_ratios": [
+                0.91987,
+                0.93213,
+                0.98748,
+                0.9266,
+                0.92716,
+                0.91852,
+                0.92718
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88204,
+            "delta_pct": -11.8,
+            "ci_delta_pct": [
+                -12.8,
+                -11.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.8,
+                "B2/C2": -12.11,
+                "B3/C3": -10.35
+            },
+            "build_spread_pct": 2.45,
+            "builds": 3,
+            "system_ms": 34.3313,
+            "bundled_ms": 30.2145,
+            "raw_delta_pct": -11.84,
+            "spread_pct": [
+                0.9,
+                4
+            ],
+            "system_runs_ms": [
+                34.3313,
+                34.2487,
+                34.3236,
+                34.5536,
+                34.4851,
+                34.3842,
+                34.3289
+            ],
+            "bundled_runs_ms": [
+                29.7987,
+                30.2145,
+                30.9937,
+                30.1179,
+                30.1651,
+                30.5731,
+                30.2658
+            ],
+            "paired_ratios": [
+                0.86797,
+                0.88221,
+                0.90299,
+                0.87163,
+                0.87473,
+                0.88916,
+                0.88164
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.66011,
+            "delta_pct": -33.99,
+            "ci_delta_pct": [
+                -34.03,
+                -31.63
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -34.01,
+                "B2/C2": -33.58,
+                "B3/C3": -30.38
+            },
+            "build_spread_pct": 3.63,
+            "builds": 3,
+            "system_ms": 21.2095,
+            "bundled_ms": 13.9946,
+            "raw_delta_pct": -34.02,
+            "spread_pct": [
+                0.6,
+                8
+            ],
+            "system_runs_ms": [
+                21.2156,
+                21.2095,
+                21.2423,
+                21.1799,
+                21.1182,
+                21.222,
+                21.1951
+            ],
+            "bundled_runs_ms": [
+                13.9946,
+                13.9864,
+                15.0495,
+                13.9747,
+                14.1154,
+                14.5026,
+                13.9338
+            ],
+            "paired_ratios": [
+                0.65964,
+                0.65944,
+                0.70847,
+                0.65981,
+                0.6684,
+                0.68338,
+                0.65741
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76032,
+            "delta_pct": -23.97,
+            "ci_delta_pct": [
+                -25.22,
+                -23.11
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.27,
+                "B2/C2": -24.39,
+                "B3/C3": -22.31
+            },
+            "build_spread_pct": 2.08,
+            "builds": 3,
+            "system_ms": 61.7413,
+            "bundled_ms": 46.7939,
+            "raw_delta_pct": -24,
+            "spread_pct": [
+                1.1,
+                5.4
+            ],
+            "system_runs_ms": [
+                61.7967,
+                61.9279,
+                61.8883,
+                61.2957,
+                61.2387,
+                61.7203,
+                61.7413
+            ],
+            "bundled_runs_ms": [
+                46.9639,
+                46.2902,
+                48.5566,
+                46.4,
+                46.7939,
+                47.4359,
+                46.0381
+            ],
+            "paired_ratios": [
+                0.75997,
+                0.74749,
+                0.78458,
+                0.75699,
+                0.76412,
+                0.76856,
+                0.74566
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86525,
+            "delta_pct": -13.48,
+            "ci_delta_pct": [
+                -13.7,
+                -13.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.7,
+                "B2/C2": -13.24,
+                "B3/C3": -13.56
+            },
+            "build_spread_pct": 0.46,
+            "builds": 3,
+            "system_ms": 33.7641,
+            "bundled_ms": 29.2206,
+            "raw_delta_pct": -13.51,
+            "spread_pct": [
+                0.5,
+                0.6
+            ],
+            "system_runs_ms": [
+                33.8987,
+                33.7242,
+                33.7641,
+                33.8144,
+                33.7492,
+                33.8641,
+                33.7376
+            ],
+            "bundled_runs_ms": [
+                29.2417,
+                29.2816,
+                29.2206,
+                29.1048,
+                29.2313,
+                29.2121,
+                29.1782
+            ],
+            "paired_ratios": [
+                0.86262,
+                0.86827,
+                0.86543,
+                0.86072,
+                0.86613,
+                0.86263,
+                0.86486
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68621,
+            "delta_pct": -31.38,
+            "ci_delta_pct": [
+                -31.54,
+                -31.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -31.41,
+                "B2/C2": -31.53,
+                "B3/C3": -31.18
+            },
+            "build_spread_pct": 0.35,
+            "builds": 3,
+            "system_ms": 18.0874,
+            "bundled_ms": 12.3996,
+            "raw_delta_pct": -31.41,
+            "spread_pct": [
+                0.8,
+                0.7
+            ],
+            "system_runs_ms": [
+                18.1309,
+                18.0778,
+                18.0926,
+                18.0321,
+                18.1018,
+                17.9829,
+                18.0874
+            ],
+            "bundled_runs_ms": [
+                12.4063,
+                12.3996,
+                12.4221,
+                12.3627,
+                12.3615,
+                12.3949,
+                12.4462
+            ],
+            "paired_ratios": [
+                0.68426,
+                0.6859,
+                0.68658,
+                0.68559,
+                0.68289,
+                0.68926,
+                0.68811
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7937,
+            "delta_pct": -20.63,
+            "ci_delta_pct": [
+                -20.97,
+                -20.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.4,
+                "B2/C2": -21.04,
+                "B3/C3": -20.35
+            },
+            "build_spread_pct": 0.69,
+            "builds": 3,
+            "system_ms": 53.5854,
+            "bundled_ms": 42.4306,
+            "raw_delta_pct": -20.67,
+            "spread_pct": [
+                1,
+                0.9
+            ],
+            "system_runs_ms": [
+                53.4854,
+                53.6047,
+                53.5854,
+                53.3266,
+                53.6363,
+                53.1032,
+                53.612
+            ],
+            "bundled_runs_ms": [
+                42.4269,
+                42.346,
+                42.5114,
+                42.4765,
+                42.2884,
+                42.4306,
+                42.6559
+            ],
+            "paired_ratios": [
+                0.79324,
+                0.78997,
+                0.79334,
+                0.79653,
+                0.78843,
+                0.79902,
+                0.79564
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89541,
+            "delta_pct": -10.46,
+            "ci_delta_pct": [
+                -10.98,
+                -10.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.98,
+                "B2/C2": -10.29,
+                "B3/C3": -10.5
+            },
+            "build_spread_pct": 0.69,
+            "builds": 3,
+            "system_ms": 44.136,
+            "bundled_ms": 39.5022,
+            "raw_delta_pct": -10.5,
+            "spread_pct": [
+                0.9,
+                0.9
+            ],
+            "system_runs_ms": [
+                44.3388,
+                44.136,
+                43.9971,
+                44.4123,
+                44.0836,
+                44.1856,
+                44.1136
+            ],
+            "bundled_runs_ms": [
+                39.4505,
+                39.5022,
+                39.551,
+                39.3612,
+                39.6013,
+                39.3369,
+                39.7113
+            ],
+            "paired_ratios": [
+                0.88975,
+                0.89501,
+                0.89895,
+                0.88627,
+                0.89832,
+                0.89027,
+                0.90021
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7896,
+            "delta_pct": -21.04,
+            "ci_delta_pct": [
+                -21.13,
+                -21.03
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.04,
+                "B2/C2": -21.1,
+                "B3/C3": -20.81
+            },
+            "build_spread_pct": 0.29,
+            "builds": 3,
+            "system_ms": 27.4774,
+            "bundled_ms": 21.7127,
+            "raw_delta_pct": -21.08,
+            "spread_pct": [
+                0.8,
+                0.4
+            ],
+            "system_runs_ms": [
+                27.5771,
+                27.547,
+                27.4673,
+                27.4774,
+                27.4578,
+                27.3661,
+                27.5059
+            ],
+            "bundled_runs_ms": [
+                21.7193,
+                21.7316,
+                21.6821,
+                21.6864,
+                21.6455,
+                21.7203,
+                21.7127
+            ],
+            "paired_ratios": [
+                0.78758,
+                0.78889,
+                0.78938,
+                0.78924,
+                0.78832,
+                0.79369,
+                0.78938
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88183,
+            "delta_pct": -11.82,
+            "ci_delta_pct": [
+                -12.21,
+                -10.91
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.44,
+                "B2/C2": -12.01,
+                "B3/C3": -11.48
+            },
+            "build_spread_pct": 0.57,
+            "builds": 3,
+            "system_ms": 62.2857,
+            "bundled_ms": 55.0137,
+            "raw_delta_pct": -11.86,
+            "spread_pct": [
+                0.9,
+                1
+            ],
+            "system_runs_ms": [
+                62.1963,
+                62.414,
+                62.4299,
+                61.869,
+                62.2857,
+                61.9344,
+                62.3524
+            ],
+            "bundled_runs_ms": [
+                55.0546,
+                55.0137,
+                54.8206,
+                55.0957,
+                54.6586,
+                55.216,
+                54.6765
+            ],
+            "paired_ratios": [
+                0.88517,
+                0.88143,
+                0.87811,
+                0.89052,
+                0.87755,
+                0.89152,
+                0.87689
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.98484,
+            "delta_pct": -1.52,
+            "ci_delta_pct": [
+                -1.69,
+                -1.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.15,
+                "B2/C2": -1.04,
+                "B3/C3": -1.58
+            },
+            "build_spread_pct": 0.54,
+            "builds": 3,
+            "system_ms": 24.8479,
+            "bundled_ms": 24.4875,
+            "raw_delta_pct": -1.56,
+            "spread_pct": [
+                0.8,
+                1
+            ],
+            "system_runs_ms": [
+                24.9776,
+                24.7706,
+                24.8479,
+                24.8303,
+                24.9013,
+                24.8756,
+                24.8375
+            ],
+            "bundled_runs_ms": [
+                24.4756,
+                24.6642,
+                24.43,
+                24.5345,
+                24.4703,
+                24.4875,
+                24.5557
+            ],
+            "paired_ratios": [
+                0.9799,
+                0.9957,
+                0.98318,
+                0.98809,
+                0.98269,
+                0.9844,
+                0.98865
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94667,
+            "delta_pct": -5.33,
+            "ci_delta_pct": [
+                -5.54,
+                -4.93
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.33,
+                "B2/C2": -5.15,
+                "B3/C3": -5.47
+            },
+            "build_spread_pct": 0.32,
+            "builds": 3,
+            "system_ms": 27.6613,
+            "bundled_ms": 26.1744,
+            "raw_delta_pct": -5.38,
+            "spread_pct": [
+                1.1,
+                0.6
+            ],
+            "system_runs_ms": [
+                27.6727,
+                27.6196,
+                27.5928,
+                27.5732,
+                27.7003,
+                27.8724,
+                27.6613
+            ],
+            "bundled_runs_ms": [
+                26.1277,
+                26.2873,
+                26.2199,
+                26.1534,
+                26.1589,
+                26.1869,
+                26.1744
+            ],
+            "paired_ratios": [
+                0.94417,
+                0.95176,
+                0.95024,
+                0.94851,
+                0.94435,
+                0.93953,
+                0.94625
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.96038,
+            "delta_pct": -3.96,
+            "ci_delta_pct": [
+                -4.37,
+                -3.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.96,
+                "B2/C2": -4.11,
+                "B3/C3": -3.91
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 111.2404,
+            "bundled_ms": 106.7499,
+            "raw_delta_pct": -4.01,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                110.7903,
+                111.5012,
+                111.0469,
+                111.0466,
+                111.2404,
+                112.0468,
+                111.3689
+            ],
+            "bundled_runs_ms": [
+                106.7499,
+                106.5804,
+                107.3265,
+                106.5985,
+                106.9003,
+                106.9399,
+                106.5922
+            ],
+            "paired_ratios": [
+                0.96353,
+                0.95587,
+                0.9665,
+                0.95994,
+                0.96098,
+                0.95442,
+                0.95711
+            ]
+        }
+    },
+    "array_vs_bundled": {
+        "core.bitset.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.15691,
+            "delta_pct": 15.69,
+            "ci_delta_pct": [
+                14.82,
+                16.12
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                89.9344,
+                88.9549,
+                88.608,
+                90.0056,
+                89.3066,
+                88.7723,
+                88.914
+            ],
+            "judy_runs_ms": [
+                103.2649,
+                102.913,
+                103.0792,
+                104.1501,
+                102.5332,
+                103.0818,
+                102.7061
+            ],
+            "array_ms": 88.9549,
+            "judy_ms": 103.0792,
+            "judy_over_array": 1.159,
+            "winner": "php-array"
+        },
+        "core.bitset.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.07327,
+            "delta_pct": 207.33,
+            "ci_delta_pct": [
+                204.49,
+                209.04
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.1806,
+                21.8956,
+                21.9194,
+                22.2806,
+                23.294,
+                21.8788,
+                21.8848
+            ],
+            "judy_runs_ms": [
+                67.5387,
+                67.6669,
+                67.0739,
+                69.6825,
+                67.6501,
+                67.5641,
+                67.258
+            ],
+            "array_ms": 21.9194,
+            "judy_ms": 67.5641,
+            "judy_over_array": 3.082,
+            "winner": "php-array"
+        },
+        "core.bitset.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.71719,
+            "delta_pct": 471.72,
+            "ci_delta_pct": [
+                461.56,
+                474.66
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.6659,
+                18.7423,
+                18.7364,
+                18.7162,
+                19.2074,
+                18.7459,
+                18.7677
+            ],
+            "judy_runs_ms": [
+                107.7099,
+                107.2559,
+                106.8819,
+                107.555,
+                107.7743,
+                105.2689,
+                107.2986
+            ],
+            "array_ms": 18.7423,
+            "judy_ms": 107.2986,
+            "judy_over_array": 5.725,
+            "winner": "php-array"
+        },
+        "core.bitset.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.00373,
+            "delta_pct": -99.63,
+            "ci_delta_pct": [
+                -99.64,
+                -99.62
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.5705,
+                4.9028,
+                5.0107,
+                5.037,
+                4.9787,
+                4.9792,
+                5.0367
+            ],
+            "judy_runs_ms": [
+                0.019,
+                0.0189,
+                0.0182,
+                0.0181,
+                0.0187,
+                0.0186,
+                0.0188
+            ],
+            "array_ms": 5.0107,
+            "judy_ms": 0.0187,
+            "judy_over_array": 0.004,
+            "winner": "php-judy"
+        },
+        "core.int_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.57373,
+            "delta_pct": 57.37,
+            "ci_delta_pct": [
+                57.07,
+                59.01
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.1433,
+                92.1625,
+                91.5714,
+                92.0428,
+                91.9472,
+                91.668,
+                91.8452
+            ],
+            "judy_runs_ms": [
+                151.4656,
+                144.67,
+                145.605,
+                144.6566,
+                144.6998,
+                143.9862,
+                144.9997
+            ],
+            "array_ms": 91.9472,
+            "judy_ms": 144.6998,
+            "judy_over_array": 1.574,
+            "winner": "php-array"
+        },
+        "core.int_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.02269,
+            "delta_pct": 202.27,
+            "ci_delta_pct": [
+                195.16,
+                204.06
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.1337,
+                22.2291,
+                21.9771,
+                22.6793,
+                23.5673,
+                22.2218,
+                21.8916
+            ],
+            "judy_runs_ms": [
+                66.9616,
+                67.1916,
+                66.8235,
+                66.9407,
+                66.979,
+                67.0256,
+                67.0986
+            ],
+            "array_ms": 22.2218,
+            "judy_ms": 66.979,
+            "judy_over_array": 3.014,
+            "winner": "php-array"
+        },
+        "core.int_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.04913,
+            "delta_pct": 504.91,
+            "ci_delta_pct": [
+                503.1,
+                510.53
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.6415,
+                18.6256,
+                18.6458,
+                18.6963,
+                19.1711,
+                18.6762,
+                18.6636
+            ],
+            "judy_runs_ms": [
+                113.8123,
+                113.1007,
+                112.4526,
+                112.9984,
+                113.2658,
+                112.9747,
+                114.1268
+            ],
+            "array_ms": 18.6636,
+            "judy_ms": 113.1007,
+            "judy_over_array": 6.06,
+            "winner": "php-array"
+        },
+        "core.int_to_int.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.38301,
+            "delta_pct": -61.7,
+            "ci_delta_pct": [
+                -62.25,
+                -60.49
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.3959,
+                5.4515,
+                5.4961,
+                5.4547,
+                5.5132,
+                5.4547,
+                5.5136
+            ],
+            "judy_runs_ms": [
+                2.3516,
+                2.0581,
+                2.0779,
+                2.1549,
+                2.1459,
+                2.0892,
+                2.0591
+            ],
+            "array_ms": 5.4547,
+            "judy_ms": 2.0892,
+            "judy_over_array": 0.383,
+            "winner": "php-judy"
+        },
+        "core.int_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.50994,
+            "delta_pct": 50.99,
+            "ci_delta_pct": [
+                50.49,
+                51.26
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                265.6644,
+                265.1363,
+                264.0139,
+                263.9682,
+                265.8573,
+                263.6503,
+                264.2683
+            ],
+            "judy_runs_ms": [
+                408.5959,
+                401.034,
+                398.6465,
+                398.5561,
+                398.5101,
+                396.7595,
+                399.0295
+            ],
+            "array_ms": 264.2683,
+            "judy_ms": 398.6465,
+            "judy_over_array": 1.508,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.29901,
+            "delta_pct": 129.9,
+            "ci_delta_pct": [
+                128.63,
+                130.84
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                120.967,
+                121.0417,
+                121.0684,
+                120.3876,
+                122.2629,
+                120.4878,
+                120.5691
+            ],
+            "judy_runs_ms": [
+                278.3241,
+                278.2761,
+                276.802,
+                276.564,
+                277.9477,
+                278.2997,
+                278.3239
+            ],
+            "array_ms": 120.967,
+            "judy_ms": 278.2761,
+            "judy_over_array": 2.3,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.76353,
+            "delta_pct": 276.35,
+            "ci_delta_pct": [
+                274.03,
+                276.87
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                85.6179,
+                85.6273,
+                84.9704,
+                84.9641,
+                85.3689,
+                84.9899,
+                87.3264
+            ],
+            "judy_runs_ms": [
+                320.2334,
+                321.2499,
+                319.9505,
+                321.0226,
+                321.727,
+                319.8619,
+                321.023
+            ],
+            "array_ms": 85.3689,
+            "judy_ms": 321.0226,
+            "judy_over_array": 3.76,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.17547,
+            "delta_pct": 117.55,
+            "ci_delta_pct": [
+                116.73,
+                118.54
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                46.0914,
+                46.2151,
+                46.0076,
+                45.8206,
+                46.0144,
+                45.9608,
+                46.0415
+            ],
+            "judy_runs_ms": [
+                100.9147,
+                100.5394,
+                99.7148,
+                99.307,
+                100.2023,
+                99.5427,
+                100.6201
+            ],
+            "array_ms": 46.0144,
+            "judy_ms": 100.2023,
+            "judy_over_array": 2.178,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.4121,
+            "delta_pct": 41.21,
+            "ci_delta_pct": [
+                40.29,
+                41.31
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                247.4712,
+                247.306,
+                245.7508,
+                245.7278,
+                246.6513,
+                246.7617,
+                245.9538
+            ],
+            "judy_runs_ms": [
+                356.3076,
+                346.9518,
+                346.7595,
+                347.0224,
+                348.2966,
+                344.6043,
+                347.5518
+            ],
+            "array_ms": 246.6513,
+            "judy_ms": 347.0224,
+            "judy_over_array": 1.407,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.92889,
+            "delta_pct": 92.89,
+            "ci_delta_pct": [
+                91.95,
+                93.06
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                106.6393,
+                106.6454,
+                106.6973,
+                106.491,
+                107.9827,
+                106.4273,
+                106.4425
+            ],
+            "judy_runs_ms": [
+                205.6957,
+                204.7107,
+                204.9991,
+                205.4319,
+                205.8392,
+                205.7007,
+                205.4948
+            ],
+            "array_ms": 106.6393,
+            "judy_ms": 205.4948,
+            "judy_over_array": 1.927,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 11.58728,
+            "delta_pct": 1058.73,
+            "ci_delta_pct": [
+                1051.1,
+                1062.51
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                21.4034,
+                21.3985,
+                21.3027,
+                21.6866,
+                21.5015,
+                21.3088,
+                21.4014
+            ],
+            "judy_runs_ms": [
+                246.569,
+                247.9505,
+                248.7612,
+                246.4768,
+                247.5042,
+                247.7162,
+                248.3553
+            ],
+            "array_ms": 21.4014,
+            "judy_ms": 247.7162,
+            "judy_over_array": 11.575,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.11064,
+            "delta_pct": 11.06,
+            "ci_delta_pct": [
+                10.78,
+                11.86
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                47.06,
+                46.9734,
+                46.8967,
+                46.6688,
+                46.7261,
+                46.7865,
+                46.8177
+            ],
+            "judy_runs_ms": [
+                51.9304,
+                52.0836,
+                52.1941,
+                52.2038,
+                52.3138,
+                51.8302,
+                51.9977
+            ],
+            "array_ms": 46.8177,
+            "judy_ms": 52.0836,
+            "judy_over_array": 1.112,
+            "winner": "php-array"
+        },
+        "api.increment.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.51796,
+            "delta_pct": 151.8,
+            "ci_delta_pct": [
+                149.07,
+                153.51
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                57.2767,
+                57.3263,
+                57.4729,
+                57.1699,
+                57.5422,
+                57.4729,
+                57.4234
+            ],
+            "judy_runs_ms": [
+                145.2034,
+                145.9268,
+                141.8263,
+                144.7937,
+                144.8887,
+                143.1506,
+                143.5616
+            ],
+            "array_ms": 57.4234,
+            "judy_ms": 144.7937,
+            "judy_over_array": 2.522,
+            "winner": "php-array"
+        },
+        "api.setop.union.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.97116,
+            "delta_pct": 97.12,
+            "ci_delta_pct": [
+                94.83,
+                97.62
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.2909,
+                95.9261,
+                95.6374,
+                92.2697,
+                92.4504,
+                92.2483,
+                92.2471
+            ],
+            "judy_runs_ms": [
+                182.3807,
+                182.394,
+                186.3256,
+                181.5828,
+                182.2349,
+                183.7177,
+                182.0284
+            ],
+            "array_ms": 92.2909,
+            "judy_ms": 182.3807,
+            "judy_over_array": 1.976,
+            "winner": "php-array"
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91323,
+            "delta_pct": -8.68,
+            "ci_delta_pct": [
+                -9.24,
+                -8.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                95.2619,
+                95.4875,
+                95.4341,
+                95.2817,
+                95.5329,
+                95.0645,
+                95.8728
+            ],
+            "judy_runs_ms": [
+                86.8661,
+                88.5066,
+                86.4986,
+                87.0292,
+                87.2437,
+                87.3123,
+                87.0147
+            ],
+            "array_ms": 95.4341,
+            "judy_ms": 87.0292,
+            "judy_over_array": 0.912,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.00428,
+            "delta_pct": 100.43,
+            "ci_delta_pct": [
+                100.19,
+                100.78
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                42.9207,
+                43.0306,
+                42.9346,
+                43.1827,
+                43.0449,
+                42.7808,
+                42.953
+            ],
+            "judy_runs_ms": [
+                85.9227,
+                86.3063,
+                86.2032,
+                86.5453,
+                85.996,
+                86.394,
+                86.0899
+            ],
+            "array_ms": 42.953,
+            "judy_ms": 86.2032,
+            "judy_over_array": 2.007,
+            "winner": "php-array"
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78206,
+            "delta_pct": -21.79,
+            "ci_delta_pct": [
+                -21.96,
+                -21.49
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                220.5865,
+                221.284,
+                221.1178,
+                221.3858,
+                221.61,
+                220.2091,
+                221.3539
+            ],
+            "judy_runs_ms": [
+                172.1419,
+                173.5926,
+                172.9268,
+                174.3812,
+                173.2124,
+                172.8768,
+                172.215
+            ],
+            "array_ms": 221.284,
+            "judy_ms": 172.9268,
+            "judy_over_array": 0.781,
+            "winner": "php-judy"
+        }
+    },
+    "judy_vs_phploop": {
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69496,
+            "delta_pct": -30.5,
+            "ci_delta_pct": [
+                -30.75,
+                -30.04
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                181.4144,
+                182.1257,
+                183.0138,
+                181.2687,
+                181.0049,
+                183.5235,
+                182.872
+            ],
+            "judy_runs_ms": [
+                126.0764,
+                127.5117,
+                127.0511,
+                126.6613,
+                126.632,
+                127.0809,
+                126.2268
+            ],
+            "array_ms": 182.1257,
+            "judy_ms": 126.6613,
+            "judy_over_array": 0.695,
+            "winner": "php-judy"
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69496,
+            "delta_pct": -30.5,
+            "ci_delta_pct": [
+                -30.86,
+                -30.02
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                181.4144,
+                182.1257,
+                183.0138,
+                181.2687,
+                181.0049,
+                183.5235,
+                182.872
+            ],
+            "judy_runs_ms": [
+                127.2111,
+                127.4474,
+                127.0895,
+                125.975,
+                126.2108,
+                126.8967,
+                126.1443
+            ],
+            "array_ms": 182.1257,
+            "judy_ms": 126.8967,
+            "judy_over_array": 0.697,
+            "winner": "php-judy"
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.82075,
+            "delta_pct": -17.93,
+            "ci_delta_pct": [
+                -18.16,
+                -17.51
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                362.7274,
+                360.9339,
+                361.3192,
+                361.1802,
+                361.2782,
+                370.0264,
+                363.297
+            ],
+            "judy_runs_ms": [
+                296.8466,
+                298.7747,
+                298.057,
+                296.4381,
+                296.7137,
+                298.1665,
+                297.5814
+            ],
+            "array_ms": 361.3192,
+            "judy_ms": 297.5814,
+            "judy_over_array": 0.824,
+            "winner": "php-judy"
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78531,
+            "delta_pct": -21.47,
+            "ci_delta_pct": [
+                -21.89,
+                -21.37
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                27.1422,
+                27.2576,
+                27.2839,
+                27.2494,
+                27.2523,
+                27.1984,
+                27.254
+            ],
+            "judy_runs_ms": [
+                21.3412,
+                21.5102,
+                21.37,
+                21.2773,
+                21.4035,
+                21.3593,
+                21.2871
+            ],
+            "array_ms": 27.2523,
+            "judy_ms": 21.3593,
+            "judy_over_array": 0.784,
+            "winner": "php-judy"
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.59949,
+            "delta_pct": -40.05,
+            "ci_delta_pct": [
+                -40.44,
+                -40.01
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                193.695,
+                193.5459,
+                194.3993,
+                193.1337,
+                193.9121,
+                194.434,
+                194.3552
+            ],
+            "judy_runs_ms": [
+                116.3136,
+                116.0998,
+                115.777,
+                115.8362,
+                116.2483,
+                115.7271,
+                115.8915
+            ],
+            "array_ms": 193.9121,
+            "judy_ms": 115.8915,
+            "judy_over_array": 0.598,
+            "winner": "php-judy"
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.62252,
+            "delta_pct": -37.75,
+            "ci_delta_pct": [
+                -38.15,
+                -37.74
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.5926,
+                194.0549,
+                194.8716,
+                194.7841,
+                193.927,
+                193.3506,
+                194.5759
+            ],
+            "judy_runs_ms": [
+                121.1408,
+                120.8156,
+                120.5279,
+                120.2569,
+                120.8527,
+                120.3642,
+                120.8106
+            ],
+            "array_ms": 194.5759,
+            "judy_ms": 120.8106,
+            "judy_over_array": 0.621,
+            "winner": "php-judy"
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.06795,
+            "delta_pct": -93.21,
+            "ci_delta_pct": [
+                -93.22,
+                -93.16
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                148.0482,
+                147.4136,
+                147.9967,
+                147.154,
+                146.6938,
+                147.5342,
+                147.9607
+            ],
+            "judy_runs_ms": [
+                10.0597,
+                9.9982,
+                10.0147,
+                10.0913,
+                10.0396,
+                10.0597,
+                10.0399
+            ],
+            "array_ms": 147.5342,
+            "judy_ms": 10.0399,
+            "judy_over_array": 0.068,
+            "winner": "php-judy"
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41078,
+            "delta_pct": -58.92,
+            "ci_delta_pct": [
+                -59.18,
+                -58.69
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                118.1223,
+                117.5284,
+                117.6935,
+                118.6241,
+                118.1666,
+                117.7848,
+                118.9712
+            ],
+            "judy_runs_ms": [
+                48.7058,
+                48.5673,
+                48.6201,
+                48.245,
+                48.5152,
+                48.3835,
+                48.5617
+            ],
+            "array_ms": 118.1223,
+            "judy_ms": 48.5617,
+            "judy_over_array": 0.411,
+            "winner": "php-judy"
+        },
+        "api.populationCount.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0,
+            "delta_pct": -100,
+            "ci_delta_pct": [
+                -100,
+                -100
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                118.5834,
+                118.4058,
+                120.7617,
+                118.2426,
+                119.133,
+                118.7462,
+                119.075
+            ],
+            "judy_runs_ms": [
+                0.0001,
+                0.0001,
+                0,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001
+            ],
+            "array_ms": 118.7462,
+            "judy_ms": 0.0001,
+            "judy_over_array": 0,
+            "winner": "php-judy"
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69742,
+            "delta_pct": -30.26,
+            "ci_delta_pct": [
+                -30.31,
+                -30.02
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                339.6644,
+                338.8756,
+                338.6283,
+                338.7618,
+                339.5388,
+                338.7298,
+                339.1392
+            ],
+            "judy_runs_ms": [
+                236.3584,
+                236.2621,
+                236.6343,
+                241.1298,
+                236.6241,
+                237.0482,
+                236.5233
+            ],
+            "array_ms": 338.8756,
+            "judy_ms": 236.6241,
+            "judy_over_array": 0.698,
+            "winner": "php-judy"
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.25819,
+            "delta_pct": -74.18,
+            "ci_delta_pct": [
+                -74.35,
+                -74.03
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                275.1844,
+                275.2902,
+                276.6991,
+                275.2225,
+                279.6269,
+                275.0878,
+                275.4675
+            ],
+            "judy_runs_ms": [
+                71.0026,
+                71.4816,
+                72.0942,
+                71.0596,
+                71.5702,
+                70.5614,
+                71.4746
+            ],
+            "array_ms": 275.2902,
+            "judy_ms": 71.4746,
+            "judy_over_array": 0.26,
+            "winner": "php-judy"
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.52217,
+            "delta_pct": -47.78,
+            "ci_delta_pct": [
+                -48.03,
+                -47.5
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                511.6874,
+                509.4505,
+                508.4369,
+                508.0019,
+                512.5875,
+                509.0794,
+                511.3117
+            ],
+            "judy_runs_ms": [
+                266.0821,
+                266.3311,
+                266.9089,
+                267.1694,
+                266.2446,
+                265.8266,
+                265.7204
+            ],
+            "array_ms": 509.4505,
+            "judy_ms": 266.2446,
+            "judy_over_array": 0.523,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.43837,
+            "delta_pct": -56.16,
+            "ci_delta_pct": [
+                -56.26,
+                -56.1
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                248.7736,
+                248.8366,
+                248.3991,
+                248.0695,
+                248.9541,
+                247.8096,
+                248.962
+            ],
+            "judy_runs_ms": [
+                109.0543,
+                109.0185,
+                109.0381,
+                108.824,
+                108.768,
+                108.4024,
+                109.4495
+            ],
+            "array_ms": 248.7736,
+            "judy_ms": 109.0185,
+            "judy_over_array": 0.438,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41992,
+            "delta_pct": -58.01,
+            "ci_delta_pct": [
+                -58.05,
+                -57.96
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                257.134,
+                256.2562,
+                257.1194,
+                258.8488,
+                256.865,
+                256.8747,
+                256.5247
+            ],
+            "judy_runs_ms": [
+                107.8578,
+                107.8351,
+                107.8609,
+                107.8433,
+                107.8635,
+                107.9877,
+                107.7324
+            ],
+            "array_ms": 256.8747,
+            "judy_ms": 107.8578,
+            "judy_over_array": 0.42,
+            "winner": "php-judy"
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42161,
+            "delta_pct": -57.84,
+            "ci_delta_pct": [
+                -57.91,
+                -57.73
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                513.3077,
+                513.1019,
+                513.6638,
+                512.4244,
+                512.942,
+                513.9302,
+                514.1807
+            ],
+            "judy_runs_ms": [
+                216.4144,
+                216.8926,
+                216.354,
+                216.7878,
+                216.808,
+                216.3133,
+                215.9537
+            ],
+            "array_ms": 513.3077,
+            "judy_ms": 216.4144,
+            "judy_over_array": 0.422,
+            "winner": "php-judy"
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85969,
+            "delta_pct": -14.03,
+            "ci_delta_pct": [
+                -14.35,
+                -13.98
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1703.1019,
+                1690.9036,
+                1695.0364,
+                1693.5883,
+                1691.3952,
+                1691.6433,
+                1700.6099
+            ],
+            "judy_runs_ms": [
+                1461.0663,
+                1448.1811,
+                1458.1417,
+                1455.969,
+                1454.1508,
+                1457.1604,
+                1455.1902
+            ],
+            "array_ms": 1693.5883,
+            "judy_ms": 1455.969,
+            "judy_over_array": 0.86,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83878,
+            "delta_pct": -16.12,
+            "ci_delta_pct": [
+                -16.32,
+                -15.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                787.9534,
+                781.0014,
+                779.4826,
+                776.2809,
+                778.3379,
+                778.4346,
+                782.4587
+            ],
+            "judy_runs_ms": [
+                657.9992,
+                655.0906,
+                657.0572,
+                654.2357,
+                656.2936,
+                651.7597,
+                654.7588
+            ],
+            "array_ms": 779.4826,
+            "judy_ms": 655.0906,
+            "judy_over_array": 0.84,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86045,
+            "delta_pct": -13.95,
+            "ci_delta_pct": [
+                -14.94,
+                -13.28
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                793.127,
+                786.6859,
+                782.2939,
+                788.3928,
+                793.4513,
+                779.3593,
+                780.3268
+            ],
+            "judy_runs_ms": [
+                674.6552,
+                676.9053,
+                678.4353,
+                676.5314,
+                674.8668,
+                675.8782,
+                679.0286
+            ],
+            "array_ms": 786.6859,
+            "judy_ms": 676.5314,
+            "judy_over_array": 0.86,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77873,
+            "delta_pct": -22.13,
+            "ci_delta_pct": [
+                -22.35,
+                -21.94
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                389.2952,
+                388.2181,
+                386.4257,
+                389.2589,
+                388.6159,
+                386.7953,
+                389.2462
+            ],
+            "judy_runs_ms": [
+                303.056,
+                303.0421,
+                302.1062,
+                303.4521,
+                302.6263,
+                300.3413,
+                302.2349
+            ],
+            "array_ms": 388.6159,
+            "judy_ms": 302.6263,
+            "judy_over_array": 0.779,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90547,
+            "delta_pct": -9.45,
+            "ci_delta_pct": [
+                -9.96,
+                -9.35
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1323.7233,
+                1323.3974,
+                1317.879,
+                1320.3925,
+                1317.2001,
+                1314.5703,
+                1322.3953
+            ],
+            "judy_runs_ms": [
+                1199.9779,
+                1191.5984,
+                1194.4826,
+                1197.0864,
+                1190.944,
+                1190.309,
+                1189.277
+            ],
+            "array_ms": 1320.3925,
+            "judy_ms": 1191.5984,
+            "judy_over_array": 0.902,
+            "winner": "php-judy"
+        },
+        "adv.forEach.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.46159,
+            "delta_pct": 46.16,
+            "ci_delta_pct": [
+                44.69,
+                48.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                127.3243,
+                126.9997,
+                128.7468,
+                127.1747,
+                127.5721,
+                131.0662,
+                131.7234
+            ],
+            "judy_runs_ms": [
+                186.0957,
+                188.837,
+                191.0394,
+                184.0067,
+                186.8692,
+                188.4844,
+                191.5767
+            ],
+            "array_ms": 127.5721,
+            "judy_ms": 188.4844,
+            "judy_over_array": 1.477,
+            "winner": "php-array"
+        },
+        "adv.forEach.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.16803,
+            "delta_pct": 16.8,
+            "ci_delta_pct": [
+                16.73,
+                17.29
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                302.7175,
+                302.3465,
+                303.1982,
+                303.9606,
+                303.2997,
+                302.9785,
+                303.4839
+            ],
+            "judy_runs_ms": [
+                355.0661,
+                354.3444,
+                353.9241,
+                357.0129,
+                354.2639,
+                353.8297,
+                354.0886
+            ],
+            "array_ms": 303.1982,
+            "judy_ms": 354.2639,
+            "judy_over_array": 1.168,
+            "winner": "php-array"
+        },
+        "adv.filter.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.22181,
+            "delta_pct": 22.18,
+            "ci_delta_pct": [
+                21.06,
+                22.54
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                224.6944,
+                225.7386,
+                223.997,
+                223.6847,
+                226.5795,
+                224.237,
+                225.1579
+            ],
+            "judy_runs_ms": [
+                274.9265,
+                273.2858,
+                273.2443,
+                275.4757,
+                274.1438,
+                274.7759,
+                275.1003
+            ],
+            "array_ms": 224.6944,
+            "judy_ms": 274.7759,
+            "judy_over_array": 1.223,
+            "winner": "php-array"
+        },
+        "adv.filter.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.05585,
+            "delta_pct": 5.58,
+            "ci_delta_pct": [
+                5.23,
+                5.87
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                738.1673,
+                740.9912,
+                735.3631,
+                737.8337,
+                737.9127,
+                737.3692,
+                738.922
+            ],
+            "judy_runs_ms": [
+                776.7947,
+                778.8982,
+                776.6947,
+                784.272,
+                776.8801,
+                780.6225,
+                780.1906
+            ],
+            "array_ms": 737.9127,
+            "judy_ms": 778.8982,
+            "judy_over_array": 1.056,
+            "winner": "php-array"
+        },
+        "adv.map.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.08972,
+            "delta_pct": 8.97,
+            "ci_delta_pct": [
+                8.41,
+                9.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                272.1159,
+                274.6732,
+                272.138,
+                271.9916,
+                275.8778,
+                273.222,
+                272.519
+            ],
+            "judy_runs_ms": [
+                297.0857,
+                297.3636,
+                297.6621,
+                298.0044,
+                299.0706,
+                296.8497,
+                296.9707
+            ],
+            "array_ms": 272.519,
+            "judy_ms": 297.3636,
+            "judy_over_array": 1.091,
+            "winner": "php-array"
+        },
+        "adv.map.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.02138,
+            "delta_pct": 2.14,
+            "ci_delta_pct": [
+                2.11,
+                2.33
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1043.6491,
+                1042.686,
+                1043.1317,
+                1042.7906,
+                1043.0623,
+                1043.8006,
+                1043.6065
+            ],
+            "judy_runs_ms": [
+                1067.9528,
+                1061.658,
+                1065.5112,
+                1069.8636,
+                1065.3642,
+                1066.029,
+                1065.5867
+            ],
+            "array_ms": 1043.1317,
+            "judy_ms": 1065.5867,
+            "judy_over_array": 1.022,
+            "winner": "php-array"
+        }
+    },
+    "memory": [
+        {
+            "workload": "int_to_int",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 160129024,
+                    "peak_rss_ci": [
+                        160124928,
+                        160133120
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 134221904,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 135946240,
+                    "bytes_per_element": 22.66
+                },
+                "B": {
+                    "peak_rss_bytes": 76480512,
+                    "peak_rss_ci": [
+                        76283904,
+                        76480512
+                    ],
+                    "index_bytes": 49885112,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 51904512,
+                    "bytes_per_element": 8.65
+                },
+                "C": {
+                    "peak_rss_bytes": 76480512,
+                    "peak_rss_ci": [
+                        76480512,
+                        76480512
+                    ],
+                    "index_bytes": 49885112,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 52101120,
+                    "bytes_per_element": 8.68
+                }
+            },
+            "array_over_bundled": 2.609,
+            "system_over_bundled": 0.996
+        },
+        {
+            "workload": "int_sparse",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 328761344,
+                    "peak_rss_ci": [
+                        328564736,
+                        328761344
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 335544400,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 304578560,
+                    "bytes_per_element": 50.76
+                },
+                "B": {
+                    "peak_rss_bytes": 102825984,
+                    "peak_rss_ci": [
+                        102629376,
+                        102825984
+                    ],
+                    "index_bytes": 75088096,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 78249984,
+                    "bytes_per_element": 13.04
+                },
+                "C": {
+                    "peak_rss_bytes": 102825984,
+                    "peak_rss_ci": [
+                        102629376,
+                        102825984
+                    ],
+                    "index_bytes": 75088096,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 78446592,
+                    "bytes_per_element": 13.07
+                }
+            },
+            "array_over_bundled": 3.883,
+            "system_over_bundled": 0.997
+        },
+        {
+            "workload": "int_to_mixed",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 225538048,
+                    "peak_rss_ci": [
+                        225533952,
+                        225538048
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 230221744,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 201355264,
+                    "bytes_per_element": 33.56
+                },
+                "B": {
+                    "peak_rss_bytes": 268369920,
+                    "peak_rss_ci": [
+                        268369920,
+                        268566528
+                    ],
+                    "index_bytes": 49885112,
+                    "php_heap_bytes": 192000000,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 243793920,
+                    "bytes_per_element": 40.63
+                },
+                "C": {
+                    "peak_rss_bytes": 268566528,
+                    "peak_rss_ci": [
+                        268566528,
+                        268566528
+                    ],
+                    "index_bytes": 49885112,
+                    "php_heap_bytes": 192000000,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 244187136,
+                    "bytes_per_element": 40.7
+                }
+            },
+            "array_over_bundled": 0.825,
+            "system_over_bundled": 0.998
+        },
+        {
+            "workload": "string_to_int",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 524615680,
+                    "peak_rss_ci": [
+                        524611584,
+                        524619776
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 575536400,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 500432896,
+                    "bytes_per_element": 83.41
+                },
+                "B": {
+                    "peak_rss_bytes": 169476096,
+                    "peak_rss_ci": [
+                        169279488,
+                        169476096
+                    ],
+                    "index_bytes": 118888890,
+                    "php_heap_bytes": 65696,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 144900096,
+                    "bytes_per_element": 24.15
+                },
+                "C": {
+                    "peak_rss_bytes": 169476096,
+                    "peak_rss_ci": [
+                        169476096,
+                        169476096
+                    ],
+                    "index_bytes": 118888890,
+                    "php_heap_bytes": 65696,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 145096704,
+                    "bytes_per_element": 24.18
+                }
+            },
+            "array_over_bundled": 3.449,
+            "system_over_bundled": 0.999
+        },
+        {
+            "workload": "bitset",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 328761344,
+                    "peak_rss_ci": [
+                        328761344,
+                        328765440
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 335544400,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 304578560,
+                    "bytes_per_element": 50.76
+                },
+                "B": {
+                    "peak_rss_bytes": 35192832,
+                    "peak_rss_ci": [
+                        34996224,
+                        35389440
+                    ],
+                    "index_bytes": 7896080,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 10616832,
+                    "bytes_per_element": 1.77
+                },
+                "C": {
+                    "peak_rss_bytes": 35192832,
+                    "peak_rss_ci": [
+                        35192832,
+                        35192832
+                    ],
+                    "index_bytes": 7896080,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 10813440,
+                    "bytes_per_element": 1.8
+                }
+            },
+            "array_over_bundled": 28.167,
+            "system_over_bundled": 0.982
+        }
+    ],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-B-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-7/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-B-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-7/B2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-B-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-7/B3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-7/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C2": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-7/C2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C3": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [
+                "/work/builds/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-threearm-7/C3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/run6-out-of-cache-6m.txt
+++ b/research/three-arm-benchmark/results/run6-out-of-cache-6m.txt
@@ -1,0 +1,154 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /work/builds/judy-B-1.so, /work/builds/judy-B-2.so, /work/builds/judy-B-3.so
+  C  php-judy + bundled libJudy : /work/builds/judy-C-1.so, /work/builds/judy-C-2.so, /work/builds/judy-C-3.so
+  timing core.int     round 1/7  timing core.int     round 2/7  timing core.int     round 3/7  timing core.int     round 4/7  timing core.int     round 5/7  timing core.int     round 6/7  timing core.int     round 7/7  timing core.int     done          
+  timing api.batch    round 1/7  timing api.batch    round 2/7  timing api.batch    round 3/7  timing api.batch    round 4/7  timing api.batch    round 5/7  timing api.batch    round 6/7  timing api.batch    round 7/7  timing api.batch    done          
+  timing api.setops   round 1/7  timing api.setops   round 2/7  timing api.setops   round 3/7  timing api.setops   round 4/7  timing api.setops   round 5/7  timing api.setops   round 6/7  timing api.setops   round 7/7  timing api.setops   done          
+  timing adv.iter     round 1/7  timing adv.iter     round 2/7  timing adv.iter     round 3/7  timing adv.iter     round 4/7  timing adv.iter     round 5/7  timing adv.iter     round 6/7  timing adv.iter     round 7/7  timing adv.iter     done          
+  memory int_to_int     n=6000000   A=129.6 MB   B=49.5 MB    C=49.7 MB     A/C=2.61x
+  memory int_sparse     n=6000000   A=290.5 MB   B=74.6 MB    C=74.8 MB     A/C=3.88x
+  memory int_to_mixed   n=6000000   A=192.0 MB   B=232.5 MB   C=232.9 MB    A/C=0.82x
+  memory string_to_int  n=6000000   A=477.2 MB   B=138.2 MB   C=138.4 MB    A/C=3.45x
+  memory bitset         n=6000000   A=290.5 MB   B=10.1 MB    C=10.3 MB     A/C=28.17x
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — linux-x86_64-gcc14.2-php8.4-out-of-cache-6M
+------------------------------------------------------------------------------------------------
+  PHP 8.4.24, Linux x86_64
+  arm B system libJudy : Debian 13 trixie (Debian GNU/Linux 13), libjudy-dev 1.0.5-5.1 SHARED lib; Baskins jp_1Index fix APPLIED (debian patch 04); dpkg hardening CFLAGS
+  arm C bundled libJudy: bundled libjudy/ static into the extension (P1-P7, O1 popcount, O3 bswap, O4 string-layer); vendor CFLAGS -O2 -fno-lto -fno-unroll-loops -mpopcnt
+  size 6000000 (out-of-cache), 7 rounds, 3 iterations, floor 1.3%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=1.22   cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-timing   load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-memory   load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    end            load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+
+  control (PHP-only rows, touch no libJudy): -0.04% [-0.11, +0.02] over 21 rows
+  measured control scatter: 1.26%  (assumed floor 1.3%)
+
+------------------------------------------------------------------------------------------------
+  MEMORY — peak RSS over per-arm empty-process floor (the headline axis)
+------------------------------------------------------------------------------------------------
+  workload                n      A array     B system    C bundled       A/C       B/C
+  int_to_int        6000000     129.6 MB      49.5 MB      49.7 MB     2.61x     1.00x
+  int_sparse        6000000     290.5 MB      74.6 MB      74.8 MB     3.88x     1.00x
+  int_to_mixed      6000000     192.0 MB     232.5 MB     232.9 MB     0.82x     1.00x
+  string_to_int     6000000     477.2 MB     138.2 MB     138.4 MB     3.45x     1.00x
+  bitset            6000000     290.5 MB      10.1 MB      10.3 MB    28.17x     0.98x
+  A/C above 1.00 means the PHP array uses that many times more memory than php-judy.
+
+------------------------------------------------------------------------------------------------
+  B vs C — bundled libJudy against system libJudy (this project's contribution)
+  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears
+  the 1.3% floor assert anything; everything else is null.
+------------------------------------------------------------------------------------------------
+  benchmark                                     system   bundled    delta CI                 verdict
+  api.range.size.string_to_int                   36.53     20.89  -42.87% [-44.56,-42.62] FASTER
+  adv.optiter.values.string_to_int_hash.optimized     16.14     10.56  -34.58% [-34.83,-34.49] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.optimized     21.21     13.99  -33.99% [-34.03,-31.63] FASTER
+  adv.optiter.foreach.string_to_int_hash.optimized     19.13     12.89  -32.61% [-33.27,-30.82] FASTER
+  adv.optiter.values.string_to_int_adaptive.optimized     18.09     12.40  -31.38% [-31.54,-31.16] FASTER
+  adv.forEach.string_to_int                     505.87    354.26  -29.87% [-30.12,-29.78] FASTER
+  api.equals.int_to_int                          97.91     71.47  -27.04% [-27.60,-26.78] FASTER
+  api.setop.intersect.int_to_int                147.87    109.02  -26.29% [-26.37,-26.20] FASTER
+  api.fromArray.int_to_int                      170.85    126.90  -26.10% [-26.60,-25.46] FASTER
+  api.putAll.int_to_int                         170.94    126.66  -25.89% [-26.46,-25.56] FASTER
+  api.setop.intersect.bitset                    116.79     87.03  -25.35% [-25.68,-25.21] FASTER
+  api.deleteRange.int_to_int                    316.03    236.62  -25.07% [-25.20,-24.98] FASTER
+  adv.map.string_to_int                        1419.42   1065.59  -24.89% [-25.03,-24.77] FASTER
+  api.setop.union.int_to_int                    354.05    266.24  -24.84% [-24.99,-24.73] FASTER
+  api.setop.union.bitset                        242.28    182.38  -24.68% [-24.73,-24.28] FASTER
+  adv.optiter.ratio.foreach.string_to_int_adaptive     61.74     46.79  -23.97% [-25.22,-23.11] FASTER
+  core.int_to_int.write                         190.24    144.70  -23.87% [-23.93,-23.47] FASTER
+  api.setop.diff.bitset                         113.03     86.20  -23.60% [-23.88,-23.54] FASTER
+  api.setop.xor.bitset                          225.05    172.93  -23.05% [-23.37,-22.83] FASTER
+  adv.filter.string_to_int                     1012.64    778.90  -23.04% [-23.25,-22.88] FASTER
+  api.setop.diff.int_to_int                     140.11    107.86  -22.98% [-23.08,-22.96] FASTER
+  api.setop.xor.int_to_int                      280.26    216.41  -22.70% [-22.77,-22.62] FASTER
+  api.setop.intersect.string_to_int             845.99    655.09  -22.44% [-22.62,-22.24] FASTER
+  api.mergeWith.int_to_int                      384.37    302.63  -21.30% [-21.79,-21.11] FASTER
+  adv.optiter.values.string_to_int_hash.default     26.22     20.62  -21.22% [-21.44,-21.09] FASTER
+  adv.optiter.toArray.string_to_int_hash.optimized     22.78     17.99  -21.09% [-21.24,-20.75] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.optimized     27.48     21.71  -21.04% [-21.13,-21.03] FASTER
+  api.setop.diff.string_to_int                  853.45    676.53  -20.65% [-20.96,-20.46] FASTER
+  adv.optiter.ratio.values.string_to_int_adaptive     53.59     42.43  -20.63% [-20.97,-20.31] FASTER
+  api.mergeWith.string_to_int                  1500.23   1191.60  -20.34% [-20.77,-20.22] FASTER
+  adv.optiter.foreach.string_to_int_hash.default     27.67     22.05  -20.29% [-20.36,-20.06] FASTER
+  api.increment.int_to_int                      179.25    144.79  -19.84% [-20.78,-18.96] FASTER
+  api.setop.union.string_to_int                1797.44   1455.97  -19.02% [-19.38,-18.84] FASTER
+  api.sumValues.int_to_int                       58.76     48.56  -17.24% [-17.95,-17.07] FASTER
+  adv.optiter.ratio.values.string_to_int_hash     61.55     51.17  -16.87% [-17.30,-16.69] FASTER
+  core.int_to_int.read                           79.77     66.98  -15.97% [-16.20,-15.89] FASTER
+  adv.optiter.ratio.foreach.string_to_int_hash     69.15     58.41  -15.67% [-16.32,-14.32] FASTER
+  adv.optiter.toArray.string_to_int_hash.default     34.41     29.34  -14.69% [-15.01,-14.42] FASTER
+  core.int_to_packed.free                        61.04     52.08  -14.68% [-15.18,-14.42] FASTER
+  adv.optiter.values.string_to_int_adaptive.default     33.76     29.22  -13.48% [-13.70,-13.35] FASTER
+  core.bitset.write                             116.83    103.08  -12.03% [-12.12,-11.79] FASTER
+  core.int_to_mixed.read                        314.79    278.28  -11.89% [-12.73,-11.48] FASTER
+  adv.optiter.ratio.toArray.string_to_int_adaptive     62.29     55.01  -11.82% [-12.21,-10.91] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.default     34.33     30.21  -11.80% [-12.80,-11.04] FASTER
+  adv.optiter.increment.string_to_int_hash.optimized     21.49     19.06  -11.22% [-11.74,-10.99] FASTER
+  adv.optiter.overwrite.string_to_int_hash.optimized     21.20     18.92  -10.74% [-11.07,-10.56] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.default     44.14     39.50  -10.46% [-10.98,-10.07] FASTER
+  api.getAll.int_to_int                          23.71     21.36  -10.03% [-10.19, -9.56] FASTER
+  adv.map.int_to_int                            327.96    297.36   -9.37% [ -9.77, -8.77] FASTER
+  core.int_to_mixed.write                       438.44    398.65   -9.03% [ -9.30, -8.44] FASTER
+  adv.filter.int_to_int                         301.28    274.78   -9.01% [ -9.59, -8.72] FASTER
+  core.int_to_packed.write                      379.44    347.02   -8.48% [ -8.50, -8.25] FASTER
+  api.range.keys.int_to_int                      10.98     10.04   -8.30% [ -8.83, -7.89] FASTER
+  adv.optiter.ratio.overwrite.string_to_int_hash    126.05    116.29   -7.60% [ -8.22, -6.32] FASTER
+  api.keys.int_to_int                           125.52    115.89   -7.54% [ -7.66, -7.35] FASTER
+  adv.optiter.ratio.toArray.string_to_int_hash     66.21     61.30   -7.45% [ -7.63, -7.15] FASTER
+  api.values.int_to_int                         130.35    120.81   -7.36% [ -7.70, -7.15] FASTER
+  core.bitset.iter                              115.93    107.30   -7.33% [ -8.58, -6.75] FASTER
+  adv.optiter.ratio.increment.string_to_int_hash    127.14    117.65   -7.24% [ -7.97, -6.74] FASTER
+  core.int_to_int.iter                          122.01    113.10   -7.14% [ -7.82, -6.66] FASTER
+  core.int_to_mixed.free                        107.93    100.20   -7.12% [ -7.66, -6.64] FASTER
+  core.int_to_mixed.iter                        344.91    321.02   -6.89% [ -7.27, -6.59] FASTER
+  api.toArray.int_to_int                        317.93    297.58   -6.72% [ -6.93, -6.01] FASTER
+  core.int_to_packed.iter                       261.50    247.72   -5.46% [ -5.48, -5.04] FASTER
+  adv.optiter.overwrite.string_to_int_adaptive.optimized     27.66     26.17   -5.33% [ -5.54, -4.93] FASTER
+  adv.forEach.int_to_int                        198.67    188.48   -5.14% [ -5.84, -4.08] FASTER
+  core.bitset.read                               71.06     67.56   -4.73% [ -5.58, -4.68] FASTER
+  core.int_to_packed.read                       215.21    205.49   -4.57% [ -4.94, -4.27] FASTER
+  adv.optiter.increment.string_to_int_hash.default     16.95     16.22   -4.24% [ -4.51, -4.10] FASTER
+  adv.optiter.ratio.overwrite.string_to_int_adaptive    111.24    106.75   -3.96% [ -4.37, -3.60] FASTER
+  adv.optiter.overwrite.string_to_int_hash.default     16.83     16.26   -3.24% [ -3.87, -2.98] FASTER
+  adv.optiter.overwrite.string_to_int_adaptive.default     24.85     24.49   -1.52% [ -1.69, -1.09] null
+  core.int_to_int.free                            2.10      2.09    1.09% [ -0.30, +2.04] null
+  totals: 71 faster, 0 slower, 2 null
+
+------------------------------------------------------------------------------------------------
+  A vs C — PHP native array against php-judy (bundled)
+  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means
+  the PHP array is FASTER — publish these, they are the honest half of the story.
+------------------------------------------------------------------------------------------------
+  benchmark                                   array ms   judy ms  judy/arr winner
+  core.bitset.free                                5.01      0.02     0.00x php-judy
+  core.int_to_int.free                            5.45      2.09     0.38x php-judy
+  api.setop.xor.bitset                          221.28    172.93     0.78x php-judy
+  api.setop.intersect.bitset                     95.43     87.03     0.91x php-judy
+  core.int_to_packed.free                        46.82     52.08     1.11x php-array
+  core.bitset.write                              88.95    103.08     1.16x php-array
+  core.int_to_packed.write                      246.65    347.02     1.41x php-array
+  core.int_to_mixed.write                       264.27    398.65     1.51x php-array
+  core.int_to_int.write                          91.95    144.70     1.57x php-array
+  core.int_to_packed.read                       106.64    205.49     1.93x php-array
+  api.setop.union.bitset                         92.29    182.38     1.98x php-array
+  api.setop.diff.bitset                          42.95     86.20     2.01x php-array
+  core.int_to_mixed.free                         46.01    100.20     2.18x php-array
+  core.int_to_mixed.read                        120.97    278.28     2.30x php-array
+  api.increment.int_to_int                       57.42    144.79     2.52x php-array
+  core.int_to_int.read                           22.22     66.98     3.01x php-array
+  core.bitset.read                               21.92     67.56     3.08x php-array
+  core.int_to_mixed.iter                         85.37    321.02     3.76x php-array
+  core.bitset.iter                               18.74    107.30     5.72x php-array
+  core.int_to_int.iter                           18.66    113.10     6.06x php-array
+  core.int_to_packed.iter                        21.40    247.72    11.57x php-array
+  totals: php-judy wins 4, PHP array wins 17, parity 0
+
+Wrote /work/results/run6-out-of-cache-6m.json


### PR DESCRIPTION
Fills the empty out-of-cache slot in `BENCHMARK.md`'s confidence-tier table. Closes the measurement tracked in #169.

Rebased onto current `main` **after #166 merged**, so this edits #166's new six-column tier table rather than the old one.

## What was run

Three campaigns on an exclusively-held honeycomb — `/var/tmp/BENCH_LOCK` taken for the whole session and released at the end, workload pinned with `--cpuset-cpus=2`, `/var/tmp` used throughout (`/home` is full). All nine `.so` built from **one tree at `f121d95`** with **one toolchain**, changing only `--with-judy`; 7 interleaved ABBA rounds, 3 independently linked builds per arm rotated across rounds.

| run | arms | result |
| --- | --- | --- |
| `run6-out-of-cache-6m` | B vs C, timing + memory | 71 faster, 0 slower, 2 null |
| `run6-attribution-6m` | S vs C, patches alone | 68 faster, 0 slower, 5 null |
| `run6-cvsc-control-6m` | C vs C rebuild control | **0 faster, 0 slower, 73 null** |

**Hygiene**: foreign CPU **0.0% at every phase boundary of all three runs**, load1 1.00-1.22 against a threshold of 12.0, no run self-marked `contaminated`. Arms verified at the instruction level before the campaign (B: 0 `popcnt`, 42 undefined `Judy*`; C: 89 `popcnt`, 985 `bswap`; S: 0 `popcnt`, 12 `bswap`, pristine tarball sha256 `d2704089…`).

## What it says

| | delivered (B→C) | our patches alone (S→C) | share |
| --- | ---: | ---: | ---: |
| integer / bitset | **-12.0%** (n=37) | **-12.8%** (n=35) | **98.7%** |
| string | **-19.7%** (n=34) | **-7.2%** (n=32) | **40.3%** |

The interesting result is a **null**: the patch share barely moves with residency (96.5% / 39.8% cache-resident → 98.7% / 40.3% out-of-cache). The prediction on record — that leaving cache should raise the patch share, since linkage overhead is fixed per call while memory stalls grow — is not supported. Magnitudes do shrink as expected (integer -17.7% → -12.0%).

Also measured at 6M: memory (`bitset` 28.17x, `int_sparse` 3.88x, `string_to_int` 3.45x, `int_to_mixed` **loses** at 0.83x, B/C 1.00 throughout), and A-vs-C timing, where the PHP array's dominance narrows from 42-of-43 cells at median 4.19x (300k) to **17 of 21 at median 1.97x**, with php-judy taking four cells outright.

## Two honest caveats, both written into the doc

- **`core.str` cannot run at 6M under any arm.** `judy-bench.php` sets its own `ini_set('memory_limit', '2G')`, which overrides `-d memory_limit=-1`, and that group's fixtures (two 6M string-keyed PHP arrays plus key lists, built before any Judy work) exhaust it — `Allowed memory size … exhausted` at line 494, identically in every arm. The cell therefore covers `core.int`, `api.batch`, `api.setops`, `adv.iter`; string API paths are well covered (34 of 71 faster cells), the `core.str` per-element table is not. Lifting that cap changes a published fixture and is deliberately **not** bundled here.
- **The 1.3% out-of-cache floor is optimistic for these runs.** Measured control scatter was 1.26% (B→C, inside), but **2.63%** (S→C) and **1.62%** (C-vs-C). Cells below ~2.6% should be read as null. Every quoted figure is 7.2-19.7%, so no headline depends on it.

## Scope

`scripts/bench-threearm.php` is **not** touched — no change to it was needed. The diff is the three result pairs plus `BENCHMARK.md`. The BENCHMARK.md edit covers **both** places out-of-cache appears: the tier row and the prose bullet that previously said the run was blocked, which would otherwise have left the document contradicting itself.

Refs #162, #168. Raw JSON + console output committed under `research/three-arm-benchmark/results/`.
