### PR TITLE
fix(bench-gate): mark the ratios the gate already knows are unresolvable

### DIFF
--- a/scripts/bench-gate-report.php
+++ b/scripts/bench-gate-report.php
@@ -15,6 +15,38 @@
  */
 
 $dir = $argv[1] ?? '.';
+
+// The gate records, per cell, whether a ratio is resolvable at all: small memory
+// cells are page-quantised and move tens of percent between identical runs, so
+// bench-gate.php marks them `gateable: false` and refuses to derive a floor from
+// them. That judgement lives in the committed baseline, and until now this report
+// did not read it -- so a cell the tooling knows is noise rendered with exactly
+// the same authority as one measured to 2%. A dense Judy1 bitset is the worst
+// case: at 1e6 keys it is ~128 KB, comparable to the RSS floor's own scatter, and
+// on musl it has come out anywhere from ~23x to ~223x across runs.
+$baseline_path = getenv('JUDY_ARM_RATIOS') ?: (__DIR__ . '/../baselines/arm-ratios.json');
+$baseline = is_file($baseline_path)
+    ? (json_decode((string) @file_get_contents($baseline_path), true) ?: [])
+    : [];
+
+/** The baseline's verdict for one cell, or null when it has never been derived. */
+function judy_cell_quality(array $baseline, string $plat, string $axis, string $cell): ?array {
+    [$section, $key] = explode('.', $axis, 2);
+    $c = $baseline['platforms'][$plat][$section][$key][$cell] ?? null;
+    return is_array($c) ? $c : null;
+}
+
+/** Render a ratio, marking it when the baseline says it is not resolvable. */
+function judy_fmt_ratio(?float $v, string $fmt, array $baseline, string $plat,
+                        string $axis, string $cell, array &$flagged): string {
+    if ($v === null) { return '—'; }
+    $q = judy_cell_quality($baseline, $plat, $axis, $cell);
+    if ($q !== null && ($q['gateable'] ?? true) === false) {
+        $flagged["$plat|$cell"] = $q['spread_pct'] ?? null;
+        return '~' . sprintf($fmt, $v) . ' ⚠';
+    }
+    return sprintf($fmt, $v);
+}
 if (!is_dir($dir)) {
     fwrite(STDERR, "not a directory: $dir\n");
     exit(2);
@@ -134,8 +166,9 @@ foreach ($axis_titles as $key => $title) {
 // Memory, which is the least equivocal axis and deserves its own table.
 $mem = [];
 foreach ($runs as $plat => $r) {
-    foreach ($r['memory']['a_over_c'] ?? [] as $k => $c) { $mem[$k][$plat] = $c['ratio']; }
+    foreach ($r['memory']['a_over_c'] ?? [] as $k => $c) { $mem[$k][$plat] = (float) $c['ratio']; }
 }
+$mem_flagged = [];
 if ($mem) {
     echo "\n### Memory — PHP array bytes / php-judy bytes (above 1.00 is a php-judy win)\n\n";
     $plats = array_keys($runs);
@@ -143,8 +176,26 @@ if ($mem) {
     echo '| --- |' . str_repeat(' ---: |', count($plats)) . "\n";
     ksort($mem);
     foreach ($mem as $k => $byplat) {
-        $row = array_map(fn($p) => isset($byplat[$p]) ? sprintf('%.2fx', $byplat[$p]) : '—', $plats);
+        // A regular closure, not an arrow function: `fn()` captures by value, so a
+        // by-reference accumulator silently collects nothing.
+        $row = array_map(
+            function ($p) use ($byplat, $baseline, $k, &$mem_flagged) {
+                return judy_fmt_ratio($byplat[$p] ?? null, '%.2fx', $baseline, $p,
+                                      'memory.a_over_c', $k, $mem_flagged);
+            },
+            $plats);
         echo "| `$k` | " . implode(' | ', $row) . " |\n";
+    }
+    if ($mem_flagged) {
+        echo "\n> ⚠ Not resolvable by this instrument, and therefore **not gated**: the";
+        echo " structure is small enough that run-to-run scatter swamps the signal.";
+        echo " Recorded for completeness; do not quote these as measurements.";
+        foreach ($mem_flagged as $what => $spread) {
+            [$p, $cell] = explode('|', $what, 2);
+            echo "\n> `$cell` on `$p` — baseline spread "
+                . ($spread === null ? 'unknown' : sprintf('%.1f%%', $spread)) . '.';
+        }
+        echo "\n";
     }
 }
 


### PR DESCRIPTION
The gate report: `bitset@1000000` shows **222.91x** on musl against 23.83x on glibc and 27.09x on macOS. Every other row agrees across platforms to within a few percent.

## What it is

Not a measurement error — a **presentation** one. `bench-gate.php` already knows: it records `gateable: false` per cell when run-to-run scatter swamps the signal, and refuses to derive a floor from those cells. From `baselines/arm-ratios.json`:

| platform | ratio | spread | gateable |
| --- | ---: | ---: | --- |
| `linux-glibc-x86_64` | 23.18x | 18.90% | **false** |
| `linux-musl-x86_64` | 99.34x | **119.93%** | **false** |
| `macos-arm64` | 28.43x | 4.36% | **false** |
| `windows-x64` | 22.59x | 3.35% | **false** |

`bench-gate-report.php` read only `$c['ratio']` and never loaded the baseline, so it printed those with the same authority as `int_to_int` (spread 2.2%).

## The part worth noting

The cell is ungateable on **all four platforms**, not just musl. The apparent agreement between glibc (23.83x) and macOS (27.09x) was coincidence, not corroboration — the eye-catching musl number is the same instrument limit being louder.

Cause is physical: a dense Judy1 bitset at 1e6 keys is ~128 KB, comparable to the RSS floor's own scatter. Same limit #172/#173 hit in `judy-bench.php`, fixed there by rendering sub-resolution cells as bounds. This brings the gate's report to the same standard.

## Change

The report loads the committed baseline and renders known-unresolvable cells as `~23.83x ⚠` with a footnote naming the measured spread. Gating is untouched — these cells were already excluded from it.

Verified by rendering the table against the observed values, not by reading the diff. That caught a bug in my own first attempt: `array_map` with `fn()` captures by value, so the by-reference accumulator collected nothing and the footnote silently never appeared.