### PR TITLE
perf(bench): derive the windows-x64 arm-ratio baseline

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -2021,12 +2021,13 @@ mining the raw JSON for small cells should apply the wider floor.
 
 ### Confidence tiers, and what is NOT measured
 
-There are now three tiers on this page and they are not interchangeable.
+There are now four tiers on this page and they are not interchangeable.
 
 | tier | what it means | who produces it |
 | --- | --- | --- |
 | **claim-grade** | absolute numbers, exclusive pinned host, hygiene clean, controls inside the claim floor. Quotable as "php-judy is X% faster". | `bench-threearm.php` on the dedicated bench host |
 | **ci-relative** | *ratios* of arms measured in the same interleaved rounds on a shared runner, with the run's own rebuild control stating how far a cell can move for no reason. Quotable as "the patches deliver about X% on this platform" and as "this has not regressed". **Not** quotable as an absolute number. | `bench-gate.php` in `bench-gate.yml` |
+| **ci-relative-single-build** | the same thing with **one** build per arm instead of two, so there is no C-vs-C rebuild control inside the run and the threshold rests entirely on the offline derived floor. Windows only, because a second MSVC build roughly doubles an already long job. | `bench-gate.php` in `bench-gate.yml`, `windows-x64` |
 | **directional** | a single measurement from a host that failed its own hygiene gate. Useful as a sanity check, not as evidence. | ad-hoc runs |
 
 | platform | toolchain | S → C timing | A → C timing | memory | tier |
@@ -2036,14 +2037,16 @@ There are now three tiers on this page and they are not interchangeable.
 | Linux x86-64 **musl**, Alpine container | gcc 15.2.0, PHP 8.4.24 | measured | measured | measured | **ci-relative** |
 | **macOS arm64**, GitHub runner | Apple clang 21.0.0, PHP 8.4.24 | measured | measured | measured | **ci-relative** |
 | macOS arm64, local workstation | Apple clang 21, PHP 8.5.8, Homebrew | directional | directional | measured | **directional** |
-| Windows x64 | MSVC | see below | see below | see below | see below |
+| **Windows x64**, GitHub runner | MSVC, PHP 8.4.24, Windows Server 2025 | measured | measured | measured | **ci-relative-single-build** |
 | Linux x86-64, **out-of-cache** (n=6M), honeycomb (dedicated) | gcc 14.2.0, PHP 8.4.24, Debian 13 | measured | measured | measured | **claim-grade** (integer/bitset + string API paths; `core.str` not measured — see below) |
 
 #### What the gate measured on each platform
 
-Pooled medians over the 51-52 comparable cells, **4 gate runs per platform
-across 2 distinct runner instances**, `--size 300000` (cache-resident), 5
-interleaved rounds, 2 independently linked builds per arm. Recorded in
+Pooled medians over the 51-52 comparable cells, **4 gate runs per platform**,
+`--size 300000` (cache-resident), 5 interleaved rounds. The three POSIX rows
+span 2 distinct runner instances with 2 independently linked builds per arm;
+the Windows row is 4 separate workflow dispatches with 1 build per arm, for the
+reasons under "Windows" below. Recorded in
 [`baselines/arm-ratios.json`](baselines/arm-ratios.json). **These are
 ci-relative ratios, not claim-grade absolutes.**
 
@@ -2052,6 +2055,7 @@ ci-relative ratios, not claim-grade absolutes.**
 | Linux glibc x86-64 | gcc 13.3.0 | **0.870** | 4.79x | 3.34x | 3.81x |
 | Linux musl x86-64 | gcc 15.2.0 | **0.906** | 6.49x | 3.34x | 3.74x |
 | macOS arm64 | Apple clang 21.0.0 | **0.910** | 6.50x | 3.21x | 3.42x |
+| Windows x64 | MSVC | **0.912** | 4.54x | 3.22x | 3.67x |
 | *(dedicated host, claim-grade, for comparison)* | *gcc 14.2.0* | *0.835 int / 0.886 string* | *4.19x median* | *3.12x @8M* | *3.32x @8M* |
 
 Four things worth saying about that table, and the last one is a caveat rather
@@ -2281,13 +2285,31 @@ why it sits below the gating floor and is not in the headline table above.
   residency needs its own derived floor, and deriving one belongs in the
   dedicated commit that writes the baseline rather than in the PR that builds
   the gate.
-- **Windows.** The job exists and builds both arms through the same
+- **Windows.** The job builds both arms through the same
   `php-windows-builder` action from one tree with `libjudy/` swapped between
   invocations — which is only possible because arm S needs no package. It runs
   one build per arm rather than two, so `rebuild_control_available` is `false`
-  there and its threshold falls back to the offline floor with no run-local
-  noise measurement behind it. Treat Windows as the lowest tier on this page
-  until it has accumulated enough scheduled runs to derive its own floor.
+  there and the threshold rests entirely on the offline derived floor with no
+  run-local noise measurement behind it. That is what the separate
+  `ci-relative-single-build` tier records.
+
+  It **now has a derived floor** — four same-commit runs, S → C axis floor
+  10.5%, all 51 cells gateable, and 1.0% on the three memory cells. Before
+  that the gate reported `no-baseline-for-platform` on every Windows run and
+  measured without gating. The A → C axis derives a 62.5% floor, above the 50%
+  ceiling, so no A → C cell is gated on Windows — the same outcome as Linux
+  glibc. That axis measures php-judy against a PHP native array, and its cells
+  drift far more between runs than the paired S → C ones do, so a floor wide
+  enough not to cry wolf is too wide to catch anything. S → C is the axis that
+  matters for `libjudy/`, and it is gated.
+
+  One caveat specific to this platform, stated because the JSON understates it:
+  `derived_from.distinct_hosts` reads **1**, not 4. The four runs really were
+  four separate ephemeral runner VMs, but GitHub's Windows Server 2025 image
+  reports the same `uname` host name from all of them, and that field counts
+  distinct `uname` strings. Nothing was edited to compensate; the consequence is
+  that the derivation stays in the conservative "axis floor is a lower bound on
+  every cell" regime, which is the regime all four platforms are in anyway.
 
 ### Reproducing this
 

--- a/baselines/arm-ratios.json
+++ b/baselines/arm-ratios.json
@@ -1,6 +1,6 @@
 {
     "schema": "judy-bench-arm-ratios/1",
-    "generated": "2026-08-19T06:04:05+00:00",
+    "generated": "2026-08-19T17:25:15+00:00",
     "note": "Per-platform WITHIN-RUN arm ratios, the reference the recurring gate (.github/workflows/bench-gate.yml, scripts/bench-gate.php) compares against. These are ratios of two arms measured in the same interleaved rounds, NOT absolute times: a ratio survives a change of runner, an absolute time does not. baselines/latest.json is a different instrument (absolute ms for the release-over-release bench-compare.php run) and the two are not interchangeable. Like latest.json, this file moves ONLY in a dedicated commit/PR, never inside a feature PR, and the noise floors are DERIVED (bench-gate.php --derive) from repeated same-commit CI runs rather than chosen.",
     "platforms": {
         "linux-glibc-x86_64": {
@@ -3722,6 +3722,1223 @@
                         "ratio": 28.43284,
                         "runs": 4,
                         "spread_pct": 4.356,
+                        "gateable": false
+                    }
+                }
+            }
+        },
+        "windows-x64": {
+            "recorded": {
+                "schema": "judy-bench-gate/1",
+                "platform": "windows-x64",
+                "label": "windows-x64",
+                "tier": "ci-relative-single-build",
+                "commit": "3ce48859299a2dc8ae043a163cc107386ab033bb",
+                "libjudy_tree": "7c9f86ea0df9ff277729297e0f23981a0e3e1a86",
+                "date": "2026-08-19T17:14:20+00:00",
+                "php_version": "8.4.24",
+                "uname": "Windows NT runnervmk2qs2 10.0 build 26100 (Windows Server 2025) AMD64",
+                "toolchain": "MSVC / PHP 8.4.24",
+                "provenance": null,
+                "arms": [
+                    {
+                        "handle": "S1",
+                        "role": "S",
+                        "so": "D:/a/_temp/arms/judy-S-1.dll",
+                        "sha256": "a72f65666e41681bb9e985ffafe5afb5cca02c5f91fdbeb9950266bac060cf49"
+                    },
+                    {
+                        "handle": "C1",
+                        "role": "C",
+                        "so": "D:/a/_temp/arms/judy-C-1.dll",
+                        "sha256": "56bc5ea320e8dfc13a188eef85a0118ba92f24adecb1c0f29bcda5a3d90d7186"
+                    }
+                ],
+                "rebuild_control_available": false,
+                "size": 300000,
+                "rounds": 5,
+                "iterations": 3,
+                "groups": [
+                    "core.int",
+                    "core.str",
+                    "api.setops"
+                ],
+                "mem_sizes": [
+                    1000000
+                ],
+                "mem_workloads": [
+                    "int_to_int",
+                    "int_sparse",
+                    "string_to_int",
+                    "bitset"
+                ],
+                "mem_min_gateable_bytes": 4194304,
+                "children": 75,
+                "wall_seconds": 281.1
+            },
+            "derived_from": {
+                "runs": 4,
+                "distinct_hosts": 1,
+                "commits": [
+                    "3ce48859299a2dc8ae043a163cc107386ab033bb"
+                ],
+                "libjudy_tree": "7c9f86ea0df9ff277729297e0f23981a0e3e1a86"
+            },
+            "noise": {
+                "timing.s_over_c": {
+                    "per_cell_floors": {
+                        "core.string_to_mixed_hash.iter": {
+                            "floor_pct": 18,
+                            "worst_drift_pct": 11.94,
+                            "gateable": true
+                        },
+                        "core.bitset.read": {
+                            "floor_pct": 15,
+                            "worst_drift_pct": 9.823,
+                            "gateable": true
+                        },
+                        "api.setop.diff.bitset": {
+                            "floor_pct": 15,
+                            "worst_drift_pct": 9.732,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed.read": {
+                            "floor_pct": 15,
+                            "worst_drift_pct": 9.71,
+                            "gateable": true
+                        },
+                        "core.int_to_int.iter": {
+                            "floor_pct": 14.5,
+                            "worst_drift_pct": 9.618,
+                            "gateable": true
+                        },
+                        "api.setop.xor.int_to_int": {
+                            "floor_pct": 14,
+                            "worst_drift_pct": 9.098,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed_adaptive.iter": {
+                            "floor_pct": 13.5,
+                            "worst_drift_pct": 8.739,
+                            "gateable": true
+                        },
+                        "api.setop.xor.bitset": {
+                            "floor_pct": 13.5,
+                            "worst_drift_pct": 8.699,
+                            "gateable": true
+                        },
+                        "api.setop.intersect.int_to_int": {
+                            "floor_pct": 13,
+                            "worst_drift_pct": 8.589,
+                            "gateable": true
+                        },
+                        "core.int_to_mixed.read": {
+                            "floor_pct": 13,
+                            "worst_drift_pct": 8.524,
+                            "gateable": true
+                        },
+                        "core.string_to_int.free": {
+                            "floor_pct": 13,
+                            "worst_drift_pct": 8.482,
+                            "gateable": true
+                        },
+                        "api.mergeWith.int_to_int": {
+                            "floor_pct": 11.5,
+                            "worst_drift_pct": 7.53,
+                            "gateable": true
+                        },
+                        "api.setop.diff.int_to_int": {
+                            "floor_pct": 11,
+                            "worst_drift_pct": 7.276,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed_hash.read": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 6.942,
+                            "gateable": true
+                        },
+                        "core.int_to_mixed.free": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 6.825,
+                            "gateable": true
+                        },
+                        "core.string_to_int_adaptive.read": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 6.641,
+                            "gateable": true
+                        },
+                        "api.setop.intersect.bitset": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 6.292,
+                            "gateable": true
+                        },
+                        "core.int_to_mixed.iter": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 6.277,
+                            "gateable": true
+                        },
+                        "api.setop.union.string_to_int": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 6.011,
+                            "gateable": true
+                        },
+                        "core.string_to_int.read": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 6,
+                            "gateable": true
+                        },
+                        "core.int_to_int.read": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 5.571,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed_adaptive.read": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 5.506,
+                            "gateable": true
+                        },
+                        "core.int_to_mixed.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 5.209,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed_adaptive.free": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 5.04,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed_hash.free": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 4.961,
+                            "gateable": true
+                        },
+                        "api.setop.union.int_to_int": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 4.666,
+                            "gateable": true
+                        },
+                        "core.bitset.iter": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 4.502,
+                            "gateable": true
+                        },
+                        "core.bitset.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 4.459,
+                            "gateable": true
+                        },
+                        "core.int_to_packed.free": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 4.354,
+                            "gateable": true
+                        },
+                        "core.int_to_packed.iter": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 4.311,
+                            "gateable": true
+                        },
+                        "core.string_to_int_adaptive.iter": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 4.21,
+                            "gateable": true
+                        },
+                        "api.setop.diff.string_to_int": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 4.092,
+                            "gateable": true
+                        },
+                        "core.string_to_int_hash.read": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.975,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed_hash.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.612,
+                            "gateable": true
+                        },
+                        "core.int_to_packed.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.602,
+                            "gateable": true
+                        },
+                        "core.int_to_packed.read": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.49,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed.iter": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.276,
+                            "gateable": true
+                        },
+                        "core.string_to_int_hash.iter": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.192,
+                            "gateable": true
+                        },
+                        "core.string_to_int_hash.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.15,
+                            "gateable": true
+                        },
+                        "api.setop.union.bitset": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.071,
+                            "gateable": true
+                        },
+                        "core.string_to_int_adaptive.free": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 3.009,
+                            "gateable": true
+                        },
+                        "core.int_to_int.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 2.8,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed.free": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 2.703,
+                            "gateable": true
+                        },
+                        "api.setop.intersect.string_to_int": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 2.419,
+                            "gateable": true
+                        },
+                        "core.string_to_int.iter": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 2.4,
+                            "gateable": true
+                        },
+                        "core.string_to_int.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 2.376,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 1.972,
+                            "gateable": true
+                        },
+                        "api.mergeWith.string_to_int": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 1.901,
+                            "gateable": true
+                        },
+                        "core.string_to_mixed_adaptive.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 1.696,
+                            "gateable": true
+                        },
+                        "core.string_to_int_adaptive.write": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 1.592,
+                            "gateable": true
+                        },
+                        "core.string_to_int_hash.free": {
+                            "floor_pct": 10.5,
+                            "worst_drift_pct": 1.568,
+                            "gateable": true
+                        }
+                    },
+                    "gateable_cells": 51,
+                    "ungateable_cells": 0,
+                    "cell_floor_ceiling_pct": 50,
+                    "cell_floor_rule": "each cell: max(10.50, its own worst cross-run drift x 1.5, rounded up to 0.5pp); above 50.0% the cell is reported but not gated",
+                    "per_cell_below_axis_allowed": false,
+                    "axis_floor_is_lower_bound": true,
+                    "why": "only 4 runs across 1 distinct runners \u2014 too few for a per-cell estimate of a SYSTEMATIC per-runner offset, so the axis floor (10.50%, pooled over 51 cells) is the lower bound for every cell",
+                    "cells": 51,
+                    "pairwise_samples": 306,
+                    "median_drift_pct": 2.154,
+                    "p90_drift_pct": 6.36,
+                    "p95_drift_pct": 8.209,
+                    "max_drift_pct": 11.94,
+                    "recommended_floor_pct": 10.5,
+                    "quantile_used": "p95 x 1.25, rounded up to 0.5pp, floored at 1.0",
+                    "axis_floor_note": "the axis floor is a FALLBACK for cells the baseline has no per-cell floor for; gating uses the per-cell floors above",
+                    "worst_cells": {
+                        "core.string_to_mixed_hash.iter": 11.94,
+                        "core.bitset.read": 9.823,
+                        "api.setop.diff.bitset": 9.732,
+                        "core.string_to_mixed.read": 9.71,
+                        "core.int_to_int.iter": 9.618,
+                        "api.setop.xor.int_to_int": 9.098,
+                        "core.string_to_mixed_adaptive.iter": 8.739,
+                        "api.setop.xor.bitset": 8.699
+                    }
+                },
+                "timing.a_over_c": {
+                    "per_cell_floors": {
+                        "api.setop.intersect.bitset": {
+                            "floor_pct": 194,
+                            "worst_drift_pct": 129.171,
+                            "gateable": false
+                        },
+                        "api.setop.xor.bitset": {
+                            "floor_pct": 156,
+                            "worst_drift_pct": 103.716,
+                            "gateable": false
+                        },
+                        "api.setop.union.bitset": {
+                            "floor_pct": 122,
+                            "worst_drift_pct": 81.114,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed_adaptive.iter": {
+                            "floor_pct": 100,
+                            "worst_drift_pct": 66.572,
+                            "gateable": false
+                        },
+                        "api.setop.diff.bitset": {
+                            "floor_pct": 98.5,
+                            "worst_drift_pct": 65.575,
+                            "gateable": false
+                        },
+                        "core.bitset.write": {
+                            "floor_pct": 87,
+                            "worst_drift_pct": 57.772,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed_hash.iter": {
+                            "floor_pct": 86.5,
+                            "worst_drift_pct": 57.466,
+                            "gateable": false
+                        },
+                        "core.string_to_int_hash.write": {
+                            "floor_pct": 77.5,
+                            "worst_drift_pct": 51.571,
+                            "gateable": false
+                        },
+                        "core.string_to_int_adaptive.write": {
+                            "floor_pct": 72.5,
+                            "worst_drift_pct": 48.279,
+                            "gateable": false
+                        },
+                        "core.string_to_int_hash.free": {
+                            "floor_pct": 70,
+                            "worst_drift_pct": 46.594,
+                            "gateable": false
+                        },
+                        "core.string_to_int.write": {
+                            "floor_pct": 70,
+                            "worst_drift_pct": 46.512,
+                            "gateable": false
+                        },
+                        "core.string_to_int_adaptive.free": {
+                            "floor_pct": 66,
+                            "worst_drift_pct": 43.936,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed_adaptive.free": {
+                            "floor_pct": 66,
+                            "worst_drift_pct": 43.777,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed.write": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 40,
+                            "gateable": false
+                        },
+                        "core.string_to_int.free": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 38.783,
+                            "gateable": false
+                        },
+                        "core.int_to_int.write": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 36.406,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed_hash.write": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 33.415,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 32.739,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed.iter": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 31.717,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed_adaptive.write": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 30.645,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed_hash.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 28.515,
+                            "gateable": false
+                        },
+                        "core.int_to_mixed.write": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 27.041,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed_adaptive.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 21.42,
+                            "gateable": false
+                        },
+                        "core.string_to_int_adaptive.iter": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 20.824,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed_hash.free": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 20.311,
+                            "gateable": false
+                        },
+                        "core.bitset.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 19.123,
+                            "gateable": false
+                        },
+                        "core.string_to_int_hash.iter": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 18.838,
+                            "gateable": false
+                        },
+                        "core.int_to_packed.free": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 18.223,
+                            "gateable": false
+                        },
+                        "core.int_to_packed.write": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 14.941,
+                            "gateable": false
+                        },
+                        "core.string_to_int.iter": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 13.937,
+                            "gateable": false
+                        },
+                        "core.string_to_mixed.free": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 13.897,
+                            "gateable": false
+                        },
+                        "core.int_to_mixed.iter": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 12.064,
+                            "gateable": false
+                        },
+                        "core.int_to_mixed.free": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 12.041,
+                            "gateable": false
+                        },
+                        "core.int_to_int.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 11.807,
+                            "gateable": false
+                        },
+                        "core.int_to_mixed.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 9.723,
+                            "gateable": false
+                        },
+                        "core.string_to_int.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 9.503,
+                            "gateable": false
+                        },
+                        "core.bitset.iter": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 8.147,
+                            "gateable": false
+                        },
+                        "core.int_to_packed.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 7.093,
+                            "gateable": false
+                        },
+                        "core.int_to_packed.iter": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 6.277,
+                            "gateable": false
+                        },
+                        "core.int_to_int.iter": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 6.257,
+                            "gateable": false
+                        },
+                        "core.string_to_int_hash.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 5.888,
+                            "gateable": false
+                        },
+                        "core.string_to_int_adaptive.read": {
+                            "floor_pct": 62.5,
+                            "worst_drift_pct": 2.355,
+                            "gateable": false
+                        }
+                    },
+                    "gateable_cells": 0,
+                    "ungateable_cells": 42,
+                    "cell_floor_ceiling_pct": 50,
+                    "cell_floor_rule": "each cell: max(62.50, its own worst cross-run drift x 1.5, rounded up to 0.5pp); above 50.0% the cell is reported but not gated",
+                    "per_cell_below_axis_allowed": false,
+                    "axis_floor_is_lower_bound": true,
+                    "why": "only 4 runs across 1 distinct runners \u2014 too few for a per-cell estimate of a SYSTEMATIC per-runner offset, so the axis floor (62.50%, pooled over 42 cells) is the lower bound for every cell",
+                    "cells": 42,
+                    "pairwise_samples": 252,
+                    "median_drift_pct": 7.551,
+                    "p90_drift_pct": 39.006,
+                    "p95_drift_pct": 49.831,
+                    "max_drift_pct": 129.171,
+                    "recommended_floor_pct": 62.5,
+                    "quantile_used": "p95 x 1.25, rounded up to 0.5pp, floored at 1.0",
+                    "axis_floor_note": "the axis floor is a FALLBACK for cells the baseline has no per-cell floor for; gating uses the per-cell floors above",
+                    "worst_cells": {
+                        "api.setop.intersect.bitset": 129.171,
+                        "api.setop.xor.bitset": 103.716,
+                        "api.setop.union.bitset": 81.114,
+                        "core.string_to_mixed_adaptive.iter": 66.572,
+                        "api.setop.diff.bitset": 65.575,
+                        "core.bitset.write": 57.772,
+                        "core.string_to_mixed_hash.iter": 57.466,
+                        "core.string_to_int_hash.write": 51.571
+                    }
+                },
+                "memory.a_over_c": {
+                    "per_cell_floors": {
+                        "int_to_int@1000000": {
+                            "floor_pct": 1,
+                            "worst_drift_pct": 0.65,
+                            "gateable": true
+                        },
+                        "int_sparse@1000000": {
+                            "floor_pct": 1,
+                            "worst_drift_pct": 0.352,
+                            "gateable": true
+                        },
+                        "string_to_int@1000000": {
+                            "floor_pct": 1,
+                            "worst_drift_pct": 0.199,
+                            "gateable": true
+                        }
+                    },
+                    "gateable_cells": 3,
+                    "ungateable_cells": 0,
+                    "cell_floor_ceiling_pct": 15,
+                    "cell_floor_rule": "each cell: max(1.00, its own worst cross-run drift x 1.5, rounded up to 0.5pp); above 15.0% the cell is reported but not gated",
+                    "per_cell_below_axis_allowed": false,
+                    "axis_floor_is_lower_bound": true,
+                    "why": "only 4 runs across 1 distinct runners \u2014 too few for a per-cell estimate of a SYSTEMATIC per-runner offset, so the axis floor (1.00%, pooled over 3 cells) is the lower bound for every cell",
+                    "cells": 3,
+                    "pairwise_samples": 18,
+                    "median_drift_pct": 0.168,
+                    "p90_drift_pct": 0.626,
+                    "p95_drift_pct": 0.65,
+                    "max_drift_pct": 0.65,
+                    "recommended_floor_pct": 1,
+                    "quantile_used": "p95 x 1.25, rounded up to 0.5pp, floored at 1.0",
+                    "axis_floor_note": "the axis floor is a FALLBACK for cells the baseline has no per-cell floor for; gating uses the per-cell floors above",
+                    "worst_cells": {
+                        "int_to_int@1000000": 0.65,
+                        "int_sparse@1000000": 0.352,
+                        "string_to_int@1000000": 0.199
+                    }
+                }
+            },
+            "timing": {
+                "s_over_c": {
+                    "core.bitset.write": {
+                        "ratio": 0.92337,
+                        "runs": 4,
+                        "spread_pct": 4.667,
+                        "gateable": true
+                    },
+                    "core.bitset.read": {
+                        "ratio": 0.99545,
+                        "runs": 4,
+                        "spread_pct": 9.823,
+                        "gateable": true
+                    },
+                    "core.bitset.iter": {
+                        "ratio": 1.05148,
+                        "runs": 4,
+                        "spread_pct": 4.502,
+                        "gateable": true
+                    },
+                    "core.int_to_int.write": {
+                        "ratio": 0.85898,
+                        "runs": 4,
+                        "spread_pct": 2.881,
+                        "gateable": true
+                    },
+                    "core.int_to_int.read": {
+                        "ratio": 0.95123,
+                        "runs": 4,
+                        "spread_pct": 5.571,
+                        "gateable": true
+                    },
+                    "core.int_to_int.iter": {
+                        "ratio": 1.0473,
+                        "runs": 4,
+                        "spread_pct": 10.642,
+                        "gateable": true
+                    },
+                    "core.int_to_mixed.write": {
+                        "ratio": 0.89626,
+                        "runs": 4,
+                        "spread_pct": 5.209,
+                        "gateable": true
+                    },
+                    "core.int_to_mixed.read": {
+                        "ratio": 0.96033,
+                        "runs": 4,
+                        "spread_pct": 8.524,
+                        "gateable": true
+                    },
+                    "core.int_to_mixed.iter": {
+                        "ratio": 1.02164,
+                        "runs": 4,
+                        "spread_pct": 6.697,
+                        "gateable": true
+                    },
+                    "core.int_to_mixed.free": {
+                        "ratio": 0.94201,
+                        "runs": 4,
+                        "spread_pct": 6.825,
+                        "gateable": true
+                    },
+                    "core.int_to_packed.write": {
+                        "ratio": 0.92433,
+                        "runs": 4,
+                        "spread_pct": 3.602,
+                        "gateable": true
+                    },
+                    "core.int_to_packed.read": {
+                        "ratio": 0.94839,
+                        "runs": 4,
+                        "spread_pct": 3.49,
+                        "gateable": true
+                    },
+                    "core.int_to_packed.iter": {
+                        "ratio": 1.01019,
+                        "runs": 4,
+                        "spread_pct": 4.311,
+                        "gateable": true
+                    },
+                    "core.int_to_packed.free": {
+                        "ratio": 0.93856,
+                        "runs": 4,
+                        "spread_pct": 4.552,
+                        "gateable": true
+                    },
+                    "core.string_to_int.write": {
+                        "ratio": 0.91422,
+                        "runs": 4,
+                        "spread_pct": 2.433,
+                        "gateable": true
+                    },
+                    "core.string_to_int.read": {
+                        "ratio": 0.92998,
+                        "runs": 4,
+                        "spread_pct": 6.383,
+                        "gateable": true
+                    },
+                    "core.string_to_int.iter": {
+                        "ratio": 0.83965,
+                        "runs": 4,
+                        "spread_pct": 2.4,
+                        "gateable": true
+                    },
+                    "core.string_to_int.free": {
+                        "ratio": 0.93503,
+                        "runs": 4,
+                        "spread_pct": 8.482,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed.write": {
+                        "ratio": 0.90039,
+                        "runs": 4,
+                        "spread_pct": 2.011,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed.read": {
+                        "ratio": 0.94766,
+                        "runs": 4,
+                        "spread_pct": 10.754,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed.iter": {
+                        "ratio": 0.84626,
+                        "runs": 4,
+                        "spread_pct": 3.387,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed.free": {
+                        "ratio": 0.83659,
+                        "runs": 4,
+                        "spread_pct": 2.703,
+                        "gateable": true
+                    },
+                    "core.string_to_int_hash.write": {
+                        "ratio": 0.91589,
+                        "runs": 4,
+                        "spread_pct": 3.15,
+                        "gateable": true
+                    },
+                    "core.string_to_int_hash.read": {
+                        "ratio": 0.91836,
+                        "runs": 4,
+                        "spread_pct": 3.975,
+                        "gateable": true
+                    },
+                    "core.string_to_int_hash.iter": {
+                        "ratio": 0.85807,
+                        "runs": 4,
+                        "spread_pct": 3.298,
+                        "gateable": true
+                    },
+                    "core.string_to_int_hash.free": {
+                        "ratio": 0.91224,
+                        "runs": 4,
+                        "spread_pct": 1.568,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_hash.write": {
+                        "ratio": 0.89842,
+                        "runs": 4,
+                        "spread_pct": 3.612,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_hash.read": {
+                        "ratio": 0.94069,
+                        "runs": 4,
+                        "spread_pct": 6.942,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_hash.iter": {
+                        "ratio": 0.88348,
+                        "runs": 4,
+                        "spread_pct": 11.94,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_hash.free": {
+                        "ratio": 0.88909,
+                        "runs": 4,
+                        "spread_pct": 4.961,
+                        "gateable": true
+                    },
+                    "core.string_to_int_adaptive.write": {
+                        "ratio": 0.92792,
+                        "runs": 4,
+                        "spread_pct": 1.592,
+                        "gateable": true
+                    },
+                    "core.string_to_int_adaptive.read": {
+                        "ratio": 0.92726,
+                        "runs": 4,
+                        "spread_pct": 6.641,
+                        "gateable": true
+                    },
+                    "core.string_to_int_adaptive.iter": {
+                        "ratio": 0.85199,
+                        "runs": 4,
+                        "spread_pct": 4.395,
+                        "gateable": true
+                    },
+                    "core.string_to_int_adaptive.free": {
+                        "ratio": 0.92047,
+                        "runs": 4,
+                        "spread_pct": 3.102,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_adaptive.write": {
+                        "ratio": 0.9121,
+                        "runs": 4,
+                        "spread_pct": 1.725,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_adaptive.read": {
+                        "ratio": 0.93709,
+                        "runs": 4,
+                        "spread_pct": 5.506,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_adaptive.iter": {
+                        "ratio": 0.88391,
+                        "runs": 4,
+                        "spread_pct": 8.739,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_adaptive.free": {
+                        "ratio": 0.89613,
+                        "runs": 4,
+                        "spread_pct": 5.04,
+                        "gateable": true
+                    },
+                    "api.setop.union.bitset": {
+                        "ratio": 0.8534,
+                        "runs": 4,
+                        "spread_pct": 3.071,
+                        "gateable": true
+                    },
+                    "api.setop.intersect.bitset": {
+                        "ratio": 0.89357,
+                        "runs": 4,
+                        "spread_pct": 6.292,
+                        "gateable": true
+                    },
+                    "api.setop.diff.bitset": {
+                        "ratio": 0.92497,
+                        "runs": 4,
+                        "spread_pct": 9.732,
+                        "gateable": true
+                    },
+                    "api.setop.xor.bitset": {
+                        "ratio": 0.90531,
+                        "runs": 4,
+                        "spread_pct": 8.699,
+                        "gateable": true
+                    },
+                    "api.setop.union.int_to_int": {
+                        "ratio": 0.77503,
+                        "runs": 4,
+                        "spread_pct": 4.666,
+                        "gateable": true
+                    },
+                    "api.setop.intersect.int_to_int": {
+                        "ratio": 0.80008,
+                        "runs": 4,
+                        "spread_pct": 9.143,
+                        "gateable": true
+                    },
+                    "api.setop.diff.int_to_int": {
+                        "ratio": 0.79271,
+                        "runs": 4,
+                        "spread_pct": 7.276,
+                        "gateable": true
+                    },
+                    "api.setop.xor.int_to_int": {
+                        "ratio": 0.7824,
+                        "runs": 4,
+                        "spread_pct": 9.098,
+                        "gateable": true
+                    },
+                    "api.setop.union.string_to_int": {
+                        "ratio": 0.88732,
+                        "runs": 4,
+                        "spread_pct": 6.396,
+                        "gateable": true
+                    },
+                    "api.setop.intersect.string_to_int": {
+                        "ratio": 0.89979,
+                        "runs": 4,
+                        "spread_pct": 2.419,
+                        "gateable": true
+                    },
+                    "api.setop.diff.string_to_int": {
+                        "ratio": 0.89013,
+                        "runs": 4,
+                        "spread_pct": 4.267,
+                        "gateable": true
+                    },
+                    "api.mergeWith.int_to_int": {
+                        "ratio": 0.82754,
+                        "runs": 4,
+                        "spread_pct": 7.53,
+                        "gateable": true
+                    },
+                    "api.mergeWith.string_to_int": {
+                        "ratio": 0.90702,
+                        "runs": 4,
+                        "spread_pct": 1.901,
+                        "gateable": true
+                    }
+                },
+                "a_over_c": {
+                    "core.bitset.write": {
+                        "ratio": 1.74439,
+                        "runs": 4,
+                        "spread_pct": 61.307,
+                        "gateable": true
+                    },
+                    "core.bitset.read": {
+                        "ratio": 2.0104,
+                        "runs": 4,
+                        "spread_pct": 19.123,
+                        "gateable": true
+                    },
+                    "core.bitset.iter": {
+                        "ratio": 3.19227,
+                        "runs": 4,
+                        "spread_pct": 8.147,
+                        "gateable": true
+                    },
+                    "core.int_to_int.write": {
+                        "ratio": 2.63804,
+                        "runs": 4,
+                        "spread_pct": 40.569,
+                        "gateable": true
+                    },
+                    "core.int_to_int.read": {
+                        "ratio": 2.14017,
+                        "runs": 4,
+                        "spread_pct": 11.807,
+                        "gateable": true
+                    },
+                    "core.int_to_int.iter": {
+                        "ratio": 3.25307,
+                        "runs": 4,
+                        "spread_pct": 6.257,
+                        "gateable": true
+                    },
+                    "core.int_to_mixed.write": {
+                        "ratio": 2.95443,
+                        "runs": 4,
+                        "spread_pct": 27.041,
+                        "gateable": true
+                    },
+                    "core.int_to_mixed.read": {
+                        "ratio": 1.94091,
+                        "runs": 4,
+                        "spread_pct": 9.723,
+                        "gateable": true
+                    },
+                    "core.int_to_mixed.iter": {
+                        "ratio": 3.23613,
+                        "runs": 4,
+                        "spread_pct": 12.064,
+                        "gateable": true
+                    },
+                    "core.int_to_mixed.free": {
+                        "ratio": 4.31741,
+                        "runs": 4,
+                        "spread_pct": 12.041,
+                        "gateable": true
+                    },
+                    "core.int_to_packed.write": {
+                        "ratio": 3.99672,
+                        "runs": 4,
+                        "spread_pct": 15.843,
+                        "gateable": true
+                    },
+                    "core.int_to_packed.read": {
+                        "ratio": 4.79931,
+                        "runs": 4,
+                        "spread_pct": 7.093,
+                        "gateable": true
+                    },
+                    "core.int_to_packed.iter": {
+                        "ratio": 7.2476,
+                        "runs": 4,
+                        "spread_pct": 6.697,
+                        "gateable": true
+                    },
+                    "core.int_to_packed.free": {
+                        "ratio": 3.19966,
+                        "runs": 4,
+                        "spread_pct": 18.223,
+                        "gateable": true
+                    },
+                    "core.string_to_int.write": {
+                        "ratio": 4.4428,
+                        "runs": 4,
+                        "spread_pct": 56.441,
+                        "gateable": true
+                    },
+                    "core.string_to_int.read": {
+                        "ratio": 4.63288,
+                        "runs": 4,
+                        "spread_pct": 10.501,
+                        "gateable": true
+                    },
+                    "core.string_to_int.iter": {
+                        "ratio": 9.06536,
+                        "runs": 4,
+                        "spread_pct": 16.194,
+                        "gateable": true
+                    },
+                    "core.string_to_int.free": {
+                        "ratio": 13.28971,
+                        "runs": 4,
+                        "spread_pct": 63.353,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed.write": {
+                        "ratio": 5.24969,
+                        "runs": 4,
+                        "spread_pct": 49.319,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed.read": {
+                        "ratio": 4.06527,
+                        "runs": 4,
+                        "spread_pct": 32.739,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed.iter": {
+                        "ratio": 8.57001,
+                        "runs": 4,
+                        "spread_pct": 31.717,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed.free": {
+                        "ratio": 12.10269,
+                        "runs": 4,
+                        "spread_pct": 13.897,
+                        "gateable": true
+                    },
+                    "core.string_to_int_hash.write": {
+                        "ratio": 8.11992,
+                        "runs": 4,
+                        "spread_pct": 63.95,
+                        "gateable": true
+                    },
+                    "core.string_to_int_hash.read": {
+                        "ratio": 3.65047,
+                        "runs": 4,
+                        "spread_pct": 6.256,
+                        "gateable": true
+                    },
+                    "core.string_to_int_hash.iter": {
+                        "ratio": 13.61855,
+                        "runs": 4,
+                        "spread_pct": 23.21,
+                        "gateable": true
+                    },
+                    "core.string_to_int_hash.free": {
+                        "ratio": 29.17212,
+                        "runs": 4,
+                        "spread_pct": 87.245,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_hash.write": {
+                        "ratio": 9.56698,
+                        "runs": 4,
+                        "spread_pct": 50.185,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_hash.read": {
+                        "ratio": 3.33803,
+                        "runs": 4,
+                        "spread_pct": 28.515,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_hash.iter": {
+                        "ratio": 14.01145,
+                        "runs": 4,
+                        "spread_pct": 62.657,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_hash.free": {
+                        "ratio": 22.99743,
+                        "runs": 4,
+                        "spread_pct": 20.311,
+                        "gateable": true
+                    },
+                    "core.string_to_int_adaptive.write": {
+                        "ratio": 7.99861,
+                        "runs": 4,
+                        "spread_pct": 66.096,
+                        "gateable": true
+                    },
+                    "core.string_to_int_adaptive.read": {
+                        "ratio": 3.57234,
+                        "runs": 4,
+                        "spread_pct": 2.355,
+                        "gateable": true
+                    },
+                    "core.string_to_int_adaptive.iter": {
+                        "ratio": 13.64074,
+                        "runs": 4,
+                        "spread_pct": 26.3,
+                        "gateable": true
+                    },
+                    "core.string_to_int_adaptive.free": {
+                        "ratio": 27.64222,
+                        "runs": 4,
+                        "spread_pct": 78.368,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_adaptive.write": {
+                        "ratio": 10.33033,
+                        "runs": 4,
+                        "spread_pct": 44.185,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_adaptive.read": {
+                        "ratio": 3.28418,
+                        "runs": 4,
+                        "spread_pct": 21.42,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_adaptive.iter": {
+                        "ratio": 13.58067,
+                        "runs": 4,
+                        "spread_pct": 73.247,
+                        "gateable": true
+                    },
+                    "core.string_to_mixed_adaptive.free": {
+                        "ratio": 24.73226,
+                        "runs": 4,
+                        "spread_pct": 43.777,
+                        "gateable": true
+                    },
+                    "api.setop.union.bitset": {
+                        "ratio": 4.9568,
+                        "runs": 4,
+                        "spread_pct": 92.538,
+                        "gateable": true
+                    },
+                    "api.setop.intersect.bitset": {
+                        "ratio": 1.71194,
+                        "runs": 4,
+                        "spread_pct": 132.455,
+                        "gateable": true
+                    },
+                    "api.setop.diff.bitset": {
+                        "ratio": 3.58431,
+                        "runs": 4,
+                        "spread_pct": 71.151,
+                        "gateable": true
+                    },
+                    "api.setop.xor.bitset": {
+                        "ratio": 1.78267,
+                        "runs": 4,
+                        "spread_pct": 108.867,
+                        "gateable": true
+                    }
+                }
+            },
+            "memory": {
+                "a_over_c": {
+                    "int_to_int@1000000": {
+                        "ratio": 2.04179,
+                        "runs": 4,
+                        "spread_pct": 0.65,
+                        "gateable": true
+                    },
+                    "int_sparse@1000000": {
+                        "ratio": 3.22389,
+                        "runs": 4,
+                        "spread_pct": 0.352,
+                        "gateable": true
+                    },
+                    "string_to_int@1000000": {
+                        "ratio": 3.66803,
+                        "runs": 4,
+                        "spread_pct": 0.199,
+                        "gateable": true
+                    },
+                    "bitset@1000000": {
+                        "ratio": 22.59398,
+                        "runs": 4,
+                        "spread_pct": 3.355,
                         "gateable": false
                     }
                 }

--- a/research/three-arm-benchmark/results/gate-2026-08-19/README.md
+++ b/research/three-arm-benchmark/results/gate-2026-08-19/README.md
@@ -11,14 +11,38 @@ an unpersisted run.
   deriving a floor from repeats inside one job understates the variance the gate
   actually faces by three to five times, and doing exactly that on the first
   attempt is why the floors in this baseline are per-cell rather than per-axis.
+- `r13..r16-gate-windows-x64-1.json` — the four runs the **windows-x64** entry
+  was derived from, added later the same day. All four are commit
+  `3ce4885`, one run per workflow dispatch, because the Windows job does not
+  honour `BENCH_REPEATS`: it drives `bench-gate.php` directly rather than
+  through `run-gate.sh`, so one dispatch produces exactly one run JSON. Four
+  dispatches were therefore issued in parallel on four refs all pointing at
+  `3ce4885` — the workflow's concurrency group is keyed on `github.ref`, so
+  same-ref dispatches cancel each other, and same-commit different-ref ones do
+  not. Each dispatch got its own ephemeral runner VM.
+
+  **`derived_from.distinct_hosts` reads 1 for this platform, and that
+  understates it.** The field counts distinct `uname` strings, and GitHub's
+  Windows Server 2025 image reports the same host name
+  (`runnervmk2qs2`) from every one of the four VMs, where the Linux images
+  vary it. The runs really are four separate runner instances. Nothing was
+  edited to compensate: the recorded value is what the tool measured, and the
+  consequence — the derivation stays in the conservative
+  `axis_floor_is_lower_bound` regime — is the same regime all three POSIX
+  platforms are in anyway.
 - `<platform>-arm-s-manifest.json` — the arm-S verification record for that
-  platform. All three read `UNPATCHED`: 21 of 28 upstream `.c`/`.h` files
+  platform. All four read `UNPATCHED`: 21 of 28 upstream `.c`/`.h` files
   byte-identical to the pristine Judy-1.0.5 import commit, the other 7 carrying
   P5 (LLP64) and nothing else, no post-`f366fdb` patched file leaked in, and no
   `__POPCNT__` / `__builtin_bswap64` fingerprint present.
 - `<platform>-census-{S,C}.json` — the instruction-level cross-check. x86-64
   fingerprints O1 as `popcnt` and O3 as `bswap`; arm64 as `cnt` and `rev`. The
-  O1 count reads exactly 0 in arm S on both architectures.
+  O1 count reads exactly 0 in arm S on both architectures. There is no
+  `windows-x64` census: that job builds through `php-windows-builder` rather
+  than `build-arms.sh`, which is where the census is taken. The arm-S manifest
+  is produced there and is identical byte-for-byte to the POSIX platforms',
+  the reconstruction being deterministic; the byte-difference check between the
+  two DLLs in the workflow is what stands in for the census.
 
 Regenerate with `.github/workflows/bench-gate.yml` (weekly, or
 `workflow_dispatch` with `repeats`), or locally per

--- a/research/three-arm-benchmark/results/gate-2026-08-19/r13-gate-windows-x64-1.json
+++ b/research/three-arm-benchmark/results/gate-2026-08-19/r13-gate-windows-x64-1.json
@@ -1,0 +1,1251 @@
+{
+    "metadata": {
+        "schema": "judy-bench-gate/1",
+        "platform": "windows-x64",
+        "label": "windows-x64",
+        "tier": "ci-relative-single-build",
+        "commit": "3ce48859299a2dc8ae043a163cc107386ab033bb",
+        "libjudy_tree": "7c9f86ea0df9ff277729297e0f23981a0e3e1a86",
+        "date": "2026-08-19T17:14:20+00:00",
+        "php_version": "8.4.24",
+        "uname": "Windows NT runnervmk2qs2 10.0 build 26100 (Windows Server 2025) AMD64",
+        "toolchain": "MSVC / PHP 8.4.24",
+        "provenance": null,
+        "arms": [
+            {
+                "handle": "S1",
+                "role": "S",
+                "so": "D:/a/_temp/arms/judy-S-1.dll",
+                "sha256": "a72f65666e41681bb9e985ffafe5afb5cca02c5f91fdbeb9950266bac060cf49"
+            },
+            {
+                "handle": "C1",
+                "role": "C",
+                "so": "D:/a/_temp/arms/judy-C-1.dll",
+                "sha256": "56bc5ea320e8dfc13a188eef85a0118ba92f24adecb1c0f29bcda5a3d90d7186"
+            }
+        ],
+        "rebuild_control_available": false,
+        "size": 300000,
+        "rounds": 5,
+        "iterations": 3,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.setops"
+        ],
+        "mem_sizes": [
+            1000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_min_gateable_bytes": 4194304,
+        "children": 75,
+        "wall_seconds": 281.1
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T17:09:39+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T17:14:12+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "after-memory",
+                "at": "2026-08-19T17:14:20+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T17:14:20+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "inconclusive_reason": null,
+        "control_ceiling_pct": 15,
+        "decides_the_run": false,
+        "note": "Sampled and reported for interpretation, but it does NOT decide this run's fate. LLC/bandwidth contention slows both arms of a pair equally (they are measured seconds apart in the same round) and divides out of a ratio \u2014 it is what ruined the dedicated host's ABSOLUTE numbers, not something a paired ratio is exposed to. The C-vs-C rebuild control's scatter decides instead, because it is a direct measurement of how far a cell can move today for no reason. --strict-hygiene restores the dedicated-host rule."
+    },
+    "controls": {
+        "php_only": {
+            "ratio": 0.99722,
+            "scatter_pct": 5.374,
+            "scatter_stat": "p90 of |per-cell deviation|",
+            "max_dev_pct": 21.946,
+            "rows": 44,
+            "measures": "runner drift (interpreter speed, CPU frequency, process startup)",
+            "blind_to": "LLC and memory-bandwidth contention \u2014 PHP array ops are neither pointer-chasing nor DRAM-bound, so this control stayed flat at +0.36% while a co-resident tenant moved an untouched Judy arm 2.2x"
+        },
+        "cc_rebuild": {
+            "available": false,
+            "ratio": 1,
+            "scatter_pct": null,
+            "scatter_stat": "p90 of |per-cell deviation|",
+            "max_dev_pct": null,
+            "rows": 0,
+            "cells": [],
+            "measures": "the apparatus itself: two independently linked builds of IDENTICAL source, so every cell should read null. Shares Judy's memory-access character (pointer-chasing, DRAM-bound) and therefore CAN see the contention the PHP-array control cannot.",
+            "role": "its scatter is this run's empirical noise floor and raises the gate threshold when it exceeds the offline-derived one"
+        }
+    },
+    "timing": {
+        "s_over_c": {
+            "core.bitset.write": {
+                "ratio": 0.93239,
+                "ci": [
+                    0.88444,
+                    1.68988
+                ],
+                "delta_pct": -6.761,
+                "n": 5
+            },
+            "core.bitset.read": {
+                "ratio": 1.06378,
+                "ci": [
+                    1.01316,
+                    1.85197
+                ],
+                "delta_pct": 6.378,
+                "n": 5
+            },
+            "core.bitset.iter": {
+                "ratio": 1.08707,
+                "ci": [
+                    0.99806,
+                    1.77543
+                ],
+                "delta_pct": 8.707,
+                "n": 5
+            },
+            "core.int_to_int.write": {
+                "ratio": 0.86211,
+                "ci": [
+                    0.5228,
+                    0.88021
+                ],
+                "delta_pct": -13.789,
+                "n": 5
+            },
+            "core.int_to_int.read": {
+                "ratio": 0.94825,
+                "ci": [
+                    0.79551,
+                    0.97796
+                ],
+                "delta_pct": -5.175,
+                "n": 5
+            },
+            "core.int_to_int.iter": {
+                "ratio": 1.0467,
+                "ci": [
+                    0.8111,
+                    1.05958
+                ],
+                "delta_pct": 4.67,
+                "n": 5
+            },
+            "core.int_to_mixed.write": {
+                "ratio": 0.91112,
+                "ci": [
+                    0.7773,
+                    1.02906
+                ],
+                "delta_pct": -8.888,
+                "n": 5
+            },
+            "core.int_to_mixed.read": {
+                "ratio": 0.95746,
+                "ci": [
+                    0.71684,
+                    0.98997
+                ],
+                "delta_pct": -4.254,
+                "n": 5
+            },
+            "core.int_to_mixed.iter": {
+                "ratio": 1.02317,
+                "ci": [
+                    0.81468,
+                    1.10012
+                ],
+                "delta_pct": 2.317,
+                "n": 5
+            },
+            "core.int_to_mixed.free": {
+                "ratio": 0.93697,
+                "ci": [
+                    0.7636,
+                    1.00929
+                ],
+                "delta_pct": -6.303,
+                "n": 5
+            },
+            "core.int_to_packed.write": {
+                "ratio": 0.92625,
+                "ci": [
+                    0.88773,
+                    1.13919
+                ],
+                "delta_pct": -7.375,
+                "n": 5
+            },
+            "core.int_to_packed.read": {
+                "ratio": 0.96416,
+                "ci": [
+                    0.95053,
+                    1.50342
+                ],
+                "delta_pct": -3.584,
+                "n": 5
+            },
+            "core.int_to_packed.iter": {
+                "ratio": 1.02868,
+                "ci": [
+                    0.99518,
+                    1.14425
+                ],
+                "delta_pct": 2.868,
+                "n": 5
+            },
+            "core.int_to_packed.free": {
+                "ratio": 0.93189,
+                "ci": [
+                    0.91264,
+                    1.51015
+                ],
+                "delta_pct": -6.811,
+                "n": 5
+            },
+            "core.string_to_int.write": {
+                "ratio": 0.90282,
+                "ci": [
+                    0.89902,
+                    0.90769
+                ],
+                "delta_pct": -9.718,
+                "n": 5
+            },
+            "core.string_to_int.read": {
+                "ratio": 0.90239,
+                "ci": [
+                    0.88835,
+                    0.9203
+                ],
+                "delta_pct": -9.761,
+                "n": 5
+            },
+            "core.string_to_int.iter": {
+                "ratio": 0.8422,
+                "ci": [
+                    0.83493,
+                    0.85436
+                ],
+                "delta_pct": -15.78,
+                "n": 5
+            },
+            "core.string_to_int.free": {
+                "ratio": 0.94538,
+                "ci": [
+                    0.91052,
+                    0.99168
+                ],
+                "delta_pct": -5.462,
+                "n": 5
+            },
+            "core.string_to_mixed.write": {
+                "ratio": 0.88496,
+                "ci": [
+                    0.86276,
+                    0.88952
+                ],
+                "delta_pct": -11.504,
+                "n": 5
+            },
+            "core.string_to_mixed.read": {
+                "ratio": 0.90174,
+                "ci": [
+                    0.85614,
+                    0.92285
+                ],
+                "delta_pct": -9.826,
+                "n": 5
+            },
+            "core.string_to_mixed.iter": {
+                "ratio": 0.83169,
+                "ci": [
+                    0.80774,
+                    0.86952
+                ],
+                "delta_pct": -16.831,
+                "n": 5
+            },
+            "core.string_to_mixed.free": {
+                "ratio": 0.83999,
+                "ci": [
+                    0.82709,
+                    0.85432
+                ],
+                "delta_pct": -16.001,
+                "n": 5
+            },
+            "core.string_to_int_hash.write": {
+                "ratio": 0.91705,
+                "ci": [
+                    0.89282,
+                    0.94716
+                ],
+                "delta_pct": -8.295,
+                "n": 5
+            },
+            "core.string_to_int_hash.read": {
+                "ratio": 0.92328,
+                "ci": [
+                    0.88506,
+                    0.93477
+                ],
+                "delta_pct": -7.672,
+                "n": 5
+            },
+            "core.string_to_int_hash.iter": {
+                "ratio": 0.84392,
+                "ci": [
+                    0.81074,
+                    0.86548
+                ],
+                "delta_pct": -15.608,
+                "n": 5
+            },
+            "core.string_to_int_hash.free": {
+                "ratio": 0.908,
+                "ci": [
+                    0.84234,
+                    1.01002
+                ],
+                "delta_pct": -9.2,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.write": {
+                "ratio": 0.90284,
+                "ci": [
+                    0.87934,
+                    0.99202
+                ],
+                "delta_pct": -9.716,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.read": {
+                "ratio": 0.96722,
+                "ci": [
+                    0.91991,
+                    0.99281
+                ],
+                "delta_pct": -3.278,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.iter": {
+                "ratio": 0.95271,
+                "ci": [
+                    0.8213,
+                    1.00094
+                ],
+                "delta_pct": -4.729,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.free": {
+                "ratio": 0.89259,
+                "ci": [
+                    0.883,
+                    0.93373
+                ],
+                "delta_pct": -10.741,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.write": {
+                "ratio": 0.93616,
+                "ci": [
+                    0.90689,
+                    0.98917
+                ],
+                "delta_pct": -6.384,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.read": {
+                "ratio": 0.95415,
+                "ci": [
+                    0.93044,
+                    1.12115
+                ],
+                "delta_pct": -4.585,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.iter": {
+                "ratio": 0.85269,
+                "ci": [
+                    0.82919,
+                    0.91763
+                ],
+                "delta_pct": -14.731,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.free": {
+                "ratio": 0.92371,
+                "ci": [
+                    0.84862,
+                    0.97169
+                ],
+                "delta_pct": -7.629,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.write": {
+                "ratio": 0.90487,
+                "ci": [
+                    0.89511,
+                    0.94695
+                ],
+                "delta_pct": -9.513,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.read": {
+                "ratio": 0.94606,
+                "ci": [
+                    0.90749,
+                    0.98308
+                ],
+                "delta_pct": -5.394,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.iter": {
+                "ratio": 0.89603,
+                "ci": [
+                    0.83741,
+                    0.94121
+                ],
+                "delta_pct": -10.397,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.free": {
+                "ratio": 0.89922,
+                "ci": [
+                    0.89229,
+                    0.95385
+                ],
+                "delta_pct": -10.078,
+                "n": 5
+            },
+            "api.setop.union.bitset": {
+                "ratio": 0.87488,
+                "ci": [
+                    0.85173,
+                    1.18145
+                ],
+                "delta_pct": -12.512,
+                "n": 5
+            },
+            "api.setop.intersect.bitset": {
+                "ratio": 0.9111,
+                "ci": [
+                    0.88107,
+                    0.96034
+                ],
+                "delta_pct": -8.89,
+                "n": 5
+            },
+            "api.setop.diff.bitset": {
+                "ratio": 0.91561,
+                "ci": [
+                    0.87642,
+                    1.18254
+                ],
+                "delta_pct": -8.439,
+                "n": 5
+            },
+            "api.setop.xor.bitset": {
+                "ratio": 0.91203,
+                "ci": [
+                    0.62041,
+                    0.95692
+                ],
+                "delta_pct": -8.797,
+                "n": 5
+            },
+            "api.setop.union.int_to_int": {
+                "ratio": 0.76431,
+                "ci": [
+                    0.65132,
+                    0.78671
+                ],
+                "delta_pct": -23.569,
+                "n": 5
+            },
+            "api.setop.intersect.int_to_int": {
+                "ratio": 0.79384,
+                "ci": [
+                    0.77187,
+                    1.01057
+                ],
+                "delta_pct": -20.616,
+                "n": 5
+            },
+            "api.setop.diff.int_to_int": {
+                "ratio": 0.79261,
+                "ci": [
+                    0.70693,
+                    0.81458
+                ],
+                "delta_pct": -20.739,
+                "n": 5
+            },
+            "api.setop.xor.int_to_int": {
+                "ratio": 0.78142,
+                "ci": [
+                    0.6538,
+                    0.79622
+                ],
+                "delta_pct": -21.858,
+                "n": 5
+            },
+            "api.setop.union.string_to_int": {
+                "ratio": 0.8728,
+                "ci": [
+                    0.85048,
+                    0.90426
+                ],
+                "delta_pct": -12.72,
+                "n": 5
+            },
+            "api.setop.intersect.string_to_int": {
+                "ratio": 0.90958,
+                "ci": [
+                    0.84483,
+                    0.93806
+                ],
+                "delta_pct": -9.042,
+                "n": 5
+            },
+            "api.setop.diff.string_to_int": {
+                "ratio": 0.85988,
+                "ci": [
+                    0.76901,
+                    0.88562
+                ],
+                "delta_pct": -14.012,
+                "n": 5
+            },
+            "api.mergeWith.int_to_int": {
+                "ratio": 0.81903,
+                "ci": [
+                    0.66759,
+                    0.84791
+                ],
+                "delta_pct": -18.097,
+                "n": 5
+            },
+            "api.mergeWith.string_to_int": {
+                "ratio": 0.90305,
+                "ci": [
+                    0.88656,
+                    0.91387
+                ],
+                "delta_pct": -9.695,
+                "n": 5
+            }
+        },
+        "a_over_c": {
+            "core.bitset.write": {
+                "ratio": 1.74979,
+                "ci": [
+                    1.71224,
+                    2.03994
+                ],
+                "delta_pct": 74.979,
+                "n": 5
+            },
+            "core.bitset.read": {
+                "ratio": 2.23656,
+                "ci": [
+                    2.03031,
+                    2.72338
+                ],
+                "delta_pct": 123.656,
+                "n": 5
+            },
+            "core.bitset.iter": {
+                "ratio": 3.24968,
+                "ci": [
+                    3.16231,
+                    5.07359
+                ],
+                "delta_pct": 224.968,
+                "n": 5
+            },
+            "core.int_to_int.write": {
+                "ratio": 2.74429,
+                "ci": [
+                    2.55079,
+                    2.81553
+                ],
+                "delta_pct": 174.429,
+                "n": 5
+            },
+            "core.int_to_int.read": {
+                "ratio": 2.17796,
+                "ci": [
+                    2.09816,
+                    2.33739
+                ],
+                "delta_pct": 117.796,
+                "n": 5
+            },
+            "core.int_to_int.iter": {
+                "ratio": 3.32432,
+                "ci": [
+                    1.99613,
+                    3.33349
+                ],
+                "delta_pct": 232.432,
+                "n": 5
+            },
+            "core.int_to_mixed.write": {
+                "ratio": 3.05086,
+                "ci": [
+                    2.96,
+                    3.39874
+                ],
+                "delta_pct": 205.086,
+                "n": 5
+            },
+            "core.int_to_mixed.read": {
+                "ratio": 1.98509,
+                "ci": [
+                    1.71162,
+                    2.0497
+                ],
+                "delta_pct": 98.509,
+                "n": 5
+            },
+            "core.int_to_mixed.iter": {
+                "ratio": 3.27852,
+                "ci": [
+                    3.15243,
+                    3.34101
+                ],
+                "delta_pct": 227.852,
+                "n": 5
+            },
+            "core.int_to_mixed.free": {
+                "ratio": 4.58303,
+                "ci": [
+                    3.98999,
+                    4.87763
+                ],
+                "delta_pct": 358.303,
+                "n": 5
+            },
+            "core.int_to_packed.write": {
+                "ratio": 3.99292,
+                "ci": [
+                    3.86998,
+                    4.73587
+                ],
+                "delta_pct": 299.292,
+                "n": 5
+            },
+            "core.int_to_packed.read": {
+                "ratio": 4.80058,
+                "ci": [
+                    4.77903,
+                    6.12006
+                ],
+                "delta_pct": 380.058,
+                "n": 5
+            },
+            "core.int_to_packed.iter": {
+                "ratio": 7.17463,
+                "ci": [
+                    5.20225,
+                    7.27374
+                ],
+                "delta_pct": 617.463,
+                "n": 5
+            },
+            "core.int_to_packed.free": {
+                "ratio": 3.68911,
+                "ci": [
+                    3.0301,
+                    4.49181
+                ],
+                "delta_pct": 268.911,
+                "n": 5
+            },
+            "core.string_to_int.write": {
+                "ratio": 4.31555,
+                "ci": [
+                    4.28531,
+                    4.47611
+                ],
+                "delta_pct": 331.555,
+                "n": 5
+            },
+            "core.string_to_int.read": {
+                "ratio": 4.4309,
+                "ci": [
+                    4.22553,
+                    4.45023
+                ],
+                "delta_pct": 343.09,
+                "n": 5
+            },
+            "core.string_to_int.iter": {
+                "ratio": 8.39473,
+                "ci": [
+                    8.11118,
+                    8.54424
+                ],
+                "delta_pct": 739.473,
+                "n": 5
+            },
+            "core.string_to_int.free": {
+                "ratio": 12.94432,
+                "ci": [
+                    12.31708,
+                    14.54112
+                ],
+                "delta_pct": 1194.432,
+                "n": 5
+            },
+            "core.string_to_mixed.write": {
+                "ratio": 5.08531,
+                "ci": [
+                    4.91621,
+                    5.22216
+                ],
+                "delta_pct": 408.531,
+                "n": 5
+            },
+            "core.string_to_mixed.read": {
+                "ratio": 4.14952,
+                "ci": [
+                    3.78979,
+                    4.354
+                ],
+                "delta_pct": 314.952,
+                "n": 5
+            },
+            "core.string_to_mixed.iter": {
+                "ratio": 8.29951,
+                "ci": [
+                    8.03336,
+                    8.39976
+                ],
+                "delta_pct": 729.951,
+                "n": 5
+            },
+            "core.string_to_mixed.free": {
+                "ratio": 11.95464,
+                "ci": [
+                    11.63414,
+                    12.5116
+                ],
+                "delta_pct": 1095.464,
+                "n": 5
+            },
+            "core.string_to_int_hash.write": {
+                "ratio": 7.95707,
+                "ci": [
+                    6.97661,
+                    8.34727
+                ],
+                "delta_pct": 695.707,
+                "n": 5
+            },
+            "core.string_to_int_hash.read": {
+                "ratio": 3.47464,
+                "ci": [
+                    3.31228,
+                    3.56515
+                ],
+                "delta_pct": 247.464,
+                "n": 5
+            },
+            "core.string_to_int_hash.iter": {
+                "ratio": 11.96659,
+                "ci": [
+                    11.61364,
+                    12.30298
+                ],
+                "delta_pct": 1096.659,
+                "n": 5
+            },
+            "core.string_to_int_hash.free": {
+                "ratio": 28.23425,
+                "ci": [
+                    27.20065,
+                    29.49592
+                ],
+                "delta_pct": 2723.425,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.write": {
+                "ratio": 9.25611,
+                "ci": [
+                    7.4873,
+                    10.00112
+                ],
+                "delta_pct": 825.611,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.read": {
+                "ratio": 3.36729,
+                "ci": [
+                    3.07717,
+                    3.43092
+                ],
+                "delta_pct": 236.729,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.iter": {
+                "ratio": 12.97581,
+                "ci": [
+                    10.68085,
+                    13.59644
+                ],
+                "delta_pct": 1197.581,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.free": {
+                "ratio": 22.85505,
+                "ci": [
+                    21.7102,
+                    23.79814
+                ],
+                "delta_pct": 2185.505,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.write": {
+                "ratio": 7.78255,
+                "ci": [
+                    7.73063,
+                    8.51433
+                ],
+                "delta_pct": 678.255,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.read": {
+                "ratio": 3.62313,
+                "ci": [
+                    3.3453,
+                    4.20391
+                ],
+                "delta_pct": 262.313,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.iter": {
+                "ratio": 11.89713,
+                "ci": [
+                    11.48325,
+                    13.0282
+                ],
+                "delta_pct": 1089.713,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.free": {
+                "ratio": 28.14297,
+                "ci": [
+                    26.60137,
+                    29.42302
+                ],
+                "delta_pct": 2714.297,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.write": {
+                "ratio": 10.01916,
+                "ci": [
+                    9.65181,
+                    10.26413
+                ],
+                "delta_pct": 901.916,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.read": {
+                "ratio": 3.30581,
+                "ci": [
+                    3.22755,
+                    3.39795
+                ],
+                "delta_pct": 230.581,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.iter": {
+                "ratio": 12.48247,
+                "ci": [
+                    11.98038,
+                    13.02972
+                ],
+                "delta_pct": 1148.247,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.free": {
+                "ratio": 25.0515,
+                "ci": [
+                    22.93898,
+                    26.34294
+                ],
+                "delta_pct": 2405.15,
+                "n": 5
+            },
+            "api.setop.union.bitset": {
+                "ratio": 4.99888,
+                "ci": [
+                    3.82006,
+                    7.02473
+                ],
+                "delta_pct": 399.888,
+                "n": 5
+            },
+            "api.setop.intersect.bitset": {
+                "ratio": 1.73542,
+                "ci": [
+                    1.72051,
+                    1.89355
+                ],
+                "delta_pct": 73.542,
+                "n": 5
+            },
+            "api.setop.diff.bitset": {
+                "ratio": 3.6151,
+                "ci": [
+                    3.50777,
+                    4.72753
+                ],
+                "delta_pct": 261.51,
+                "n": 5
+            },
+            "api.setop.xor.bitset": {
+                "ratio": 1.80219,
+                "ci": [
+                    1.72763,
+                    1.86505
+                ],
+                "delta_pct": 80.219,
+                "n": 5
+            }
+        },
+        "b_over_c": []
+    },
+    "memory": {
+        "a_over_c": {
+            "int_to_int@1000000": {
+                "ratio": 2.05424,
+                "bytes": {
+                    "A": 18460672,
+                    "C": 8986624
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "int_sparse@1000000": {
+                "ratio": 3.23204,
+                "bytes": {
+                    "A": 43130880,
+                    "C": 13344768
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "string_to_int@1000000": {
+                "ratio": 3.66872,
+                "bytes": {
+                    "A": 80515072,
+                    "C": 21946368
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "bitset@1000000": {
+                "ratio": 22.59442,
+                "bytes": {
+                    "A": 43126784,
+                    "C": 1908736
+                },
+                "gateable": false,
+                "not_gateable_reason": "below the 4.0 MB gating floor \u2014 peak RSS is page-quantised and a small structure moves several percent between identical runs"
+            }
+        },
+        "s_over_c": {
+            "int_to_int@1000000": {
+                "ratio": 1.00182,
+                "bytes": {
+                    "S": 9003008,
+                    "C": 8986624
+                },
+                "gateable": true
+            },
+            "int_sparse@1000000": {
+                "ratio": 1.00123,
+                "bytes": {
+                    "S": 13361152,
+                    "C": 13344768
+                },
+                "gateable": true
+            },
+            "string_to_int@1000000": {
+                "ratio": 0.99851,
+                "bytes": {
+                    "S": 21913600,
+                    "C": 21946368
+                },
+                "gateable": true
+            },
+            "bitset@1000000": {
+                "ratio": 1.01931,
+                "bytes": {
+                    "S": 1945600,
+                    "C": 1908736
+                },
+                "gateable": false
+            }
+        }
+    },
+    "memory_raw": [
+        {
+            "workload": "int_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 34586624,
+                    "peak_rss_ci": [
+                        34521088,
+                        34586624
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 18874448,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 18460672
+                },
+                "S": {
+                    "peak_rss_bytes": 25198592,
+                    "peak_rss_ci": [
+                        25182208,
+                        25235456
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 9003008
+                },
+                "C": {
+                    "peak_rss_bytes": 25178112,
+                    "peak_rss_ci": [
+                        25178112,
+                        25276416
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 8986624
+                }
+            }
+        },
+        {
+            "workload": "int_sparse",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 59256832,
+                    "peak_rss_ci": [
+                        59146240,
+                        59269120
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43130880
+                },
+                "S": {
+                    "peak_rss_bytes": 29556736,
+                    "peak_rss_ci": [
+                        29540352,
+                        29569024
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13361152
+                },
+                "C": {
+                    "peak_rss_bytes": 29536256,
+                    "peak_rss_ci": [
+                        29536256,
+                        29544448
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13344768
+                }
+            }
+        },
+        {
+            "workload": "string_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 96641024,
+                    "peak_rss_ci": [
+                        96620544,
+                        96681984
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 81935120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 80515072
+                },
+                "S": {
+                    "peak_rss_bytes": 38109184,
+                    "peak_rss_ci": [
+                        38068224,
+                        38133760
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21913600
+                },
+                "C": {
+                    "peak_rss_bytes": 38137856,
+                    "peak_rss_ci": [
+                        38113280,
+                        38166528
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21946368
+                }
+            }
+        },
+        {
+            "workload": "bitset",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 59252736,
+                    "peak_rss_ci": [
+                        59199488,
+                        59265024
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43126784
+                },
+                "S": {
+                    "peak_rss_bytes": 18141184,
+                    "peak_rss_ci": [
+                        18096128,
+                        18165760
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1945600
+                },
+                "C": {
+                    "peak_rss_bytes": 18100224,
+                    "peak_rss_ci": [
+                        18087936,
+                        18153472
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1908736
+                }
+            }
+        }
+    ],
+    "gate": {
+        "status": "no-baseline-for-platform",
+        "baseline": "baselines/arm-ratios.json",
+        "thresholds": [],
+        "findings": [],
+        "regressions": 0,
+        "suppressed": 0
+    },
+    "verify": {
+        "S1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp/judy-bench-arms-3580/S1-ini\\judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp/judy-bench-arms-3580/C1-ini\\judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/gate-2026-08-19/r14-gate-windows-x64-1.json
+++ b/research/three-arm-benchmark/results/gate-2026-08-19/r14-gate-windows-x64-1.json
@@ -1,0 +1,1251 @@
+{
+    "metadata": {
+        "schema": "judy-bench-gate/1",
+        "platform": "windows-x64",
+        "label": "windows-x64",
+        "tier": "ci-relative-single-build",
+        "commit": "3ce48859299a2dc8ae043a163cc107386ab033bb",
+        "libjudy_tree": "7c9f86ea0df9ff277729297e0f23981a0e3e1a86",
+        "date": "2026-08-19T17:21:23+00:00",
+        "php_version": "8.4.24",
+        "uname": "Windows NT runnervmk2qs2 10.0 build 26100 (Windows Server 2025) AMD64",
+        "toolchain": "MSVC / PHP 8.4.24",
+        "provenance": null,
+        "arms": [
+            {
+                "handle": "S1",
+                "role": "S",
+                "so": "D:/a/_temp/arms/judy-S-1.dll",
+                "sha256": "8efe8497a479e0338df9038c7b0b5ae8b9149aca2fd3ae79045fedc08a3e696a"
+            },
+            {
+                "handle": "C1",
+                "role": "C",
+                "so": "D:/a/_temp/arms/judy-C-1.dll",
+                "sha256": "a90fab5025acd6f7a983bb33eac8cb9dcc06271b0296a60a8680c1dc9e6846ea"
+            }
+        ],
+        "rebuild_control_available": false,
+        "size": 300000,
+        "rounds": 5,
+        "iterations": 3,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.setops"
+        ],
+        "mem_sizes": [
+            1000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_min_gateable_bytes": 4194304,
+        "children": 75,
+        "wall_seconds": 210.5
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T17:17:53+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T17:21:18+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "after-memory",
+                "at": "2026-08-19T17:21:23+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T17:21:23+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "inconclusive_reason": null,
+        "control_ceiling_pct": 15,
+        "decides_the_run": false,
+        "note": "Sampled and reported for interpretation, but it does NOT decide this run's fate. LLC/bandwidth contention slows both arms of a pair equally (they are measured seconds apart in the same round) and divides out of a ratio \u2014 it is what ruined the dedicated host's ABSOLUTE numbers, not something a paired ratio is exposed to. The C-vs-C rebuild control's scatter decides instead, because it is a direct measurement of how far a cell can move today for no reason. --strict-hygiene restores the dedicated-host rule."
+    },
+    "controls": {
+        "php_only": {
+            "ratio": 1.0031,
+            "scatter_pct": 4.556,
+            "scatter_stat": "p90 of |per-cell deviation|",
+            "max_dev_pct": 6.17,
+            "rows": 44,
+            "measures": "runner drift (interpreter speed, CPU frequency, process startup)",
+            "blind_to": "LLC and memory-bandwidth contention \u2014 PHP array ops are neither pointer-chasing nor DRAM-bound, so this control stayed flat at +0.36% while a co-resident tenant moved an untouched Judy arm 2.2x"
+        },
+        "cc_rebuild": {
+            "available": false,
+            "ratio": 1,
+            "scatter_pct": null,
+            "scatter_stat": "p90 of |per-cell deviation|",
+            "max_dev_pct": null,
+            "rows": 0,
+            "cells": [],
+            "measures": "the apparatus itself: two independently linked builds of IDENTICAL source, so every cell should read null. Shares Judy's memory-access character (pointer-chasing, DRAM-bound) and therefore CAN see the contention the PHP-array control cannot.",
+            "role": "its scatter is this run's empirical noise floor and raises the gate threshold when it exceeds the offline-derived one"
+        }
+    },
+    "timing": {
+        "s_over_c": {
+            "core.bitset.write": {
+                "ratio": 0.90351,
+                "ci": [
+                    0.85315,
+                    0.92321
+                ],
+                "delta_pct": -9.649,
+                "n": 5
+            },
+            "core.bitset.read": {
+                "ratio": 0.96863,
+                "ci": [
+                    0.95618,
+                    0.9771
+                ],
+                "delta_pct": -3.137,
+                "n": 5
+            },
+            "core.bitset.iter": {
+                "ratio": 1.04024,
+                "ci": [
+                    1.02858,
+                    1.04487
+                ],
+                "delta_pct": 4.024,
+                "n": 5
+            },
+            "core.int_to_int.write": {
+                "ratio": 0.84484,
+                "ci": [
+                    0.69904,
+                    0.8526
+                ],
+                "delta_pct": -15.516,
+                "n": 5
+            },
+            "core.int_to_int.read": {
+                "ratio": 0.95422,
+                "ci": [
+                    0.78219,
+                    0.99246
+                ],
+                "delta_pct": -4.578,
+                "n": 5
+            },
+            "core.int_to_int.iter": {
+                "ratio": 1.0479,
+                "ci": [
+                    0.85636,
+                    1.14135
+                ],
+                "delta_pct": 4.79,
+                "n": 5
+            },
+            "core.int_to_mixed.write": {
+                "ratio": 0.8901,
+                "ci": [
+                    0.76241,
+                    0.9014
+                ],
+                "delta_pct": -10.99,
+                "n": 5
+            },
+            "core.int_to_mixed.read": {
+                "ratio": 0.96324,
+                "ci": [
+                    0.82892,
+                    1.08593
+                ],
+                "delta_pct": -3.676,
+                "n": 5
+            },
+            "core.int_to_mixed.iter": {
+                "ratio": 1.01906,
+                "ci": [
+                    0.96067,
+                    1.28128
+                ],
+                "delta_pct": 1.906,
+                "n": 5
+            },
+            "core.int_to_mixed.free": {
+                "ratio": 0.94708,
+                "ci": [
+                    0.91383,
+                    1.01284
+                ],
+                "delta_pct": -5.292,
+                "n": 5
+            },
+            "core.int_to_packed.write": {
+                "ratio": 0.93365,
+                "ci": [
+                    0.92131,
+                    1.05153
+                ],
+                "delta_pct": -6.635,
+                "n": 5
+            },
+            "core.int_to_packed.read": {
+                "ratio": 0.94311,
+                "ci": [
+                    0.80104,
+                    0.96028
+                ],
+                "delta_pct": -5.689,
+                "n": 5
+            },
+            "core.int_to_packed.iter": {
+                "ratio": 1.00265,
+                "ci": [
+                    0.94887,
+                    1.05265
+                ],
+                "delta_pct": 0.265,
+                "n": 5
+            },
+            "core.int_to_packed.free": {
+                "ratio": 0.9081,
+                "ci": [
+                    0.88935,
+                    0.94987
+                ],
+                "delta_pct": -9.19,
+                "n": 5
+            },
+            "core.string_to_int.write": {
+                "ratio": 0.91434,
+                "ci": [
+                    0.86059,
+                    1.01851
+                ],
+                "delta_pct": -8.566,
+                "n": 5
+            },
+            "core.string_to_int.read": {
+                "ratio": 0.95999,
+                "ci": [
+                    0.93318,
+                    1.04069
+                ],
+                "delta_pct": -4.001,
+                "n": 5
+            },
+            "core.string_to_int.iter": {
+                "ratio": 0.83965,
+                "ci": [
+                    0.78503,
+                    0.98567
+                ],
+                "delta_pct": -16.035,
+                "n": 5
+            },
+            "core.string_to_int.free": {
+                "ratio": 1.00199,
+                "ci": [
+                    0.94907,
+                    1.09708
+                ],
+                "delta_pct": 0.199,
+                "n": 5
+            },
+            "core.string_to_mixed.write": {
+                "ratio": 0.90073,
+                "ci": [
+                    0.82371,
+                    0.97841
+                ],
+                "delta_pct": -9.927,
+                "n": 5
+            },
+            "core.string_to_mixed.read": {
+                "ratio": 0.99871,
+                "ci": [
+                    0.85143,
+                    1.0999
+                ],
+                "delta_pct": -0.129,
+                "n": 5
+            },
+            "core.string_to_mixed.iter": {
+                "ratio": 0.85986,
+                "ci": [
+                    0.79424,
+                    0.92626
+                ],
+                "delta_pct": -14.014,
+                "n": 5
+            },
+            "core.string_to_mixed.free": {
+                "ratio": 0.8332,
+                "ci": [
+                    0.73237,
+                    0.91595
+                ],
+                "delta_pct": -16.68,
+                "n": 5
+            },
+            "core.string_to_int_hash.write": {
+                "ratio": 0.92323,
+                "ci": [
+                    0.9223,
+                    0.9392
+                ],
+                "delta_pct": -7.677,
+                "n": 5
+            },
+            "core.string_to_int_hash.read": {
+                "ratio": 0.91346,
+                "ci": [
+                    0.90582,
+                    0.94536
+                ],
+                "delta_pct": -8.654,
+                "n": 5
+            },
+            "core.string_to_int_hash.iter": {
+                "ratio": 0.85464,
+                "ci": [
+                    0.75322,
+                    0.88436
+                ],
+                "delta_pct": -14.536,
+                "n": 5
+            },
+            "core.string_to_int_hash.free": {
+                "ratio": 0.91649,
+                "ci": [
+                    0.88024,
+                    0.93974
+                ],
+                "delta_pct": -8.351,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.write": {
+                "ratio": 0.92283,
+                "ci": [
+                    0.81,
+                    1.04721
+                ],
+                "delta_pct": -7.717,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.read": {
+                "ratio": 0.90443,
+                "ci": [
+                    0.76775,
+                    1.07074
+                ],
+                "delta_pct": -9.557,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.iter": {
+                "ratio": 0.89056,
+                "ci": [
+                    0.85915,
+                    0.92508
+                ],
+                "delta_pct": -10.944,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.free": {
+                "ratio": 0.9064,
+                "ci": [
+                    0.78395,
+                    0.98246
+                ],
+                "delta_pct": -9.36,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.write": {
+                "ratio": 0.93425,
+                "ci": [
+                    0.84211,
+                    0.99066
+                ],
+                "delta_pct": -6.575,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.read": {
+                "ratio": 0.89473,
+                "ci": [
+                    0.76963,
+                    0.97549
+                ],
+                "delta_pct": -10.527,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.iter": {
+                "ratio": 0.82545,
+                "ci": [
+                    0.81443,
+                    0.90831
+                ],
+                "delta_pct": -17.455,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.free": {
+                "ratio": 0.89942,
+                "ci": [
+                    0.84234,
+                    0.95942
+                ],
+                "delta_pct": -10.058,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.write": {
+                "ratio": 0.90932,
+                "ci": [
+                    0.88972,
+                    1.02313
+                ],
+                "delta_pct": -9.068,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.read": {
+                "ratio": 0.89669,
+                "ci": [
+                    0.81833,
+                    1.03389
+                ],
+                "delta_pct": -10.331,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.iter": {
+                "ratio": 0.82402,
+                "ci": [
+                    0.7854,
+                    0.99695
+                ],
+                "delta_pct": -17.598,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.free": {
+                "ratio": 0.92134,
+                "ci": [
+                    0.8859,
+                    0.99378
+                ],
+                "delta_pct": -7.866,
+                "n": 5
+            },
+            "api.setop.union.bitset": {
+                "ratio": 0.85246,
+                "ci": [
+                    0.74074,
+                    0.96857
+                ],
+                "delta_pct": -14.754,
+                "n": 5
+            },
+            "api.setop.intersect.bitset": {
+                "ratio": 0.87638,
+                "ci": [
+                    0.79569,
+                    0.99479
+                ],
+                "delta_pct": -12.362,
+                "n": 5
+            },
+            "api.setop.diff.bitset": {
+                "ratio": 0.97666,
+                "ci": [
+                    0.80266,
+                    1.31192
+                ],
+                "delta_pct": -2.334,
+                "n": 5
+            },
+            "api.setop.xor.bitset": {
+                "ratio": 0.89863,
+                "ci": [
+                    0.80718,
+                    1.01041
+                ],
+                "delta_pct": -10.137,
+                "n": 5
+            },
+            "api.setop.union.int_to_int": {
+                "ratio": 0.79437,
+                "ci": [
+                    0.74457,
+                    0.99128
+                ],
+                "delta_pct": -20.563,
+                "n": 5
+            },
+            "api.setop.intersect.int_to_int": {
+                "ratio": 0.86642,
+                "ci": [
+                    0.7852,
+                    1.01748
+                ],
+                "delta_pct": -13.358,
+                "n": 5
+            },
+            "api.setop.diff.int_to_int": {
+                "ratio": 0.81487,
+                "ci": [
+                    0.77106,
+                    0.94687
+                ],
+                "delta_pct": -18.513,
+                "n": 5
+            },
+            "api.setop.xor.int_to_int": {
+                "ratio": 0.81767,
+                "ci": [
+                    0.77101,
+                    0.84965
+                ],
+                "delta_pct": -18.233,
+                "n": 5
+            },
+            "api.setop.union.string_to_int": {
+                "ratio": 0.85492,
+                "ci": [
+                    0.79971,
+                    0.90049
+                ],
+                "delta_pct": -14.508,
+                "n": 5
+            },
+            "api.setop.intersect.string_to_int": {
+                "ratio": 0.8881,
+                "ci": [
+                    0.85309,
+                    0.94034
+                ],
+                "delta_pct": -11.19,
+                "n": 5
+            },
+            "api.setop.diff.string_to_int": {
+                "ratio": 0.8947,
+                "ci": [
+                    0.8438,
+                    0.91055
+                ],
+                "delta_pct": -10.53,
+                "n": 5
+            },
+            "api.mergeWith.int_to_int": {
+                "ratio": 0.87466,
+                "ci": [
+                    0.82942,
+                    0.90872
+                ],
+                "delta_pct": -12.534,
+                "n": 5
+            },
+            "api.mergeWith.string_to_int": {
+                "ratio": 0.91401,
+                "ci": [
+                    0.826,
+                    1.0221
+                ],
+                "delta_pct": -8.599,
+                "n": 5
+            }
+        },
+        "a_over_c": {
+            "core.bitset.write": {
+                "ratio": 1.10906,
+                "ci": [
+                    1.09248,
+                    1.12905
+                ],
+                "delta_pct": 10.906,
+                "n": 5
+            },
+            "core.bitset.read": {
+                "ratio": 1.97383,
+                "ci": [
+                    1.88042,
+                    1.99202
+                ],
+                "delta_pct": 97.383,
+                "n": 5
+            },
+            "core.bitset.iter": {
+                "ratio": 3.00487,
+                "ci": [
+                    2.88051,
+                    3.06797
+                ],
+                "delta_pct": 200.487,
+                "n": 5
+            },
+            "core.int_to_int.write": {
+                "ratio": 2.01185,
+                "ci": [
+                    1.9786,
+                    2.04299
+                ],
+                "delta_pct": 101.185,
+                "n": 5
+            },
+            "core.int_to_int.read": {
+                "ratio": 2.10818,
+                "ci": [
+                    2.08213,
+                    2.18634
+                ],
+                "delta_pct": 110.818,
+                "n": 5
+            },
+            "core.int_to_int.iter": {
+                "ratio": 3.12856,
+                "ci": [
+                    2.98577,
+                    3.19689
+                ],
+                "delta_pct": 212.856,
+                "n": 5
+            },
+            "core.int_to_mixed.write": {
+                "ratio": 2.40147,
+                "ci": [
+                    1.81685,
+                    2.43095
+                ],
+                "delta_pct": 140.147,
+                "n": 5
+            },
+            "core.int_to_mixed.read": {
+                "ratio": 1.89772,
+                "ci": [
+                    1.86328,
+                    2.07742
+                ],
+                "delta_pct": 89.772,
+                "n": 5
+            },
+            "core.int_to_mixed.iter": {
+                "ratio": 2.92559,
+                "ci": [
+                    2.83672,
+                    3.54714
+                ],
+                "delta_pct": 192.559,
+                "n": 5
+            },
+            "core.int_to_mixed.free": {
+                "ratio": 4.09051,
+                "ci": [
+                    4.05377,
+                    4.21165
+                ],
+                "delta_pct": 309.051,
+                "n": 5
+            },
+            "core.int_to_packed.write": {
+                "ratio": 3.47389,
+                "ci": [
+                    3.27612,
+                    3.83023
+                ],
+                "delta_pct": 247.389,
+                "n": 5
+            },
+            "core.int_to_packed.read": {
+                "ratio": 5.00216,
+                "ci": [
+                    4.62015,
+                    5.49527
+                ],
+                "delta_pct": 400.216,
+                "n": 5
+            },
+            "core.int_to_packed.iter": {
+                "ratio": 7.32131,
+                "ci": [
+                    6.97948,
+                    7.55941
+                ],
+                "delta_pct": 632.131,
+                "n": 5
+            },
+            "core.int_to_packed.free": {
+                "ratio": 3.22053,
+                "ci": [
+                    2.63846,
+                    3.29844
+                ],
+                "delta_pct": 222.053,
+                "n": 5
+            },
+            "core.string_to_int.write": {
+                "ratio": 2.94553,
+                "ci": [
+                    2.91893,
+                    3.17307
+                ],
+                "delta_pct": 194.553,
+                "n": 5
+            },
+            "core.string_to_int.read": {
+                "ratio": 4.89619,
+                "ci": [
+                    4.15864,
+                    5.00131
+                ],
+                "delta_pct": 389.619,
+                "n": 5
+            },
+            "core.string_to_int.iter": {
+                "ratio": 9.75421,
+                "ci": [
+                    9.26665,
+                    9.97942
+                ],
+                "delta_pct": 875.421,
+                "n": 5
+            },
+            "core.string_to_int.free": {
+                "ratio": 11.27057,
+                "ci": [
+                    9.84471,
+                    12.28818
+                ],
+                "delta_pct": 1027.057,
+                "n": 5
+            },
+            "core.string_to_mixed.write": {
+                "ratio": 3.63236,
+                "ci": [
+                    3.50096,
+                    3.77247
+                ],
+                "delta_pct": 263.236,
+                "n": 5
+            },
+            "core.string_to_mixed.read": {
+                "ratio": 5.26407,
+                "ci": [
+                    4.66243,
+                    5.37113
+                ],
+                "delta_pct": 426.407,
+                "n": 5
+            },
+            "core.string_to_mixed.iter": {
+                "ratio": 10.81538,
+                "ci": [
+                    10.52859,
+                    11.15986
+                ],
+                "delta_pct": 981.538,
+                "n": 5
+            },
+            "core.string_to_mixed.free": {
+                "ratio": 13.33473,
+                "ci": [
+                    13.24782,
+                    13.83931
+                ],
+                "delta_pct": 1233.473,
+                "n": 5
+            },
+            "core.string_to_int_hash.write": {
+                "ratio": 5.24974,
+                "ci": [
+                    4.86957,
+                    5.3047
+                ],
+                "delta_pct": 424.974,
+                "n": 5
+            },
+            "core.string_to_int_hash.read": {
+                "ratio": 3.64804,
+                "ci": [
+                    3.46243,
+                    3.82702
+                ],
+                "delta_pct": 264.804,
+                "n": 5
+            },
+            "core.string_to_int_hash.iter": {
+                "ratio": 14.74406,
+                "ci": [
+                    10.7968,
+                    15.2185
+                ],
+                "delta_pct": 1374.406,
+                "n": 5
+            },
+            "core.string_to_int_hash.free": {
+                "ratio": 22.07127,
+                "ci": [
+                    21.42546,
+                    24.13659
+                ],
+                "delta_pct": 2107.127,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.write": {
+                "ratio": 7.17529,
+                "ci": [
+                    6.81418,
+                    7.29635
+                ],
+                "delta_pct": 617.529,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.read": {
+                "ratio": 4.04983,
+                "ci": [
+                    3.73237,
+                    4.17588
+                ],
+                "delta_pct": 304.983,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.iter": {
+                "ratio": 21.10605,
+                "ci": [
+                    16.89673,
+                    22.99383
+                ],
+                "delta_pct": 2010.605,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.free": {
+                "ratio": 26.03218,
+                "ci": [
+                    24.63171,
+                    27.03734
+                ],
+                "delta_pct": 2503.218,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.write": {
+                "ratio": 5.24858,
+                "ci": [
+                    5.14232,
+                    5.55438
+                ],
+                "delta_pct": 424.858,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.read": {
+                "ratio": 3.53978,
+                "ci": [
+                    3.45946,
+                    3.74318
+                ],
+                "delta_pct": 253.978,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.iter": {
+                "ratio": 14.35621,
+                "ci": [
+                    13.37906,
+                    14.45172
+                ],
+                "delta_pct": 1335.621,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.free": {
+                "ratio": 22.22319,
+                "ci": [
+                    21.3549,
+                    23.42695
+                ],
+                "delta_pct": 2122.319,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.write": {
+                "ratio": 7.83176,
+                "ci": [
+                    7.58014,
+                    8.70296
+                ],
+                "delta_pct": 683.176,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.read": {
+                "ratio": 3.92293,
+                "ci": [
+                    3.78696,
+                    4.0886
+                ],
+                "delta_pct": 292.293,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.iter": {
+                "ratio": 21.62547,
+                "ci": [
+                    19.81453,
+                    23.32801
+                ],
+                "delta_pct": 2062.547,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.free": {
+                "ratio": 31.87475,
+                "ci": [
+                    27.70034,
+                    32.62071
+                ],
+                "delta_pct": 3087.475,
+                "n": 5
+            },
+            "api.setop.union.bitset": {
+                "ratio": 2.76008,
+                "ci": [
+                    2.14663,
+                    3.06598
+                ],
+                "delta_pct": 176.008,
+                "n": 5
+            },
+            "api.setop.intersect.bitset": {
+                "ratio": 0.75726,
+                "ci": [
+                    0.74485,
+                    0.78739
+                ],
+                "delta_pct": -24.274,
+                "n": 5
+            },
+            "api.setop.diff.bitset": {
+                "ratio": 2.18336,
+                "ci": [
+                    2.11547,
+                    2.84809
+                ],
+                "delta_pct": 118.336,
+                "n": 5
+            },
+            "api.setop.xor.bitset": {
+                "ratio": 0.88466,
+                "ci": [
+                    0.84367,
+                    0.92048
+                ],
+                "delta_pct": -11.534,
+                "n": 5
+            }
+        },
+        "b_over_c": []
+    },
+    "memory": {
+        "a_over_c": {
+            "int_to_int@1000000": {
+                "ratio": 2.04146,
+                "bytes": {
+                    "A": 18354176,
+                    "C": 8990720
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "int_sparse@1000000": {
+                "ratio": 3.22069,
+                "bytes": {
+                    "A": 43098112,
+                    "C": 13381632
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "string_to_int@1000000": {
+                "ratio": 3.66735,
+                "bytes": {
+                    "A": 80515072,
+                    "C": 21954560
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "bitset@1000000": {
+                "ratio": 22.59355,
+                "bytes": {
+                    "A": 43032576,
+                    "C": 1904640
+                },
+                "gateable": false,
+                "not_gateable_reason": "below the 4.0 MB gating floor \u2014 peak RSS is page-quantised and a small structure moves several percent between identical runs"
+            }
+        },
+        "s_over_c": {
+            "int_to_int@1000000": {
+                "ratio": 1.0082,
+                "bytes": {
+                    "S": 9064448,
+                    "C": 8990720
+                },
+                "gateable": true
+            },
+            "int_sparse@1000000": {
+                "ratio": 0.99541,
+                "bytes": {
+                    "S": 13320192,
+                    "C": 13381632
+                },
+                "gateable": true
+            },
+            "string_to_int@1000000": {
+                "ratio": 0.99813,
+                "bytes": {
+                    "S": 21913600,
+                    "C": 21954560
+                },
+                "gateable": true
+            },
+            "bitset@1000000": {
+                "ratio": 1.00645,
+                "bytes": {
+                    "S": 1916928,
+                    "C": 1904640
+                },
+                "gateable": false
+            }
+        }
+    },
+    "memory_raw": [
+        {
+            "workload": "int_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 34467840,
+                    "peak_rss_ci": [
+                        34463744,
+                        34516992
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 18874448,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 18354176
+                },
+                "S": {
+                    "peak_rss_bytes": 25243648,
+                    "peak_rss_ci": [
+                        25202688,
+                        25255936
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 9064448
+                },
+                "C": {
+                    "peak_rss_bytes": 25169920,
+                    "peak_rss_ci": [
+                        25120768,
+                        25194496
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 8990720
+                }
+            }
+        },
+        {
+            "workload": "int_sparse",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 59211776,
+                    "peak_rss_ci": [
+                        59211776,
+                        59211776
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43098112
+                },
+                "S": {
+                    "peak_rss_bytes": 29499392,
+                    "peak_rss_ci": [
+                        29487104,
+                        29552640
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13320192
+                },
+                "C": {
+                    "peak_rss_bytes": 29560832,
+                    "peak_rss_ci": [
+                        29548544,
+                        29564928
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13381632
+                }
+            }
+        },
+        {
+            "workload": "string_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 96628736,
+                    "peak_rss_ci": [
+                        96620544,
+                        96677888
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 81935120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 80515072
+                },
+                "S": {
+                    "peak_rss_bytes": 38092800,
+                    "peak_rss_ci": [
+                        38064128,
+                        38141952
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21913600
+                },
+                "C": {
+                    "peak_rss_bytes": 38133760,
+                    "peak_rss_ci": [
+                        38051840,
+                        38146048
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21954560
+                }
+            }
+        },
+        {
+            "workload": "bitset",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 59146240,
+                    "peak_rss_ci": [
+                        59142144,
+                        59256832
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43032576
+                },
+                "S": {
+                    "peak_rss_bytes": 18096128,
+                    "peak_rss_ci": [
+                        18079744,
+                        18116608
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1916928
+                },
+                "C": {
+                    "peak_rss_bytes": 18083840,
+                    "peak_rss_ci": [
+                        18079744,
+                        18104320
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1904640
+                }
+            }
+        }
+    ],
+    "gate": {
+        "status": "no-baseline-for-platform",
+        "baseline": "baselines/arm-ratios.json",
+        "thresholds": [],
+        "findings": [],
+        "regressions": 0,
+        "suppressed": 0
+    },
+    "verify": {
+        "S1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp/judy-bench-arms-692/S1-ini\\judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp/judy-bench-arms-692/C1-ini\\judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/gate-2026-08-19/r15-gate-windows-x64-1.json
+++ b/research/three-arm-benchmark/results/gate-2026-08-19/r15-gate-windows-x64-1.json
@@ -1,0 +1,1269 @@
+{
+    "metadata": {
+        "schema": "judy-bench-gate/1",
+        "platform": "windows-x64",
+        "label": "windows-x64",
+        "tier": "ci-relative-single-build",
+        "commit": "3ce48859299a2dc8ae043a163cc107386ab033bb",
+        "libjudy_tree": "7c9f86ea0df9ff277729297e0f23981a0e3e1a86",
+        "date": "2026-08-19T17:22:27+00:00",
+        "php_version": "8.4.24",
+        "uname": "Windows NT runnervmk2qs2 10.0 build 26100 (Windows Server 2025) AMD64",
+        "toolchain": "MSVC / PHP 8.4.24",
+        "provenance": null,
+        "arms": [
+            {
+                "handle": "S1",
+                "role": "S",
+                "so": "D:/a/_temp/arms/judy-S-1.dll",
+                "sha256": "528cdab975975a70f5b9469c774992d529e686d6fe9b28fdf7f280833f9890fe"
+            },
+            {
+                "handle": "C1",
+                "role": "C",
+                "so": "D:/a/_temp/arms/judy-C-1.dll",
+                "sha256": "367b611439b859f40c096da322c55e1e34bcacecded4b66333fc68acc939232f"
+            }
+        ],
+        "rebuild_control_available": false,
+        "size": 300000,
+        "rounds": 5,
+        "iterations": 3,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.setops"
+        ],
+        "mem_sizes": [
+            1000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_min_gateable_bytes": 4194304,
+        "children": 75,
+        "wall_seconds": 291.7
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T17:17:35+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T17:22:20+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "after-memory",
+                "at": "2026-08-19T17:22:27+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T17:22:27+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "inconclusive_reason": null,
+        "control_ceiling_pct": 15,
+        "decides_the_run": false,
+        "note": "Sampled and reported for interpretation, but it does NOT decide this run's fate. LLC/bandwidth contention slows both arms of a pair equally (they are measured seconds apart in the same round) and divides out of a ratio \u2014 it is what ruined the dedicated host's ABSOLUTE numbers, not something a paired ratio is exposed to. The C-vs-C rebuild control's scatter decides instead, because it is a direct measurement of how far a cell can move today for no reason. --strict-hygiene restores the dedicated-host rule."
+    },
+    "controls": {
+        "php_only": {
+            "ratio": 1.00111,
+            "scatter_pct": 5.091,
+            "scatter_stat": "p90 of |per-cell deviation|",
+            "max_dev_pct": 8.743,
+            "rows": 44,
+            "measures": "runner drift (interpreter speed, CPU frequency, process startup)",
+            "blind_to": "LLC and memory-bandwidth contention \u2014 PHP array ops are neither pointer-chasing nor DRAM-bound, so this control stayed flat at +0.36% while a co-resident tenant moved an untouched Judy arm 2.2x"
+        },
+        "cc_rebuild": {
+            "available": false,
+            "ratio": 1,
+            "scatter_pct": null,
+            "scatter_stat": "p90 of |per-cell deviation|",
+            "max_dev_pct": null,
+            "rows": 0,
+            "cells": [],
+            "measures": "the apparatus itself: two independently linked builds of IDENTICAL source, so every cell should read null. Shares Judy's memory-access character (pointer-chasing, DRAM-bound) and therefore CAN see the contention the PHP-array control cannot.",
+            "role": "its scatter is this run's empirical noise floor and raises the gate threshold when it exceeds the offline-derived one"
+        }
+    },
+    "timing": {
+        "s_over_c": {
+            "core.bitset.write": {
+                "ratio": 0.91444,
+                "ci": [
+                    0.90156,
+                    0.93252
+                ],
+                "delta_pct": -8.556,
+                "n": 5
+            },
+            "core.bitset.read": {
+                "ratio": 0.99713,
+                "ci": [
+                    0.97136,
+                    1.04194
+                ],
+                "delta_pct": -0.287,
+                "n": 5
+            },
+            "core.bitset.iter": {
+                "ratio": 1.055,
+                "ci": [
+                    1.03822,
+                    1.08713
+                ],
+                "delta_pct": 5.5,
+                "n": 5
+            },
+            "core.int_to_int.write": {
+                "ratio": 0.86918,
+                "ci": [
+                    0.8603,
+                    0.88956
+                ],
+                "delta_pct": -13.082,
+                "n": 5
+            },
+            "core.int_to_int.read": {
+                "ratio": 0.97813,
+                "ci": [
+                    0.91803,
+                    1.00204
+                ],
+                "delta_pct": -2.187,
+                "n": 5
+            },
+            "core.int_to_int.iter": {
+                "ratio": 1.03063,
+                "ci": [
+                    1.02023,
+                    1.06375
+                ],
+                "delta_pct": 3.063,
+                "n": 5
+            },
+            "core.int_to_int.free": {
+                "ratio": 1.2882,
+                "ci": [
+                    0.72602,
+                    1.52727
+                ],
+                "delta_pct": 28.82,
+                "n": 5
+            },
+            "core.int_to_mixed.write": {
+                "ratio": 0.90246,
+                "ci": [
+                    0.87652,
+                    0.91618
+                ],
+                "delta_pct": -9.754,
+                "n": 5
+            },
+            "core.int_to_mixed.read": {
+                "ratio": 0.9632,
+                "ci": [
+                    0.91077,
+                    0.98784
+                ],
+                "delta_pct": -3.68,
+                "n": 5
+            },
+            "core.int_to_mixed.iter": {
+                "ratio": 1.02011,
+                "ci": [
+                    1.00263,
+                    1.05817
+                ],
+                "delta_pct": 2.011,
+                "n": 5
+            },
+            "core.int_to_mixed.free": {
+                "ratio": 0.9997,
+                "ci": [
+                    0.92174,
+                    1.05445
+                ],
+                "delta_pct": -0.03,
+                "n": 5
+            },
+            "core.int_to_packed.write": {
+                "ratio": 0.92242,
+                "ci": [
+                    0.74984,
+                    0.9295
+                ],
+                "delta_pct": -7.758,
+                "n": 5
+            },
+            "core.int_to_packed.read": {
+                "ratio": 0.95369,
+                "ci": [
+                    0.82672,
+                    0.98006
+                ],
+                "delta_pct": -4.631,
+                "n": 5
+            },
+            "core.int_to_packed.iter": {
+                "ratio": 1.01779,
+                "ci": [
+                    0.98074,
+                    1.04631
+                ],
+                "delta_pct": 1.779,
+                "n": 5
+            },
+            "core.int_to_packed.free": {
+                "ratio": 0.94527,
+                "ci": [
+                    0.925,
+                    1.01661
+                ],
+                "delta_pct": -5.473,
+                "n": 5
+            },
+            "core.string_to_int.write": {
+                "ratio": 0.9141,
+                "ci": [
+                    0.89147,
+                    0.99743
+                ],
+                "delta_pct": -8.59,
+                "n": 5
+            },
+            "core.string_to_int.read": {
+                "ratio": 0.94481,
+                "ci": [
+                    0.88551,
+                    0.96453
+                ],
+                "delta_pct": -5.519,
+                "n": 5
+            },
+            "core.string_to_int.iter": {
+                "ratio": 0.83966,
+                "ci": [
+                    0.81718,
+                    0.86261
+                ],
+                "delta_pct": -16.034,
+                "n": 5
+            },
+            "core.string_to_int.free": {
+                "ratio": 0.92365,
+                "ci": [
+                    0.91678,
+                    0.94948
+                ],
+                "delta_pct": -7.635,
+                "n": 5
+            },
+            "core.string_to_mixed.write": {
+                "ratio": 0.90006,
+                "ci": [
+                    0.86919,
+                    0.98578
+                ],
+                "delta_pct": -9.994,
+                "n": 5
+            },
+            "core.string_to_mixed.read": {
+                "ratio": 0.94722,
+                "ci": [
+                    0.91686,
+                    0.96295
+                ],
+                "delta_pct": -5.278,
+                "n": 5
+            },
+            "core.string_to_mixed.iter": {
+                "ratio": 0.85298,
+                "ci": [
+                    0.81199,
+                    0.86806
+                ],
+                "delta_pct": -14.702,
+                "n": 5
+            },
+            "core.string_to_mixed.free": {
+                "ratio": 0.8493,
+                "ci": [
+                    0.84556,
+                    0.87422
+                ],
+                "delta_pct": -15.07,
+                "n": 5
+            },
+            "core.string_to_int_hash.write": {
+                "ratio": 0.89504,
+                "ci": [
+                    0.89161,
+                    0.91282
+                ],
+                "delta_pct": -10.496,
+                "n": 5
+            },
+            "core.string_to_int_hash.read": {
+                "ratio": 0.9369,
+                "ci": [
+                    0.83305,
+                    1.10365
+                ],
+                "delta_pct": -6.31,
+                "n": 5
+            },
+            "core.string_to_int_hash.iter": {
+                "ratio": 0.87175,
+                "ci": [
+                    0.84923,
+                    0.9024
+                ],
+                "delta_pct": -12.825,
+                "n": 5
+            },
+            "core.string_to_int_hash.free": {
+                "ratio": 0.91677,
+                "ci": [
+                    0.90532,
+                    0.9329
+                ],
+                "delta_pct": -8.323,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.write": {
+                "ratio": 0.89066,
+                "ci": [
+                    0.78899,
+                    0.8979
+                ],
+                "delta_pct": -10.934,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.read": {
+                "ratio": 0.93881,
+                "ci": [
+                    0.8841,
+                    0.9766
+                ],
+                "delta_pct": -6.119,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.iter": {
+                "ratio": 0.87646,
+                "ci": [
+                    0.74793,
+                    0.89732
+                ],
+                "delta_pct": -12.354,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.free": {
+                "ratio": 0.8856,
+                "ci": [
+                    0.80789,
+                    0.91988
+                ],
+                "delta_pct": -11.44,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.write": {
+                "ratio": 0.92163,
+                "ci": [
+                    0.85509,
+                    0.94727
+                ],
+                "delta_pct": -7.837,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.read": {
+                "ratio": 0.93864,
+                "ci": [
+                    0.89316,
+                    0.96828
+                ],
+                "delta_pct": -6.136,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.iter": {
+                "ratio": 0.86173,
+                "ci": [
+                    0.85237,
+                    0.86786
+                ],
+                "delta_pct": -13.827,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.free": {
+                "ratio": 0.92732,
+                "ci": [
+                    0.89826,
+                    0.96101
+                ],
+                "delta_pct": -7.268,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.write": {
+                "ratio": 0.92048,
+                "ci": [
+                    0.88866,
+                    1.06633
+                ],
+                "delta_pct": -7.952,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.read": {
+                "ratio": 0.9429,
+                "ci": [
+                    0.88313,
+                    1.00047
+                ],
+                "delta_pct": -5.71,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.iter": {
+                "ratio": 0.88715,
+                "ci": [
+                    0.85525,
+                    0.95107
+                ],
+                "delta_pct": -11.285,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.free": {
+                "ratio": 0.87713,
+                "ci": [
+                    0.85084,
+                    0.94826
+                ],
+                "delta_pct": -12.287,
+                "n": 5
+            },
+            "api.setop.union.bitset": {
+                "ratio": 0.84881,
+                "ci": [
+                    0.80995,
+                    0.86405
+                ],
+                "delta_pct": -15.119,
+                "n": 5
+            },
+            "api.setop.intersect.bitset": {
+                "ratio": 0.91526,
+                "ci": [
+                    0.76809,
+                    0.92159
+                ],
+                "delta_pct": -8.474,
+                "n": 5
+            },
+            "api.setop.diff.bitset": {
+                "ratio": 0.93443,
+                "ci": [
+                    0.90696,
+                    0.93598
+                ],
+                "delta_pct": -6.557,
+                "n": 5
+            },
+            "api.setop.xor.bitset": {
+                "ratio": 0.9232,
+                "ci": [
+                    0.91629,
+                    0.93357
+                ],
+                "delta_pct": -7.68,
+                "n": 5
+            },
+            "api.setop.union.int_to_int": {
+                "ratio": 0.75896,
+                "ci": [
+                    0.7465,
+                    0.77303
+                ],
+                "delta_pct": -24.104,
+                "n": 5
+            },
+            "api.setop.intersect.int_to_int": {
+                "ratio": 0.79789,
+                "ci": [
+                    0.77021,
+                    0.83484
+                ],
+                "delta_pct": -20.211,
+                "n": 5
+            },
+            "api.setop.diff.int_to_int": {
+                "ratio": 0.79282,
+                "ci": [
+                    0.73455,
+                    0.85969
+                ],
+                "delta_pct": -20.718,
+                "n": 5
+            },
+            "api.setop.xor.int_to_int": {
+                "ratio": 0.78338,
+                "ci": [
+                    0.66437,
+                    0.80359
+                ],
+                "delta_pct": -21.662,
+                "n": 5
+            },
+            "api.setop.union.string_to_int": {
+                "ratio": 0.90208,
+                "ci": [
+                    0.76735,
+                    0.93362
+                ],
+                "delta_pct": -9.792,
+                "n": 5
+            },
+            "api.setop.intersect.string_to_int": {
+                "ratio": 0.89344,
+                "ci": [
+                    0.80734,
+                    0.91624
+                ],
+                "delta_pct": -10.656,
+                "n": 5
+            },
+            "api.setop.diff.string_to_int": {
+                "ratio": 0.89657,
+                "ci": [
+                    0.75629,
+                    1.01212
+                ],
+                "delta_pct": -10.343,
+                "n": 5
+            },
+            "api.mergeWith.int_to_int": {
+                "ratio": 0.83613,
+                "ci": [
+                    0.72951,
+                    0.84734
+                ],
+                "delta_pct": -16.387,
+                "n": 5
+            },
+            "api.mergeWith.string_to_int": {
+                "ratio": 0.911,
+                "ci": [
+                    0.89262,
+                    0.93072
+                ],
+                "delta_pct": -8.9,
+                "n": 5
+            }
+        },
+        "a_over_c": {
+            "core.bitset.write": {
+                "ratio": 1.739,
+                "ci": [
+                    1.72093,
+                    1.74466
+                ],
+                "delta_pct": 73.9,
+                "n": 5
+            },
+            "core.bitset.read": {
+                "ratio": 2.04764,
+                "ci": [
+                    2.00915,
+                    2.17458
+                ],
+                "delta_pct": 104.764,
+                "n": 5
+            },
+            "core.bitset.iter": {
+                "ratio": 3.17271,
+                "ci": [
+                    3.12374,
+                    3.19483
+                ],
+                "delta_pct": 217.271,
+                "n": 5
+            },
+            "core.int_to_int.write": {
+                "ratio": 2.82803,
+                "ci": [
+                    2.73434,
+                    2.85294
+                ],
+                "delta_pct": 182.803,
+                "n": 5
+            },
+            "core.int_to_int.read": {
+                "ratio": 2.17265,
+                "ci": [
+                    2.10321,
+                    2.20101
+                ],
+                "delta_pct": 117.265,
+                "n": 5
+            },
+            "core.int_to_int.iter": {
+                "ratio": 3.26267,
+                "ci": [
+                    2.74405,
+                    3.38551
+                ],
+                "delta_pct": 226.267,
+                "n": 5
+            },
+            "core.int_to_int.free": {
+                "ratio": 1.72328,
+                "ci": [
+                    1.20298,
+                    1.81706
+                ],
+                "delta_pct": 72.328,
+                "n": 5
+            },
+            "core.int_to_mixed.write": {
+                "ratio": 2.96483,
+                "ci": [
+                    2.91651,
+                    3.04269
+                ],
+                "delta_pct": 196.483,
+                "n": 5
+            },
+            "core.int_to_mixed.read": {
+                "ratio": 2.0417,
+                "ci": [
+                    1.99858,
+                    2.12201
+                ],
+                "delta_pct": 104.17,
+                "n": 5
+            },
+            "core.int_to_mixed.iter": {
+                "ratio": 3.24532,
+                "ci": [
+                    3.22982,
+                    3.54135
+                ],
+                "delta_pct": 224.532,
+                "n": 5
+            },
+            "core.int_to_mixed.free": {
+                "ratio": 4.29025,
+                "ci": [
+                    3.94271,
+                    4.48086
+                ],
+                "delta_pct": 329.025,
+                "n": 5
+            },
+            "core.int_to_packed.write": {
+                "ratio": 4.00053,
+                "ci": [
+                    3.87688,
+                    4.13703
+                ],
+                "delta_pct": 300.053,
+                "n": 5
+            },
+            "core.int_to_packed.read": {
+                "ratio": 4.79805,
+                "ci": [
+                    4.416,
+                    4.89626
+                ],
+                "delta_pct": 379.805,
+                "n": 5
+            },
+            "core.int_to_packed.iter": {
+                "ratio": 6.92676,
+                "ci": [
+                    6.71169,
+                    7.26986
+                ],
+                "delta_pct": 592.676,
+                "n": 5
+            },
+            "core.int_to_packed.free": {
+                "ratio": 3.17893,
+                "ci": [
+                    2.92096,
+                    3.57095
+                ],
+                "delta_pct": 217.893,
+                "n": 5
+            },
+            "core.string_to_int.write": {
+                "ratio": 4.60802,
+                "ci": [
+                    4.10068,
+                    4.99592
+                ],
+                "delta_pct": 360.802,
+                "n": 5
+            },
+            "core.string_to_int.read": {
+                "ratio": 4.62875,
+                "ci": [
+                    4.44374,
+                    4.9061
+                ],
+                "delta_pct": 362.875,
+                "n": 5
+            },
+            "core.string_to_int.iter": {
+                "ratio": 8.66302,
+                "ci": [
+                    8.60787,
+                    8.83993
+                ],
+                "delta_pct": 766.302,
+                "n": 5
+            },
+            "core.string_to_int.free": {
+                "ratio": 13.64431,
+                "ci": [
+                    12.51462,
+                    14.46662
+                ],
+                "delta_pct": 1264.431,
+                "n": 5
+            },
+            "core.string_to_mixed.write": {
+                "ratio": 5.41938,
+                "ci": [
+                    5.17699,
+                    6.03256
+                ],
+                "delta_pct": 441.938,
+                "n": 5
+            },
+            "core.string_to_mixed.read": {
+                "ratio": 3.96574,
+                "ci": [
+                    3.29981,
+                    4.11535
+                ],
+                "delta_pct": 296.574,
+                "n": 5
+            },
+            "core.string_to_mixed.iter": {
+                "ratio": 8.21107,
+                "ci": [
+                    7.63339,
+                    8.96146
+                ],
+                "delta_pct": 721.107,
+                "n": 5
+            },
+            "core.string_to_mixed.free": {
+                "ratio": 11.70772,
+                "ci": [
+                    11.21184,
+                    12.34529
+                ],
+                "delta_pct": 1070.772,
+                "n": 5
+            },
+            "core.string_to_int_hash.write": {
+                "ratio": 8.28611,
+                "ci": [
+                    7.87892,
+                    8.45822
+                ],
+                "delta_pct": 728.611,
+                "n": 5
+            },
+            "core.string_to_int_hash.read": {
+                "ratio": 3.69203,
+                "ci": [
+                    3.61017,
+                    4.32994
+                ],
+                "delta_pct": 269.203,
+                "n": 5
+            },
+            "core.string_to_int_hash.iter": {
+                "ratio": 12.77308,
+                "ci": [
+                    12.27743,
+                    13.81978
+                ],
+                "delta_pct": 1177.308,
+                "n": 5
+            },
+            "core.string_to_int_hash.free": {
+                "ratio": 30.14114,
+                "ci": [
+                    25.99971,
+                    31.57658
+                ],
+                "delta_pct": 2914.114,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.write": {
+                "ratio": 9.8883,
+                "ci": [
+                    8.1726,
+                    10.79855
+                ],
+                "delta_pct": 888.83,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.read": {
+                "ratio": 3.15125,
+                "ci": [
+                    2.42256,
+                    3.51114
+                ],
+                "delta_pct": 215.125,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.iter": {
+                "ratio": 13.40357,
+                "ci": [
+                    12.89705,
+                    14.08072
+                ],
+                "delta_pct": 1240.357,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.free": {
+                "ratio": 21.63749,
+                "ci": [
+                    18.36959,
+                    24.27908
+                ],
+                "delta_pct": 2063.749,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.write": {
+                "ratio": 8.22066,
+                "ci": [
+                    7.63828,
+                    8.8156
+                ],
+                "delta_pct": 722.066,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.read": {
+                "ratio": 3.54259,
+                "ci": [
+                    3.53083,
+                    3.73884
+                ],
+                "delta_pct": 254.259,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.iter": {
+                "ratio": 12.96093,
+                "ci": [
+                    12.51769,
+                    13.44864
+                ],
+                "delta_pct": 1196.093,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.free": {
+                "ratio": 27.15038,
+                "ci": [
+                    25.20067,
+                    28.59503
+                ],
+                "delta_pct": 2615.038,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.write": {
+                "ratio": 10.65117,
+                "ci": [
+                    10.14812,
+                    11.01199
+                ],
+                "delta_pct": 965.117,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.read": {
+                "ratio": 3.2627,
+                "ci": [
+                    3.17924,
+                    3.28816
+                ],
+                "delta_pct": 226.27,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.iter": {
+                "ratio": 12.98267,
+                "ci": [
+                    10.82297,
+                    13.24323
+                ],
+                "delta_pct": 1198.267,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.free": {
+                "ratio": 22.16964,
+                "ci": [
+                    18.84565,
+                    25.5857
+                ],
+                "delta_pct": 2116.964,
+                "n": 5
+            },
+            "api.setop.union.bitset": {
+                "ratio": 4.91507,
+                "ci": [
+                    3.59474,
+                    4.94758
+                ],
+                "delta_pct": 391.507,
+                "n": 5
+            },
+            "api.setop.intersect.bitset": {
+                "ratio": 1.76029,
+                "ci": [
+                    1.56138,
+                    1.83732
+                ],
+                "delta_pct": 76.029,
+                "n": 5
+            },
+            "api.setop.diff.bitset": {
+                "ratio": 3.73684,
+                "ci": [
+                    3.32509,
+                    3.75921
+                ],
+                "delta_pct": 273.684,
+                "n": 5
+            },
+            "api.setop.xor.bitset": {
+                "ratio": 1.84776,
+                "ci": [
+                    1.47522,
+                    1.8722
+                ],
+                "delta_pct": 84.776,
+                "n": 5
+            }
+        },
+        "b_over_c": []
+    },
+    "memory": {
+        "a_over_c": {
+            "int_to_int@1000000": {
+                "ratio": 2.04212,
+                "bytes": {
+                    "A": 18468864,
+                    "C": 9043968
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "int_sparse@1000000": {
+                "ratio": 3.22662,
+                "bytes": {
+                    "A": 43098112,
+                    "C": 13357056
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "string_to_int@1000000": {
+                "ratio": 3.67445,
+                "bytes": {
+                    "A": 80580608,
+                    "C": 21929984
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "bitset@1000000": {
+                "ratio": 22.4307,
+                "bytes": {
+                    "A": 43089920,
+                    "C": 1921024
+                },
+                "gateable": false,
+                "not_gateable_reason": "below the 4.0 MB gating floor \u2014 peak RSS is page-quantised and a small structure moves several percent between identical runs"
+            }
+        },
+        "s_over_c": {
+            "int_to_int@1000000": {
+                "ratio": 1.00226,
+                "bytes": {
+                    "S": 9064448,
+                    "C": 9043968
+                },
+                "gateable": true
+            },
+            "int_sparse@1000000": {
+                "ratio": 1.00521,
+                "bytes": {
+                    "S": 13426688,
+                    "C": 13357056
+                },
+                "gateable": true
+            },
+            "string_to_int@1000000": {
+                "ratio": 0.99925,
+                "bytes": {
+                    "S": 21913600,
+                    "C": 21929984
+                },
+                "gateable": true
+            },
+            "bitset@1000000": {
+                "ratio": 0.98507,
+                "bytes": {
+                    "S": 1892352,
+                    "C": 1921024
+                },
+                "gateable": false
+            }
+        }
+    },
+    "memory_raw": [
+        {
+            "workload": "int_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 34570240,
+                    "peak_rss_ci": [
+                        34521088,
+                        34594816
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 18874448,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 18468864
+                },
+                "S": {
+                    "peak_rss_bytes": 25255936,
+                    "peak_rss_ci": [
+                        25243648,
+                        25264128
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 9064448
+                },
+                "C": {
+                    "peak_rss_bytes": 25223168,
+                    "peak_rss_ci": [
+                        25178112,
+                        25227264
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 9043968
+                }
+            }
+        },
+        {
+            "workload": "int_sparse",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 59199488,
+                    "peak_rss_ci": [
+                        59191296,
+                        59199488
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43098112
+                },
+                "S": {
+                    "peak_rss_bytes": 29618176,
+                    "peak_rss_ci": [
+                        29536256,
+                        29622272
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13426688
+                },
+                "C": {
+                    "peak_rss_bytes": 29536256,
+                    "peak_rss_ci": [
+                        29532160,
+                        29601792
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13357056
+                }
+            }
+        },
+        {
+            "workload": "string_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 96681984,
+                    "peak_rss_ci": [
+                        96612352,
+                        96681984
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 81935120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 80580608
+                },
+                "S": {
+                    "peak_rss_bytes": 38105088,
+                    "peak_rss_ci": [
+                        37994496,
+                        38182912
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21913600
+                },
+                "C": {
+                    "peak_rss_bytes": 38109184,
+                    "peak_rss_ci": [
+                        38064128,
+                        38141952
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21929984
+                }
+            }
+        },
+        {
+            "workload": "bitset",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 59191296,
+                    "peak_rss_ci": [
+                        59084800,
+                        59195392
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43089920
+                },
+                "S": {
+                    "peak_rss_bytes": 18083840,
+                    "peak_rss_ci": [
+                        18042880,
+                        18116608
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1892352
+                },
+                "C": {
+                    "peak_rss_bytes": 18100224,
+                    "peak_rss_ci": [
+                        18087936,
+                        18132992
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1921024
+                }
+            }
+        }
+    ],
+    "gate": {
+        "status": "no-baseline-for-platform",
+        "baseline": "baselines/arm-ratios.json",
+        "thresholds": [],
+        "findings": [],
+        "regressions": 0,
+        "suppressed": 0
+    },
+    "verify": {
+        "S1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp/judy-bench-arms-8672/S1-ini\\judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp/judy-bench-arms-8672/C1-ini\\judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/gate-2026-08-19/r16-gate-windows-x64-1.json
+++ b/research/three-arm-benchmark/results/gate-2026-08-19/r16-gate-windows-x64-1.json
@@ -1,0 +1,1251 @@
+{
+    "metadata": {
+        "schema": "judy-bench-gate/1",
+        "platform": "windows-x64",
+        "label": "windows-x64",
+        "tier": "ci-relative-single-build",
+        "commit": "3ce48859299a2dc8ae043a163cc107386ab033bb",
+        "libjudy_tree": "7c9f86ea0df9ff277729297e0f23981a0e3e1a86",
+        "date": "2026-08-19T17:22:35+00:00",
+        "php_version": "8.4.24",
+        "uname": "Windows NT runnervmk2qs2 10.0 build 26100 (Windows Server 2025) AMD64",
+        "toolchain": "MSVC / PHP 8.4.24",
+        "provenance": null,
+        "arms": [
+            {
+                "handle": "S1",
+                "role": "S",
+                "so": "D:/a/_temp/arms/judy-S-1.dll",
+                "sha256": "2b23b9408e8e3a98a7c72c47d3d13fe21fd8cb4ea4a880651a26049574dba0e4"
+            },
+            {
+                "handle": "C1",
+                "role": "C",
+                "so": "D:/a/_temp/arms/judy-C-1.dll",
+                "sha256": "cfc7f3474c5ed32aee5508fac1b009f5c6157e7ee576b29f03384b71fbaa94f9"
+            }
+        ],
+        "rebuild_control_available": false,
+        "size": 300000,
+        "rounds": 5,
+        "iterations": 3,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.setops"
+        ],
+        "mem_sizes": [
+            1000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_min_gateable_bytes": 4194304,
+        "children": 75,
+        "wall_seconds": 307.2
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T17:17:28+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T17:22:28+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "after-memory",
+                "at": "2026-08-19T17:22:35+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T17:22:35+00:00",
+                "load1": null,
+                "cpus": 4,
+                "threshold": null,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": null,
+                "foreign_busy": false,
+                "heavy": [],
+                "unavailable": "no load average and no per-process CPU sampling on Windows"
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "inconclusive_reason": null,
+        "control_ceiling_pct": 15,
+        "decides_the_run": false,
+        "note": "Sampled and reported for interpretation, but it does NOT decide this run's fate. LLC/bandwidth contention slows both arms of a pair equally (they are measured seconds apart in the same round) and divides out of a ratio \u2014 it is what ruined the dedicated host's ABSOLUTE numbers, not something a paired ratio is exposed to. The C-vs-C rebuild control's scatter decides instead, because it is a direct measurement of how far a cell can move today for no reason. --strict-hygiene restores the dedicated-host rule."
+    },
+    "controls": {
+        "php_only": {
+            "ratio": 1.00692,
+            "scatter_pct": 3.827,
+            "scatter_stat": "p90 of |per-cell deviation|",
+            "max_dev_pct": 9.995,
+            "rows": 44,
+            "measures": "runner drift (interpreter speed, CPU frequency, process startup)",
+            "blind_to": "LLC and memory-bandwidth contention \u2014 PHP array ops are neither pointer-chasing nor DRAM-bound, so this control stayed flat at +0.36% while a co-resident tenant moved an untouched Judy arm 2.2x"
+        },
+        "cc_rebuild": {
+            "available": false,
+            "ratio": 1,
+            "scatter_pct": null,
+            "scatter_stat": "p90 of |per-cell deviation|",
+            "max_dev_pct": null,
+            "rows": 0,
+            "cells": [],
+            "measures": "the apparatus itself: two independently linked builds of IDENTICAL source, so every cell should read null. Shares Judy's memory-access character (pointer-chasing, DRAM-bound) and therefore CAN see the contention the PHP-array control cannot.",
+            "role": "its scatter is this run's empirical noise floor and raises the gate threshold when it exceeds the offline-derived one"
+        }
+    },
+    "timing": {
+        "s_over_c": {
+            "core.bitset.write": {
+                "ratio": 0.94568,
+                "ci": [
+                    0.90477,
+                    1.0108
+                ],
+                "delta_pct": -5.432,
+                "n": 5
+            },
+            "core.bitset.read": {
+                "ratio": 0.99377,
+                "ci": [
+                    0.97345,
+                    1.09216
+                ],
+                "delta_pct": -0.623,
+                "n": 5
+            },
+            "core.bitset.iter": {
+                "ratio": 1.04798,
+                "ci": [
+                    0.98521,
+                    1.05747
+                ],
+                "delta_pct": 4.798,
+                "n": 5
+            },
+            "core.int_to_int.write": {
+                "ratio": 0.85586,
+                "ci": [
+                    0.81942,
+                    0.8853
+                ],
+                "delta_pct": -14.414,
+                "n": 5
+            },
+            "core.int_to_int.read": {
+                "ratio": 0.92651,
+                "ci": [
+                    0.83604,
+                    0.96193
+                ],
+                "delta_pct": -7.349,
+                "n": 5
+            },
+            "core.int_to_int.iter": {
+                "ratio": 1.14031,
+                "ci": [
+                    1.04542,
+                    1.16698
+                ],
+                "delta_pct": 14.031,
+                "n": 5
+            },
+            "core.int_to_mixed.write": {
+                "ratio": 0.86601,
+                "ci": [
+                    0.85842,
+                    0.8794
+                ],
+                "delta_pct": -13.399,
+                "n": 5
+            },
+            "core.int_to_mixed.read": {
+                "ratio": 0.88758,
+                "ci": [
+                    0.85794,
+                    0.92771
+                ],
+                "delta_pct": -11.242,
+                "n": 5
+            },
+            "core.int_to_mixed.iter": {
+                "ratio": 1.08731,
+                "ci": [
+                    1.0474,
+                    1.10951
+                ],
+                "delta_pct": 8.731,
+                "n": 5
+            },
+            "core.int_to_mixed.free": {
+                "ratio": 0.93583,
+                "ci": [
+                    0.81142,
+                    0.98874
+                ],
+                "delta_pct": -6.417,
+                "n": 5
+            },
+            "core.int_to_packed.write": {
+                "ratio": 0.90119,
+                "ci": [
+                    0.85679,
+                    0.93238
+                ],
+                "delta_pct": -9.881,
+                "n": 5
+            },
+            "core.int_to_packed.read": {
+                "ratio": 0.93165,
+                "ci": [
+                    0.85753,
+                    0.93424
+                ],
+                "delta_pct": -6.835,
+                "n": 5
+            },
+            "core.int_to_packed.iter": {
+                "ratio": 0.98617,
+                "ci": [
+                    0.91324,
+                    0.99768
+                ],
+                "delta_pct": -1.383,
+                "n": 5
+            },
+            "core.int_to_packed.free": {
+                "ratio": 0.94944,
+                "ci": [
+                    0.92187,
+                    0.95811
+                ],
+                "delta_pct": -5.056,
+                "n": 5
+            },
+            "core.string_to_int.write": {
+                "ratio": 0.92479,
+                "ci": [
+                    0.9027,
+                    0.94863
+                ],
+                "delta_pct": -7.521,
+                "n": 5
+            },
+            "core.string_to_int.read": {
+                "ratio": 0.91538,
+                "ci": [
+                    0.83334,
+                    0.93731
+                ],
+                "delta_pct": -8.462,
+                "n": 5
+            },
+            "core.string_to_int.iter": {
+                "ratio": 0.82246,
+                "ci": [
+                    0.79311,
+                    0.83577
+                ],
+                "delta_pct": -17.754,
+                "n": 5
+            },
+            "core.string_to_int.free": {
+                "ratio": 0.9248,
+                "ci": [
+                    0.90743,
+                    0.97052
+                ],
+                "delta_pct": -7.52,
+                "n": 5
+            },
+            "core.string_to_mixed.write": {
+                "ratio": 0.90276,
+                "ci": [
+                    0.88151,
+                    1.00682
+                ],
+                "delta_pct": -9.724,
+                "n": 5
+            },
+            "core.string_to_mixed.read": {
+                "ratio": 0.94811,
+                "ci": [
+                    0.88349,
+                    1.18155
+                ],
+                "delta_pct": -5.189,
+                "n": 5
+            },
+            "core.string_to_mixed.iter": {
+                "ratio": 0.83959,
+                "ci": [
+                    0.82656,
+                    0.99337
+                ],
+                "delta_pct": -16.041,
+                "n": 5
+            },
+            "core.string_to_mixed.free": {
+                "ratio": 0.82695,
+                "ci": [
+                    0.79476,
+                    0.88446
+                ],
+                "delta_pct": -17.305,
+                "n": 5
+            },
+            "core.string_to_int_hash.write": {
+                "ratio": 0.91474,
+                "ci": [
+                    0.81072,
+                    0.93223
+                ],
+                "delta_pct": -8.526,
+                "n": 5
+            },
+            "core.string_to_int_hash.read": {
+                "ratio": 0.90108,
+                "ci": [
+                    0.72318,
+                    0.92701
+                ],
+                "delta_pct": -9.892,
+                "n": 5
+            },
+            "core.string_to_int_hash.iter": {
+                "ratio": 0.86151,
+                "ci": [
+                    0.70736,
+                    0.86531
+                ],
+                "delta_pct": -13.849,
+                "n": 5
+            },
+            "core.string_to_int_hash.free": {
+                "ratio": 0.90262,
+                "ci": [
+                    0.81795,
+                    0.95529
+                ],
+                "delta_pct": -9.738,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.write": {
+                "ratio": 0.89402,
+                "ci": [
+                    0.82192,
+                    0.93468
+                ],
+                "delta_pct": -10.598,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.read": {
+                "ratio": 0.94257,
+                "ci": [
+                    0.88857,
+                    0.95455
+                ],
+                "delta_pct": -5.743,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.iter": {
+                "ratio": 0.85109,
+                "ci": [
+                    0.84548,
+                    0.88379
+                ],
+                "delta_pct": -14.891,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.free": {
+                "ratio": 0.86356,
+                "ci": [
+                    0.84295,
+                    0.90553
+                ],
+                "delta_pct": -13.644,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.write": {
+                "ratio": 0.92149,
+                "ci": [
+                    0.88775,
+                    0.93231
+                ],
+                "delta_pct": -7.851,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.read": {
+                "ratio": 0.91601,
+                "ci": [
+                    0.81861,
+                    0.96069
+                ],
+                "delta_pct": -8.399,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.iter": {
+                "ratio": 0.85129,
+                "ci": [
+                    0.79823,
+                    0.898
+                ],
+                "delta_pct": -14.871,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.free": {
+                "ratio": 0.91725,
+                "ci": [
+                    0.8647,
+                    0.97932
+                ],
+                "delta_pct": -8.275,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.write": {
+                "ratio": 0.91488,
+                "ci": [
+                    0.89911,
+                    0.91724
+                ],
+                "delta_pct": -8.512,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.read": {
+                "ratio": 0.93131,
+                "ci": [
+                    0.91139,
+                    0.96584
+                ],
+                "delta_pct": -6.869,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.iter": {
+                "ratio": 0.88068,
+                "ci": [
+                    0.86918,
+                    0.90573
+                ],
+                "delta_pct": -11.932,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.free": {
+                "ratio": 0.89306,
+                "ci": [
+                    0.86687,
+                    0.91867
+                ],
+                "delta_pct": -10.694,
+                "n": 5
+            },
+            "api.setop.union.bitset": {
+                "ratio": 0.85435,
+                "ci": [
+                    0.76803,
+                    0.87343
+                ],
+                "delta_pct": -14.565,
+                "n": 5
+            },
+            "api.setop.intersect.bitset": {
+                "ratio": 0.86108,
+                "ci": [
+                    0.76954,
+                    0.88606
+                ],
+                "delta_pct": -13.892,
+                "n": 5
+            },
+            "api.setop.diff.bitset": {
+                "ratio": 0.89004,
+                "ci": [
+                    0.72508,
+                    1.21749
+                ],
+                "delta_pct": -10.996,
+                "n": 5
+            },
+            "api.setop.xor.bitset": {
+                "ratio": 0.84932,
+                "ci": [
+                    0.81407,
+                    0.92296
+                ],
+                "delta_pct": -15.068,
+                "n": 5
+            },
+            "api.setop.union.int_to_int": {
+                "ratio": 0.7859,
+                "ci": [
+                    0.60611,
+                    1.00259
+                ],
+                "delta_pct": -21.41,
+                "n": 5
+            },
+            "api.setop.intersect.int_to_int": {
+                "ratio": 0.80228,
+                "ci": [
+                    0.52646,
+                    0.83132
+                ],
+                "delta_pct": -19.772,
+                "n": 5
+            },
+            "api.setop.diff.int_to_int": {
+                "ratio": 0.7596,
+                "ci": [
+                    0.53922,
+                    0.81878
+                ],
+                "delta_pct": -24.04,
+                "n": 5
+            },
+            "api.setop.xor.int_to_int": {
+                "ratio": 0.74948,
+                "ci": [
+                    0.66956,
+                    0.80604
+                ],
+                "delta_pct": -25.052,
+                "n": 5
+            },
+            "api.setop.union.string_to_int": {
+                "ratio": 0.9096,
+                "ci": [
+                    0.88063,
+                    0.94658
+                ],
+                "delta_pct": -9.04,
+                "n": 5
+            },
+            "api.setop.intersect.string_to_int": {
+                "ratio": 0.90618,
+                "ci": [
+                    0.81012,
+                    0.93717
+                ],
+                "delta_pct": -9.382,
+                "n": 5
+            },
+            "api.setop.diff.string_to_int": {
+                "ratio": 0.88558,
+                "ci": [
+                    0.83153,
+                    0.9425
+                ],
+                "delta_pct": -11.442,
+                "n": 5
+            },
+            "api.mergeWith.int_to_int": {
+                "ratio": 0.81341,
+                "ci": [
+                    0.70098,
+                    0.90176
+                ],
+                "delta_pct": -18.659,
+                "n": 5
+            },
+            "api.mergeWith.string_to_int": {
+                "ratio": 0.89696,
+                "ci": [
+                    0.85761,
+                    1.00665
+                ],
+                "delta_pct": -10.304,
+                "n": 5
+            }
+        },
+        "a_over_c": {
+            "core.bitset.write": {
+                "ratio": 1.78899,
+                "ci": [
+                    1.65261,
+                    1.83531
+                ],
+                "delta_pct": 78.899,
+                "n": 5
+            },
+            "core.bitset.read": {
+                "ratio": 1.87752,
+                "ci": [
+                    1.85265,
+                    2.08915
+                ],
+                "delta_pct": 87.752,
+                "n": 5
+            },
+            "core.bitset.iter": {
+                "ratio": 3.21195,
+                "ci": [
+                    3.10708,
+                    3.28815
+                ],
+                "delta_pct": 221.195,
+                "n": 5
+            },
+            "core.int_to_int.write": {
+                "ratio": 2.53591,
+                "ci": [
+                    2.42626,
+                    2.70674
+                ],
+                "delta_pct": 153.591,
+                "n": 5
+            },
+            "core.int_to_int.read": {
+                "ratio": 1.94797,
+                "ci": [
+                    1.91115,
+                    1.98092
+                ],
+                "delta_pct": 94.797,
+                "n": 5
+            },
+            "core.int_to_int.iter": {
+                "ratio": 3.24349,
+                "ci": [
+                    3.22608,
+                    3.55864
+                ],
+                "delta_pct": 224.349,
+                "n": 5
+            },
+            "core.int_to_mixed.write": {
+                "ratio": 2.94406,
+                "ci": [
+                    2.88526,
+                    3.06256
+                ],
+                "delta_pct": 194.406,
+                "n": 5
+            },
+            "core.int_to_mixed.read": {
+                "ratio": 1.86078,
+                "ci": [
+                    1.81307,
+                    1.87521
+                ],
+                "delta_pct": 86.078,
+                "n": 5
+            },
+            "core.int_to_mixed.iter": {
+                "ratio": 3.22696,
+                "ci": [
+                    3.20381,
+                    3.25944
+                ],
+                "delta_pct": 222.696,
+                "n": 5
+            },
+            "core.int_to_mixed.free": {
+                "ratio": 4.34475,
+                "ci": [
+                    4.0202,
+                    4.84148
+                ],
+                "delta_pct": 334.475,
+                "n": 5
+            },
+            "core.int_to_packed.write": {
+                "ratio": 4.02425,
+                "ci": [
+                    3.9889,
+                    4.09074
+                ],
+                "delta_pct": 302.425,
+                "n": 5
+            },
+            "core.int_to_packed.read": {
+                "ratio": 4.67086,
+                "ci": [
+                    4.6071,
+                    4.80535
+                ],
+                "delta_pct": 367.086,
+                "n": 5
+            },
+            "core.int_to_packed.iter": {
+                "ratio": 7.39067,
+                "ci": [
+                    6.30195,
+                    7.75577
+                ],
+                "delta_pct": 639.067,
+                "n": 5
+            },
+            "core.int_to_packed.free": {
+                "ratio": 3.12048,
+                "ci": [
+                    2.96564,
+                    3.71177
+                ],
+                "delta_pct": 212.048,
+                "n": 5
+            },
+            "core.string_to_int.write": {
+                "ratio": 4.57381,
+                "ci": [
+                    4.04613,
+                    4.59298
+                ],
+                "delta_pct": 357.381,
+                "n": 5
+            },
+            "core.string_to_int.read": {
+                "ratio": 4.63701,
+                "ci": [
+                    4.47071,
+                    4.78984
+                ],
+                "delta_pct": 363.701,
+                "n": 5
+            },
+            "core.string_to_int.iter": {
+                "ratio": 9.48639,
+                "ci": [
+                    8.94451,
+                    9.83265
+                ],
+                "delta_pct": 848.639,
+                "n": 5
+            },
+            "core.string_to_int.free": {
+                "ratio": 18.41087,
+                "ci": [
+                    17.81587,
+                    20.17577
+                ],
+                "delta_pct": 1741.087,
+                "n": 5
+            },
+            "core.string_to_mixed.write": {
+                "ratio": 5.42382,
+                "ci": [
+                    4.83085,
+                    5.42719
+                ],
+                "delta_pct": 442.382,
+                "n": 5
+            },
+            "core.string_to_mixed.read": {
+                "ratio": 3.98273,
+                "ci": [
+                    3.75251,
+                    4.44075
+                ],
+                "delta_pct": 298.273,
+                "n": 5
+            },
+            "core.string_to_mixed.iter": {
+                "ratio": 8.84933,
+                "ci": [
+                    8.78588,
+                    10.50326
+                ],
+                "delta_pct": 784.933,
+                "n": 5
+            },
+            "core.string_to_mixed.free": {
+                "ratio": 12.25258,
+                "ci": [
+                    10.57861,
+                    12.50854
+                ],
+                "delta_pct": 1125.258,
+                "n": 5
+            },
+            "core.string_to_int_hash.write": {
+                "ratio": 8.60697,
+                "ci": [
+                    6.84567,
+                    8.81483
+                ],
+                "delta_pct": 760.697,
+                "n": 5
+            },
+            "core.string_to_int_hash.read": {
+                "ratio": 3.65291,
+                "ci": [
+                    3.51684,
+                    3.94673
+                ],
+                "delta_pct": 265.291,
+                "n": 5
+            },
+            "core.string_to_int_hash.iter": {
+                "ratio": 14.51998,
+                "ci": [
+                    11.42172,
+                    14.60384
+                ],
+                "delta_pct": 1351.998,
+                "n": 5
+            },
+            "core.string_to_int_hash.free": {
+                "ratio": 41.32744,
+                "ci": [
+                    39.81031,
+                    43.12228
+                ],
+                "delta_pct": 4032.744,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.write": {
+                "ratio": 10.77619,
+                "ci": [
+                    10.25967,
+                    10.85993
+                ],
+                "delta_pct": 977.619,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.read": {
+                "ratio": 3.30903,
+                "ci": [
+                    3.17811,
+                    3.40909
+                ],
+                "delta_pct": 230.903,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.iter": {
+                "ratio": 14.6469,
+                "ci": [
+                    14.38075,
+                    15.21614
+                ],
+                "delta_pct": 1364.69,
+                "n": 5
+            },
+            "core.string_to_mixed_hash.free": {
+                "ratio": 23.14069,
+                "ci": [
+                    21.42968,
+                    23.48718
+                ],
+                "delta_pct": 2214.069,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.write": {
+                "ratio": 8.71768,
+                "ci": [
+                    8.51493,
+                    8.84544
+                ],
+                "delta_pct": 771.768,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.read": {
+                "ratio": 3.60234,
+                "ci": [
+                    3.47699,
+                    3.9099
+                ],
+                "delta_pct": 260.234,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.iter": {
+                "ratio": 15.02611,
+                "ci": [
+                    14.28919,
+                    15.3526
+                ],
+                "delta_pct": 1402.611,
+                "n": 5
+            },
+            "core.string_to_int_adaptive.free": {
+                "ratio": 39.63902,
+                "ci": [
+                    34.46147,
+                    42.13998
+                ],
+                "delta_pct": 3863.902,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.write": {
+                "ratio": 11.29224,
+                "ci": [
+                    11.18907,
+                    11.73161
+                ],
+                "delta_pct": 1029.224,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.read": {
+                "ratio": 3.23087,
+                "ci": [
+                    3.19603,
+                    3.36357
+                ],
+                "delta_pct": 223.087,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.iter": {
+                "ratio": 14.20621,
+                "ci": [
+                    13.70871,
+                    14.8715
+                ],
+                "delta_pct": 1320.621,
+                "n": 5
+            },
+            "core.string_to_mixed_adaptive.free": {
+                "ratio": 24.41708,
+                "ci": [
+                    22.18801,
+                    27.09648
+                ],
+                "delta_pct": 2341.708,
+                "n": 5
+            },
+            "api.setop.union.bitset": {
+                "ratio": 5.3142,
+                "ci": [
+                    4.93214,
+                    5.44989
+                ],
+                "delta_pct": 431.42,
+                "n": 5
+            },
+            "api.setop.intersect.bitset": {
+                "ratio": 1.68877,
+                "ci": [
+                    1.37797,
+                    1.69849
+                ],
+                "delta_pct": 68.877,
+                "n": 5
+            },
+            "api.setop.diff.bitset": {
+                "ratio": 3.55378,
+                "ci": [
+                    3.5247,
+                    4.42015
+                ],
+                "delta_pct": 255.378,
+                "n": 5
+            },
+            "api.setop.xor.bitset": {
+                "ratio": 1.76337,
+                "ci": [
+                    1.73278,
+                    1.86427
+                ],
+                "delta_pct": 76.337,
+                "n": 5
+            }
+        },
+        "b_over_c": []
+    },
+    "memory": {
+        "a_over_c": {
+            "int_to_int@1000000": {
+                "ratio": 2.04098,
+                "bytes": {
+                    "A": 18358272,
+                    "C": 8994816
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "int_sparse@1000000": {
+                "ratio": 3.22117,
+                "bytes": {
+                    "A": 43012096,
+                    "C": 13352960
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "string_to_int@1000000": {
+                "ratio": 3.66716,
+                "bytes": {
+                    "A": 80465920,
+                    "C": 21942272
+                },
+                "gateable": true,
+                "not_gateable_reason": null
+            },
+            "bitset@1000000": {
+                "ratio": 23.18322,
+                "bytes": {
+                    "A": 43016192,
+                    "C": 1855488
+                },
+                "gateable": false,
+                "not_gateable_reason": "below the 4.0 MB gating floor \u2014 peak RSS is page-quantised and a small structure moves several percent between identical runs"
+            }
+        },
+        "s_over_c": {
+            "int_to_int@1000000": {
+                "ratio": 0.9959,
+                "bytes": {
+                    "S": 8957952,
+                    "C": 8994816
+                },
+                "gateable": true
+            },
+            "int_sparse@1000000": {
+                "ratio": 1.00123,
+                "bytes": {
+                    "S": 13369344,
+                    "C": 13352960
+                },
+                "gateable": true
+            },
+            "string_to_int@1000000": {
+                "ratio": 0.99496,
+                "bytes": {
+                    "S": 21831680,
+                    "C": 21942272
+                },
+                "gateable": true
+            },
+            "bitset@1000000": {
+                "ratio": 1.03091,
+                "bytes": {
+                    "S": 1912832,
+                    "C": 1855488
+                },
+                "gateable": false
+            }
+        }
+    },
+    "memory_raw": [
+        {
+            "workload": "int_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 34545664,
+                    "peak_rss_ci": [
+                        34516992,
+                        34590720
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 18874448,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 18358272
+                },
+                "S": {
+                    "peak_rss_bytes": 25198592,
+                    "peak_rss_ci": [
+                        25194496,
+                        25268224
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 8957952
+                },
+                "C": {
+                    "peak_rss_bytes": 25182208,
+                    "peak_rss_ci": [
+                        25128960,
+                        25239552
+                    ],
+                    "index_bytes": 8323832,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 8994816
+                }
+            }
+        },
+        {
+            "workload": "int_sparse",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 59199488,
+                    "peak_rss_ci": [
+                        59162624,
+                        59269120
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43012096
+                },
+                "S": {
+                    "peak_rss_bytes": 29609984,
+                    "peak_rss_ci": [
+                        29609984,
+                        29618176
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13369344
+                },
+                "C": {
+                    "peak_rss_bytes": 29540352,
+                    "peak_rss_ci": [
+                        29491200,
+                        29605888
+                    ],
+                    "index_bytes": 12520168,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 13352960
+                }
+            }
+        },
+        {
+            "workload": "string_to_int",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 96653312,
+                    "peak_rss_ci": [
+                        96628736,
+                        96690176
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 81935120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 80465920
+                },
+                "S": {
+                    "peak_rss_bytes": 38072320,
+                    "peak_rss_ci": [
+                        38035456,
+                        38137856
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21831680
+                },
+                "C": {
+                    "peak_rss_bytes": 38129664,
+                    "peak_rss_ci": [
+                        38084608,
+                        38178816
+                    ],
+                    "index_bytes": 18888890,
+                    "php_heap_bytes": 65696,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 21942272
+                }
+            }
+        },
+        {
+            "workload": "bitset",
+            "n": 1000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 59203584,
+                    "peak_rss_ci": [
+                        59199488,
+                        59285504
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 41943120,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 43016192
+                },
+                "S": {
+                    "peak_rss_bytes": 18153472,
+                    "peak_rss_ci": [
+                        18087936,
+                        18161664
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1912832
+                },
+                "C": {
+                    "peak_rss_bytes": 18042880,
+                    "peak_rss_ci": [
+                        18034688,
+                        18153472
+                    ],
+                    "index_bytes": 1321520,
+                    "php_heap_bytes": 160,
+                    "count": 1000000,
+                    "runs": 3,
+                    "over_floor_bytes": 1855488
+                }
+            }
+        }
+    ],
+    "gate": {
+        "status": "no-baseline-for-platform",
+        "baseline": "baselines/arm-ratios.json",
+        "thresholds": [],
+        "findings": [],
+        "regressions": 0,
+        "suppressed": 0
+    },
+    "verify": {
+        "S1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp/judy-bench-arms-7448/S1-ini\\judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.5.2",
+            "paths": [],
+            "inis": [
+                "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp/judy-bench-arms-7448/C1-ini\\judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/gate-2026-08-19/windows-x64-arm-s-manifest.json
+++ b/research/three-arm-benchmark/results/gate-2026-08-19/windows-x64-arm-s-manifest.json
@@ -1,0 +1,22 @@
+{
+    "arm_s_ref": "f366fdb42f17a65f031305b00d908f0c6e241b8a",
+    "pristine_ref": "0f687cb19f326eed52a9d3db550261701226fa76",
+    "upstream_files": 28,
+    "identical": 21,
+    "allowed_delta": {
+        "libjudy/src/Judy.h": "P5 (LLP64 Word_t + constant widths)",
+        "libjudy/src/JudyCommon/JudyInsArray.c": "P5 (LLP64 constant widths)",
+        "libjudy/src/JudyCommon/JudyMallocIF.c": "P5 (LLP64 constant widths)",
+        "libjudy/src/JudyCommon/JudyPrevNextEmpty.c": "P5 (LLP64 shift widths)",
+        "libjudy/src/JudyCommon/JudyPrivate.h": "P5 (LLP64 constant widths)",
+        "libjudy/src/JudyCommon/JudyPrivateBranch.h": "P5 (LLP64 constant widths)",
+        "libjudy/src/JudySL/JudySL.c": "P5 (LLP64 constant widths)"
+    },
+    "unexpected": [],
+    "missing": [],
+    "missing_allowed_delta": [],
+    "leaked_patched_files": [],
+    "patch_fingerprints_found": [],
+    "verdict": "UNPATCHED",
+    "instruction_census": null
+}


### PR DESCRIPTION
Dedicated baseline PR, per the repo rule that `baselines/*.json` move only in
their own commits. It touches **`arm-ratios.json` only** — see "Why
`latest.json` is not here" below.

## The problem

`baselines/arm-ratios.json` carried `linux-glibc-x86_64`, `linux-musl-x86_64`
and `macos-arm64`. On Windows the gate therefore returned
`no-baseline-for-platform` on every run: it measured, and compared against
nothing. This adds the fourth entry.

## How it was derived (not hand-written)

`php scripts/bench-gate.php --derive <4 runs> --update-baseline baselines/arm-ratios.json`

over four `windows-x64` gate runs, all at commit `3ce4885`, all on the same
`libjudy/` tree — so no `--allow-mixed-commits`, and no axis measuring real
change instead of noise.

**Four dispatches rather than one with `repeats=4`**: the Windows job does not
honour `BENCH_REPEATS`. It drives `scripts/bench-gate.php` directly rather than
going through `tools/bench-gate/run-gate.sh`, so one dispatch produces exactly
one run JSON, and `--derive` needs at least two. The four were issued in
parallel against four refs all pointing at `3ce4885` — the workflow's
concurrency group is keyed on `github.ref` with `cancel-in-progress`, so
same-ref dispatches cancel each other while same-commit different-ref ones run
side by side on their own ephemeral VMs.

The refs could not contain a slash. `php/php-windows-builder` embeds the ref
name in a build-log path, so `bench/win-baseline-1` became a nonexistent
directory component and failed the arm-C build in every job
(`Could not find a part of the path '...\build-php_judy-bench\win-baseline-1-8.4-nts-vs17-x64.txt'`).
Renamed flat, all four succeeded.

## What came out

| axis | cells | gateable | floor |
| --- | ---: | ---: | ---: |
| `timing.s_over_c` | 51 | **51** | 10.5% (median drift 2.15%, p95 8.21% over 306 pairs) |
| `timing.a_over_c` | 42 | 0 | 62.5%, above the 50% ceiling — exactly as on `linux-glibc` |
| `memory.a_over_c` | 3 | **3** | 1.0% |

Pooled `S → C` median **0.912**, against 0.870 glibc / 0.906 musl / 0.910
macOS. The vendored patches deliver on MSVC too, in the same direction and
about the same size as the other platforms without x86 popcount specialisation.

## Checks run before committing

- the three existing platform entries are **byte-identical** afterwards; the
  only other change in the file is `generated`
- **every one of the four contributing runs sits inside its own derived
  per-cell floor** — 0 cells would have been flagged
- recomputing the published pooled medians for the three existing platforms
  from the committed file reproduces **0.870 / 0.906 / 0.910** and their memory
  ratios exactly, so the Windows row is computed the same way as its neighbours
- all four arm-S manifests are byte-identical and read `UNPATCHED`

## Honest caveat

`derived_from.distinct_hosts` reads **1**, not 4. That field counts distinct
`uname` strings, and GitHub's Windows Server 2025 image reports the same host
name from every VM where the Linux images vary it. The four runs really are
four separate runner instances. **Nothing was edited to compensate** — the
recorded value is what the tool measured. The consequence is that the
derivation stays in the conservative `axis_floor_is_lower_bound` regime, which
is the regime all four platforms are in anyway. It is stated in
`BENCHMARK.md` and in the record README rather than left for someone to
discover in the JSON.

## Why `latest.json` is not here

Different instrument, and it **cannot be produced yet**. Per the README
"Releasing" section (and the last three bumps — `672bf93`, `472db9f`,
`0b064b0`), `latest.json` is replaced with the `benchmark-linux-php8.4`
artifact from the CI run **on the tagged commit**, in the same commit that
moves the `pie install orieg/judy:X.Y.Z` pin, and only once the release is
installable from PECL. The tag does not exist yet. Attempting it now would mean
either inventing numbers or stamping a pre-release build as the release
baseline. It is a follow-up after tagging.

## Not run on honeycomb

The gate is `ci-relative` by construction: it compares arms measured in the
same interleaved rounds on the machine being gated, and a `windows-x64`
baseline can only be recorded on a Windows runner. honeycomb is a Linux host
and could not have produced this entry, so `tools/bench-lock.sh` was never
taken.

## Records

The four run JSONs and the arm-S manifest are added to the existing
`research/three-arm-benchmark/results/gate-2026-08-19/` directory, alongside
the twelve POSIX runs the other three entries came from, and its README is
updated. Nothing under `research/` ships —
`tools/check-package-contents.sh` asserts that, and `package.xml` needs no
change.

Does **not** tag, publish, or touch versions — that is #177.