### PR TITLE
ci(concurrency): cancel superseded pull-request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,33 @@ on:
   pull_request:
     branches: [main]
 
+# Only the newest commit of a pull request gets CI. Pushing a new commit (or a
+# force-push during a rebase) cancels the run for the commit it replaces: that
+# run's verdict describes code that no longer exists, so finishing it buys
+# nothing and costs a runner slot. Actions concurrency is an account-wide pool
+# shared with this owner's other repositories, and one full CI run here is 22
+# jobs -- enough on its own to saturate it -- so a superseded run is not merely
+# wasted, it delays the run that replaced it and every other repo's queue with
+# it. Measured on 2026-08-19: 9 of 28 pull-request runs were superseded, 25% of
+# the day's CI job-minutes went to results nobody could read, and median job
+# queue delay rose from 0.1 min (2026-08-18) to 3.5 min, p90 21 min.
+#
+# push:main is deliberately NOT cancellable. Those runs are the project's
+# historical record and feed the release path; a main run must always finish
+# even if the next merge lands while it is in flight. Two things enforce that
+# independently, on purpose:
+#   - the group key falls back to github.sha outside a pull request
+#     (github.event.pull_request.number is empty there), so every main commit
+#     gets its own group and main runs neither cancel nor queue behind another;
+#   - cancel-in-progress is switched off outright for non-pull_request events.
+#
+# github.workflow is part of the key so this never reaches across workflows:
+# a CI run and the Benchmark Gate's own "bench-gate-<ref>" group on the same
+# ref are separate groups and cannot cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   checks: write
   pull-requests: write


### PR DESCRIPTION
## What this does

Adds a `concurrency` block to `ci.yml` so that pushing a new commit to a pull
request cancels the in-flight run for the commit it replaces. Nothing else
changes: same jobs, same matrix, same gates, all still running on every PR —
just once, for the newest commit.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why — and explicitly *not* for cost

This repository is **public, so GitHub Actions is free for it**. The account's
billing page reads `$168.94 consumed − $168.94 discounts = $0 billable`; the
"2,000 / 2,000 minutes included" bar is the *private-repo* allowance and does
not apply here. Please do not read this change as a cost measure or cite it as
one later — the dollar figures on that page are notional list prices.

The real problem is **latency and throughput**. Actions concurrency is an
account-wide pool shared with this owner's other repositories, and one full CI
run here is **22 jobs** — enough on its own to saturate it. A superseded run
does not merely waste capacity; it delays the run that replaced it, and every
other repo's queue with it.

Measured from the Actions API:

| | 2026-08-18 (72 CI runs) | 2026-08-19 (39 CI runs, partial day) |
|---|---|---|
| PR runs superseded | 4 / 38 | **9 / 28** |
| share of CI job-minutes discarded | 10% | **25%** |
| median job queue delay | 0.1 min | **3.5 min** |
| p90 job queue delay | 7.1 min | **21.1 min** |
| max job queue delay | 363.6 min | 77.5 min |

The rebase-heavy day is the one that hurts: a third of PR runs were obsolete
before they finished, and queue delay went up 35× at the median.

## Measured per-job cost table

Median wall time per job, over successful jobs in the 39 runs on 2026-08-19.
"billed" is GitHub's per-job accounting (ceiling to the whole minute, minimum 1).

| OS | job | median | billed |
|---|---|---:|---:|
| linux | `build-linux (8.4)` | 421s | 8m |
| win | `build-windows (8.6, x64, nts, exp)` | 206s | 4m |
| win | `build-windows (8.5, x64, nts)` | 203s | 4m |
| win | `build-windows (8.4, x64, nts)` | 203s | 4m |
| win | `build-windows (8.2, x64, nts)` | 196s | 4m |
| win | `build-windows (8.3, x64, nts)` | 194s | 4m |
| win | `build-windows (8.1, x64, nts)` | 194s | 4m |
| linux | `validate-pecl` | 159s | 3m |
| linux | `build-linux (8.5)` | 127s | 3m |
| linux | `build-linux (8.6, exp)` | 127s | 3m |
| linux | `build-linux (8.3)` | 125s | 3m |
| linux | `build-linux (8.1)` | 125s | 3m |
| linux | `build-linux (8.2)` | 124s | 3m |
| linux | `differential-fuzz` | 88s | 2m |
| linux | `build-research` | 69s | 2m |
| linux | `debug-mirror-assertions` | 52s | 1m |
| linux | `build-alpine` | 47s | 1m |
| linux | `debug-php-assertions` | 32s | 1m |
| linux | `report-results` | 18s | 1m |
| linux | `guard-32bit` (negative control) | 6s | 1m |

**Per full run: 22 jobs, 38 Linux + 24 Windows billed job-minutes.** Every
superseded run threw away up to that much. Note how cheap the correctness gates
are relative to the build matrix: `differential-fuzz` + `build-alpine` + both
debug-assertion jobs + `guard-32bit` together are 6 billed minutes, against 62
for the two build matrices.

## Verified live on this PR

`pull_request` runs use the workflow from the merge ref, so this change tests
itself. Two further commits were pushed to this branch and then removed, leaving
one clean commit:

```
32230757856  queued     <- current, from the force-push
32230679953  cancelled  <- superseded by the force-push
32230630702  cancelled  <- superseded by the second commit
```

Each older run was cancelled the moment its replacement started. Before this
change both would have run all 22 jobs to completion.

## Coverage impact

**None.** No job, matrix entry, or gate was removed or made conditional. The
only behavioural difference is that a run for a commit that has already been
replaced stops early instead of finishing. `push: main` runs are never
cancelled, by two independent guards:

- the group key falls back to `github.sha` outside a pull request
  (`github.event.pull_request.number` is empty there), so every main commit gets
  its own group — main runs neither cancel nor queue behind one another;
- `cancel-in-progress` is switched off outright for non-`pull_request` events.

`github.workflow` is in the group key, so a CI run and the Benchmark Gate's
`bench-gate-<ref>` group on the same ref are separate groups and cannot cancel
each other.

## Benchmark Gate: is cancellation safe for `/var/tmp/BENCH_LOCK`?

**Yes, and no change was needed here.** `bench-gate.yml` already carries
`concurrency: { group: bench-gate-${{ github.ref }}, cancel-in-progress: true }`,
deliberately, for the co-tenancy reason documented in its header. Three findings:

1. **No workflow touches the lock at all.** `grep -rn "bench-lock\|BENCH_LOCK\|honeycomb" .github/`
   returns nothing. `/var/tmp/BENCH_LOCK` is a convention for the owner's shared
   local bench host, taken by the hand-run drivers under
   `research/libjudy-modernization/o5p-harness/` that source `tools/bench-lock.sh`.
2. **The gate runs only on ephemeral GitHub-hosted runners** (`ubuntu-latest`,
   `macos-latest`, `windows-latest`) — no self-hosted runner, and the VM is
   destroyed after the run whether or not it was cancelled.
3. **Even on honeycomb it would be safe**: `bench_lock_acquire` installs
   `trap 'bench_lock_release' EXIT INT TERM` immediately after winning the
   `O_EXCL` create, and GitHub sends SIGINT then SIGTERM on cancellation.

One pre-existing edge case, noted but not changed: because the gate's group is
keyed on `github.ref`, a `workflow_dispatch` on `main` shares a group with the
weekly `schedule` run and would cancel it, losing a time-series point. That is
the existing design's trade against co-tenancy and is out of scope here.

## `release.yml` — untouched

Deliberately left with no `concurrency` block. A release publish must never be
cancelled *or* queued behind another run, and it builds the full supported
matrix. Unchanged.

## Re-running the full matrix on demand

Nothing needs to be forced — **the full matrix still runs on every PR**. If a
cancelled run needs to be brought back for inspection, "Re-run all jobs" on the
cancelled run in the Actions UI works normally, or `gh run rerun <id>`.

## Verified while investigating: `main` has no required status checks

The `main-branch-protection` ruleset (id 13303262) contains only `deletion`,
`non_fast_forward`, and a `pull_request` rule with
`required_approving_review_count: 0`. There is **no `required_status_checks`
rule**. So no CI check currently gates a merge, and cancellation cannot block
one. Flagging this because it is probably not the intent, and because it is the
precondition for the deferred item below.

## Deferred — options for the owner, deliberately not implemented

These were investigated and are written up rather than applied, because with
Actions free on this repo they trade coverage for a little latency, and this
project's CI caught three real defects in the last day alone.

1. **Advisory benchmark steps inside `ci.yml`.** `Run benchmarks` is the single
   largest component of every build job — 86s of a 124s `build-linux (8.2)`, 134s
   of a 203s `build-windows (8.4)` — running on all 12 build jobs, roughly 22
   minutes of wall time per run. `build-linux (8.4)` additionally spends 269s on
   `Run interleaved release comparison`. The project's own docs call these
   numbers advisory, and #166 has since landed a dedicated ratio-based
   `bench-gate.yml`. Dropping or narrowing them would cut each build job to about
   a third of its current length. **Not done here** because the artifacts feed
   `report-results`' consolidated PR comment, and #171/#173 are open against that
   machinery.
2. **PHP-version matrix trimming on PRs.** Deliberately rejected: the coverage
   loss is real and the saving is only latency.
3. **`paths-ignore` for docs-only changes.** Safe from the blocked-merge angle
   *today* only because nothing is a required check — which is exactly why it
   should not be relied on. If required checks are ever added, a `paths-ignore`
   filter would make them never report and block merges permanently.

Method note: durations are from `gh api repos/orieg/php-judy/actions/runs/<id>/jobs`
over every run on 2026-08-18 and 2026-08-19; "superseded" means another run on the
same PR branch was created before that run finished.
