### PR TITLE
fix(bench): measure memory as peak RSS, not the emalloc heap

### DIFF
--- a/.github/workflows/bench-gate.yml
+++ b/.github/workflows/bench-gate.yml
@@ -448,6 +448,9 @@ jobs:
     needs: [linux-glibc, linux-musl, macos-arm64, windows-x64]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v4
@@ -456,4 +459,81 @@ jobs:
           path: results
         continue-on-error: true
       - name: Render the summary
-        run: php scripts/bench-gate-report.php results >> "$GITHUB_STEP_SUMMARY"
+        run: php scripts/bench-gate-report.php results | tee gate-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # ── The S → C axis, on the PR that changed libjudy/ ───────────────────
+      #
+      # The number a maintainer most wants on a PR touching the vendored tree is
+      # arm S (pristine-reconstructed) versus arm C (bundled): did the patches
+      # help, hurt, or do nothing? It is measured here and, until now, only ever
+      # written to a job summary nobody opens from the PR page.
+      #
+      # This posts the report bench-gate-report.php already renders. It does NOT
+      # reimplement the gate, and it cannot claim a gate result that does not
+      # exist: this workflow runs on pull_request only for libjudy/** and the
+      # gate's own machinery, so on any other PR the job never runs and no
+      # comment appears. ci.yml's consolidated comment is deliberately left
+      # alone — reaching across workflow boundaries for these artifacts would
+      # mean either blocking that comment on this workflow or rendering a stale
+      # one, and both are worse than a second, self-dating comment.
+      #
+      # Skipped for forks: the pull_request token is read-only there, and a
+      # failed createComment is noise, not information (see the same limitation
+      # on ci.yml's report comment).
+      - name: Comment the gate result on the PR
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- bench-gate-results -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`
+              + `/actions/runs/${context.runId}`;
+
+            let report = '';
+            try {
+              report = fs.readFileSync('gate-report.md', 'utf8').trim();
+            } catch (e) {
+              report = '';
+            }
+            if (!report) {
+              core.info('No gate report rendered; not commenting.');
+              return;
+            }
+
+            // A GitHub comment caps at 65536 characters. Truncating the middle
+            // of a table would produce a comment that reads as a result while
+            // being one; link out instead.
+            const LIMIT = 60000;
+            let body = marker + '\n' + report
+              + `\n\n<sub>Full run: ${runUrl}</sub>\n`;
+            if (body.length > LIMIT) {
+              const head = report.split('\n').slice(0, 12).join('\n');
+              body = marker + '\n' + head
+                + `\n\n_Report too long to inline._ Full result: ${runUrl}\n`;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,11 @@ jobs:
           echo "extension=$JUDY_SO" > /tmp/php-judy-ini/judy.ini
 
           # Unified benchmark: all suites, JSON output for cross-version comparison
+          # --memory rss is the default; named here because it is what makes the
+          # consolidated comment's memory table honest (issue #172). It costs one
+          # child process per type per arm.
           PHP_INI_SCAN_DIR=/tmp/php-judy-ini php examples/benchmarks/judy-bench.php \
-            --json bench.json --size 500000 --iterations 7 --suite all \
+            --json bench.json --size 500000 --iterations 7 --suite all --memory rss \
             2>&1 | tee benchmark-output.txt
 
       - name: Upload benchmark results
@@ -1268,16 +1271,20 @@ jobs:
               return f"{b} B"
 
           def fmt_mem_savings(judy_bytes, php_bytes):
+              # Direction is stated in words, never left to the reader to infer
+              # from a number below 1.0: Judy::INT_TO_MIXED genuinely uses MORE
+              # memory than a PHP array, and "0.6x" read as a saving is how that
+              # loss got published as a win.
               if judy_bytes is None or php_bytes is None:
                   return "-"
               if judy_bytes <= 0:
-                  return "**\u221e**"
+                  return "-"
               ratio = php_bytes / judy_bytes
               if ratio >= 1.05:
-                  return f"**{ratio:.1f}x less**"
-              elif ratio >= 0.95:
-                  return "~1.0x"
-              return f"{ratio:.1f}x"
+                  return f"**{ratio:.1f}x smaller**"
+              if ratio >= 0.95:
+                  return "about the same"
+              return f"{1 / ratio:.2f}x **larger**"
 
           def get_metric(benchmarks, key, field="median_ms"):
               entry = benchmarks.get(key)
@@ -1331,6 +1338,14 @@ jobs:
               ("adv.filter.string_to_int", "filter() Str\u2192Int"),
               ("adv.map.string_to_int", "map() Str\u2192Int"),
           ]
+
+          # Rows whose "speedup" is a property of the two algorithms' complexity
+          # classes, not of this build. Arithmetically true, rhetorically empty:
+          # populationCount() reported 235,315x on a 500k run purely because the
+          # PHP arm walks every element and libJudy answers from a counter. The
+          # multiple grows with --size and shrinks with it, which is exactly why
+          # it should not be read as a result.
+          definitional_ratio_ops = {"api.populationCount.int_to_int"}
 
           # Load JSON benchmark data per (platform, php_ver)
           bench_json = {}
@@ -1410,19 +1425,71 @@ jobs:
 
                   tag = f" ({platform}, PHP {ver})"
 
-                  # Memory Efficiency
-                  lines.append(f"### Memory Efficiency{tag}{heading_suffix}\n")
-                  lines.append("| Type | Judy | PHP array | Savings |")
-                  lines.append("|------|-----:|----------:|---------|")
-                  for type_id, label in all_types:
-                      j_heap = get_metric(bm, f"core.{type_id}.heap.judy", "heap_bytes")
-                      p_heap = get_metric(bm, f"core.{type_id}.heap.php", "heap_bytes")
-                      if j_heap is None and p_heap is None:
-                          continue
+                  # Memory. `rss_bytes` (floor-subtracted peak RSS of a child
+                  # process) is the ONLY field here that can see a Judy index:
+                  # libJudy allocates through malloc(3), so the `heap_bytes`
+                  # this table used to print was the PHP-object wrapper and
+                  # nothing else — 160 B for a 500,000-element BITSET, published
+                  # as "52454.9x less". See issue #172. When rss_bytes is absent
+                  # (no getrusage(), i.e. Windows) say so instead of falling
+                  # back to the number that caused the defect.
+                  meta = data.get("metadata", {})
+                  n_meas = meta.get("size")
+                  size_tag = f", n = {n_meas:,}" if isinstance(n_meas, int) else ""
+                  # Resolution = the floor's own run-to-run spread. A structure
+                  # smaller than that is reported as an upper bound; quoting a
+                  # point estimate there would publish noise (a dense 500k
+                  # BITSET is ~41 KB against a floor that moves ~250 KB).
+                  res = meta.get("memory_resolution_bytes") or 0
+                  mem_rows = [
+                      (label,
+                       get_metric(bm, f"core.{t}.heap.judy", "rss_bytes"),
+                       get_metric(bm, f"core.{t}.heap.php", "rss_bytes"))
+                      for t, label in all_types
+                  ]
+                  mem_rows = [r for r in mem_rows if r[1] is not None or r[2] is not None]
+                  lines.append(f"### Memory{tag}{heading_suffix}\n")
+                  if mem_rows:
                       lines.append(
-                          f"| {label} | {fmt_bytes(j_heap)} "
-                          f"| {fmt_bytes(p_heap)} "
-                          f"| {fmt_mem_savings(j_heap, p_heap)} |"
+                          f"Peak RSS of a child process building one structure{size_tag}, "
+                          "minus an empty-process floor. Judy's memory advantage is "
+                          "type- and scale-dependent — see "
+                          "[BENCHMARK.md](../blob/main/BENCHMARK.md#memory--the-headline-and-the-least-equivocal-result) "
+                          "for the curve across sizes on a dedicated host.\n"
+                      )
+                      lines.append("| Type | Judy | PHP array | Judy vs PHP array |")
+                      lines.append("|------|-----:|----------:|-------------------|")
+                      any_bounded = False
+                      for label, j_mem, p_mem in mem_rows:
+                          if j_mem is not None and res and j_mem <= res:
+                              any_bounded = True
+                              j_str = f"< {fmt_bytes(res)}"
+                              s_str = (f"> **{p_mem / res:.0f}x smaller**"
+                                       if p_mem else "-")
+                          else:
+                              j_str = fmt_bytes(j_mem)
+                              s_str = fmt_mem_savings(j_mem, p_mem)
+                          lines.append(
+                              f"| {label} | {j_str} "
+                              f"| {fmt_bytes(p_mem)} "
+                              f"| {s_str} |"
+                          )
+                      if any_bounded:
+                          lines.append(
+                              f"\n`<` marks a structure smaller than this instrument can "
+                              f"resolve at n = {n_meas:,}: run-to-run movement in the "
+                              f"empty-process floor puts the resolution at "
+                              f"{fmt_bytes(res)}. The bound is real, the "
+                              f"exact figure is not available at this size — "
+                              "BENCHMARK.md measures the same types up to n = 8M, where "
+                              "they are well clear of the floor.\n"
+                          )
+                  else:
+                      lines.append(
+                          "Not measured on this platform: the footprint instrument is "
+                          "`getrusage()`, which PHP does not provide on Windows. "
+                          "`memory_get_usage()` is not a substitute — it cannot see a "
+                          "Judy index at all.\n"
                       )
                   lines.append("")
 
@@ -1445,10 +1512,26 @@ jobs:
                           if j_ms is None:
                               continue
                           j_str, p_str, s_str = fmt_speedup(j_ms, p_ms)
+                          # A ratio whose value is fixed by the two complexity
+                          # classes is not a measurement of this build. Both
+                          # timings still print — they are what a regression
+                          # would move — but the ratio is labelled for what it
+                          # is instead of shouting a five-figure multiple.
+                          if prefix in definitional_ratio_ops:
+                              s_str = "O(1) vs O(n)"
                           lines.append(
                               f"| {label} | {j_str} | {p_str} | {s_str} |"
                           )
                       lines.append("")
+                      if any(p in definitional_ratio_ops for p, _ in api_ops):
+                          lines.append(
+                              "`O(1) vs O(n)` marks a row whose ratio is decided by the "
+                              "complexity classes rather than measured: `populationCount()` "
+                              "reads libJudy's cached population, the PHP arm counts every "
+                              "element. It scales with `n` and says nothing about this "
+                              "change. judy-bench.php declines the same comparison for "
+                              "`size($lo, $hi)` for the same reason.\n"
+                          )
 
                   # Core Types (representative in main, all in detail)
                   def emit_core_table(type_list, detail_tag=""):
@@ -1978,6 +2061,7 @@ jobs:
                       mem_counts = {
                           "better": 0, "worse": 0, "same": 0,
                       }
+                      mem_fields_used = set()
                       type_label_map = dict(all_types)
 
                       for bid in all_ids:
@@ -1986,15 +2070,24 @@ jobs:
                           bid_parts = bid.split(".")
                           if len(bid_parts) < 4:
                               continue
-                          b_heap = base_bm.get(
-                              bid, {}
-                          ).get("heap_bytes")
-                          c_heap = cur_bm.get(
-                              bid, {}
-                          ).get("heap_bytes")
+                          # Prefer the footprint (peak RSS) over the emalloc
+                          # heap, but only when BOTH sides carry it — mixing
+                          # instruments across the two arms would manufacture a
+                          # delta out of nothing. Stored baselines predating
+                          # issue #172 have heap_bytes only, so this keeps
+                          # comparing that until the baseline is next bumped.
+                          b_e = base_bm.get(bid, {})
+                          c_e = cur_bm.get(bid, {})
+                          mem_field = ("rss_bytes"
+                                       if b_e.get("rss_bytes") is not None
+                                       and c_e.get("rss_bytes") is not None
+                                       else "heap_bytes")
+                          b_heap = b_e.get(mem_field)
+                          c_heap = c_e.get(mem_field)
                           if (b_heap is None
                                   or c_heap is None):
                               continue
+                          mem_fields_used.add(mem_field)
                           tid = bid_parts[1]
                           name = type_label_map.get(
                               tid, tid
@@ -2026,6 +2119,16 @@ jobs:
                           lines.append(
                               "#### Memory Comparison\n"
                           )
+                          if mem_fields_used == {"heap_bytes"}:
+                              lines.append(
+                                  "Compared on the emalloc heap only: the stored "
+                                  "baseline predates the peak-RSS footprint "
+                                  "measurement (issue #172), so these rows track "
+                                  "PHP-heap pressure, not the size of the Judy "
+                                  "index. Meaningful for the zval-storing types; "
+                                  "a flat ~160 B for `Bitset` and `Int to Int`, "
+                                  "which is the wrapper object and nothing else.\n"
+                              )
                           mparts = []
                           if mem_counts["better"]:
                               mparts.append(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,6 +488,24 @@ jobs:
       - name: Run the full suite on the debug PHP
         run: make test TESTS=tests/ NO_INTERACTION=1 REPORT_EXIT_STATUS=1
 
+      # run-tests.php leaves tests/<name>.diff next to a failing .phpt, but the
+      # job has never printed it, so a failure that reproduces only here has
+      # been opaque from outside -- the debug PHP is a cached from-source build
+      # and is not cheap to stand up locally just to read one diff. Print them.
+      - name: Show the diff for any failing test
+        if: failure()
+        run: |
+          shopt -s nullglob
+          found=0
+          for d in tests/*.diff; do
+            found=1
+            echo "::group::$d"
+            head -c 8000 "$d"
+            echo
+            echo "::endgroup::"
+          done
+          [ "$found" = 1 ] || echo "no tests/*.diff produced"
+
       - name: Negative control — restore the mismatch, require the fatal
         run: |
           # The whole suite gates again now that Judy::__construct calls zpp

--- a/examples/benchmarks/judy-bench.php
+++ b/examples/benchmarks/judy-bench.php
@@ -27,7 +27,7 @@
 // ── CLI argument parsing ────────────────────────────────────────────────────
 
 $opts = getopt('', ['json:', 'size:', 'iterations:', 'suite:', 'group:', 'list-groups',
-                    'memory-limit:']);
+                    'memory-limit:', 'memory:', 'memory-runs:']);
 $size       = isset($opts['size'])       ? (int)$opts['size']       : 500000;
 $iterations = isset($opts['iterations']) ? (int)$opts['iterations'] : 5;
 $suite      = isset($opts['suite'])      ? $opts['suite']           : 'all';
@@ -113,6 +113,22 @@ if ($mem_target !== null && ini_set('memory_limit', $mem_target) === false) {
     exit(1);
 }
 $memory_limit = (string)ini_get('memory_limit');
+// --memory rss  measure each structure's footprint as peak RSS of a child
+//               process, minus an empty-process floor (the default, and the
+//               only instrument here that can see a Judy index at all).
+// --memory off  skip it; emit only the emalloc-heap figure, as before. The
+//               automated drivers pass this: they have their own peak-RSS
+//               memory axis and only want timings out of this script.
+$mem_mode = isset($opts['memory']) ? (string)$opts['memory'] : 'rss';
+if (!in_array($mem_mode, ['rss', 'off'], true)) {
+    fwrite(STDERR, "Invalid --memory: $mem_mode. Choose from: rss, off\n");
+    exit(1);
+}
+$mem_runs = isset($opts['memory-runs']) ? (int)$opts['memory-runs'] : 3;
+if ($mem_runs < 1) {
+    fwrite(STDERR, "Invalid --memory-runs: must be >= 1\n");
+    exit(1);
+}
 
 // Groups are the finest unit the runner can execute on its own. Each one owns
 // its setup, so running a group in isolation costs only that group's work —
@@ -182,6 +198,22 @@ function bench_median(callable $fn, int $iterations): array {
 /**
  * Measure emalloc'd PHP heap consumed while $fn() runs.
  * $fn must return the created container.
+ *
+ * WHAT THIS DOES NOT MEASURE. libJudy is the single caller of malloc(3) for
+ * every trie node it builds (`libjudy/src/JudyCommon/JudyMalloc.c`; there is no
+ * emalloc interception anywhere in the vendored tree, and a system libJudy has
+ * none either), so PHP's memory manager never sees a Judy index. For BITSET and
+ * INT_TO_INT — where the *only* thing on the Zend heap is the wrapper object —
+ * this returns ~160 bytes no matter how many elements were inserted. Types that
+ * store zvals (INT_TO_MIXED, INT_TO_PACKED, the *_to_mixed family) look
+ * plausible here only because their payload genuinely is emalloc'd; the trie
+ * holding it still is not counted.
+ *
+ * It is kept, unchanged, because it is a real measurement of one real thing —
+ * PHP-heap pressure — and because bench-compare / bench-gate / bench-threearm
+ * key their "this row is memory, not timing" test on the `heap_bytes` field.
+ * The figure a reader wants for "how big is the structure" is `rss_bytes`,
+ * measured by bench_mem_cell() below. See issue #172.
  */
 function measure_heap(callable $fn): int {
     gc_collect_cycles();
@@ -210,6 +242,232 @@ function measure_free(callable $create_fn, int $iterations): array {
     return ['median' => $times[intdiv($iterations, 2)], 'runs' => $times];
 }
 
+// ── Memory: peak RSS of a child process ─────────────────────────────────────
+//
+// The honest instrument for "how big is this structure". Same shape as the
+// three-arm study's (scripts/bench-lib.php) and the coverage-index example's:
+// build exactly one container in a fresh process, read getrusage()['ru_maxrss'],
+// and subtract an empty-process floor so neither the interpreter nor the loaded
+// extension is charged to the data. Unlike Judy::memoryUsage() it is uniform
+// across every type — memoryUsage() reports J1MU/JLMU (exact for the trie, but
+// blind to the emalloc'd zvals of INT_TO_MIXED / INT_TO_PACKED) and, for the
+// STRING_TO_* family, only a payload-bytes approximation with libJudy's
+// JudySL/JudyHS internals missing entirely.
+//
+// It costs one process per (type, arm) plus one floor. That is why the drivers
+// pass --memory off.
+
+/** ru_maxrss is bytes on macOS, kilobytes on Linux. */
+function bench_peak_rss(): int {
+    $ru = getrusage();
+    return (int)$ru['ru_maxrss'] * (PHP_OS_FAMILY === 'Darwin' ? 1 : 1024);
+}
+
+/**
+ * The Judy type constant and value shape behind each core.* id, so a child can
+ * rebuild the identical structure from the id alone.
+ *
+ * The child builds DIRECTLY from the loop counter rather than copying out of a
+ * fixture array the way the timing closures do, because a fixture array kept
+ * alive alongside the structure would land in the same peak.
+ */
+function bench_mem_spec(string $id): ?array {
+    static $specs = null;
+    if ($specs === null) {
+        $specs = [
+            'core.bitset'                 => ['BITSET',                 'bool',  'int'],
+            'core.int_to_int'             => ['INT_TO_INT',             'int',   'int'],
+            'core.int_to_mixed'           => ['INT_TO_MIXED',           'mixed', 'int'],
+            'core.int_to_packed'          => ['INT_TO_PACKED',          'mixed', 'int'],
+            'core.string_to_int'          => ['STRING_TO_INT',          'int',   'str'],
+            'core.string_to_mixed'        => ['STRING_TO_MIXED',        'mixed', 'str'],
+            'core.string_to_int_hash'     => ['STRING_TO_INT_HASH',     'int',   'str'],
+            'core.string_to_mixed_hash'   => ['STRING_TO_MIXED_HASH',   'mixed', 'str'],
+            'core.string_to_int_adaptive' => ['STRING_TO_INT_ADAPTIVE', 'int',   'str'],
+            'core.string_to_mixed_adaptive' => ['STRING_TO_MIXED_ADAPTIVE', 'mixed', 'str'],
+        ];
+    }
+    return $specs[$id] ?? null;
+}
+
+/** The value stored at ordinal $i, matching the parent's generators exactly. */
+function bench_mem_value(string $shape, int $i) {
+    if ($shape === 'bool') { return true; }
+    if ($shape === 'int')  { return $i; }
+    switch ($i & 3) {
+        case 0:  return "str_$i";
+        case 1:  return $i * 7;
+        case 2:  return [$i, $i + 1];
+        default: return ($i & 1) === 0;
+    }
+}
+
+/**
+ * Child entry point. Returns immediately unless --mem-child is present; builds
+ * one structure, prints one JSON line and exits when it is.
+ */
+function bench_mem_child_main(array $argv): void {
+    $at = array_search('--mem-child', $argv, true);
+    if ($at === false) { return; }
+
+    $id   = (string)($argv[$at + 1] ?? 'floor');
+    $impl = (string)($argv[$at + 2] ?? 'php');   // 'judy' | 'php'
+    $n    = (int)   ($argv[$at + 3] ?? 0);
+
+    $count = 0;
+    $index_bytes = null;
+    $before = memory_get_usage();
+
+    if ($id === 'floor') {
+        // Nothing built. Establishes the process floor: interpreter plus the
+        // loaded extension, with no data structure at all.
+        $store = null;
+    } else {
+        $spec = bench_mem_spec($id);
+        if ($spec === null) {
+            fwrite(STDERR, "mem-child: unknown workload $id\n");
+            exit(2);
+        }
+        [$type_name, $shape, $keys] = $spec;
+
+        if ($impl === 'judy') {
+            if (!extension_loaded('judy')) {
+                fwrite(STDERR, "mem-child: judy extension not loaded\n");
+                exit(2);
+            }
+            if (!defined("Judy::$type_name")) {
+                fwrite(STDERR, "mem-child: this build has no Judy::$type_name\n");
+                exit(3);
+            }
+            $store = new Judy(constant("Judy::$type_name"));
+        } else {
+            $store = [];
+        }
+
+        if ($keys === 'int') {
+            for ($i = 0; $i < $n; $i++) { $store[$i] = bench_mem_value($shape, $i); }
+        } else {
+            for ($i = 0; $i < $n; $i++) { $store["key_$i"] = bench_mem_value($shape, $i); }
+        }
+        $count = count($store);
+        if ($impl === 'judy') { $index_bytes = $store->memoryUsage(); }
+    }
+
+    // Read the population back so no optimiser can elide the build and so the
+    // pages are genuinely resident when peak RSS is sampled.
+    echo json_encode([
+        'id'          => $id,
+        'impl'        => $impl,
+        'n'           => $n,
+        'count'       => $count,
+        'peak_rss'    => bench_peak_rss(),
+        'heap_bytes'  => memory_get_usage() - $before,
+        'index_bytes' => $index_bytes,
+        'judy_version' => extension_loaded('judy') ? judy_version() : null,
+    ]), "\n";
+    exit(0);
+}
+
+/**
+ * Flags every memory child is spawned with. Mirrors examples/coverage-index.php:
+ * point the child at a specific judy.so when one is identifiable, with -n so an
+ * already-enabled judy in conf.d cannot silently shadow the build under test;
+ * otherwise inherit the parent's ini (which is how CI loads it, via
+ * PHP_INI_SCAN_DIR) and take that.
+ */
+function bench_mem_child_flags(): string {
+    static $flags = null;
+    if ($flags !== null) { return $flags; }
+
+    $limit = (string)ini_get('memory_limit');
+    $so    = getenv('JUDY_SO') ?: null;
+    if ($so === null) {
+        $local = __DIR__ . '/../../modules/judy.so';
+        if (is_file($local)) { $so = realpath($local); }
+    }
+    $flags = $so !== null
+        ? ' -n -d memory_limit=' . escapeshellarg($limit) . ' -d extension=' . escapeshellarg($so)
+        : ' -d memory_limit=' . escapeshellarg($limit);
+    return $flags;
+}
+
+/** Run one memory child and decode its JSON line, or null if it failed. */
+function bench_mem_run(string $id, string $impl, int $n): ?array {
+    $cmd = escapeshellarg(PHP_BINARY) . bench_mem_child_flags()
+        . ' ' . escapeshellarg(__FILE__)
+        . ' --mem-child ' . escapeshellarg($id) . ' ' . escapeshellarg($impl) . ' ' . $n;
+    $out = shell_exec($cmd . ' 2>' . (DIRECTORY_SEPARATOR === '\\' ? 'NUL' : '/dev/null'));
+    $last = trim(strrchr("\n" . trim((string)$out), "\n") ?: '');
+    $row  = json_decode($last, true);
+    return is_array($row) && isset($row['peak_rss']) ? $row : null;
+}
+
+/**
+ * Peak-RSS footprint of one structure, floor subtracted, median of $runs.
+ * Returns null when the measurement is not available on this platform or the
+ * child could not be verified — a missing number is correct where a wrong one
+ * is not.
+ */
+function bench_mem_cell(string $id, string $impl, int $n): ?int {
+    global $mem_mode, $mem_runs, $mem_floor, $mem_unavailable;
+
+    if ($mem_mode !== 'rss' || $mem_unavailable) { return null; }
+
+    if ($mem_floor === null) {
+        // The floor is measured more times than a cell because its SPREAD, not
+        // just its centre, is load-bearing: it is this measurement's resolution.
+        // A structure smaller than that spread cannot be resolved by subtracting
+        // the floor from a peak, and saying so is the only honest option — a
+        // 500,000-element dense BITSET is ~41 KB by J1MU against a floor that
+        // moves ~250 KB run to run, so a point estimate for it would swing 4x
+        // between runs. bench_mem_resolution() is what the report uses to mark
+        // such a cell as an upper bound instead of quoting the noise.
+        $floors = [];
+        for ($r = 0; $r < max(5, $mem_runs); $r++) {
+            $row = bench_mem_run('floor', 'php', 0);
+            // A child that cannot report the same extension the parent is
+            // running would measure something other than the build under test.
+            if ($row === null || $row['judy_version'] !== judy_version()) {
+                $mem_unavailable = true;
+                fwrite(STDERR, "  note: peak-RSS memory measurement unavailable "
+                    . "(child process could not be verified); reporting PHP heap only\n");
+                return null;
+            }
+            $floors[] = (int)$row['peak_rss'];
+        }
+        sort($floors);
+        $mem_floor = [
+            'median' => $floors[intdiv(count($floors), 2)],
+            'spread' => $floors[count($floors) - 1] - $floors[0],
+        ];
+    }
+
+    $peaks = [];
+    for ($r = 0; $r < $mem_runs; $r++) {
+        $row = bench_mem_run($id, $impl, $n);
+        if ($row === null) { return null; }
+        $peaks[] = (int)$row['peak_rss'];
+    }
+    sort($peaks);
+    return max(0, $peaks[intdiv(count($peaks), 2)] - $mem_floor['median']);
+}
+
+/**
+ * The smallest footprint this instrument can report as a measurement rather
+ * than an upper bound, in bytes.
+ *
+ * Twice the observed run-to-run spread of the empty-process floor. Twice
+ * because the spread is itself estimated from a handful of samples and so
+ * understates the true variability — a cell one spread above the floor is not
+ * reliably distinguishable from it. Observed on macOS arm64 (16 KB pages): a
+ * ~250 KB floor spread, against which a dense 500,000-element BITSET (41 KB by
+ * J1MU) simply does not resolve.
+ */
+function bench_mem_resolution(): ?int {
+    global $mem_floor;
+    return $mem_floor === null ? null : 2 * (int)$mem_floor['spread'];
+}
+
 function fmt_bytes(int $bytes): string {
     if ($bytes <= 0)       return '—';
     if ($bytes >= 1 << 20) return sprintf('%.1f MB', $bytes / (1 << 20));
@@ -226,6 +484,27 @@ function fmt_ratio(float $baseline, float $optimized): string {
     return sprintf('%8.1fx', $baseline / $optimized);
 }
 
+// ── Memory harness state ────────────────────────────────────────────────────
+
+/** Empty-process peak RSS, measured once and reused by every cell. */
+$mem_floor = null;
+
+// getrusage() is POSIX and PHP does not provide it on Windows, so there is no
+// whole-process instrument to reach for there. Report no memory figure rather
+// than substituting one that cannot see a Judy index.
+$mem_unavailable = !function_exists('getrusage') || !function_exists('shell_exec');
+if ($mem_mode === 'rss' && $mem_unavailable) {
+    fwrite(STDERR, "  note: peak-RSS memory measurement unavailable on this platform "
+        . "(no getrusage()); reporting PHP heap only\n");
+}
+
+// Must come after the harness is defined and before anything expensive runs.
+bench_mem_child_main($argv);
+
+$mem_method = ($mem_mode === 'rss' && !$mem_unavailable)
+    ? 'peak_rss_child_floor_subtracted'
+    : 'php_heap_only';
+
 // ── Results collector ───────────────────────────────────────────────────────
 
 $json_results = [
@@ -239,6 +518,12 @@ $json_results = [
         'suite'        => $suite,
         'groups'       => $active_groups,
         'memory_limit' => $memory_limit,
+        // Which instrument produced `rss_bytes`, and at what n. Consumers that
+        // quote a memory figure should quote the size with it: Judy's advantage
+        // is scale-dependent (BENCHMARK.md measures BITSET at 18.5x at 100k and
+        // 22.7x at 8M on its own workload).
+        'memory_method' => $mem_method,
+        'memory_runs'   => ($mem_method === 'php_heap_only') ? 0 : $mem_runs,
     ],
     'benchmarks' => [],
 ];
@@ -246,9 +531,13 @@ $json_results = [
 /**
  * Record a benchmark result into the JSON structure.
  * $id is a stable dotted key like "core.int_to_int.write".
- * $data has keys: median, runs (optional), heap (optional).
+ *
+ * `heap_bytes` doubles as the marker every driver uses to tell a memory row
+ * from a timing row (bench-compare.php, bench-gate.php, bench-threearm.php all
+ * test `array_key_exists('heap_bytes', ...)`), so it is always emitted on a
+ * memory row even when `rss_bytes` is the number worth reading.
  */
-function record(string $id, float $median_ms, array $runs = [], ?int $heap = null): void {
+function record(string $id, float $median_ms, array $runs = [], ?int $heap = null, ?int $rss = null): void {
     global $json_results;
     $entry = ['median_ms' => round($median_ms, 4)];
     if (!empty($runs)) {
@@ -256,6 +545,9 @@ function record(string $id, float $median_ms, array $runs = [], ?int $heap = nul
     }
     if ($heap !== null) {
         $entry['heap_bytes'] = $heap;
+    }
+    if ($rss !== null) {
+        $entry['rss_bytes'] = $rss;
     }
     $json_results['benchmarks'][$id] = $entry;
 }
@@ -318,6 +610,10 @@ echo "  php-judy Benchmark Suite — " . number_format($size) . " elements, $ite
 echo "  PHP " . phpversion() . " | Judy ext " . judy_version() . " | " . PHP_OS . " " . php_uname('m') . "\n";
 echo "  Suite: $suite | Groups: " . implode(',', $active_groups) . "\n";
 echo "  memory_limit: $memory_limit\n";
+echo "  Memory: " . ($mem_method === 'php_heap_only'
+        ? 'not measured (PHP heap cannot see a Judy index; see --memory)'
+        : "peak RSS of a child process, empty-process floor subtracted, median of $mem_runs")
+    . "\n";
 echo "$div\n\n";
 
 // ╔═══════════════════════════════════════════════════════════════════════════╗
@@ -360,9 +656,14 @@ function bench_core_type(
     $fr_judy = measure_free($populate_judy, $iterations);
     $fr_php  = measure_free($populate_php, $iterations);
 
-    // Heap
+    // Memory. Two instruments, deliberately: the emalloc heap (what PHP's own
+    // memory manager sees) and, when it can be measured, the structure's actual
+    // footprint as floor-subtracted peak RSS of a child process. Only the
+    // second one can see a Judy index — see measure_heap()'s note.
     $h_judy = measure_heap(function() use ($populate_judy) { return $populate_judy(); });
     $h_php  = measure_heap(function() use ($populate_php)  { return $populate_php(); });
+    $m_judy = bench_mem_cell($id_prefix, 'judy', $size);
+    $m_php  = bench_mem_cell($id_prefix, 'php',  $size);
 
     unset($j_ref, $p_ref);
 
@@ -375,8 +676,8 @@ function bench_core_type(
     record("{$id_prefix}.iter.php",   $f_php['median'],  $f_php['runs']);
     record("{$id_prefix}.free.judy",  $fr_judy['median'], $fr_judy['runs']);
     record("{$id_prefix}.free.php",   $fr_php['median'],  $fr_php['runs']);
-    record("{$id_prefix}.heap.judy",  0, [], $h_judy);
-    record("{$id_prefix}.heap.php",   0, [], $h_php);
+    record("{$id_prefix}.heap.judy",  0, [], $h_judy, $m_judy);
+    record("{$id_prefix}.heap.php",   0, [], $h_php,  $m_php);
 
     return [
         'label'   => $label,
@@ -385,7 +686,21 @@ function bench_core_type(
         'iter'    => [$f_judy['median'], $f_php['median']],
         'free'    => [$fr_judy['median'], $fr_php['median']],
         'heap'    => [$h_judy, $h_php],
+        'mem'     => [$m_judy, $m_php],
     ];
+}
+
+/**
+ * The memory column: the structure's footprint when it could be measured, and
+ * an explicit marker when it could not. Never the emalloc heap dressed up as a
+ * footprint — that is the number that read 160 B for a 500,000-element BITSET.
+ */
+function fmt_mem(?int $bytes): string {
+    if ($bytes === null) { return 'n/a'; }
+    $res = bench_mem_resolution();
+    // Below the instrument's resolution the honest statement is an upper bound.
+    if ($res !== null && $bytes <= $res) { return '< ' . fmt_bytes(max($res, 1)); }
+    return fmt_bytes($bytes);
 }
 
 $col = [24, 12, 12, 12, 12, 12, 12];
@@ -395,7 +710,7 @@ if (bench_group('core.int')) {
 echo "── Core: Integer-Keyed Types ────────────────────────────────────────────────\n\n";
 
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
-    'Type', 'Write(ms)', 'Read(ms)', 'Iter(ms)', 'Free(ms)', 'Heap');
+    'Type', 'Write(ms)', 'Read(ms)', 'Iter(ms)', 'Free(ms)', 'Memory');
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
     str_repeat('─', $col[0]),
     str_repeat('─', $col[1]), str_repeat('─', $col[2]),
@@ -423,12 +738,12 @@ printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$c
     'BITSET',
     sprintf('%.2f', $r['write'][0]), sprintf('%.2f', $r['read'][0]),
     sprintf('%.2f', $r['iter'][0]),  sprintf('%.2f', $r['free'][0]),
-    fmt_bytes($r['heap'][0]));
+    fmt_mem($r['mem'][0]));
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
     '  PHP array',
     sprintf('%.2f', $r['write'][1]), sprintf('%.2f', $r['read'][1]),
     sprintf('%.2f', $r['iter'][1]),  sprintf('%.2f', $r['free'][1]),
-    fmt_bytes($r['heap'][1]));
+    fmt_mem($r['mem'][1]));
 unset($j_ref_bs, $p_ref_bs);
 
 // -- INT_TO_INT --
@@ -452,12 +767,12 @@ printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$c
     'INT_TO_INT',
     sprintf('%.2f', $r['write'][0]), sprintf('%.2f', $r['read'][0]),
     sprintf('%.2f', $r['iter'][0]),  sprintf('%.2f', $r['free'][0]),
-    fmt_bytes($r['heap'][0]));
+    fmt_mem($r['mem'][0]));
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
     '  PHP array',
     sprintf('%.2f', $r['write'][1]), sprintf('%.2f', $r['read'][1]),
     sprintf('%.2f', $r['iter'][1]),  sprintf('%.2f', $r['free'][1]),
-    fmt_bytes($r['heap'][1]));
+    fmt_mem($r['mem'][1]));
 unset($j_ref_ii, $p_ref_ii);
 
 // -- INT_TO_MIXED --
@@ -491,12 +806,12 @@ printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$c
     'INT_TO_MIXED',
     sprintf('%.2f', $r['write'][0]), sprintf('%.2f', $r['read'][0]),
     sprintf('%.2f', $r['iter'][0]),  sprintf('%.2f', $r['free'][0]),
-    fmt_bytes($r['heap'][0]));
+    fmt_mem($r['mem'][0]));
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
     '  PHP array',
     sprintf('%.2f', $r['write'][1]), sprintf('%.2f', $r['read'][1]),
     sprintf('%.2f', $r['iter'][1]),  sprintf('%.2f', $r['free'][1]),
-    fmt_bytes($r['heap'][1]));
+    fmt_mem($r['mem'][1]));
 unset($j_ref_im, $p_ref_im);
 
 // -- INT_TO_PACKED --
@@ -522,12 +837,12 @@ if ($has_packed) {
         'INT_TO_PACKED',
         sprintf('%.2f', $r['write'][0]), sprintf('%.2f', $r['read'][0]),
         sprintf('%.2f', $r['iter'][0]),  sprintf('%.2f', $r['free'][0]),
-        fmt_bytes($r['heap'][0]));
+        fmt_mem($r['mem'][0]));
     printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
         '  PHP array',
         sprintf('%.2f', $r['write'][1]), sprintf('%.2f', $r['read'][1]),
         sprintf('%.2f', $r['iter'][1]),  sprintf('%.2f', $r['free'][1]),
-        fmt_bytes($r['heap'][1]));
+        fmt_mem($r['mem'][1]));
     unset($j_ref_ip, $p_ref_ip);
 }
 
@@ -543,7 +858,7 @@ if (bench_group('core.str')) {
 echo "── Core: String-Keyed Types ────────────────────────────────────────────────\n\n";
 
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
-    'Type', 'Write(ms)', 'Read(ms)', 'Iter(ms)', 'Free(ms)', 'Heap');
+    'Type', 'Write(ms)', 'Read(ms)', 'Iter(ms)', 'Free(ms)', 'Memory');
 printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
     str_repeat('─', $col[0]),
     str_repeat('─', $col[1]), str_repeat('─', $col[2]),
@@ -589,12 +904,12 @@ function bench_str_type(string $id, string $label, int $jtype, array $data, arra
         $label,
         sprintf('%.2f', $r['write'][0]), sprintf('%.2f', $r['read'][0]),
         sprintf('%.2f', $r['iter'][0]),  sprintf('%.2f', $r['free'][0]),
-        fmt_bytes($r['heap'][0]));
+        fmt_mem($r['mem'][0]));
     printf("  %-{$col[0]}s  %{$col[1]}s  %{$col[2]}s  %{$col[3]}s  %{$col[4]}s  %{$col[5]}s\n",
         '  PHP array',
         sprintf('%.2f', $r['write'][1]), sprintf('%.2f', $r['read'][1]),
         sprintf('%.2f', $r['iter'][1]),  sprintf('%.2f', $r['free'][1]),
-        fmt_bytes($r['heap'][1]));
+        fmt_mem($r['mem'][1]));
     unset($j_ref, $p_ref);
 }
 
@@ -1536,9 +1851,24 @@ echo "\n";
 echo "$div\n";
 echo "  Benchmark complete — " . date('Y-m-d H:i:s') . "\n";
 echo "  All timings: median of $iterations iterations via hrtime(true), 1 warmup run\n";
+if ($mem_method === 'php_heap_only') {
+    echo "  Memory: NOT MEASURED. libJudy allocates through malloc(3), outside PHP's\n";
+    echo "          memory manager, so memory_get_usage() cannot see a Judy index.\n";
+} else {
+    echo "  Memory: peak RSS of a child process building one structure of "
+        . number_format($size) . " elements,\n";
+    echo "          minus an empty-process floor. Measured with getrusage(), not\n";
+    echo "          memory_get_usage(), for the reason above. Judy's memory advantage is\n";
+    echo "          scale- and type-dependent — see BENCHMARK.md for the curve.\n";
+}
 echo "$div\n";
 
 // ── JSON output ─────────────────────────────────────────────────────────────
+
+// The floor's run-to-run spread is this instrument's resolution, and it is only
+// known once at least one cell has run. Consumers need it to tell a measured
+// footprint from an upper bound — see fmt_mem().
+$json_results['metadata']['memory_resolution_bytes'] = bench_mem_resolution();
 
 if ($json_file !== null) {
     $json = json_encode($json_results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/package.xml
+++ b/package.xml
@@ -95,6 +95,7 @@
          <file name="tests/bench_compare_drift_001.phpt" role="test" />
          <file name="tests/bench_compare_fake_bench.inc" role="test" />
          <file name="tests/bench_memory_limit_001.phpt" role="test" />
+         <file name="tests/bench_memory_measurement_001.phpt" role="test" />
          <file md5sum="43e01c2e189ff2523a83016559b80391" name="tests/bitset_001.phpt" role="test" />
          <file md5sum="9f3363cc4c6d15cb52184351cf710fd7" name="tests/bitset_002.phpt" role="test" />
          <file md5sum="e859b3b92086bc165b3ec98800920f03" name="tests/bitset_003.phpt" role="test" />

--- a/scripts/bench-compare.php
+++ b/scripts/bench-compare.php
@@ -263,6 +263,10 @@ function run_group(string $arm, string $group): array {
         . ' --size ' . $size
         . ' --iterations ' . $iterations
         . ' --json ' . escapeshellarg($json)
+        // Last on purpose: PHP's getopt() stops parsing at an option it does
+        // not know, so a --memory placed before --json would swallow it in any
+        // judy-bench.php that predates the flag.
+        . ' --memory off'
         . ' > /dev/null 2> ' . escapeshellarg($err);
 
     exec($cmd, $_, $status);

--- a/scripts/bench-gate.php
+++ b/scripts/bench-gate.php
@@ -656,6 +656,10 @@ function gate_run_group(string $handle, string $group, int $size, int $iteration
         . ' --size ' . $size
         . ' --iterations ' . $iterations
         . ' --json ' . escapeshellarg($json)
+        // Last on purpose: PHP's getopt() stops parsing at an option it does
+        // not know, so a --memory placed before --json would swallow it in any
+        // judy-bench.php that predates the flag.
+        . ' --memory off'
         . ' > ' . TAM_DEVNULL . ' 2> ' . escapeshellarg($err);
     exec($cmd, $_, $status);
     $stderr = (string) @file_get_contents($err);

--- a/tests/bench_memory_measurement_001.phpt
+++ b/tests/bench_memory_measurement_001.phpt
@@ -57,9 +57,14 @@ echo "== child ==\n";
 echo "floor is json: ", is_array($floor) ? 'yes' : 'no', "\n";
 echo "cell count: ", $cell['count'], "\n";
 echo "cell built above floor: ", ($cell['peak_rss'] > $floor['peak_rss']) ? 'yes' : 'no', "\n";
-// The defect in one line: PHP's own memory manager sees ~160 bytes of wrapper
-// for 200,000 integer keys, because libJudy allocates through malloc(3).
-echo "child heap_bytes under 1 KB: ", ($cell['heap_bytes'] < 1024) ? 'yes' : 'no', "\n";
+// The defect in one line: PHP's own memory manager barely moves for 200,000
+// integer keys, because libJudy allocates through malloc(3). Relational, not an
+// absolute bound -- a --enable-debug PHP adds per-allocation bookkeeping to
+// memory_get_usage(), so the reading is larger there while staying negligible
+// against the real footprint, which is the property being asserted.
+$child_rss = $cell['peak_rss'] - $floor['peak_rss'];
+echo "child heap negligible vs its rss: ",
+    ($cell['heap_bytes'] * 100 < $child_rss) ? 'yes' : 'no', "\n";
 $child_unknown = shell_exec($child . 'core.nope judy 10 2>&1');
 echo "unknown workload rejected: ",
     (strpos((string)$child_unknown, 'unknown workload') !== false) ? 'yes' : 'no', "\n";
@@ -130,7 +135,7 @@ echo "json written: ", $j === null ? 'no' : 'yes', "\n";
 floor is json: yes
 cell count: 200000
 cell built above floor: yes
-child heap_bytes under 1 KB: yes
+child heap negligible vs its rss: yes
 unknown workload rejected: yes
 
 == --memory rss (default) ==

--- a/tests/bench_memory_measurement_001.phpt
+++ b/tests/bench_memory_measurement_001.phpt
@@ -20,7 +20,8 @@ function run_bench(string $extra, int $size = 200000): array {
     global $so, $script;
     $out = tempnam(sys_get_temp_dir(), 'jbm');
     $cmd = escapeshellarg(PHP_BINARY)
-        . ' -n -d memory_limit=2G -d extension=' . escapeshellarg($so)
+        . ' -n -d memory_limit=2G -d display_errors=stderr -d error_reporting=0'
+        . ' -d extension=' . escapeshellarg($so)
         . ' ' . escapeshellarg($script)
         . ' --group core.int --size ' . $size . ' --iterations 1'
         . ' ' . $extra
@@ -37,10 +38,20 @@ function run_bench(string $extra, int $size = 200000): array {
 // report a peak that is above an empty process, or the whole measurement is
 // worthless.
 $child = escapeshellarg(PHP_BINARY)
-    . ' -n -d memory_limit=2G -d extension=' . escapeshellarg($so)
+    . ' -n -d memory_limit=2G -d display_errors=stderr -d error_reporting=0'
+    . ' -d extension=' . escapeshellarg($so)
     . ' ' . escapeshellarg($script) . ' --mem-child ';
-$floor = json_decode((string)shell_exec($child . 'floor php 0 2>/dev/null'), true);
-$cell  = json_decode((string)shell_exec($child . 'core.int_to_int judy 200000 2>/dev/null'), true);
+$floor_raw = (string)shell_exec($child . 'floor php 0 2>/dev/null');
+$cell_raw  = (string)shell_exec($child . 'core.int_to_int judy 200000 2>/dev/null');
+$floor = json_decode($floor_raw, true);
+$cell  = json_decode($cell_raw, true);
+if (!is_array($floor) || !is_array($cell)) {
+    // Self-diagnosis: the CI log does not carry the .diff, so make the failure
+    // itself say what the child actually emitted.
+    echo "CHILD OUTPUT NOT JSON\n";
+    echo 'floor: ', substr($floor_raw, 0, 400), "\n";
+    echo 'cell: ',  substr($cell_raw, 0, 400), "\n";
+}
 
 echo "== child ==\n";
 echo "floor is json: ", is_array($floor) ? 'yes' : 'no', "\n";

--- a/tests/bench_memory_measurement_001.phpt
+++ b/tests/bench_memory_measurement_001.phpt
@@ -76,8 +76,12 @@ echo "rss_bytes added: ",
 // collapses back to heap_bytes, the measurement has reverted.
 $h = $bm['core.int_to_int.heap.judy']['heap_bytes'];
 $r = $bm['core.int_to_int.heap.judy']['rss_bytes'];
-echo "int_to_int heap under 1 KB: ", ($h < 1024) ? 'yes' : 'no', "\n";
-echo "int_to_int rss over 256 KB: ", ($r > 262144) ? 'yes' : 'no', "\n";
+// Stated relationally, not as absolute byte bounds: libJudy is compiled
+// separately from PHP, so a --enable-debug PHP inflates the array arm and the
+// emalloc bookkeeping while leaving the Judy trie untouched. Absolute
+// thresholds calibrated on a release build do not survive that; the asymmetry
+// they exist to prove does.
+echo "int_to_int rss dwarfs its own heap reading: ", ($r > $h * 100) ? 'yes' : 'no', "\n";
 
 // And the headline consequence: measured against the PHP array, the ratio is a
 // small multiple rather than the five-figure one the heap delta produced.
@@ -86,10 +90,11 @@ $ph = $bm['core.int_to_int.heap.php']['heap_bytes'];
 // The old instrument reported a five-figure multiple here; the new one a
 // small one. Asserted as thresholds, not exact values: the PHP array's own
 // footprint moves with the PHP version and the page size.
-echo "int_to_int ratio by heap over 1000x: ",
-    (($ph / max($h, 1)) > 1000.0) ? 'yes' : 'no', "\n";
-echo "int_to_int ratio by rss under 10x: ",
-    (($pr / max($r, 1)) < 10.0) ? 'yes' : 'no', "\n";
+// The heap instrument sees PHP arrays but not Judy: that asymmetry IS the bug.
+echo "php arm heap and rss same order: ", ($ph * 10 > $pr) ? 'yes' : 'no', "\n";
+echo "ratio by heap absurd: ", (($ph / max($h, 1)) > 1000.0) ? 'yes' : 'no', "\n";
+echo "ratio by rss orders of magnitude smaller: ",
+    (($ph / max($h, 1)) > 100.0 * ($pr / max($r, 1))) ? 'yes' : 'no', "\n";
 
 // ── 3. --memory off is the old behaviour, unchanged ────────────────────────
 // The automated drivers pass this; they must keep getting heap_bytes and no
@@ -123,10 +128,10 @@ method: peak_rss_child_floor_subtracted
 resolution is int: yes
 heap_bytes still present: yes
 rss_bytes added: yes
-int_to_int heap under 1 KB: yes
-int_to_int rss over 256 KB: yes
-int_to_int ratio by heap over 1000x: yes
-int_to_int ratio by rss under 10x: yes
+int_to_int rss dwarfs its own heap reading: yes
+php arm heap and rss same order: yes
+ratio by heap absurd: yes
+ratio by rss orders of magnitude smaller: yes
 
 == --memory off ==
 exit=0

--- a/tests/bench_memory_measurement_001.phpt
+++ b/tests/bench_memory_measurement_001.phpt
@@ -1,0 +1,139 @@
+--TEST--
+judy-bench: memory is measured as peak RSS, not the emalloc heap (issue #172)
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) === 'WIN') die('skip POSIX shell required');
+if (!function_exists('getrusage')) die('skip getrusage() not available');
+if (!function_exists('shell_exec')) die('skip shell_exec() disabled');
+$root = dirname(__DIR__);
+if (!is_file("$root/examples/benchmarks/judy-bench.php")) die('skip judy-bench.php not present');
+if (!is_file("$root/modules/judy.so")) die('skip requires in-tree build (modules/judy.so)');
+?>
+--FILE--
+<?php
+$root   = dirname(__DIR__);
+$so     = "$root/modules/judy.so";
+$script = "$root/examples/benchmarks/judy-bench.php";
+
+/** Run judy-bench.php over core.int only, return [exit, decoded json]. */
+function run_bench(string $extra, int $size = 200000): array {
+    global $so, $script;
+    $out = tempnam(sys_get_temp_dir(), 'jbm');
+    $cmd = escapeshellarg(PHP_BINARY)
+        . ' -n -d memory_limit=2G -d extension=' . escapeshellarg($so)
+        . ' ' . escapeshellarg($script)
+        . ' --group core.int --size ' . $size . ' --iterations 1'
+        . ' ' . $extra
+        . ' --json ' . escapeshellarg($out)
+        . ' 2>/dev/null';
+    exec($cmd . ' >/dev/null', $_, $status);
+    $j = json_decode((string)@file_get_contents($out), true);
+    @unlink($out);
+    return [$status, is_array($j) ? $j : null];
+}
+
+// ── 1. The child entry point builds the structure it is asked for ───────────
+// This is the instrument itself. It must load the extension under test and
+// report a peak that is above an empty process, or the whole measurement is
+// worthless.
+$child = escapeshellarg(PHP_BINARY)
+    . ' -n -d memory_limit=2G -d extension=' . escapeshellarg($so)
+    . ' ' . escapeshellarg($script) . ' --mem-child ';
+$floor = json_decode((string)shell_exec($child . 'floor php 0 2>/dev/null'), true);
+$cell  = json_decode((string)shell_exec($child . 'core.int_to_int judy 200000 2>/dev/null'), true);
+
+echo "== child ==\n";
+echo "floor is json: ", is_array($floor) ? 'yes' : 'no', "\n";
+echo "cell count: ", $cell['count'], "\n";
+echo "cell built above floor: ", ($cell['peak_rss'] > $floor['peak_rss']) ? 'yes' : 'no', "\n";
+// The defect in one line: PHP's own memory manager sees ~160 bytes of wrapper
+// for 200,000 integer keys, because libJudy allocates through malloc(3).
+echo "child heap_bytes under 1 KB: ", ($cell['heap_bytes'] < 1024) ? 'yes' : 'no', "\n";
+$child_unknown = shell_exec($child . 'core.nope judy 10 2>&1');
+echo "unknown workload rejected: ",
+    (strpos((string)$child_unknown, 'unknown workload') !== false) ? 'yes' : 'no', "\n";
+
+// ── 2. --memory rss (the default) records a footprint next to the heap ──────
+[$status, $j] = run_bench('');
+echo "\n== --memory rss (default) ==\n";
+echo "exit=$status\n";
+echo "method: ", $j['metadata']['memory_method'], "\n";
+echo "resolution is int: ", is_int($j['metadata']['memory_resolution_bytes']) ? 'yes' : 'no', "\n";
+
+$bm = $j['benchmarks'];
+// heap_bytes must survive: bench-compare.php, bench-gate.php and
+// bench-threearm.php all use its presence to tell a memory row from a timing
+// row. Removing it would silently reclassify these rows as 0 ms timings.
+echo "heap_bytes still present: ",
+    (isset($bm['core.bitset.heap.judy']['heap_bytes'])
+     && isset($bm['core.bitset.heap.php']['heap_bytes'])) ? 'yes' : 'no', "\n";
+echo "rss_bytes added: ",
+    (isset($bm['core.bitset.heap.judy']['rss_bytes'])
+     && isset($bm['core.int_to_int.heap.judy']['rss_bytes'])) ? 'yes' : 'no', "\n";
+
+// The regression this test exists to catch. INT_TO_INT at 200k is ~1.6 MB of
+// trie; the emalloc heap reports the wrapper object only. If rss_bytes ever
+// collapses back to heap_bytes, the measurement has reverted.
+$h = $bm['core.int_to_int.heap.judy']['heap_bytes'];
+$r = $bm['core.int_to_int.heap.judy']['rss_bytes'];
+echo "int_to_int heap under 1 KB: ", ($h < 1024) ? 'yes' : 'no', "\n";
+echo "int_to_int rss over 256 KB: ", ($r > 262144) ? 'yes' : 'no', "\n";
+
+// And the headline consequence: measured against the PHP array, the ratio is a
+// small multiple rather than the five-figure one the heap delta produced.
+$pr = $bm['core.int_to_int.heap.php']['rss_bytes'];
+$ph = $bm['core.int_to_int.heap.php']['heap_bytes'];
+// The old instrument reported a five-figure multiple here; the new one a
+// small one. Asserted as thresholds, not exact values: the PHP array's own
+// footprint moves with the PHP version and the page size.
+echo "int_to_int ratio by heap over 1000x: ",
+    (($ph / max($h, 1)) > 1000.0) ? 'yes' : 'no', "\n";
+echo "int_to_int ratio by rss under 10x: ",
+    (($pr / max($r, 1)) < 10.0) ? 'yes' : 'no', "\n";
+
+// ── 3. --memory off is the old behaviour, unchanged ────────────────────────
+// The automated drivers pass this; they must keep getting heap_bytes and no
+// child processes.
+[$status, $j] = run_bench('--memory off');
+echo "\n== --memory off ==\n";
+echo "exit=$status\n";
+echo "method: ", $j['metadata']['memory_method'], "\n";
+echo "heap_bytes present: ",
+    isset($j['benchmarks']['core.bitset.heap.judy']['heap_bytes']) ? 'yes' : 'no', "\n";
+echo "rss_bytes absent: ",
+    !isset($j['benchmarks']['core.bitset.heap.judy']['rss_bytes']) ? 'yes' : 'no', "\n";
+
+// ── 4. A bad --memory value is rejected, not reinterpreted ─────────────────
+[$status, $j] = run_bench('--memory heap');
+echo "\n== --memory heap (invalid) ==\n";
+echo "exit=$status\n";
+echo "json written: ", $j === null ? 'no' : 'yes', "\n";
+?>
+--EXPECT--
+== child ==
+floor is json: yes
+cell count: 200000
+cell built above floor: yes
+child heap_bytes under 1 KB: yes
+unknown workload rejected: yes
+
+== --memory rss (default) ==
+exit=0
+method: peak_rss_child_floor_subtracted
+resolution is int: yes
+heap_bytes still present: yes
+rss_bytes added: yes
+int_to_int heap under 1 KB: yes
+int_to_int rss over 256 KB: yes
+int_to_int ratio by heap over 1000x: yes
+int_to_int ratio by rss under 10x: yes
+
+== --memory off ==
+exit=0
+method: php_heap_only
+heap_bytes present: yes
+rss_bytes absent: yes
+
+== --memory heap (invalid) ==
+exit=1
+json written: no


### PR DESCRIPTION
Fixes the measurement defect in #172.

## The mechanism, verified

`libjudy/src/JudyCommon/JudyMalloc.c` is the single call site for `malloc(3)` in
the library, and `grep -rn emalloc libjudy/` returns **zero hits** — the Stage 2
patch series (`libjudy/PATCHES.md` P1-P7, O1-O4d) contains no JudyMalloc
interception. A system libJudy has none either. So PHP's memory manager never
sees a Judy index, in **any** build configuration, and
`memory_get_usage()` is blind to it uniformly rather than differently per build.

Measured directly on the built extension:

```
BITSET n=500000  heap_delta=160 B  rss_delta=376832 B  memoryUsage()=41040 B
```

## The numbers

`--size 500000`, macOS arm64 / PHP 8.5.8, this build. Old = what CI publishes
today, new = `rss_bytes`.

| Type | old Judy | old ratio | new Judy | new ratio | BENCHMARK.md (independent) |
| --- | ---: | ---: | ---: | ---: | --- |
| Bitset | 160 B | 52532x less | < 224 KB | > 40x smaller | 18.5x @100k → 22.7x @8M |
| Int to Int | 160 B | 52532x less | 4.1 MB | 2.1x smaller | **2.12x @1M** |
| Int to Mixed | 7.6 MB | ~1.0x | 42.4 MB | **1.11x larger** | 0.95x @100k, **0.78x @1M** |
| Int to Packed | 13.3 MB | 0.6x | 17.0 MB | 2.2x smaller | not measured there |
| String to Int | 64.2 KB | 319.2x less | 11.1 MB | 3.4x smaller | **3.42x @100k, 3.32x @8M** |

The three shared cells land on BENCHMARK.md's dedicated-host figures across a
different OS, libc, page size and CPU architecture. `bitset` reads higher than
BENCHMARK.md because the workloads differ — judy-bench uses dense keys
(`$j[$i]`), BENCHMARK.md stride-7 sparse — and dense is Judy1's best case, so
the direction is right.

`BENCHMARK.md` is **not touched**: its results are correct and were taken with a
sound instrument. `scripts/bench-threearm.php` is not touched either (#169).

## The instrument

Peak RSS of a child process building one structure, minus an empty-process
floor — the same shape as `scripts/bench-lib.php`'s `tam_mem_cell()` and
`examples/coverage-index.php`. Not `Judy::memoryUsage()`, which is not uniform
across types (exact for BITSET/INT_TO_INT, blind to INT_TO_MIXED's `emalloc`'d
zvals, payload-approximation only for STRING_TO_*) and would mix instruments
within one table.

**Sub-resolution cells are reported as upper bounds.** A dense 500k BITSET is
41 KB by `J1MU` against a floor whose run-to-run spread is ~250 KB. A point
estimate there is noise — three consecutive runs gave 51x / 37.7x / 187.7x. The
harness now measures the floor's spread, calls twice that its resolution, and
renders anything below it as `< 416 KB` / `> 21x smaller`. Verified stable
across runs.

## Contract kept

`heap_bytes` is unchanged in name, value and semantics. `bench-compare.php`,
`bench-gate.php` and `bench-threearm.php` all use `array_key_exists('heap_bytes',
$entry)` to tell a memory row from a timing row; removing it would silently
reclassify these rows as 0 ms timings. `rss_bytes` is purely additive, so
`baselines/latest.json` needs no bump here (per CLAUDE.md, that is its own PR).

`--memory off` restores the old behaviour and is what the two automated drivers
pass, so the gate does not pay a process per type on every invocation. It goes
**last** in their argv: PHP's `getopt()` halts at an unknown option, so placed
earlier it swallowed the following `--json`. `tests/bench_compare_drift_001.phpt`
caught that on the first attempt — the fixture died with
`Path must not be empty`.

## Judgement calls

**Keeping a single "savings" multiple — yes, but qualified.** The consolidated
comment is a per-PR regression view, not a marketing claim, and one number per
type is what makes it scannable. What made the old one misleading was not that
it was single but that it was unlabelled: no size, no instrument, no direction.
It now states `n = 500,000`, names the instrument, and links BENCHMARK.md for
the curve across sizes on a dedicated host.

**Losses shown as losses.** `0.6x` and `~1.0x` both read as wins. `Int to Mixed`
genuinely uses more memory than a PHP array — stable at 0.78-0.79x from 1M up in
BENCHMARK.md — and now renders `1.11x larger`. A bare ratio below 1.0 is how a
loss got published as break-even.

**`populationCount() 235315x` — removed from the speedup column.** It compares an
O(1) read of libJudy's cached population against an O(n) PHP `foreach`. The
multiple is arithmetically true, scales with `--size`, and carries no
information about any change. `judy-bench.php` already refuses the identical
comparison for `size($lo, $hi)`, in a comment stating the reason: *"the ratio
would be definitional rather than measured"*. Applying the repo's own stated
standard consistently. Both timings still print — they are what a regression
would move — and the ratio cell reads `O(1) vs O(n)` with a footnote.

**Windows reports nothing rather than something wrong.** PHP does not provide
`getrusage()` there, so no whole-process instrument exists. The table is
replaced by one sentence naming the reason. Falling back to `memory_get_usage()`
would reintroduce the defect on exactly the platform where nobody would notice.

## Vendored-vs-unpatched (S → C) on PR comments — done

The gate's `summary` job already downloads every `bench-gate-*` artifact and
renders `scripts/bench-gate-report.php`, whose output already contains the
S → C section. Posting that rendered report as an upserted PR comment is ~50
lines and duplicates none of the gate's logic.

It cannot lie when the gate did not run: `bench-gate.yml`'s `pull_request`
trigger is scoped to `libjudy/**` and the gate's own machinery, so on any other
PR the job never executes and no comment appears. Skipped on fork PRs (read-only
token — the same limitation `ci.yml`'s comment has). Falls back to a link when
the report exceeds GitHub's 65536-character comment limit, rather than
truncating a table into something that still reads as a result.

`ci.yml`'s consolidated comment is deliberately left alone. Pulling these
artifacts across a workflow boundary would mean either blocking that comment on
this workflow or rendering a stale one; both are worse than a second, self-dating
comment.

## Verification

- Mechanism: source-level (`JudyMalloc.c`, zero `emalloc` in `libjudy/`) and
  empirical (160 B heap vs 377 KB RSS for the same 500k BITSET).
- Every corrected number above is reproducible with
  `php -d extension=modules/judy.so examples/benchmarks/judy-bench.php --suite core --size 500000 --json out.json`
  (28 s wall including the memory children).
- Cross-check against BENCHMARK.md as tabled above.
- Reproducibility: 3 consecutive runs per cell. All types stable to ±2% except
  `bitset`, which is what motivated the upper-bound reporting.
- New `tests/bench_memory_measurement_001.phpt` pins the contract. **Negative
  control run**: against `origin/main`'s script it fails on every assertion —
  no `memory_method`, no `rss_bytes`, `--mem-child` runs the whole suite, and
  the ratio reads 26317x.
- Full suite **224/224**. `package.xml` updated.
- CI comment: the workflow's python block was extracted and rendered against a
  real `bench.json` from this build; both tables verified.

**No timing claim is made from any run in this PR.** The host had a VM at ~100%
CPU throughout (load avg 4.25-4.95 on 8 cores). Peak RSS is insensitive to CPU
contention; wall-clock timings are not, and none are quoted.

## Docs

`git grep` finds no doc quoting the inflated figures. `README.md`'s "2-4x less
memory / ~10x for BITSET" is conservative and consistent with the corrected
numbers. `AGENTS.md` and `BENCHMARK.md` already state that Judy memory is
invisible to `memory_get_usage()` — the benchmark simply was not following its
own documentation.
