### PR TITLE
docs(benchmark): stop quoting a figure the blind instrument produced

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -64,7 +64,13 @@ Modern data structures like Swiss tables (used in abseil and Folly) and Robin Ho
   [The optimizeIteration mirror](#the-optimizeiteration-mirror-measured) and in
   the bounded-read benchmarks described there.
 - **Test Methodology**: Multiple iterations with statistical analysis (min/max/median/percentiles)
-- **Memory Measurement**: Using `memory_get_usage(true)` and `Judy::memoryUsage()`
+- **Memory Measurement**: `memory_get_usage(true)` and `Judy::memoryUsage()`.
+  **Both under-report, and `memory_get_usage()` is blind to a Judy index
+  entirely** — libJudy allocates through `malloc(3)`, outside PHP's memory
+  manager (see [issue #172](https://github.com/orieg/php-judy/issues/172) and
+  the note further down this file). The figures in this section inherit that
+  limitation. The measurements taken with peak RSS, which does see it, are in
+  [Three-arm benchmark](#three-arm-benchmark-array-vs-system-libjudy-vs-bundled-libjudy-measured).
 
 *Note: Results may vary based on hardware, system load, and PHP configuration. All benchmarks use the same Docker environment for consistency.*
 
@@ -79,7 +85,7 @@ Modern data structures like Swiss tables (used in abseil and Folly) and Robin Ho
 > [Judy in PHP Developer Tooling](#judy-in-php-developer-tooling).
 
 **Use Judy Arrays When:**
-- ✅ Memory is constrained (2-4x less memory usage)
+- ✅ Memory is constrained (savings are type-dependent — see [Three-arm benchmark](#three-arm-benchmark-array-vs-system-libjudy-vs-bundled-libjudy-measured))
 - ✅ Large datasets (> 1M elements) where memory efficiency matters
 - ✅ Sequential access patterns and ordered iteration
 - ✅ Range queries and ordered operations
@@ -235,8 +241,14 @@ returns an empty array for an empty range. And a walk is right when you mean to
 ## Key Findings
 
 ### **Memory Efficiency**
-- Judy arrays provide **2-4x memory savings** compared to PHP arrays
-- Memory efficiency is consistent across all dataset sizes
+- Judy arrays use less memory than PHP arrays for most types, but **"2-4x" was
+  the wrong summary**: it came from `memory_get_usage()`, which cannot see a
+  Judy index at all (#172). Measured with peak RSS, the saving is strongly
+  type-dependent — `BITSET` far above that range, `string_to_int` ~3.4x,
+  `int_to_int` ~2.1x, and **`INT_TO_MIXED` is a loss**, using ~1.1x *more*
+  than a PHP array. Per-type figures:
+  [Three-arm benchmark](#three-arm-benchmark-array-vs-system-libjudy-vs-bundled-libjudy-measured).
+- The advantage grows with scale for `BITSET` (18.5x at 100k -> 22.7x at 8M)
 - String-based Judy arrays show moderate memory savings with performance trade-offs
 
 ### **Performance Characteristics**


### PR DESCRIPTION
`BENCHMARK.md` contradicts itself:

- **Key Findings** claims **"2-4x memory savings"** (headline, unqualified)
- **Methodology** names `memory_get_usage(true)` as the instrument
- a note further down the *same file* states that `memory_get_usage()` **cannot see a Judy index at all** — libJudy allocates through `malloc(3)`, outside PHP's memory manager

So the headline number was produced by an instrument the document elsewhere describes as blind. This is the defect #172/#173 fixed in the tooling but never in the prose, and it shipped in 2.6.0's flagship document.

## What the number actually is

Measured with peak RSS, the saving is strongly type-dependent, and "2-4x" is wrong in **both** directions:

| type | vs PHP array |
| --- | ---: |
| `BITSET` | 18.5x at 100k → **22.7x** at 8M |
| `string_to_int` | ~3.4x |
| `int_to_int` | ~2.1x |
| `INT_TO_MIXED` | **a loss** — ~1.1x *more* memory |

## Change

Three edits, all pointing at the three-arm section that carries the per-type figures and the instrument that produced them. The methodology bullet keeps `memory_get_usage()` — the older section's numbers really were taken with it — but now states the limitation those figures inherit instead of presenting them as authoritative.

Anchors were verified by resolving every in-file `](#...)` against the actual headings. Worth noting because the first attempt guessed a slug that does not exist and would have shipped three broken links.