### PR TITLE
chore(release): 2.6.0 — version bump and changelog

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -2419,7 +2419,7 @@ php examples/benchmarks/run-benchmarks-robust.php
 
 Our methodology and insights are informed by the [Rusty Russell benchmark comparison](https://rusty.ozlabs.org/2010/11/08/hashtables-vs-judy-arrays-round-1.html) between hashtables and Judy arrays, which demonstrates Judy's strengths in ordered access patterns and memory efficiency.
 
-**Describes**: php-judy 2.5.2
+**Describes**: php-judy 2.6.0
 **Figures measured on**: 2.4.2, verified unchanged on 2.5.0 (0 regressions, run-wide
 median -0.04%; see Benchmarking Environment)
 **Last Updated**: August 2026

--- a/README.md
+++ b/README.md
@@ -747,9 +747,16 @@ A release touches two version files, which must stay in lockstep (CI enforces bo
 Then:
 
 3. Refresh `BENCHMARK.md` version/date stamps.
-4. Bump the CI performance baseline in `.github/workflows/ci.yml` (the `pie install orieg/judy:X.Y.Z` step) to the previous release, so benchmark comparisons stay apples-to-apples.
+4. Confirm the CI performance baseline in `.github/workflows/ci.yml` (the `pie install orieg/judy:X.Y.Z` step) names the *previous* release, so benchmark comparisons stay apples-to-apples. Normally it already does — step 7 of the previous release set it.
 5. Tag and publish the GitHub release as `vX.Y.Z`. The `Publish Release` workflow validates the tag against `package.xml`, builds the Windows DLLs, and attaches them plus the PECL `.tgz`.
 6. Upload the `.tgz` to pecl.php.net (manual, requires a PECL account).
+7. **Once the release is actually on pecl.php.net**, in one dedicated commit (never inside a feature PR — it is a baseline move):
+   - bump the `pie install orieg/judy:X.Y.Z` pin in `.github/workflows/ci.yml` to the just-published release, and
+   - replace `baselines/latest.json` with the `benchmark-linux-php8.4` artifact from the CI run **on the tagged commit**, keeping the parameters identical to the baseline it replaces (PHP 8.4, Linux x86_64, size 500000, iterations 7, suite `all`).
+
+   Neither can be done before the tag exists and the package is installable: the numbers must come from a build that reports the new version, and the pin must resolve on PECL. Record the interleaved comparison and its PHP-array control in the commit message, as `0b064b0` does.
+
+`baselines/arm-ratios.json` is **not** part of this cycle. It is the cross-platform gate's reference, refreshed by `bench-gate.php --derive --update-baseline` when a platform's floors need re-deriving — also in its own PR, but on the gate's schedule rather than the release's. See [BENCHMARK.md](BENCHMARK.md#reproducing-the-gate-on-any-platform).
 
 `Dockerfile.validate` can smoke-test an already-built `.tgz` via `pecl install`.
 

--- a/package.xml
+++ b/package.xml
@@ -16,11 +16,11 @@
       <email>nicolas@brousse.info</email>
       <active>yes</active>
    </lead>
-   <date>2026-08-18</date>
+   <date>2026-08-19</date>
    <time>00:00:00</time>
    <version>
-      <release>2.5.2</release>
-      <api>2.5.2</api>
+      <release>2.6.0</release>
+      <api>2.6.0</api>
    </version>
    <stability>
       <release>stable</release>
@@ -28,24 +28,39 @@
    </stability>
    <license uri="http://www.php.net/license">PHP</license>
    <notes>
-- PERF: mergeWith() no longer re-descends from the root for a key its own
-  cursor is already standing on. The slot-to-zval conversion is shared with the
-  descending read path so the two cannot drift, and the cursor's slot is reused
-  only where it genuinely holds the value: directly on the integer-keyed and
-  trie types, and on *_HASH / *_ADAPTIVE only when the payload is mirrored
-  (an optimizeIteration instance of STRING_TO_INT_HASH, or long-keyed
-  STRING_TO_INT_ADAPTIVE). Behaviour-preserving: the three new .phpt files pass
-  against the pre-change build too. **No performance number is claimed** — the
-  redundant descend is gone, but no benchmark accompanies the change and none
-  should be inferred pending a run on an idle host. baselines/latest.json and
-  BENCHMARK.md figures are untouched.
-- DOC: API.md now documents that toArray() coerces integer-looking string keys
-  on string-keyed types ("42" comes back as int 42, while "07" and " 42" stay
-  strings) and that feeding such a key back as an offset throws. The warning
-  reached the stub and AGENTS.md in 2.5.1 but not API.md, which is the reference
-  composer.json advertises.
-- DOC: BENCHMARK.md records why php-code-coverage and Infection were examined
-  and rejected as Judy fits.
+- FIX: use-after-free during teardown of the MIXED types (INT_TO_MIXED,
+  STRING_TO_MIXED, STRING_TO_MIXED_HASH, STRING_TO_MIXED_ADAPTIVE), reachable
+  through both Judy::free() and ordinary object destruction (#162). Freeing a
+  slot calls zval_ptr_dtor(); where the value is a shared collectable one that
+  fills the GC root buffer, gc_collect_cycles() then runs synchronously inside
+  the free loop and re-enters judy_object_get_gc() on the half-destroyed
+  object. The usual symptom is a "zend_mm_heap corrupted" abort. This defect
+  PREDATES the bundled libJudy and is present in every previously shipped
+  release: anyone using a MIXED type should upgrade.
+- FIX: libJudy compiled with aggressive loop optimization silently loses
+  Judy::BITSET keys — jp_1Index is 8 bytes where the code writes up to 15
+  (#131). Fixed in the bundled tree (patch P1) and guarded by a differential
+  fuzzer that re-proves itself on every CI run by planting the defect and
+  failing if the fuzzer does not catch it.
+- FIX: further upstream libJudy 1.0.5 defects, fixed in the bundled tree
+  (#127): the SEARCH_LINEAR/COPYINDEX pair, which was a no-op masking silent
+  data loss; an off-by-one in InsArray; an out-of-scope read in Cascade; and
+  hygiene fixes (patches P2-P7). Every patch carries an entry in
+  libjudy/PATCHES.md and a per-file LGPL section 2(b) change notice.
+- BUILD: the bundled, patched libJudy is now the DEFAULT build. ./configure
+  needs no system library and downloads nothing at build time, and the Windows
+  build no longer regex-patches library sources in CI. --with-judy=DIR still
+  links a system libJudy, is CI-tested on every push, and stays supported
+  indefinitely.
+- BUILD: a 32-bit target is now refused with a clear message instead of being
+  mis-built, and the release matrix is constrained to x64 (#159, #160).
+- PERF: integer-keyed paths gain hardware popcount (#149) and a byte-order fix
+  on the JudyL descend (#150); the string layer loses redundant work (#154).
+  Figures are in BENCHMARK.md and are deliberately not restated here. Note
+  that the delivered speedup is NOT one number: with linkage held constant
+  against an unpatched build of the same tree, about 96.5% of the gain on
+  integer paths is attributable to these patches but only about 40% of the
+  gain on string paths, the remainder being static-versus-shared linkage.
    </notes>
    <contents>
       <dir name="/">
@@ -442,6 +457,37 @@
       <configureoption default="bundled" name="with-judy" prompt="libJudy to build against: &quot;bundled&quot; compiles the bundled copy (default); give the install prefix DIR of a system libJudy to link against it instead" />
    </extsrcrelease>
    <changelog>
+      <release>
+         <date>2026-08-18</date>
+         <version>
+            <release>2.5.2</release>
+            <api>2.5.2</api>
+         </version>
+         <stability>
+            <release>stable</release>
+            <api>stable</api>
+         </stability>
+         <notes>
+- PERF: mergeWith() no longer re-descends from the root for a key its own
+  cursor is already standing on. The slot-to-zval conversion is shared with the
+  descending read path so the two cannot drift, and the cursor's slot is reused
+  only where it genuinely holds the value: directly on the integer-keyed and
+  trie types, and on *_HASH / *_ADAPTIVE only when the payload is mirrored
+  (an optimizeIteration instance of STRING_TO_INT_HASH, or long-keyed
+  STRING_TO_INT_ADAPTIVE). Behaviour-preserving: the three new .phpt files pass
+  against the pre-change build too. **No performance number is claimed** — the
+  redundant descend is gone, but no benchmark accompanies the change and none
+  should be inferred pending a run on an idle host. baselines/latest.json and
+  BENCHMARK.md figures are untouched.
+- DOC: API.md now documents that toArray() coerces integer-looking string keys
+  on string-keyed types ("42" comes back as int 42, while "07" and " 42" stay
+  strings) and that feeding such a key back as an offset throws. The warning
+  reached the stub and AGENTS.md in 2.5.1 but not API.md, which is the reference
+  composer.json advertises.
+- DOC: BENCHMARK.md records why php-code-coverage and Infection were examined
+  and rejected as Judy fits.
+         </notes>
+      </release>
       <release>
          <date>2026-08-18</date>
          <version>

--- a/php_judy.h
+++ b/php_judy.h
@@ -19,7 +19,7 @@
 #ifndef PHP_JUDY_H
 #define PHP_JUDY_H
 
-#define PHP_JUDY_VERSION "2.5.2"
+#define PHP_JUDY_VERSION "2.6.0"
 #define PHP_JUDY_EXTNAME "judy"
 
 /* Windows x64 (LLP64): Force 64-bit Word_t to match libjudy ABI.


### PR DESCRIPTION
Release preparation for **2.6.0**. This PR does the version lockstep and the
changelog; it does **not** tag, publish, or touch either benchmark baseline.

`baselines/arm-ratios.json` moves in its own PR, per the repo rule that the two
baseline files only ever move in dedicated PRs.

## What moves

| file | change |
| --- | --- |
| `php_judy.h` | `PHP_JUDY_VERSION` 2.5.2 → 2.6.0 |
| `package.xml` | `<release>`/`<api>` → 2.6.0, `<date>` → 2026-08-19, the 2.5.2 `<notes>` moved into `<changelog>`, new `<notes>` |
| `BENCHMARK.md` | `**Describes**` stamp → 2.6.0 |

## Why 2.6.0 and not 2.5.3

Bundling libJudy changes what the package *is*: `./configure` no longer needs a
system library and downloads nothing at build time. A patch bump would
understate that.

## Changelog ordering

Correctness first, performance last — that is the ordering the evidence
supports.

1. **#162** — use-after-free during teardown of the four MIXED types, via both
   `Judy::free()` and object destruction. `zval_ptr_dtor()` on a shared
   collectable value fills the GC root buffer, `gc_collect_cycles()` then runs
   synchronously inside the free loop and re-enters `judy_object_get_gc()` on
   the half-destroyed object. **This predates the vendoring and is present in
   every previously shipped release**; the notes tell MIXED-type users to
   upgrade.
2. **#131** — stock libJudy silently loses `Judy::BITSET` keys under aggressive
   loop optimization. Fixed in-tree (P1) and guarded by a differential fuzzer
   that re-proves itself every CI run by planting the defect.
3. **#127** — the `SEARCH_LINEAR`/`COPYINDEX` pair, an `InsArray` off-by-one, a
   Cascade out-of-scope read, and hygiene fixes (P2–P7).
4. **#146** — bundled patched libJudy is the default build; `--with-judy=DIR`
   still links a system libJudy and stays supported indefinitely.
5. **#159 / #160** — 32-bit bundled Windows builds are refused with a clear
   message rather than mis-built; the release matrix is constrained to x64.
6. **Performance** (#149 popcount, #150 JudyL descend byte order, #154
   string-layer redundancy) — last, and pointing at `BENCHMARK.md` rather than
   restating figures.

The performance entry deliberately quotes **no single "vendoring made it N%
faster" number**. The measured attribution splits: with linkage held constant
against an unpatched build of the same tree, ~96.5% of the integer-path gain is
attributable to our patches but only ~40% of the string-path gain, the
remainder being static-versus-shared linkage. That distinction is documented in
`BENCHMARK.md` and flattening it would overclaim.

## Checked against the README release checklist

- [x] Step 1/2 — `php_judy.h` and `package.xml` in lockstep, notes rotated into
      `<changelog>`
- [x] Step 3 — `BENCHMARK.md` stamp; the release-over-release row is added in a
      follow-up commit on this branch once this PR's own CI has measured
      2.5.2 → 2.6.0 (the numbers must come from a build that actually reports
      2.6.0)
- [x] Step 4 — the `pie install orieg/judy:X.Y.Z` baseline in `ci.yml` already
      names 2.5.2, which *is* the previous release for 2.6.0. Nothing to move
      now; it becomes 2.6.0 on the release *after* this one, at which point the
      `libjudy-dev` install that step still needs can also go away.
- [ ] Step 5/6 — tag, GitHub release, PECL upload. **Deliberately not done
      here**; the tag is cut after both release PRs land.

`package.xml` completeness re-verified locally against `git ls-files tests/`
and `git ls-files libjudy/`, and it carries no `tools/` or `research/` entries.

No `MIGRATION_2.6.0.md`: there is no API or behaviour change to migrate for.
`llms.txt` and `README.md` already describe the bundled-by-default build and
carry no version stamp, so neither needs a release-specific note.
