### PR TITLE
docs: correct the memory claims #184 left outside BENCHMARK.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A Judy array is a complex but very fast associative array data structure for sto
 
 ### Why PHP Judy?
 
-- **2-4x less memory** than native PHP arrays for large integer-keyed datasets, and **~10x less** for presence tracking with `BITSET` (1M elements)
+- **Less memory than native PHP arrays**: 2-5x for integer and string keys, and **18.5-22.7x** for presence tracking with `BITSET`. Measured as peak RSS — `INT_TO_MIXED` is the one exception and costs slightly *more* than a PHP array ([per-type figures](BENCHMARK.md#memory--the-headline-and-the-least-equivocal-result))
 - **Faster bulk operations**: `getAll()`, `toArray()`, and `fromArray()` run in native C, 1.3-3x faster than element-by-element loops; atomic `increment()` avoids the read-modify-write round trip
 - **Ordered keys for free**: range queries, `first()`/`next()` navigation, and neighbor lookups that hash tables can't do
 - **Honest trade-off**: for random access on small dense datasets, native PHP arrays are faster. See [BENCHMARK.md](BENCHMARK.md) for full numbers and a decision guide on when (not) to use Judy.
@@ -51,7 +51,7 @@ Each pattern below is a runnable script in [examples/](examples/README.md):
 
 | Problem | Why Judy | Demo |
 | ------- | -------- | ---- |
-| "Have I seen this ID?" over millions of items — crawler frontiers, queue dedup, processed-ID sets | `BITSET` uses ~10x less memory than a PHP array at 1M elements | [dedup-large-stream.php](examples/dedup-large-stream.php) |
+| "Have I seen this ID?" over millions of items — crawler frontiers, queue dedup, processed-ID sets | `BITSET` uses 18.5-22.7x less memory than a PHP array (21.9x at 1M elements) | [dedup-large-stream.php](examples/dedup-large-stream.php) |
 | Which CIDR/tariff/shard does this value fall in? | `last()` resolves the greatest key ≤ N in one call; hash tables must scan | [ip-range-lookup.php](examples/ip-range-lookup.php) |
 | Rate limiting and rolling metrics over a time window | `deleteRange()` expires aged-out buckets without touching the retained set | [sliding-window-rate-limit.php](examples/sliding-window-rate-limit.php) |
 | Invalidate every cache key under `user:123:*` | Ordered keys make a namespace one contiguous slice — cost follows the slice, not the cache size | [prefix-invalidation.php](examples/prefix-invalidation.php) |
@@ -322,6 +322,7 @@ $arr = $judy[2]; // Returns [1, 2, 3]
 **When to use INT_TO_PACKED vs INT_TO_MIXED:**
 - Use `INT_TO_MIXED` for small-to-medium arrays or when read/write speed is critical
 - Use `INT_TO_PACKED` for large arrays (100K+ elements) where GC pause reduction matters more than individual read/write latency
+- On memory: `INT_TO_MIXED` holds a pointer to a separately allocated zval per element and measures *larger* than a PHP array, while `INT_TO_PACKED` stores values as opaque buffers and measures smaller ([#172](https://github.com/orieg/php-judy/issues/172)). Pick `INT_TO_MIXED` for the ordering or the API, not the footprint
 
 ### String-Keyed Types (Trie-Based)
 
@@ -494,7 +495,7 @@ while ($judy->valid()) {
 
 ### Performance Considerations
 
-- **Memory Efficiency**: Judy arrays use 2-4x less memory than PHP arrays
+- **Memory Efficiency**: 2-5x less memory than PHP arrays for integer and string keys and 18.5-22.7x for `BITSET`, measured as peak RSS — but `INT_TO_MIXED` uses ~1.3x *more* than a PHP array, so it is not a memory optimization. Per-type figures: [BENCHMARK.md](BENCHMARK.md#memory--the-headline-and-the-least-equivocal-result)
 - **Sequential Access**: Excellent performance for ordered iteration
 - **Range Queries**: Native support via `slice()`, `deleteRange()`, and the bounded forms of `keys()`, `values()`, `toArray()` and `size()`
 - **Random Access**: Trie types are slower than PHP arrays (O(log n) vs O(1)); Hash types offer O(1) average-case lookups for string keys

--- a/examples/benchmarks/iterator_performance_analysis.md
+++ b/examples/benchmarks/iterator_performance_analysis.md
@@ -79,7 +79,7 @@ This document analyzes the inconsistent iterator performance results across our 
 #### Judy vs PHP Performance:
 - **Judy iterators**: 11-21x slower than PHP arrays
 - **Judy sequential**: 4-5x slower than PHP arrays
-- **Memory efficiency**: 12.5x less memory than PHP arrays
+- **Memory efficiency**: 2-5x less memory than PHP arrays for integer and string keys, 18.5-22.7x for `BITSET` (peak RSS; see [BENCHMARK.md](../../BENCHMARK.md#memory--the-headline-and-the-least-equivocal-result)). The "12.5x" previously quoted here came from `memory_get_usage()`, which cannot see a Judy index at all ([#172](https://github.com/orieg/php-judy/issues/172)).
 
 #### Trade-off Analysis:
 - **Memory-constrained scenarios**: Judy is beneficial despite performance cost

--- a/examples/worker-counters.php
+++ b/examples/worker-counters.php
@@ -5,8 +5,10 @@
  * In a queue worker or Swoole/RoadRunner/FrankenPHP/Octane process, state
  * survives across jobs/requests. Judy's atomic increment() makes it a
  * compact metrics accumulator: no read-modify-write, keys created on
- * first touch, and 2-4x less memory than a PHP array when the key space
- * gets large (e.g. per-user or per-entity counters).
+ * first touch, and less memory than a PHP array when the key space gets
+ * large: the INT_TO_INT per-user counters below measure 2.0-2.5x smaller for
+ * dense IDs and 3.1-5.3x for sparse ones (peak RSS; see BENCHMARK.md). The
+ * JudyHS-backed STRING_TO_*_HASH types are not part of that measurement.
  *
  * Run: php examples/worker-counters.php
  */


### PR DESCRIPTION
Follow-up to #183 and #184, which corrected `BENCHMARK.md`. The same figures survived in `README.md` and two example files — where most readers meet them first.

## The gap

| Site | Was | Measured (peak RSS) |
| --- | --- | --- |
| README "Why PHP Judy?" | `~10x less` for `BITSET` | **18.5-22.7x** (21.9x at 1M) |
| README use-case table | `~10x less` at 1M | **21.9x** |
| README "Performance Considerations" | `2-4x less memory` flat | 2.0-5.3x for int/string keys; `INT_TO_MIXED` a **loss** |
| `examples/worker-counters.php` | `2-4x less memory` | 2.0-2.5x dense / 3.1-5.3x sparse for `INT_TO_INT` |
| `examples/benchmarks/iterator_performance_analysis.md` | `12.5x less memory` | same per-type figures |

The `BITSET` claim understated the library's strongest result by half, and no site outside `BENCHMARK.md` mentioned that `INT_TO_MIXED` costs *more* than a PHP array.

## What changed

- **README.md** — headline bullet, the dedup row of the use-case table, and "Performance Considerations" now carry per-type peak-RSS figures and name `INT_TO_MIXED` as the exception.
- **README.md, `INT_TO_PACKED` vs `INT_TO_MIXED` guide** — gains the memory axis it was missing. It compared the two on GC pressure and read/write latency only, which is how a reader could pick `INT_TO_MIXED` to save memory and get the opposite. *(This is the one discretionary addition here — the other four sites are stale-figure corrections.)*
- **`examples/worker-counters.php`** — replaced with the measured `INT_TO_INT` range. It no longer implies a figure for the `STRING_TO_INT_HASH` counters it also demonstrates: **JudyHS memory is not measured anywhere in this repo**, only JudySL's `STRING_TO_INT`.
- **`examples/benchmarks/iterator_performance_analysis.md`** — `12.5x` came from the same blind instrument; corrected and labelled.

## Verified correct, left alone

`AGENTS.md`, `.github/workflows/ci.yml` (fixed in #172/#173), `examples/dedup-large-stream.php`, and `examples/coverage-index.php` all already measure or describe peak RSS. The two remaining `12.5x`/`3.5x` strings in `BENCHMARK.md` are Table 1 rows sitting under the "superseded" callout #184 added — intentional.

## Scope

- Documentation and comments only. No baseline touched, no shipped-file list change (`package.xml` unaffected — edits to tracked files only).
- Cross-file anchors into `BENCHMARK.md` resolved against its actual headings; `php -l` clean on the edited example.
- Ratios sourced to `BENCHMARK.md`'s three-arm table (ranges across 100k-8M) so README and BENCHMARK.md now agree. The `INT_TO_PACKED` note cites #172, whose single 500k macOS run is the only measurement of that type.

Refs #172
