### PR TITLE
perf(bench): fill the out-of-cache core.str cell — the last hole in the 6M row

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1984,7 +1984,9 @@ interleaved ABBA rounds, 3 independently linked builds per arm rotated across
 rounds, **~1.3% out-of-cache claim floor** applied automatically because
 6M ≥ the driver's `--dram-size` of 4M. Raw JSON and console output:
 `research/three-arm-benchmark/results/run6-out-of-cache-6m.{json,txt}`,
-`run6-attribution-6m.{json,txt}`, `run6-cvsc-control-6m.{json,txt}`.
+`run6-attribution-6m.{json,txt}`, `run6-cvsc-control-6m.{json,txt}`; the
+`core.str` completion run (below) is `run7-out-of-cache-6m-str.{json,txt}` and
+`run7-cvsc-control-6m-str.{json,txt}`.
 
 Host hygiene held flat across all four phase boundaries of all three runs:
 load1 1.00-1.22 against a threshold of 12.0, **foreign CPU 0.0% at every
@@ -2015,6 +2017,62 @@ B→C goes from -17.7% cache-resident to **-12.0%** out-of-cache, and string fro
 -22.2% to **-19.7%**. Instruction-level wins (O1 popcount, O3 word-access
 metadata) buy less when the pipeline is waiting on DRAM. This is consistent with
 the C-level gates, where O3's win survived DRAM-bound intact while O1's shrank.
+
+#### The `core.str` per-element table, filled (run7, 2026-08-19)
+
+The one group the original campaign could not run — `core.str` per-element
+write/read/iterate/free, blocked by the unconditional `2G` `memory_limit`
+documented below — was measured after
+[#170](https://github.com/orieg/php-judy/pull/170) lifted the cap. Same
+apparatus, same host, same protocol: 7 interleaved ABBA rounds, 3 independently
+linked builds per arm rotated across rounds, `--cpuset-cpus=2`, bench lock held
+throughout, foreign CPU 0.0% at every phase boundary, PHP-only drift control
++0.12% [-0.01, +0.21] over 45 rows, run not self-marked contaminated. The C-vs-C
+rebuild control at the same working set read null everywhere, as it must for
+any of this to be interpretable: 97 of 97 cells null, median |delta| 0.14%,
+p90 0.44%, worst 1.02% — all inside the 1.3% floor.
+
+**Replication first, because it is the more load-bearing number:** this run
+re-measured every group run6 covered, and the overlapping aggregates reproduce
+run6 within half a point — integer/bitset **-11.6%** (n=38) against run6's
+-12.0%, string API **-18.8%** (n=35) against -19.7%. The arms were rebuilt
+independently for this run — different `.so` binaries, fresh links — and landed
+on the same medians, which is what licenses reading the new cells at face
+value.
+
+The new cells, B→C median per-round delta (all 24 FASTER, every CI clear of the
+1.3% floor by 7x or more, per-build spread ≤ 1.7% on every cell):
+
+| type | write | read | iter | free |
+| --- | ---: | ---: | ---: | ---: |
+| `STRING_TO_INT` | -28.4% | -36.8% | -36.2% | **-42.6%** |
+| `STRING_TO_MIXED` | -28.2% | -33.6% | -34.6% | -39.1% |
+| `STRING_TO_INT_HASH` | -19.1% | -9.7% | -34.5% | -30.5% |
+| `STRING_TO_MIXED_HASH` | -27.4% | -32.5% | -32.8% | -34.2% |
+| `STRING_TO_INT_ADAPTIVE` | -19.2% | -9.9% | -35.0% | -30.5% |
+| `STRING_TO_MIXED_ADAPTIVE` | -25.5% | -10.8% | -32.5% | -32.9% |
+
+Median across the 24 cells: **-32.5%** — larger than the -18.8% the string
+**API** cells show in the same run. The three ~-10% `read` outliers are all
+`HASH`/`ADAPTIVE` variants, whose lookups spend most of their time in the
+extension's own hash layer rather than in libJudy — the component being
+swapped — so a smaller effect there is the expected direction. It is not the
+whole story (`STRING_TO_MIXED_HASH.read` sits at -32.5% under the same
+reasoning), so the pattern is reported as an observation, not a mechanism.
+
+**What this run does not measure: attribution.** It ran arms B and C only — no
+pristine-static S arm — so there is no S→C share for these 24 cells, and the
+string row in the decomposition table above remains an API-paths-only
+statement. Whether `core.str`'s -32.5% splits toward the patches or toward
+static linkage the way the API cells' 40% does is unmeasured.
+
+The A-vs-C side of the same cells says nothing new but is worth pinning: the
+PHP array wins **all 24** per-element timing cells out-of-cache, from 2.1x
+(`string_to_mixed.write`) to 16.4x (`string_to_mixed_hash.read`), while the
+memory matrix (below, reproduced by this run within rounding) has Judy at
+**3.44x smaller** on `string_to_int` at the same n. That is the standing
+trade-off of the string types stated at full working set: per-element loops
+lose, footprint and the batch/API paths win.
 
 #### Memory at the same working set
 
@@ -2097,7 +2155,7 @@ There are now four tiers on this page and they are not interchangeable.
 | **macOS arm64**, GitHub runner | Apple clang 21.0.0, PHP 8.4.24 | measured | measured | measured | **ci-relative** |
 | macOS arm64, local workstation | Apple clang 21, PHP 8.5.8, Homebrew | directional | directional | measured | **directional** |
 | **Windows x64**, GitHub runner | MSVC, PHP 8.4.24, Windows Server 2025 | measured | measured | measured | **ci-relative-single-build** |
-| Linux x86-64, **out-of-cache** (n=6M), honeycomb (dedicated) | gcc 14.2.0, PHP 8.4.24, Debian 13 | measured | measured | measured | **claim-grade** (integer/bitset + string API paths; `core.str` not measured — see below) |
+| Linux x86-64, **out-of-cache** (n=6M), honeycomb (dedicated) | gcc 14.2.0, PHP 8.4.24, Debian 13 | measured | measured | measured | **claim-grade** (all groups; `core.str` filled by run7 — see below) |
 
 #### What the gate measured on each platform
 
@@ -2262,8 +2320,10 @@ why it sits below the gating floor and is not in the headline table above.
   [out-of-cache section](#out-of-cache-n6m-what-survives-when-the-working-set-leaves-l3)
   above for the figures. What follows is the record of the memory-safety
   blocker that held the slot empty, kept because it is the reason the cell sat
-  unmeasured for so long. **One hole remains inside the cell**: the `core.str`
-  group did not run at 6M, for a reason that had nothing to do with php-judy.
+  unmeasured for so long. **The one hole that remained inside the cell — the
+  `core.str` group — was filled on 2026-08-19 by run7 (see the out-of-cache
+  section above).** The record of why it was ever empty: the group did not run
+  at 6M, for a reason that had nothing to do with php-judy.
   At the time of this run `judy-bench.php` set `ini_set('memory_limit', '2G')`
   unconditionally, which overrode the `-d memory_limit=-1` the driver passes,
   and the group exhausted that cap. It failed identically under every arm with
@@ -2278,8 +2338,8 @@ why it sits below the gating floor and is not in the headline table above.
   the `2G` a floor a lower caller is raised to rather than an override, so the
   harness no longer refuses the group (methodology above).
 
-  **The group is now confirmed to run at this size, and the cause above is
-  measured rather than inferred.** On honeycomb (Debian 13 container, gcc
+  **The group runs at this size, and the cause above is measured rather than
+  inferred.** On honeycomb (Debian 13 container, gcc
   14.2.0, PHP 8.4.24, bundled arm), `--group core.str --size 6000000
   --iterations 1`:
 
@@ -2292,10 +2352,8 @@ why it sits below the gating floor and is not in the headline table above.
   so this is the same failure, not a lookalike. Budget the group at ~3.7 GB of
   RSS at n=6M rather than at the fixtures' 1.69 GB.
 
-  **That is still not the same as the cell being complete**: the above is a
-  feasibility and memory measurement on a single arm, asserting nothing about
-  timing. The three-arm `core.str` cell has not been re-taken, and the figures
-  linked above remain that run as published. Tracked in
+  The feasibility probe above asserted nothing about timing; the timing
+  measurement itself is run7 in the out-of-cache section, which closed
   [#179](https://github.com/orieg/php-judy/issues/179).
 
   The original blocker, for the record: the intended 6M run aborted when arm B terminated
@@ -2403,20 +2461,18 @@ php scripts/bench-threearm.php \
 
 For the **out-of-cache** cell, raise `--size` past the driver's `--dram-size`
 (default 4M) so the ~1.3% floor is selected. The command below reproduces the
-cell **as published**, which drops `core.str`: that group exhausted the
-unconditional `2G` cap `judy-bench.php` set for itself at the time. That cap is
-now a floor rather than an override (#170), and the group has since been
-confirmed to complete at this size uncapped (see above), so a fresh run can
-include it — but that would be a new measurement, not a reproduction of this
-one:
+cell: run6 dropped `core.str` (the group exhausted the unconditional `2G` cap
+`judy-bench.php` set for itself at the time; the cap became a floor in #170) and
+run7 completed the group, so the full group list below reproduces run7. Budget
+~3.7 GB RSS per timing child for `core.str` at this size:
 
 ```sh
 php scripts/bench-threearm.php \
   --system-so judy-system.so --bundled-so judy-bundled.so \
   --rounds 7 --size 6000000 --assert-same-source \
-  --groups core.int,api.batch,api.setops,adv.iter --mem-sizes 6000000 \
+  --groups core.int,core.str,api.batch,api.setops,adv.iter --mem-sizes 6000000 \
   --system-provenance "$(. /etc/os-release; echo "$PRETTY_NAME") $(dpkg-query -W -f='${Version}' libjudy-dev 2>/dev/null)" \
-  --out research/three-arm-benchmark/results/run6-out-of-cache-6m.json
+  --out research/three-arm-benchmark/results/run7-out-of-cache-6m-str.json
 ```
 
 Pass `--system-so` / `--bundled-so` more than once to rotate independent builds.

--- a/research/three-arm-benchmark/results/run7-cvsc-control-6m-str.json
+++ b/research/three-arm-benchmark/results/run7-cvsc-control-6m-str.json
@@ -1,0 +1,8048 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "cvsc-control-out-of-cache-6m-with-core-str",
+        "date": "2026-08-19T21:28:17+00:00",
+        "php_version": "8.4.24",
+        "platform": "Linux x86_64",
+        "uname": "Linux 904495aef260 6.8.0-136-generic #136~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  3 16:29:11 UTC  x86_64",
+        "judy_version": "2.6.0",
+        "system_so": [
+            "/usr/src/php-judy/arms/judy-C-1.so",
+            "/usr/src/php-judy/arms/judy-C-3.so"
+        ],
+        "bundled_so": [
+            "/usr/src/php-judy/arms/judy-C-2.so"
+        ],
+        "system_so_sha256": [
+            "c39c3ad51e63355d74f3c9ce4c429870d5775f59e48bd4c9874511ae5668efaf",
+            "cda430e9c2fab6eefeb7a5075a06954a9b3c45ceeefa72d1bce5cbc463ff299b"
+        ],
+        "bundled_so_sha256": [
+            "71bac259a3202658342ac6d04597bf986716b44070af8a68700e80b44bf16ca4"
+        ],
+        "system_provenance": null,
+        "bundled_provenance": null,
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 6000000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            100000,
+            1000000,
+            8000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "out-of-cache",
+        "claim_floor_pct": 1.3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 70,
+        "memory_children": 0,
+        "wall_seconds": 4184.6
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T20:18:32+00:00",
+                "load1": 0,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T21:28:16+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T21:28:16+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "note": "load average alone is necessary but not sufficient: a co-resident memory-bound benchmark contends for LLC and memory bandwidth at low load, and a PHP-array control does not detect it"
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 0.99985,
+            "delta_pct": -0.01,
+            "ci_delta_pct": [
+                -0.09,
+                0.05
+            ],
+            "measured_spread_pct": 0.81,
+            "row_count": 45,
+            "eligibility": "genuine PHP-array rows only (TAM_ARM_A_ROWS); Judy-touching .php rows are excluded because they carry real signal",
+            "rows": {
+                "core.bitset.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00036,
+                    "delta_pct": 0.04,
+                    "ci_delta_pct": [
+                        -0.1,
+                        0.37
+                    ],
+                    "n": 7,
+                    "b_ms": 89.8487,
+                    "c_ms": 89.8821
+                },
+                "core.bitset.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00614,
+                    "delta_pct": 0.61,
+                    "ci_delta_pct": [
+                        -3.46,
+                        1.43
+                    ],
+                    "n": 7,
+                    "b_ms": 22.0959,
+                    "c_ms": 22.0431
+                },
+                "core.bitset.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00198,
+                    "delta_pct": 0.2,
+                    "ci_delta_pct": [
+                        -0.31,
+                        0.36
+                    ],
+                    "n": 7,
+                    "b_ms": 18.7153,
+                    "c_ms": 18.6775
+                },
+                "core.bitset.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00807,
+                    "delta_pct": 0.81,
+                    "ci_delta_pct": [
+                        -1.65,
+                        1.98
+                    ],
+                    "n": 7,
+                    "b_ms": 5.5502,
+                    "c_ms": 5.5374
+                },
+                "core.int_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99951,
+                    "delta_pct": -0.05,
+                    "ci_delta_pct": [
+                        -0.3,
+                        1.15
+                    ],
+                    "n": 7,
+                    "b_ms": 92.6167,
+                    "c_ms": 92.6502
+                },
+                "core.int_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99377,
+                    "delta_pct": -0.62,
+                    "ci_delta_pct": [
+                        -2.85,
+                        1.47
+                    ],
+                    "n": 7,
+                    "b_ms": 22.1303,
+                    "c_ms": 21.9227
+                },
+                "core.int_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99865,
+                    "delta_pct": -0.13,
+                    "ci_delta_pct": [
+                        -0.23,
+                        0.23
+                    ],
+                    "n": 7,
+                    "b_ms": 18.6162,
+                    "c_ms": 18.6155
+                },
+                "core.int_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99394,
+                    "delta_pct": -0.61,
+                    "ci_delta_pct": [
+                        -1.54,
+                        0.19
+                    ],
+                    "n": 7,
+                    "b_ms": 5.4876,
+                    "c_ms": 5.4764
+                },
+                "core.int_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99912,
+                    "delta_pct": -0.09,
+                    "ci_delta_pct": [
+                        -0.35,
+                        0.01
+                    ],
+                    "n": 7,
+                    "b_ms": 267.1857,
+                    "c_ms": 267.0062
+                },
+                "core.int_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99942,
+                    "delta_pct": -0.06,
+                    "ci_delta_pct": [
+                        -0.14,
+                        0.23
+                    ],
+                    "n": 7,
+                    "b_ms": 122.0413,
+                    "c_ms": 121.8671
+                },
+                "core.int_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.999,
+                    "delta_pct": -0.1,
+                    "ci_delta_pct": [
+                        -0.18,
+                        0.2
+                    ],
+                    "n": 7,
+                    "b_ms": 86.1949,
+                    "c_ms": 86.2321
+                },
+                "core.int_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99989,
+                    "delta_pct": -0.01,
+                    "ci_delta_pct": [
+                        -0.32,
+                        0.53
+                    ],
+                    "n": 7,
+                    "b_ms": 46.6547,
+                    "c_ms": 46.6498
+                },
+                "core.int_to_packed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00181,
+                    "delta_pct": 0.18,
+                    "ci_delta_pct": [
+                        -0.35,
+                        0.7
+                    ],
+                    "n": 7,
+                    "b_ms": 251.1768,
+                    "c_ms": 251.579
+                },
+                "core.int_to_packed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99985,
+                    "delta_pct": -0.01,
+                    "ci_delta_pct": [
+                        -0.26,
+                        0.21
+                    ],
+                    "n": 7,
+                    "b_ms": 107.9781,
+                    "c_ms": 107.9634
+                },
+                "core.int_to_packed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.9962,
+                    "delta_pct": -0.38,
+                    "ci_delta_pct": [
+                        -0.9,
+                        0.42
+                    ],
+                    "n": 7,
+                    "b_ms": 21.4276,
+                    "c_ms": 21.3461
+                },
+                "core.int_to_packed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99804,
+                    "delta_pct": -0.2,
+                    "ci_delta_pct": [
+                        -0.43,
+                        2.65
+                    ],
+                    "n": 7,
+                    "b_ms": 47.7319,
+                    "c_ms": 47.6816
+                },
+                "core.string_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00055,
+                    "delta_pct": 0.06,
+                    "ci_delta_pct": [
+                        -0.22,
+                        0.19
+                    ],
+                    "n": 7,
+                    "b_ms": 245.6423,
+                    "c_ms": 245.8589
+                },
+                "core.string_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00709,
+                    "delta_pct": 0.71,
+                    "ci_delta_pct": [
+                        -1.55,
+                        1.19
+                    ],
+                    "n": 7,
+                    "b_ms": 49.2241,
+                    "c_ms": 49.7199
+                },
+                "core.string_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.9957,
+                    "delta_pct": -0.43,
+                    "ci_delta_pct": [
+                        -1.2,
+                        0.96
+                    ],
+                    "n": 7,
+                    "b_ms": 28.4834,
+                    "c_ms": 28.2455
+                },
+                "core.string_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00081,
+                    "delta_pct": 0.08,
+                    "ci_delta_pct": [
+                        -0.6,
+                        0.27
+                    ],
+                    "n": 7,
+                    "b_ms": 22.2342,
+                    "c_ms": 22.2521
+                },
+                "core.string_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99828,
+                    "delta_pct": -0.17,
+                    "ci_delta_pct": [
+                        -0.44,
+                        0.25
+                    ],
+                    "n": 7,
+                    "b_ms": 471.2022,
+                    "c_ms": 470.2728
+                },
+                "core.string_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99925,
+                    "delta_pct": -0.07,
+                    "ci_delta_pct": [
+                        -0.8,
+                        0.05
+                    ],
+                    "n": 7,
+                    "b_ms": 237.9827,
+                    "c_ms": 237.5879
+                },
+                "core.string_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00042,
+                    "delta_pct": 0.04,
+                    "ci_delta_pct": [
+                        -1.03,
+                        0.22
+                    ],
+                    "n": 7,
+                    "b_ms": 146.3903,
+                    "c_ms": 146.3891
+                },
+                "core.string_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99885,
+                    "delta_pct": -0.11,
+                    "ci_delta_pct": [
+                        -0.68,
+                        0.19
+                    ],
+                    "n": 7,
+                    "b_ms": 64.3529,
+                    "c_ms": 64.1819
+                },
+                "core.string_to_int_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00007,
+                    "delta_pct": 0.01,
+                    "ci_delta_pct": [
+                        -0.63,
+                        0.09
+                    ],
+                    "n": 7,
+                    "b_ms": 244.9705,
+                    "c_ms": 244.9154
+                },
+                "core.string_to_int_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00601,
+                    "delta_pct": 0.6,
+                    "ci_delta_pct": [
+                        -0.56,
+                        2.05
+                    ],
+                    "n": 7,
+                    "b_ms": 49.7135,
+                    "c_ms": 50.0173
+                },
+                "core.string_to_int_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99531,
+                    "delta_pct": -0.47,
+                    "ci_delta_pct": [
+                        -1.52,
+                        0.95
+                    ],
+                    "n": 7,
+                    "b_ms": 28.2465,
+                    "c_ms": 28.1857
+                },
+                "core.string_to_int_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99914,
+                    "delta_pct": -0.09,
+                    "ci_delta_pct": [
+                        -0.36,
+                        0.12
+                    ],
+                    "n": 7,
+                    "b_ms": 22.1172,
+                    "c_ms": 22.1074
+                },
+                "core.string_to_mixed_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00144,
+                    "delta_pct": 0.14,
+                    "ci_delta_pct": [
+                        -0.31,
+                        0.22
+                    ],
+                    "n": 7,
+                    "b_ms": 452.1071,
+                    "c_ms": 452.691
+                },
+                "core.string_to_mixed_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00321,
+                    "delta_pct": 0.32,
+                    "ci_delta_pct": [
+                        -0.83,
+                        0.88
+                    ],
+                    "n": 7,
+                    "b_ms": 55.9914,
+                    "c_ms": 56.1243
+                },
+                "core.string_to_mixed_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99651,
+                    "delta_pct": -0.35,
+                    "ci_delta_pct": [
+                        -1.27,
+                        1.6
+                    ],
+                    "n": 7,
+                    "b_ms": 35.153,
+                    "c_ms": 35.4394
+                },
+                "core.string_to_mixed_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00049,
+                    "delta_pct": 0.05,
+                    "ci_delta_pct": [
+                        -0.5,
+                        0.24
+                    ],
+                    "n": 7,
+                    "b_ms": 64.8598,
+                    "c_ms": 64.8349
+                },
+                "core.string_to_int_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.001,
+                    "delta_pct": 0.1,
+                    "ci_delta_pct": [
+                        -0.16,
+                        0.33
+                    ],
+                    "n": 7,
+                    "b_ms": 246.3846,
+                    "c_ms": 246.675
+                },
+                "core.string_to_int_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00269,
+                    "delta_pct": 0.27,
+                    "ci_delta_pct": [
+                        -1.35,
+                        3.03
+                    ],
+                    "n": 7,
+                    "b_ms": 49.6388,
+                    "c_ms": 49.8013
+                },
+                "core.string_to_int_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00566,
+                    "delta_pct": 0.57,
+                    "ci_delta_pct": [
+                        0.15,
+                        1.18
+                    ],
+                    "n": 7,
+                    "b_ms": 28.1055,
+                    "c_ms": 28.2868
+                },
+                "core.string_to_int_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99911,
+                    "delta_pct": -0.09,
+                    "ci_delta_pct": [
+                        -0.48,
+                        0.05
+                    ],
+                    "n": 7,
+                    "b_ms": 22.1764,
+                    "c_ms": 22.1556
+                },
+                "core.string_to_mixed_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99848,
+                    "delta_pct": -0.15,
+                    "ci_delta_pct": [
+                        -0.25,
+                        0.34
+                    ],
+                    "n": 7,
+                    "b_ms": 263.8144,
+                    "c_ms": 263.8566
+                },
+                "core.string_to_mixed_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00533,
+                    "delta_pct": 0.53,
+                    "ci_delta_pct": [
+                        -0.63,
+                        2.11
+                    ],
+                    "n": 7,
+                    "b_ms": 55.682,
+                    "c_ms": 56.6911
+                },
+                "core.string_to_mixed_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00096,
+                    "delta_pct": 0.1,
+                    "ci_delta_pct": [
+                        -1.59,
+                        1.93
+                    ],
+                    "n": 7,
+                    "b_ms": 35.1821,
+                    "c_ms": 35.216
+                },
+                "core.string_to_mixed_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99876,
+                    "delta_pct": -0.12,
+                    "ci_delta_pct": [
+                        -0.44,
+                        0.23
+                    ],
+                    "n": 7,
+                    "b_ms": 64.884,
+                    "c_ms": 64.8036
+                },
+                "api.increment.int_to_int": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99943,
+                    "delta_pct": -0.06,
+                    "ci_delta_pct": [
+                        -0.26,
+                        0.12
+                    ],
+                    "n": 7,
+                    "b_ms": 57.3728,
+                    "c_ms": 57.3123
+                },
+                "api.setop.union.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99995,
+                    "delta_pct": -0,
+                    "ci_delta_pct": [
+                        -0.25,
+                        0.05
+                    ],
+                    "n": 7,
+                    "b_ms": 92.3506,
+                    "c_ms": 92.3235
+                },
+                "api.setop.intersect.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00096,
+                    "delta_pct": 0.1,
+                    "ci_delta_pct": [
+                        -0.26,
+                        0.15
+                    ],
+                    "n": 7,
+                    "b_ms": 95.3934,
+                    "c_ms": 95.381
+                },
+                "api.setop.diff.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99872,
+                    "delta_pct": -0.13,
+                    "ci_delta_pct": [
+                        -0.57,
+                        -0.03
+                    ],
+                    "n": 7,
+                    "b_ms": 43.043,
+                    "c_ms": 43.0139
+                },
+                "api.setop.xor.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99952,
+                    "delta_pct": -0.05,
+                    "ci_delta_pct": [
+                        -0.28,
+                        0.04
+                    ],
+                    "n": 7,
+                    "b_ms": 221.3741,
+                    "c_ms": 221.103
+                }
+            }
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 0,
+        "slower": 0,
+        "null": 97
+    },
+    "a_counts": {
+        "php-judy": 4,
+        "php-array": 41,
+        "parity": 0
+    },
+    "bundled_vs_system": {
+        "core.bitset.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99916,
+            "delta_pct": -0.08,
+            "ci_delta_pct": [
+                -0.47,
+                0.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.28,
+                "B2/C1": 0.16
+            },
+            "build_spread_pct": 0.44,
+            "builds": 2,
+            "system_ms": 102.9182,
+            "bundled_ms": 102.8966,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                102.8262,
+                102.9182,
+                102.7491,
+                103.2838,
+                103.3985,
+                102.714,
+                103.8761
+            ],
+            "bundled_runs_ms": [
+                102.725,
+                103.0643,
+                102.8966,
+                102.826,
+                102.8938,
+                103.4951,
+                103.0895
+            ],
+            "paired_ratios": [
+                0.99902,
+                1.00142,
+                1.00144,
+                0.99557,
+                0.99512,
+                1.0076,
+                0.99243
+            ]
+        },
+        "core.bitset.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00198,
+            "delta_pct": 0.2,
+            "ci_delta_pct": [
+                -1.59,
+                0.42
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.1,
+                "B2/C1": 0.27
+            },
+            "build_spread_pct": 1.37,
+            "builds": 2,
+            "system_ms": 67.6458,
+            "bundled_ms": 67.5465,
+            "raw_delta_pct": 0.18,
+            "spread_pct": [
+                3.5,
+                2.9
+            ],
+            "system_runs_ms": [
+                67.6458,
+                68.2453,
+                68.752,
+                67.4861,
+                67.2012,
+                67.4231,
+                69.5807
+            ],
+            "bundled_runs_ms": [
+                67.2222,
+                69.1733,
+                67.6468,
+                67.6572,
+                67.4739,
+                67.5465,
+                67.3479
+            ],
+            "paired_ratios": [
+                0.99374,
+                1.0136,
+                0.98392,
+                1.00254,
+                1.00406,
+                1.00183,
+                0.96791
+            ]
+        },
+        "core.bitset.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9967,
+            "delta_pct": -0.33,
+            "ci_delta_pct": [
+                -0.88,
+                0.72
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.32,
+                "B2/C1": -0.33
+            },
+            "build_spread_pct": 0.01,
+            "builds": 2,
+            "system_ms": 107.7192,
+            "bundled_ms": 107.4812,
+            "raw_delta_pct": -0.34,
+            "spread_pct": [
+                3.3,
+                1.4
+            ],
+            "system_runs_ms": [
+                107.7036,
+                104.565,
+                107.7192,
+                108.0871,
+                107.5022,
+                107.8529,
+                107.9559
+            ],
+            "bundled_runs_ms": [
+                106.7418,
+                107.4959,
+                106.9373,
+                106.9868,
+                108.2549,
+                107.4812,
+                108.0094
+            ],
+            "paired_ratios": [
+                0.99107,
+                1.02803,
+                0.99274,
+                0.98982,
+                1.007,
+                0.99655,
+                1.0005
+            ]
+        },
+        "core.int_to_int.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99886,
+            "delta_pct": -0.11,
+            "ci_delta_pct": [
+                -0.26,
+                0.19
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.15,
+                "B2/C1": -0.11
+            },
+            "build_spread_pct": 0.04,
+            "builds": 2,
+            "system_ms": 144.8169,
+            "bundled_ms": 144.8664,
+            "raw_delta_pct": -0.13,
+            "spread_pct": [
+                0.7,
+                4.2
+            ],
+            "system_runs_ms": [
+                145.7084,
+                144.8169,
+                144.7831,
+                145.5862,
+                145.1679,
+                144.7069,
+                144.6732
+            ],
+            "bundled_runs_ms": [
+                144.4174,
+                150.4855,
+                145.0328,
+                145.1867,
+                144.8664,
+                144.5212,
+                144.4985
+            ],
+            "paired_ratios": [
+                0.99114,
+                1.03914,
+                1.00172,
+                0.99726,
+                0.99792,
+                0.99872,
+                0.99879
+            ]
+        },
+        "core.int_to_int.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99861,
+            "delta_pct": -0.14,
+            "ci_delta_pct": [
+                -0.36,
+                0.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.18,
+                "B2/C1": -0.14
+            },
+            "build_spread_pct": 0.04,
+            "builds": 2,
+            "system_ms": 67.3038,
+            "bundled_ms": 67.1811,
+            "raw_delta_pct": -0.15,
+            "spread_pct": [
+                2.9,
+                1
+            ],
+            "system_runs_ms": [
+                66.7169,
+                67.3038,
+                67.2301,
+                67.4901,
+                67.8307,
+                66.9452,
+                68.6583
+            ],
+            "bundled_runs_ms": [
+                66.8983,
+                67.0507,
+                67.221,
+                67.3862,
+                67.5783,
+                67.0005,
+                67.1811
+            ],
+            "paired_ratios": [
+                1.00272,
+                0.99624,
+                0.99986,
+                0.99846,
+                0.99628,
+                1.00083,
+                0.97848
+            ]
+        },
+        "core.int_to_int.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00445,
+            "delta_pct": 0.44,
+            "ci_delta_pct": [
+                -0.51,
+                0.99
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.48,
+                "B2/C1": 0.99
+            },
+            "build_spread_pct": 1.47,
+            "builds": 2,
+            "system_ms": 113.0232,
+            "bundled_ms": 113.5094,
+            "raw_delta_pct": 0.43,
+            "spread_pct": [
+                0.8,
+                1.7
+            ],
+            "system_runs_ms": [
+                112.9922,
+                112.6407,
+                113.5614,
+                113.1768,
+                112.9845,
+                113.0232,
+                113.033
+            ],
+            "bundled_runs_ms": [
+                113.742,
+                113.7384,
+                112.8614,
+                114.3344,
+                112.3957,
+                113.5094,
+                112.5001
+            ],
+            "paired_ratios": [
+                1.00664,
+                1.00975,
+                0.99384,
+                1.01023,
+                0.99479,
+                1.0043,
+                0.99529
+            ]
+        },
+        "core.int_to_int.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.98984,
+            "delta_pct": -1.02,
+            "ci_delta_pct": [
+                -2.5,
+                3.02
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 1.93,
+                "B2/C1": -2.5
+            },
+            "build_spread_pct": 4.43,
+            "builds": 2,
+            "system_ms": 2.2026,
+            "bundled_ms": 2.2004,
+            "raw_delta_pct": -1.03,
+            "spread_pct": [
+                16,
+                3.9
+            ],
+            "system_runs_ms": [
+                1.9524,
+                2.2026,
+                2.1875,
+                2.3049,
+                2.1362,
+                2.2256,
+                2.2122
+            ],
+            "bundled_runs_ms": [
+                2.2354,
+                2.149,
+                2.2055,
+                2.2129,
+                2.2004,
+                2.1697,
+                2.1894
+            ],
+            "paired_ratios": [
+                1.14495,
+                0.97567,
+                1.00823,
+                0.96009,
+                1.03005,
+                0.97488,
+                0.98969
+            ]
+        },
+        "core.int_to_mixed.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00263,
+            "delta_pct": 0.26,
+            "ci_delta_pct": [
+                -0.56,
+                1.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.18,
+                "B2/C1": 0.31
+            },
+            "build_spread_pct": 0.13,
+            "builds": 2,
+            "system_ms": 401.1736,
+            "bundled_ms": 402.1801,
+            "raw_delta_pct": 0.25,
+            "spread_pct": [
+                1.5,
+                1.9
+            ],
+            "system_runs_ms": [
+                395.9782,
+                400.9255,
+                402.1881,
+                401.0152,
+                401.1736,
+                402.0827,
+                401.4831
+            ],
+            "bundled_runs_ms": [
+                404.6785,
+                407.2962,
+                399.8164,
+                402.1801,
+                401.4752,
+                399.7588,
+                402.4808
+            ],
+            "paired_ratios": [
+                1.02197,
+                1.01589,
+                0.9941,
+                1.0029,
+                1.00075,
+                0.99422,
+                1.00249
+            ]
+        },
+        "core.int_to_mixed.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00076,
+            "delta_pct": 0.08,
+            "ci_delta_pct": [
+                -0.18,
+                0.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0,
+                "B2/C1": 0.18
+            },
+            "build_spread_pct": 0.18,
+            "builds": 2,
+            "system_ms": 279.3453,
+            "bundled_ms": 279.1111,
+            "raw_delta_pct": 0.06,
+            "spread_pct": [
+                1.5,
+                0.7
+            ],
+            "system_runs_ms": [
+                276.5857,
+                278.6914,
+                279.3453,
+                278.6334,
+                279.4899,
+                280.3527,
+                280.6813
+            ],
+            "bundled_runs_ms": [
+                277.9227,
+                279.795,
+                279.1111,
+                279.1029,
+                279.6624,
+                279.8186,
+                278.9621
+            ],
+            "paired_ratios": [
+                1.00483,
+                1.00396,
+                0.99916,
+                1.00169,
+                1.00062,
+                0.99809,
+                0.99387
+            ]
+        },
+        "core.int_to_mixed.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00008,
+            "delta_pct": 0.01,
+            "ci_delta_pct": [
+                -0.46,
+                0.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.16,
+                "B2/C1": -0.44
+            },
+            "build_spread_pct": 0.6,
+            "builds": 2,
+            "system_ms": 321.7168,
+            "bundled_ms": 321.9846,
+            "raw_delta_pct": -0.01,
+            "spread_pct": [
+                1.5,
+                1
+            ],
+            "system_runs_ms": [
+                318.9556,
+                321.6497,
+                321.0226,
+                322.8511,
+                321.7168,
+                323.3236,
+                323.9263
+            ],
+            "bundled_runs_ms": [
+                321.9997,
+                320.1109,
+                321.9846,
+                323.1812,
+                321.6965,
+                321.8427,
+                322.1492
+            ],
+            "paired_ratios": [
+                1.00954,
+                0.99522,
+                1.003,
+                1.00102,
+                0.99994,
+                0.99542,
+                0.99451
+            ]
+        },
+        "core.int_to_mixed.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00086,
+            "delta_pct": 0.09,
+            "ci_delta_pct": [
+                -0.12,
+                1.39
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.64,
+                "B2/C1": 0.09
+            },
+            "build_spread_pct": 0.55,
+            "builds": 2,
+            "system_ms": 100.5153,
+            "bundled_ms": 100.9816,
+            "raw_delta_pct": 0.07,
+            "spread_pct": [
+                1.7,
+                1.2
+            ],
+            "system_runs_ms": [
+                99.2102,
+                100.0914,
+                100.5153,
+                100.6128,
+                99.8507,
+                100.9472,
+                100.8403
+            ],
+            "bundled_runs_ms": [
+                100.9816,
+                101.1999,
+                100.3802,
+                100.6087,
+                101.2273,
+                101.0193,
+                100.0604
+            ],
+            "paired_ratios": [
+                1.01786,
+                1.01107,
+                0.99866,
+                0.99996,
+                1.01379,
+                1.00071,
+                0.99227
+            ]
+        },
+        "core.int_to_packed.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00643,
+            "delta_pct": 0.64,
+            "ci_delta_pct": [
+                0.11,
+                0.93
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.39,
+                "B2/C1": 0.64
+            },
+            "build_spread_pct": 0.25,
+            "builds": 2,
+            "system_ms": 348.2607,
+            "bundled_ms": 349.6312,
+            "raw_delta_pct": 0.63,
+            "spread_pct": [
+                0.7,
+                3.6
+            ],
+            "system_runs_ms": [
+                347.3611,
+                348.2607,
+                348.2934,
+                347.447,
+                349.2084,
+                349.3771,
+                346.853
+            ],
+            "bundled_runs_ms": [
+                346.1556,
+                358.6959,
+                351.4893,
+                349.6312,
+                349.5575,
+                350.9368,
+                349.1281
+            ],
+            "paired_ratios": [
+                0.99653,
+                1.02996,
+                1.00918,
+                1.00629,
+                1.001,
+                1.00446,
+                1.00656
+            ]
+        },
+        "core.int_to_packed.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99931,
+            "delta_pct": -0.07,
+            "ci_delta_pct": [
+                -0.39,
+                0.13
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.23,
+                "B2/C1": 0.09
+            },
+            "build_spread_pct": 0.32,
+            "builds": 2,
+            "system_ms": 205.5598,
+            "bundled_ms": 205.4722,
+            "raw_delta_pct": -0.08,
+            "spread_pct": [
+                0.6,
+                0.3
+            ],
+            "system_runs_ms": [
+                206.0207,
+                205.1042,
+                205.5598,
+                205.2617,
+                206.3782,
+                205.9573,
+                205.2828
+            ],
+            "bundled_runs_ms": [
+                205.1865,
+                205.2684,
+                205.3869,
+                205.7361,
+                205.4722,
+                205.5619,
+                205.5217
+            ],
+            "paired_ratios": [
+                0.99595,
+                1.0008,
+                0.99916,
+                1.00231,
+                0.99561,
+                0.99808,
+                1.00116
+            ]
+        },
+        "core.int_to_packed.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00484,
+            "delta_pct": 0.48,
+            "ci_delta_pct": [
+                -0.18,
+                0.95
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.21,
+                "B2/C1": 0.48
+            },
+            "build_spread_pct": 0.27,
+            "builds": 2,
+            "system_ms": 246.9595,
+            "bundled_ms": 247.403,
+            "raw_delta_pct": 0.47,
+            "spread_pct": [
+                1.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                246.9595,
+                246.1456,
+                248.4382,
+                244.4834,
+                247.5038,
+                247.5687,
+                244.5764
+            ],
+            "bundled_runs_ms": [
+                248.386,
+                247.3002,
+                247.403,
+                247.9125,
+                247.0255,
+                247.4031,
+                246.865
+            ],
+            "paired_ratios": [
+                1.00578,
+                1.00469,
+                0.99583,
+                1.01403,
+                0.99807,
+                0.99933,
+                1.00936
+            ]
+        },
+        "core.int_to_packed.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00308,
+            "delta_pct": 0.31,
+            "ci_delta_pct": [
+                -0.02,
+                0.4
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.32,
+                "B2/C1": 0.2
+            },
+            "build_spread_pct": 0.12,
+            "builds": 2,
+            "system_ms": 52.3667,
+            "bundled_ms": 52.4542,
+            "raw_delta_pct": 0.29,
+            "spread_pct": [
+                0.5,
+                0.8
+            ],
+            "system_runs_ms": [
+                52.448,
+                52.3079,
+                52.2397,
+                52.4934,
+                52.3667,
+                52.2636,
+                52.4699
+            ],
+            "bundled_runs_ms": [
+                52.6017,
+                52.4047,
+                52.4058,
+                52.1988,
+                52.5672,
+                52.5294,
+                52.4542
+            ],
+            "paired_ratios": [
+                1.00293,
+                1.00185,
+                1.00318,
+                0.99439,
+                1.00383,
+                1.00509,
+                0.9997
+            ]
+        },
+        "core.string_to_int.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99743,
+            "delta_pct": -0.26,
+            "ci_delta_pct": [
+                -0.52,
+                0.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.28,
+                "B2/C1": -0.12
+            },
+            "build_spread_pct": 0.16,
+            "builds": 2,
+            "system_ms": 641.117,
+            "bundled_ms": 639.9591,
+            "raw_delta_pct": -0.27,
+            "spread_pct": [
+                1.1,
+                0.4
+            ],
+            "system_runs_ms": [
+                647.4179,
+                640.1065,
+                640.3937,
+                640.8289,
+                641.117,
+                642.9909,
+                641.8332
+            ],
+            "bundled_runs_ms": [
+                640.713,
+                640.6131,
+                641.7364,
+                639.9591,
+                639.3744,
+                639.5788,
+                639.789
+            ],
+            "paired_ratios": [
+                0.98964,
+                1.00079,
+                1.0021,
+                0.99864,
+                0.99728,
+                0.99469,
+                0.99682
+            ]
+        },
+        "core.string_to_int.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99949,
+            "delta_pct": -0.05,
+            "ci_delta_pct": [
+                -0.51,
+                0.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.28,
+                "B2/C1": -0.03
+            },
+            "build_spread_pct": 0.25,
+            "builds": 2,
+            "system_ms": 205.2593,
+            "bundled_ms": 204.9717,
+            "raw_delta_pct": -0.07,
+            "spread_pct": [
+                1.1,
+                1.2
+            ],
+            "system_runs_ms": [
+                205.2593,
+                204.6834,
+                206.8692,
+                205.0533,
+                205.9825,
+                205.1979,
+                205.7051
+            ],
+            "bundled_runs_ms": [
+                205.3388,
+                205.0315,
+                206.7337,
+                204.9717,
+                204.4778,
+                204.3554,
+                204.6255
+            ],
+            "paired_ratios": [
+                1.00039,
+                1.0017,
+                0.99934,
+                0.9996,
+                0.9927,
+                0.99589,
+                0.99475
+            ]
+        },
+        "core.string_to_int.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99857,
+            "delta_pct": -0.14,
+            "ci_delta_pct": [
+                -0.86,
+                -0.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.12,
+                "B2/C1": -0.27
+            },
+            "build_spread_pct": 0.15,
+            "builds": 2,
+            "system_ms": 291.7518,
+            "bundled_ms": 291.206,
+            "raw_delta_pct": -0.16,
+            "spread_pct": [
+                1.3,
+                0.9
+            ],
+            "system_runs_ms": [
+                294.6096,
+                293.7836,
+                291.7564,
+                291.7518,
+                290.7135,
+                291.7449,
+                291.1843
+            ],
+            "bundled_runs_ms": [
+                290.9574,
+                291.206,
+                291.3178,
+                290.9336,
+                290.3728,
+                291.2844,
+                292.9071
+            ],
+            "paired_ratios": [
+                0.9876,
+                0.99123,
+                0.9985,
+                0.9972,
+                0.99883,
+                0.99842,
+                1.00592
+            ]
+        },
+        "core.string_to_int.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99818,
+            "delta_pct": -0.18,
+            "ci_delta_pct": [
+                -0.44,
+                0.6
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.32,
+                "B2/C1": -0.44
+            },
+            "build_spread_pct": 0.76,
+            "builds": 2,
+            "system_ms": 110.354,
+            "bundled_ms": 110.2139,
+            "raw_delta_pct": -0.2,
+            "spread_pct": [
+                1,
+                0.7
+            ],
+            "system_runs_ms": [
+                110.0733,
+                110.354,
+                109.662,
+                110.6342,
+                110.1751,
+                110.7155,
+                110.5964
+            ],
+            "bundled_runs_ms": [
+                110.7448,
+                110.1364,
+                110.3011,
+                110.1288,
+                110.2139,
+                109.9295,
+                110.301
+            ],
+            "paired_ratios": [
+                1.0061,
+                0.99803,
+                1.00583,
+                0.99543,
+                1.00035,
+                0.9929,
+                0.99733
+            ]
+        },
+        "core.string_to_mixed.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99778,
+            "delta_pct": -0.22,
+            "ci_delta_pct": [
+                -0.42,
+                0.59
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.08,
+                "B2/C1": -0.22
+            },
+            "build_spread_pct": 0.14,
+            "builds": 2,
+            "system_ms": 992.0277,
+            "bundled_ms": 991.4836,
+            "raw_delta_pct": -0.24,
+            "spread_pct": [
+                0.7,
+                1.6
+            ],
+            "system_runs_ms": [
+                996.4483,
+                991.5253,
+                990.0441,
+                993.1218,
+                989.966,
+                992.0277,
+                992.9061
+            ],
+            "bundled_runs_ms": [
+                991.6477,
+                989.1745,
+                995.757,
+                1003.7372,
+                991.4836,
+                987.7196,
+                989.4244
+            ],
+            "paired_ratios": [
+                0.99518,
+                0.99763,
+                1.00577,
+                1.01069,
+                1.00153,
+                0.99566,
+                0.99649
+            ]
+        },
+        "core.string_to_mixed.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99858,
+            "delta_pct": -0.14,
+            "ci_delta_pct": [
+                -0.3,
+                0.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.03,
+                "B2/C1": -0.17
+            },
+            "build_spread_pct": 0.14,
+            "builds": 2,
+            "system_ms": 787.6743,
+            "bundled_ms": 786.7103,
+            "raw_delta_pct": -0.16,
+            "spread_pct": [
+                0.7,
+                0.2
+            ],
+            "system_runs_ms": [
+                791.7677,
+                787.6743,
+                786.1681,
+                788.4212,
+                788.3664,
+                787.6331,
+                786.318
+            ],
+            "bundled_runs_ms": [
+                786.7059,
+                787.7166,
+                786.7103,
+                785.9475,
+                787.1274,
+                786.2054,
+                786.9566
+            ],
+            "paired_ratios": [
+                0.99361,
+                1.00005,
+                1.00069,
+                0.99686,
+                0.99843,
+                0.99819,
+                1.00081
+            ]
+        },
+        "core.string_to_mixed.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00014,
+            "delta_pct": 0.01,
+            "ci_delta_pct": [
+                -0.58,
+                0.24
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.06,
+                "B2/C1": -0.19
+            },
+            "build_spread_pct": 0.25,
+            "builds": 2,
+            "system_ms": 821.1199,
+            "bundled_ms": 821.0843,
+            "raw_delta_pct": -0,
+            "spread_pct": [
+                0.9,
+                0.7
+            ],
+            "system_runs_ms": [
+                826.336,
+                820.5073,
+                819.0967,
+                823.2545,
+                821.0933,
+                821.1199,
+                821.8151
+            ],
+            "bundled_runs_ms": [
+                821.4581,
+                822.4037,
+                819.9065,
+                818.101,
+                821.0843,
+                819.4484,
+                823.7054
+            ],
+            "paired_ratios": [
+                0.9941,
+                1.00231,
+                1.00099,
+                0.99374,
+                0.99999,
+                0.99796,
+                1.0023
+            ]
+        },
+        "core.string_to_mixed.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.0008,
+            "delta_pct": 0.08,
+            "ci_delta_pct": [
+                -0.24,
+                0.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.04,
+                "B2/C1": 0.08
+            },
+            "build_spread_pct": 0.12,
+            "builds": 2,
+            "system_ms": 346.2062,
+            "bundled_ms": 346.0984,
+            "raw_delta_pct": 0.07,
+            "spread_pct": [
+                0.5,
+                0.4
+            ],
+            "system_runs_ms": [
+                347.4997,
+                346.8343,
+                346.0118,
+                345.8719,
+                346.3141,
+                346.0794,
+                346.2062
+            ],
+            "bundled_runs_ms": [
+                345.8905,
+                346.091,
+                346.4991,
+                346.0984,
+                345.4159,
+                346.8503,
+                346.7093
+            ],
+            "paired_ratios": [
+                0.99537,
+                0.99786,
+                1.00141,
+                1.00065,
+                0.99741,
+                1.00223,
+                1.00145
+            ]
+        },
+        "core.string_to_int_hash.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99835,
+            "delta_pct": -0.17,
+            "ci_delta_pct": [
+                -0.31,
+                0.28
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.14,
+                "B2/C1": -0.24
+            },
+            "build_spread_pct": 0.38,
+            "builds": 2,
+            "system_ms": 1049.6145,
+            "bundled_ms": 1048.5147,
+            "raw_delta_pct": -0.18,
+            "spread_pct": [
+                0.3,
+                0.8
+            ],
+            "system_runs_ms": [
+                1049.6145,
+                1051.1652,
+                1048.5174,
+                1050.5085,
+                1048.382,
+                1049.5226,
+                1051.5174
+            ],
+            "bundled_runs_ms": [
+                1049.4798,
+                1048.5147,
+                1055.8519,
+                1047.1381,
+                1051.1106,
+                1047.6327,
+                1047.3091
+            ],
+            "paired_ratios": [
+                0.99987,
+                0.99748,
+                1.007,
+                0.99679,
+                1.0026,
+                0.9982,
+                0.996
+            ]
+        },
+        "core.string_to_int_hash.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00153,
+            "delta_pct": 0.15,
+            "ci_delta_pct": [
+                -0.69,
+                0.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.22,
+                "B2/C1": 0.15
+            },
+            "build_spread_pct": 0.37,
+            "builds": 2,
+            "system_ms": 170.4217,
+            "bundled_ms": 170.5389,
+            "raw_delta_pct": 0.14,
+            "spread_pct": [
+                0.9,
+                1
+            ],
+            "system_runs_ms": [
+                170.1592,
+                170.3365,
+                171.5374,
+                170.4217,
+                171.6326,
+                170.9147,
+                170.1381
+            ],
+            "bundled_runs_ms": [
+                171.5751,
+                170.2103,
+                170.3249,
+                170.7519,
+                169.9357,
+                171.1508,
+                170.5389
+            ],
+            "paired_ratios": [
+                1.00832,
+                0.99926,
+                0.99293,
+                1.00194,
+                0.99011,
+                1.00138,
+                1.00236
+            ]
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99984,
+            "delta_pct": -0.02,
+            "ci_delta_pct": [
+                -0.13,
+                0.17
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.05,
+                "B2/C1": 0.03
+            },
+            "build_spread_pct": 0.08,
+            "builds": 2,
+            "system_ms": 388.3459,
+            "bundled_ms": 388.2263,
+            "raw_delta_pct": -0.03,
+            "spread_pct": [
+                0.3,
+                0.4
+            ],
+            "system_runs_ms": [
+                388.1256,
+                388.4556,
+                388.2832,
+                388.8884,
+                388.0268,
+                389.0524,
+                388.3459
+            ],
+            "bundled_runs_ms": [
+                388.7145,
+                389.1141,
+                387.735,
+                388.1019,
+                387.6313,
+                389.1006,
+                388.2263
+            ],
+            "paired_ratios": [
+                1.00152,
+                1.0017,
+                0.99859,
+                0.99798,
+                0.99898,
+                1.00012,
+                0.99969
+            ]
+        },
+        "core.string_to_int_hash.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99991,
+            "delta_pct": -0.01,
+            "ci_delta_pct": [
+                -0.17,
+                0.22
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.08,
+                "B2/C1": -0.01
+            },
+            "build_spread_pct": 0.07,
+            "builds": 2,
+            "system_ms": 234.6709,
+            "bundled_ms": 234.9169,
+            "raw_delta_pct": -0.02,
+            "spread_pct": [
+                0.9,
+                0.4
+            ],
+            "system_runs_ms": [
+                236.1557,
+                235.344,
+                234.643,
+                234.4708,
+                235.3428,
+                234.6709,
+                234.0008
+            ],
+            "bundled_runs_ms": [
+                234.4168,
+                235.116,
+                234.604,
+                234.9547,
+                234.9169,
+                234.6148,
+                235.2802
+            ],
+            "paired_ratios": [
+                0.99264,
+                0.99903,
+                0.99983,
+                1.00206,
+                0.99819,
+                0.99976,
+                1.00547
+            ]
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00105,
+            "delta_pct": 0.11,
+            "ci_delta_pct": [
+                -0.07,
+                0.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.18,
+                "B2/C1": -0.05
+            },
+            "build_spread_pct": 0.23,
+            "builds": 2,
+            "system_ms": 1907.4261,
+            "bundled_ms": 1907.7527,
+            "raw_delta_pct": 0.09,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                1925.6116,
+                1907.4261,
+                1906.3411,
+                1909.5777,
+                1904.06,
+                1908.9804,
+                1906.0319
+            ],
+            "bundled_runs_ms": [
+                1905.4464,
+                1906.2198,
+                1918.4924,
+                1914.739,
+                1908.5081,
+                1907.3984,
+                1907.7527
+            ],
+            "paired_ratios": [
+                0.98953,
+                0.99937,
+                1.00637,
+                1.0027,
+                1.00234,
+                0.99917,
+                1.0009
+            ]
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99914,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.44,
+                -0.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.26,
+                "B2/C1": -0.06
+            },
+            "build_spread_pct": 0.2,
+            "builds": 2,
+            "system_ms": 932.9583,
+            "bundled_ms": 932.1733,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                1.4,
+                0.2
+            ],
+            "system_runs_ms": [
+                936.4463,
+                932.9583,
+                945.5189,
+                932.2202,
+                932.6793,
+                933.5316,
+                932.0387
+            ],
+            "bundled_runs_ms": [
+                932.1733,
+                932.3985,
+                933.3162,
+                931.559,
+                931.7406,
+                931.0606,
+                932.623
+            ],
+            "paired_ratios": [
+                0.99544,
+                0.9994,
+                0.98709,
+                0.99929,
+                0.99899,
+                0.99735,
+                1.00063
+            ]
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00083,
+            "delta_pct": 0.08,
+            "ci_delta_pct": [
+                0,
+                0.37
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.06,
+                "B2/C1": 0.19
+            },
+            "build_spread_pct": 0.13,
+            "builds": 2,
+            "system_ms": 428.291,
+            "bundled_ms": 428.5544,
+            "raw_delta_pct": 0.07,
+            "spread_pct": [
+                0.4,
+                1
+            ],
+            "system_runs_ms": [
+                428.5992,
+                427.4824,
+                429.032,
+                428.291,
+                428.4905,
+                427.8249,
+                427.6132
+            ],
+            "bundled_runs_ms": [
+                427.736,
+                432.0613,
+                429.3266,
+                428.2379,
+                429.9933,
+                428.5544,
+                427.7315
+            ],
+            "paired_ratios": [
+                0.99799,
+                1.01071,
+                1.00069,
+                0.99988,
+                1.00351,
+                1.00171,
+                1.00028
+            ]
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99895,
+            "delta_pct": -0.11,
+            "ci_delta_pct": [
+                -0.25,
+                0.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.09,
+                "B2/C1": -0.12
+            },
+            "build_spread_pct": 0.21,
+            "builds": 2,
+            "system_ms": 615.4886,
+            "bundled_ms": 614.7517,
+            "raw_delta_pct": -0.12,
+            "spread_pct": [
+                0.7,
+                0.8
+            ],
+            "system_runs_ms": [
+                617.213,
+                616.2733,
+                614.4146,
+                615.5804,
+                614.8277,
+                615.4886,
+                613.0509
+            ],
+            "bundled_runs_ms": [
+                613.7464,
+                614.6129,
+                613.8644,
+                614.7654,
+                616.2662,
+                614.7517,
+                618.6391
+            ],
+            "paired_ratios": [
+                0.99438,
+                0.99731,
+                0.9991,
+                0.99868,
+                1.00234,
+                0.9988,
+                1.00912
+            ]
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9967,
+            "delta_pct": -0.33,
+            "ci_delta_pct": [
+                -0.42,
+                0.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.14,
+                "B2/C1": -0.38
+            },
+            "build_spread_pct": 0.24,
+            "builds": 2,
+            "system_ms": 1051.1305,
+            "bundled_ms": 1048.5221,
+            "raw_delta_pct": -0.34,
+            "spread_pct": [
+                0.7,
+                0.5
+            ],
+            "system_runs_ms": [
+                1047.4555,
+                1052.1489,
+                1051.5857,
+                1050.4696,
+                1054.7023,
+                1050.6367,
+                1051.1305
+            ],
+            "bundled_runs_ms": [
+                1050.2367,
+                1048.5221,
+                1051.5296,
+                1046.277,
+                1050.13,
+                1045.9655,
+                1047.9316
+            ],
+            "paired_ratios": [
+                1.00266,
+                0.99655,
+                0.99995,
+                0.99601,
+                0.99566,
+                0.99555,
+                0.99696
+            ]
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9996,
+            "delta_pct": -0.04,
+            "ci_delta_pct": [
+                -0.47,
+                0.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.26,
+                "B2/C1": 0
+            },
+            "build_spread_pct": 0.26,
+            "builds": 2,
+            "system_ms": 171.058,
+            "bundled_ms": 171.0371,
+            "raw_delta_pct": -0.05,
+            "spread_pct": [
+                1,
+                0.9
+            ],
+            "system_runs_ms": [
+                170.8847,
+                170.6908,
+                170.3235,
+                171.058,
+                172.0055,
+                171.3769,
+                171.2588
+            ],
+            "bundled_runs_ms": [
+                170.7917,
+                170.4481,
+                171.0453,
+                171.9192,
+                171.0371,
+                171.3583,
+                170.4238
+            ],
+            "paired_ratios": [
+                0.99946,
+                0.99858,
+                1.00424,
+                1.00503,
+                0.99437,
+                0.99989,
+                0.99512
+            ]
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99812,
+            "delta_pct": -0.19,
+            "ci_delta_pct": [
+                -0.35,
+                0.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.07,
+                "B2/C1": -0.19
+            },
+            "build_spread_pct": 0.12,
+            "builds": 2,
+            "system_ms": 388.2959,
+            "bundled_ms": 387.7204,
+            "raw_delta_pct": -0.2,
+            "spread_pct": [
+                1.1,
+                0.9
+            ],
+            "system_runs_ms": [
+                388.4868,
+                392.0515,
+                387.6353,
+                387.8604,
+                388.2959,
+                388.535,
+                388.0059
+            ],
+            "bundled_runs_ms": [
+                387.0634,
+                390.4505,
+                387.7884,
+                387.2768,
+                390.3602,
+                387.7204,
+                387.2188
+            ],
+            "paired_ratios": [
+                0.99634,
+                0.99592,
+                1.00039,
+                0.9985,
+                1.00532,
+                0.9979,
+                0.99797
+            ]
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99926,
+            "delta_pct": -0.07,
+            "ci_delta_pct": [
+                -0.45,
+                0.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.04,
+                "B2/C1": -0.45
+            },
+            "build_spread_pct": 0.49,
+            "builds": 2,
+            "system_ms": 235.3097,
+            "bundled_ms": 234.9156,
+            "raw_delta_pct": -0.09,
+            "spread_pct": [
+                0.5,
+                1.1
+            ],
+            "system_runs_ms": [
+                235.1248,
+                235.8369,
+                235.3097,
+                235.3877,
+                235.2936,
+                235.3499,
+                234.7042
+            ],
+            "bundled_runs_ms": [
+                234.9156,
+                234.7508,
+                235.3924,
+                234.9384,
+                235.3448,
+                232.8441,
+                234.7623
+            ],
+            "paired_ratios": [
+                0.99911,
+                0.99539,
+                1.00035,
+                0.99809,
+                1.00022,
+                0.98935,
+                1.00025
+            ]
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00026,
+            "delta_pct": 0.03,
+            "ci_delta_pct": [
+                -0.13,
+                0.37
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.09,
+                "B2/C1": 0.03
+            },
+            "build_spread_pct": 0.06,
+            "builds": 2,
+            "system_ms": 1351.1881,
+            "bundled_ms": 1351.3363,
+            "raw_delta_pct": 0.01,
+            "spread_pct": [
+                1,
+                0.6
+            ],
+            "system_runs_ms": [
+                1351.7257,
+                1351.1881,
+                1350.034,
+                1351.7219,
+                1349.5999,
+                1362.5256,
+                1349.889
+            ],
+            "bundled_runs_ms": [
+                1349.7098,
+                1351.3363,
+                1354.8034,
+                1358.4111,
+                1351.7266,
+                1350.662,
+                1349.7857
+            ],
+            "paired_ratios": [
+                0.99851,
+                1.00011,
+                1.00353,
+                1.00495,
+                1.00158,
+                0.99129,
+                0.99992
+            ]
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99916,
+            "delta_pct": -0.08,
+            "ci_delta_pct": [
+                -0.3,
+                0.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0,
+                "B2/C1": -0.3
+            },
+            "build_spread_pct": 0.3,
+            "builds": 2,
+            "system_ms": 176.0919,
+            "bundled_ms": 175.8719,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                0.3,
+                0.8
+            ],
+            "system_runs_ms": [
+                176.0919,
+                176.4213,
+                176.1007,
+                175.8628,
+                175.8789,
+                176.0101,
+                176.3075
+            ],
+            "bundled_runs_ms": [
+                176.3936,
+                175.8719,
+                176.2201,
+                175.7124,
+                175.7045,
+                174.9681,
+                176.0504
+            ],
+            "paired_ratios": [
+                1.00171,
+                0.99689,
+                1.00068,
+                0.99914,
+                0.99901,
+                0.99408,
+                0.99854
+            ]
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99764,
+            "delta_pct": -0.24,
+            "ci_delta_pct": [
+                -0.32,
+                -0.15
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.29,
+                "B2/C1": -0.24
+            },
+            "build_spread_pct": 0.05,
+            "builds": 2,
+            "system_ms": 450.7767,
+            "bundled_ms": 449.6333,
+            "raw_delta_pct": -0.25,
+            "spread_pct": [
+                0.6,
+                0.3
+            ],
+            "system_runs_ms": [
+                450.7767,
+                450.8281,
+                450.8318,
+                450.2704,
+                453.1037,
+                450.3267,
+                450.7655
+            ],
+            "bundled_runs_ms": [
+                449.2589,
+                450.092,
+                449.6333,
+                449.1394,
+                450.003,
+                449.1999,
+                450.411
+            ],
+            "paired_ratios": [
+                0.99663,
+                0.99837,
+                0.99734,
+                0.99749,
+                0.99316,
+                0.9975,
+                0.99921
+            ]
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99691,
+            "delta_pct": -0.31,
+            "ci_delta_pct": [
+                -0.4,
+                -0.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.35,
+                "B2/C1": -0.19
+            },
+            "build_spread_pct": 0.16,
+            "builds": 2,
+            "system_ms": 650.4752,
+            "bundled_ms": 648.7412,
+            "raw_delta_pct": -0.32,
+            "spread_pct": [
+                0.3,
+                0.5
+            ],
+            "system_runs_ms": [
+                650.7937,
+                650.7947,
+                649.3768,
+                650.4752,
+                651.6124,
+                650.097,
+                649.747
+            ],
+            "bundled_runs_ms": [
+                647.8736,
+                649.9177,
+                650.6088,
+                648.215,
+                648.9287,
+                648.7412,
+                647.6445
+            ],
+            "paired_ratios": [
+                0.99551,
+                0.99865,
+                1.0019,
+                0.99653,
+                0.99588,
+                0.99791,
+                0.99676
+            ]
+        },
+        "api.putAll.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99992,
+            "delta_pct": -0.01,
+            "ci_delta_pct": [
+                -0.87,
+                1.2
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.59,
+                "B2/C1": -0.01
+            },
+            "build_spread_pct": 0.6,
+            "builds": 2,
+            "system_ms": 126.2203,
+            "bundled_ms": 126.3074,
+            "raw_delta_pct": -0.02,
+            "spread_pct": [
+                3.5,
+                1.8
+            ],
+            "system_runs_ms": [
+                126.0694,
+                130.4176,
+                126.0257,
+                126.2203,
+                126.3474,
+                126.1379,
+                127.4495
+            ],
+            "bundled_runs_ms": [
+                126.0116,
+                125.9638,
+                128.1993,
+                126.3074,
+                127.8482,
+                126.1096,
+                126.3206
+            ],
+            "paired_ratios": [
+                0.99954,
+                0.96585,
+                1.01725,
+                1.00069,
+                1.01188,
+                0.99978,
+                0.99114
+            ]
+        },
+        "api.fromArray.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00193,
+            "delta_pct": 0.19,
+            "ci_delta_pct": [
+                -0.84,
+                1.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.62,
+                "B2/C1": -0.04
+            },
+            "build_spread_pct": 0.66,
+            "builds": 2,
+            "system_ms": 126.2691,
+            "bundled_ms": 126.4939,
+            "raw_delta_pct": 0.18,
+            "spread_pct": [
+                0.9,
+                1.6
+            ],
+            "system_runs_ms": [
+                127.0193,
+                126.405,
+                125.968,
+                126.1485,
+                125.9241,
+                126.3963,
+                126.2691
+            ],
+            "bundled_runs_ms": [
+                125.6858,
+                125.3277,
+                127.3972,
+                126.8529,
+                127.2116,
+                126.3286,
+                126.4939
+            ],
+            "paired_ratios": [
+                0.9895,
+                0.99148,
+                1.01135,
+                1.00558,
+                1.01022,
+                0.99946,
+                1.00178
+            ]
+        },
+        "api.toArray.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99667,
+            "delta_pct": -0.33,
+            "ci_delta_pct": [
+                -0.74,
+                0.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.05,
+                "B2/C1": -0.5
+            },
+            "build_spread_pct": 0.45,
+            "builds": 2,
+            "system_ms": 299.072,
+            "bundled_ms": 297.4463,
+            "raw_delta_pct": -0.35,
+            "spread_pct": [
+                1,
+                1.1
+            ],
+            "system_runs_ms": [
+                297.932,
+                299.072,
+                297.6011,
+                296.9891,
+                299.3358,
+                299.9651,
+                299.1045
+            ],
+            "bundled_runs_ms": [
+                299.0632,
+                297.5284,
+                296.5668,
+                297.4463,
+                297.066,
+                296.8664,
+                299.7599
+            ],
+            "paired_ratios": [
+                1.0038,
+                0.99484,
+                0.99652,
+                1.00154,
+                0.99242,
+                0.98967,
+                1.00219
+            ]
+        },
+        "api.getAll.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99067,
+            "delta_pct": -0.93,
+            "ci_delta_pct": [
+                -1.1,
+                -0.65
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.99,
+                "B2/C1": -0.93
+            },
+            "build_spread_pct": 0.06,
+            "builds": 2,
+            "system_ms": 21.5679,
+            "bundled_ms": 21.3784,
+            "raw_delta_pct": -0.95,
+            "spread_pct": [
+                1,
+                0.6
+            ],
+            "system_runs_ms": [
+                21.6103,
+                21.4911,
+                21.5784,
+                21.5679,
+                21.5227,
+                21.4093,
+                21.6194
+            ],
+            "bundled_runs_ms": [
+                21.4056,
+                21.2887,
+                21.3486,
+                21.3229,
+                21.3807,
+                21.4213,
+                21.3784
+            ],
+            "paired_ratios": [
+                0.99053,
+                0.99058,
+                0.98935,
+                0.98864,
+                0.9934,
+                1.00056,
+                0.98885
+            ]
+        },
+        "api.increment.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00514,
+            "delta_pct": 0.51,
+            "ci_delta_pct": [
+                -0.92,
+                1.87
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.83,
+                "B2/C1": 1.87
+            },
+            "build_spread_pct": 2.7,
+            "builds": 2,
+            "system_ms": 144.7932,
+            "bundled_ms": 145.1778,
+            "raw_delta_pct": 0.5,
+            "spread_pct": [
+                4.4,
+                3.1
+            ],
+            "system_runs_ms": [
+                144.8384,
+                142.566,
+                144.7932,
+                139.969,
+                145.8989,
+                144.7422,
+                146.2972
+            ],
+            "bundled_runs_ms": [
+                145.5619,
+                145.2116,
+                141.8969,
+                144.7407,
+                144.5387,
+                146.4351,
+                145.1778
+            ],
+            "paired_ratios": [
+                1.005,
+                1.01856,
+                0.98,
+                1.03409,
+                0.99068,
+                1.0117,
+                0.99235
+            ]
+        },
+        "api.keys.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9991,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.4,
+                0.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.14,
+                "B2/C1": -0.29
+            },
+            "build_spread_pct": 0.43,
+            "builds": 2,
+            "system_ms": 116.2174,
+            "bundled_ms": 116.1625,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                1.2,
+                0.8
+            ],
+            "system_runs_ms": [
+                115.3601,
+                116.2698,
+                116.7961,
+                116.1937,
+                116.2174,
+                116.0573,
+                116.415
+            ],
+            "bundled_runs_ms": [
+                116.5602,
+                115.7902,
+                116.2124,
+                115.8449,
+                116.1625,
+                115.9359,
+                116.7727
+            ],
+            "paired_ratios": [
+                1.0104,
+                0.99588,
+                0.995,
+                0.997,
+                0.99953,
+                0.99895,
+                1.00307
+            ]
+        },
+        "api.values.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.0017,
+            "delta_pct": 0.17,
+            "ci_delta_pct": [
+                -0.12,
+                0.85
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.44,
+                "B2/C1": 0.17
+            },
+            "build_spread_pct": 0.27,
+            "builds": 2,
+            "system_ms": 120.7241,
+            "bundled_ms": 120.8973,
+            "raw_delta_pct": 0.16,
+            "spread_pct": [
+                0.8,
+                2.3
+            ],
+            "system_runs_ms": [
+                120.2413,
+                120.8728,
+                121.2363,
+                120.5319,
+                120.7241,
+                120.6597,
+                121.0656
+            ],
+            "bundled_runs_ms": [
+                121.24,
+                120.705,
+                120.7557,
+                123.4573,
+                120.8973,
+                120.8473,
+                121.9134
+            ],
+            "paired_ratios": [
+                1.00831,
+                0.99861,
+                0.99604,
+                1.02427,
+                1.00143,
+                1.00155,
+                1.007
+            ]
+        },
+        "api.range.keys.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.0014,
+            "delta_pct": 0.14,
+            "ci_delta_pct": [
+                -0.05,
+                0.81
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.06,
+                "B2/C1": 0.26
+            },
+            "build_spread_pct": 0.2,
+            "builds": 2,
+            "system_ms": 10.0934,
+            "bundled_ms": 10.1138,
+            "raw_delta_pct": 0.13,
+            "spread_pct": [
+                1.3,
+                0.7
+            ],
+            "system_runs_ms": [
+                10.0566,
+                10.128,
+                10.084,
+                10.0934,
+                10.1505,
+                10.0149,
+                10.1407
+            ],
+            "bundled_runs_ms": [
+                10.1364,
+                10.1529,
+                10.08,
+                10.0871,
+                10.1093,
+                10.1138,
+                10.1534
+            ],
+            "paired_ratios": [
+                1.00794,
+                1.00246,
+                0.9996,
+                0.99938,
+                0.99594,
+                1.00988,
+                1.00125
+            ]
+        },
+        "api.range.size.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00159,
+            "delta_pct": 0.16,
+            "ci_delta_pct": [
+                -0.02,
+                0.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.24,
+                "B2/C1": 0.1
+            },
+            "build_spread_pct": 0.14,
+            "builds": 2,
+            "system_ms": 20.938,
+            "bundled_ms": 20.9454,
+            "raw_delta_pct": 0.14,
+            "spread_pct": [
+                1.4,
+                1
+            ],
+            "system_runs_ms": [
+                20.938,
+                20.948,
+                20.8505,
+                20.9037,
+                20.9068,
+                20.9702,
+                21.1399
+            ],
+            "bundled_runs_ms": [
+                20.9918,
+                20.9414,
+                21.1449,
+                20.9339,
+                20.9454,
+                20.9872,
+                20.935
+            ],
+            "paired_ratios": [
+                1.00257,
+                0.99968,
+                1.01412,
+                1.00144,
+                1.00185,
+                1.00081,
+                0.99031
+            ]
+        },
+        "api.sumValues.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99939,
+            "delta_pct": -0.06,
+            "ci_delta_pct": [
+                -0.67,
+                0.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.37,
+                "B2/C1": 0.22
+            },
+            "build_spread_pct": 0.59,
+            "builds": 2,
+            "system_ms": 48.5166,
+            "bundled_ms": 48.4467,
+            "raw_delta_pct": -0.08,
+            "spread_pct": [
+                2.5,
+                0.8
+            ],
+            "system_runs_ms": [
+                48.6848,
+                48.5798,
+                48.4523,
+                48.5166,
+                48.5149,
+                48.1612,
+                49.3881
+            ],
+            "bundled_runs_ms": [
+                48.3496,
+                48.6787,
+                48.4155,
+                48.2774,
+                48.6271,
+                48.4473,
+                48.4467
+            ],
+            "paired_ratios": [
+                0.99311,
+                1.00204,
+                0.99924,
+                0.99507,
+                1.00231,
+                1.00594,
+                0.98094
+            ]
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99988,
+            "delta_pct": -0.01,
+            "ci_delta_pct": [
+                -0.22,
+                0.11
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.03,
+                "B2/C1": -0.01
+            },
+            "build_spread_pct": 0.04,
+            "builds": 2,
+            "system_ms": 237.264,
+            "bundled_ms": 236.9143,
+            "raw_delta_pct": -0.03,
+            "spread_pct": [
+                0.5,
+                0.6
+            ],
+            "system_runs_ms": [
+                236.7095,
+                237.8986,
+                236.6835,
+                237.3938,
+                237.264,
+                236.923,
+                237.2819
+            ],
+            "bundled_runs_ms": [
+                236.9022,
+                236.7718,
+                236.9143,
+                237.3313,
+                236.7143,
+                238.0207,
+                237.1513
+            ],
+            "paired_ratios": [
+                1.00081,
+                0.99526,
+                1.00098,
+                0.99974,
+                0.99768,
+                1.00463,
+                0.99945
+            ]
+        },
+        "api.equals.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00213,
+            "delta_pct": 0.21,
+            "ci_delta_pct": [
+                -0.33,
+                0.85
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.06,
+                "B2/C1": 0.85
+            },
+            "build_spread_pct": 0.91,
+            "builds": 2,
+            "system_ms": 71.0444,
+            "bundled_ms": 71.2161,
+            "raw_delta_pct": 0.2,
+            "spread_pct": [
+                0.9,
+                0.8
+            ],
+            "system_runs_ms": [
+                71.2791,
+                70.6746,
+                71.0444,
+                71.2818,
+                71.2539,
+                70.6257,
+                70.8554
+            ],
+            "bundled_runs_ms": [
+                70.9924,
+                71.527,
+                71.185,
+                71.3658,
+                71.0115,
+                71.2161,
+                71.2967
+            ],
+            "paired_ratios": [
+                0.99598,
+                1.01206,
+                1.00198,
+                1.00118,
+                0.9966,
+                1.00836,
+                1.00623
+            ]
+        },
+        "api.setop.union.bitset": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99688,
+            "delta_pct": -0.31,
+            "ci_delta_pct": [
+                -0.6,
+                0.88
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.46,
+                "B2/C1": 0.28
+            },
+            "build_spread_pct": 0.74,
+            "builds": 2,
+            "system_ms": 182.9087,
+            "bundled_ms": 182.9012,
+            "raw_delta_pct": -0.33,
+            "spread_pct": [
+                1.3,
+                1.8
+            ],
+            "system_runs_ms": [
+                182.9087,
+                182.4949,
+                183.8546,
+                182.4232,
+                181.7668,
+                184.1783,
+                183.8865
+            ],
+            "bundled_runs_ms": [
+                182.3108,
+                185.5733,
+                182.2712,
+                182.9012,
+                183.3426,
+                183.5152,
+                182.7579
+            ],
+            "paired_ratios": [
+                0.99673,
+                1.01687,
+                0.99139,
+                1.00262,
+                1.00867,
+                0.9964,
+                0.99386
+            ]
+        },
+        "api.setop.intersect.bitset": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99894,
+            "delta_pct": -0.11,
+            "ci_delta_pct": [
+                -0.45,
+                0.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.28,
+                "B2/C1": 0.01
+            },
+            "build_spread_pct": 0.29,
+            "builds": 2,
+            "system_ms": 87.0342,
+            "bundled_ms": 87.0472,
+            "raw_delta_pct": -0.12,
+            "spread_pct": [
+                0.9,
+                1
+            ],
+            "system_runs_ms": [
+                87.5911,
+                87.016,
+                86.7941,
+                87.0342,
+                86.7911,
+                87.051,
+                87.1035
+            ],
+            "bundled_runs_ms": [
+                87.067,
+                87.2746,
+                87.094,
+                86.7833,
+                86.3858,
+                87.0472,
+                86.9984
+            ],
+            "paired_ratios": [
+                0.99402,
+                1.00297,
+                1.00346,
+                0.99712,
+                0.99533,
+                0.99996,
+                0.99879
+            ]
+        },
+        "api.setop.diff.bitset": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99933,
+            "delta_pct": -0.07,
+            "ci_delta_pct": [
+                -0.11,
+                0.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.08,
+                "B2/C1": -0.07
+            },
+            "build_spread_pct": 0.15,
+            "builds": 2,
+            "system_ms": 86.2641,
+            "bundled_ms": 86.2545,
+            "raw_delta_pct": -0.08,
+            "spread_pct": [
+                1.4,
+                0.6
+            ],
+            "system_runs_ms": [
+                86.2441,
+                86.3192,
+                86.2562,
+                86.7881,
+                85.5814,
+                86.2641,
+                86.4403
+            ],
+            "bundled_runs_ms": [
+                86.4453,
+                86.249,
+                86.1632,
+                86.1097,
+                86.6663,
+                86.2545,
+                86.3291
+            ],
+            "paired_ratios": [
+                1.00233,
+                0.99919,
+                0.99892,
+                0.99218,
+                1.01268,
+                0.99989,
+                0.99871
+            ]
+        },
+        "api.setop.xor.bitset": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99769,
+            "delta_pct": -0.23,
+            "ci_delta_pct": [
+                -0.42,
+                0.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.13,
+                "B2/C1": -0.23
+            },
+            "build_spread_pct": 0.1,
+            "builds": 2,
+            "system_ms": 173.1094,
+            "bundled_ms": 172.8478,
+            "raw_delta_pct": -0.25,
+            "spread_pct": [
+                0.9,
+                0.3
+            ],
+            "system_runs_ms": [
+                173.4469,
+                173.898,
+                173.1094,
+                173.2733,
+                172.4916,
+                172.9932,
+                172.426
+            ],
+            "bundled_runs_ms": [
+                172.6965,
+                173.0343,
+                172.4826,
+                172.8478,
+                172.6119,
+                172.9824,
+                173.0564
+            ],
+            "paired_ratios": [
+                0.99567,
+                0.99503,
+                0.99638,
+                0.99754,
+                1.0007,
+                0.99994,
+                1.00366
+            ]
+        },
+        "api.setop.union.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00364,
+            "delta_pct": 0.36,
+            "ci_delta_pct": [
+                -0.1,
+                0.99
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.5,
+                "B2/C1": 0.36
+            },
+            "build_spread_pct": 0.14,
+            "builds": 2,
+            "system_ms": 265.5745,
+            "bundled_ms": 266.4736,
+            "raw_delta_pct": 0.35,
+            "spread_pct": [
+                0.6,
+                1.3
+            ],
+            "system_runs_ms": [
+                266.5497,
+                266.4324,
+                265.0297,
+                265.5469,
+                265.5745,
+                266.5798,
+                264.938
+            ],
+            "bundled_runs_ms": [
+                266.239,
+                269.0234,
+                265.7866,
+                266.4736,
+                267.4036,
+                265.4999,
+                268.0678
+            ],
+            "paired_ratios": [
+                0.99883,
+                1.00972,
+                1.00286,
+                1.00349,
+                1.00689,
+                0.99595,
+                1.01181
+            ]
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00102,
+            "delta_pct": 0.1,
+            "ci_delta_pct": [
+                -0.23,
+                0.37
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.09,
+                "B2/C1": 0.37
+            },
+            "build_spread_pct": 0.28,
+            "builds": 2,
+            "system_ms": 109.2268,
+            "bundled_ms": 109.0533,
+            "raw_delta_pct": 0.09,
+            "spread_pct": [
+                0.7,
+                1.2
+            ],
+            "system_runs_ms": [
+                109.1523,
+                109.2484,
+                108.59,
+                108.5546,
+                109.2268,
+                109.2487,
+                109.3224
+            ],
+            "bundled_runs_ms": [
+                109.2477,
+                109.9984,
+                108.6642,
+                108.9449,
+                109.414,
+                108.8791,
+                109.0533
+            ],
+            "paired_ratios": [
+                1.00087,
+                1.00687,
+                1.00068,
+                1.0036,
+                1.00171,
+                0.99662,
+                0.99754
+            ]
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00179,
+            "delta_pct": 0.18,
+            "ci_delta_pct": [
+                -0.01,
+                0.32
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.19,
+                "B2/C1": 0.18
+            },
+            "build_spread_pct": 0.01,
+            "builds": 2,
+            "system_ms": 107.8702,
+            "bundled_ms": 108.0288,
+            "raw_delta_pct": 0.16,
+            "spread_pct": [
+                0.9,
+                0.6
+            ],
+            "system_runs_ms": [
+                107.7571,
+                108.1429,
+                107.385,
+                107.8005,
+                108.3148,
+                107.8702,
+                107.9055
+            ],
+            "bundled_runs_ms": [
+                107.7275,
+                107.8434,
+                108.0288,
+                107.9777,
+                108.3966,
+                108.2003,
+                108.2089
+            ],
+            "paired_ratios": [
+                0.99973,
+                0.99723,
+                1.006,
+                1.00164,
+                1.00076,
+                1.00306,
+                1.00281
+            ]
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00083,
+            "delta_pct": 0.08,
+            "ci_delta_pct": [
+                -0.24,
+                0.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.06,
+                "B2/C1": 0.2
+            },
+            "build_spread_pct": 0.26,
+            "builds": 2,
+            "system_ms": 217.0423,
+            "bundled_ms": 216.8782,
+            "raw_delta_pct": 0.07,
+            "spread_pct": [
+                0.5,
+                0.9
+            ],
+            "system_runs_ms": [
+                216.705,
+                217.0478,
+                216.6467,
+                216.4846,
+                217.132,
+                217.5437,
+                217.0423
+            ],
+            "bundled_runs_ms": [
+                216.2274,
+                218.0716,
+                216.7956,
+                216.8782,
+                217.7339,
+                216.9988,
+                216.1776
+            ],
+            "paired_ratios": [
+                0.9978,
+                1.00472,
+                1.00069,
+                1.00182,
+                1.00277,
+                0.9975,
+                0.99602
+            ]
+        },
+        "api.setop.union.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00164,
+            "delta_pct": 0.16,
+            "ci_delta_pct": [
+                -0.51,
+                0.42
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.22,
+                "B2/C1": 0.16
+            },
+            "build_spread_pct": 0.06,
+            "builds": 2,
+            "system_ms": 1452.1746,
+            "bundled_ms": 1455.7458,
+            "raw_delta_pct": 0.15,
+            "spread_pct": [
+                1.3,
+                0.7
+            ],
+            "system_runs_ms": [
+                1449.8938,
+                1452.1746,
+                1454.6851,
+                1451.2517,
+                1467.0852,
+                1456.7018,
+                1448.3173
+            ],
+            "bundled_runs_ms": [
+                1455.7458,
+                1458.8227,
+                1456.0335,
+                1453.416,
+                1459.4202,
+                1448.7014,
+                1452.9215
+            ],
+            "paired_ratios": [
+                1.00404,
+                1.00458,
+                1.00093,
+                1.00149,
+                0.99478,
+                0.99451,
+                1.00318
+            ]
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00076,
+            "delta_pct": 0.08,
+            "ci_delta_pct": [
+                -1.13,
+                0.61
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.02,
+                "B2/C1": 0.37
+            },
+            "build_spread_pct": 0.35,
+            "builds": 2,
+            "system_ms": 654.1733,
+            "bundled_ms": 651.6157,
+            "raw_delta_pct": 0.06,
+            "spread_pct": [
+                1,
+                2.1
+            ],
+            "system_runs_ms": [
+                650.6047,
+                653.9001,
+                656.6502,
+                657.1653,
+                651.9809,
+                654.1733,
+                657.0141
+            ],
+            "bundled_runs_ms": [
+                651.0061,
+                657.7933,
+                648.5774,
+                649.6544,
+                651.6157,
+                656.4931,
+                662.5451
+            ],
+            "paired_ratios": [
+                1.00062,
+                1.00595,
+                0.98771,
+                0.98857,
+                0.99944,
+                1.00355,
+                1.00842
+            ]
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99896,
+            "delta_pct": -0.1,
+            "ci_delta_pct": [
+                -0.19,
+                0.51
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.08,
+                "B2/C1": -0.1
+            },
+            "build_spread_pct": 0.02,
+            "builds": 2,
+            "system_ms": 671.5199,
+            "bundled_ms": 671.641,
+            "raw_delta_pct": -0.12,
+            "spread_pct": [
+                1.1,
+                0.5
+            ],
+            "system_runs_ms": [
+                670.3783,
+                671.5199,
+                675.864,
+                668.4658,
+                672.2462,
+                672.4401,
+                669.7928
+            ],
+            "bundled_runs_ms": [
+                670.0581,
+                670.1665,
+                672.2965,
+                671.7647,
+                671.2991,
+                671.641,
+                673.565
+            ],
+            "paired_ratios": [
+                0.99952,
+                0.99798,
+                0.99472,
+                1.00494,
+                0.99859,
+                0.99881,
+                1.00563
+            ]
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99963,
+            "delta_pct": -0.04,
+            "ci_delta_pct": [
+                -0.14,
+                0.4
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.01,
+                "B2/C1": -0.14
+            },
+            "build_spread_pct": 0.15,
+            "builds": 2,
+            "system_ms": 303.0698,
+            "bundled_ms": 303.1554,
+            "raw_delta_pct": -0.05,
+            "spread_pct": [
+                1.3,
+                0.5
+            ],
+            "system_runs_ms": [
+                303.311,
+                303.5322,
+                302.3186,
+                305.9163,
+                302.033,
+                302.3983,
+                303.0698
+            ],
+            "bundled_runs_ms": [
+                303.1554,
+                303.0581,
+                302.1051,
+                302.8379,
+                303.5602,
+                303.555,
+                303.1704
+            ],
+            "paired_ratios": [
+                0.99949,
+                0.99844,
+                0.99929,
+                0.98994,
+                1.00506,
+                1.00383,
+                1.00033
+            ]
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00518,
+            "delta_pct": 0.52,
+            "ci_delta_pct": [
+                -0.1,
+                0.69
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.53,
+                "B2/C1": 0.32
+            },
+            "build_spread_pct": 0.21,
+            "builds": 2,
+            "system_ms": 1194.9601,
+            "bundled_ms": 1201.2973,
+            "raw_delta_pct": 0.5,
+            "spread_pct": [
+                0.4,
+                1.1
+            ],
+            "system_runs_ms": [
+                1196.1323,
+                1192.9894,
+                1191.9266,
+                1195.1119,
+                1196.6722,
+                1192.0241,
+                1194.9601
+            ],
+            "bundled_runs_ms": [
+                1204.2184,
+                1201.9803,
+                1190.594,
+                1193.4476,
+                1202.6897,
+                1195.6496,
+                1201.2973
+            ],
+            "paired_ratios": [
+                1.00676,
+                1.00754,
+                0.99888,
+                0.99861,
+                1.00503,
+                1.00304,
+                1.0053
+            ]
+        },
+        "adv.forEach.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99635,
+            "delta_pct": -0.37,
+            "ci_delta_pct": [
+                -0.98,
+                0.72
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.44,
+                "B2/C1": 0.38
+            },
+            "build_spread_pct": 0.82,
+            "builds": 2,
+            "system_ms": 190.391,
+            "bundled_ms": 189.8636,
+            "raw_delta_pct": -0.38,
+            "spread_pct": [
+                2.4,
+                1.4
+            ],
+            "system_runs_ms": [
+                188.5253,
+                191.3073,
+                191.8443,
+                190.391,
+                189.0771,
+                187.3337,
+                190.454
+            ],
+            "bundled_runs_ms": [
+                189.8636,
+                188.4064,
+                190.8257,
+                191.0787,
+                188.3585,
+                190.6425,
+                188.5638
+            ],
+            "paired_ratios": [
+                1.0071,
+                0.98484,
+                0.99469,
+                1.00361,
+                0.9962,
+                1.01766,
+                0.99008
+            ]
+        },
+        "adv.forEach.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00458,
+            "delta_pct": 0.46,
+            "ci_delta_pct": [
+                -0.28,
+                0.55
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.31,
+                "B2/C1": 0.46
+            },
+            "build_spread_pct": 0.15,
+            "builds": 2,
+            "system_ms": 354.0218,
+            "bundled_ms": 355.2025,
+            "raw_delta_pct": 0.44,
+            "spread_pct": [
+                1.1,
+                1.2
+            ],
+            "system_runs_ms": [
+                357.3678,
+                353.9805,
+                354.0218,
+                353.9051,
+                356.3403,
+                354.7974,
+                353.3106
+            ],
+            "bundled_runs_ms": [
+                354.6881,
+                355.5494,
+                354.4387,
+                357.5204,
+                358.0298,
+                353.7622,
+                355.2025
+            ],
+            "paired_ratios": [
+                0.9925,
+                1.00443,
+                1.00118,
+                1.01022,
+                1.00474,
+                0.99708,
+                1.00535
+            ]
+        },
+        "adv.filter.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.998,
+            "delta_pct": -0.2,
+            "ci_delta_pct": [
+                -0.6,
+                0.52
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.4,
+                "B2/C1": 0.19
+            },
+            "build_spread_pct": 0.59,
+            "builds": 2,
+            "system_ms": 283.5845,
+            "bundled_ms": 282.4149,
+            "raw_delta_pct": -0.21,
+            "spread_pct": [
+                1.2,
+                0.9
+            ],
+            "system_runs_ms": [
+                284.0827,
+                282.3694,
+                281.3634,
+                283.666,
+                284.65,
+                283.5845,
+                282.5772
+            ],
+            "bundled_runs_ms": [
+                282.3339,
+                283.8048,
+                284.3871,
+                284.1589,
+                282.4149,
+                281.864,
+                281.9701
+            ],
+            "paired_ratios": [
+                0.99384,
+                1.00508,
+                1.01075,
+                1.00174,
+                0.99215,
+                0.99393,
+                0.99785
+            ]
+        },
+        "adv.filter.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99919,
+            "delta_pct": -0.08,
+            "ci_delta_pct": [
+                -0.09,
+                0.11
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.09,
+                "B2/C1": 0.11
+            },
+            "build_spread_pct": 0.2,
+            "builds": 2,
+            "system_ms": 781.569,
+            "bundled_ms": 781.1413,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                0.6,
+                0.5
+            ],
+            "system_runs_ms": [
+                782.8473,
+                782.5958,
+                781.569,
+                780.8558,
+                780.9919,
+                778.9399,
+                783.5087
+            ],
+            "bundled_runs_ms": [
+                779.2169,
+                781.7831,
+                780.7435,
+                781.5833,
+                780.2476,
+                781.1413,
+                782.8624
+            ],
+            "paired_ratios": [
+                0.99536,
+                0.99896,
+                0.99894,
+                1.00093,
+                0.99905,
+                1.00283,
+                0.99918
+            ]
+        },
+        "adv.map.int_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99733,
+            "delta_pct": -0.27,
+            "ci_delta_pct": [
+                -0.38,
+                -0.02
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.31,
+                "B2/C1": -0.27
+            },
+            "build_spread_pct": 0.04,
+            "builds": 2,
+            "system_ms": 298.6934,
+            "bundled_ms": 298.0578,
+            "raw_delta_pct": -0.28,
+            "spread_pct": [
+                0.8,
+                2.4
+            ],
+            "system_runs_ms": [
+                299.8855,
+                298.1681,
+                299.5665,
+                298.0167,
+                297.5203,
+                298.6934,
+                299.5123
+            ],
+            "bundled_runs_ms": [
+                299.1071,
+                298.0578,
+                298.3694,
+                297.1772,
+                304.2754,
+                297.5103,
+                297.4202
+            ],
+            "paired_ratios": [
+                0.9974,
+                0.99963,
+                0.996,
+                0.99718,
+                1.0227,
+                0.99604,
+                0.99301
+            ]
+        },
+        "adv.map.string_to_int": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99825,
+            "delta_pct": -0.17,
+            "ci_delta_pct": [
+                -0.25,
+                0.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.21,
+                "B2/C1": 0.1
+            },
+            "build_spread_pct": 0.31,
+            "builds": 2,
+            "system_ms": 1067.7461,
+            "bundled_ms": 1066.3385,
+            "raw_delta_pct": -0.19,
+            "spread_pct": [
+                0.4,
+                0.4
+            ],
+            "system_runs_ms": [
+                1068.8497,
+                1068.3628,
+                1068.5902,
+                1066.1072,
+                1066.8098,
+                1064.7717,
+                1067.7461
+            ],
+            "bundled_runs_ms": [
+                1066.8213,
+                1066.3385,
+                1065.8104,
+                1066.9639,
+                1063.8354,
+                1066.1625,
+                1068.5465
+            ],
+            "paired_ratios": [
+                0.9981,
+                0.99811,
+                0.9974,
+                1.0008,
+                0.99721,
+                1.00131,
+                1.00075
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99517,
+            "delta_pct": -0.48,
+            "ci_delta_pct": [
+                -0.64,
+                -0.05
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.27,
+                "B2/C1": -0.64
+            },
+            "build_spread_pct": 0.37,
+            "builds": 2,
+            "system_ms": 22.0623,
+            "bundled_ms": 21.9843,
+            "raw_delta_pct": -0.5,
+            "spread_pct": [
+                3.1,
+                1.1
+            ],
+            "system_runs_ms": [
+                22.0332,
+                22.717,
+                22.0875,
+                22.0827,
+                22.0623,
+                22.0543,
+                22.0621
+            ],
+            "bundled_runs_ms": [
+                22.1019,
+                22.1822,
+                21.9775,
+                21.939,
+                22.0484,
+                21.9843,
+                21.9441
+            ],
+            "paired_ratios": [
+                1.00312,
+                0.97646,
+                0.99502,
+                0.99349,
+                0.99937,
+                0.99683,
+                0.99465
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99823,
+            "delta_pct": -0.18,
+            "ci_delta_pct": [
+                -0.77,
+                0.02
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.13,
+                "B2/C1": -0.18
+            },
+            "build_spread_pct": 0.05,
+            "builds": 2,
+            "system_ms": 12.8532,
+            "bundled_ms": 12.8316,
+            "raw_delta_pct": -0.19,
+            "spread_pct": [
+                1.6,
+                1.2
+            ],
+            "system_runs_ms": [
+                12.8504,
+                12.8532,
+                12.7741,
+                12.7288,
+                12.8681,
+                12.8563,
+                12.9363
+            ],
+            "bundled_runs_ms": [
+                12.8514,
+                12.7127,
+                12.7436,
+                12.7662,
+                12.8625,
+                12.8316,
+                12.8349
+            ],
+            "paired_ratios": [
+                1.00008,
+                0.98907,
+                0.99761,
+                1.00294,
+                0.99956,
+                0.99808,
+                0.99216
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00141,
+            "delta_pct": 0.14,
+            "ci_delta_pct": [
+                -0.24,
+                0.97
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.1,
+                "B2/C1": 0.97
+            },
+            "build_spread_pct": 1.07,
+            "builds": 2,
+            "system_ms": 58.2936,
+            "bundled_ms": 58.1894,
+            "raw_delta_pct": 0.13,
+            "spread_pct": [
+                3.5,
+                2
+            ],
+            "system_runs_ms": [
+                58.323,
+                56.5794,
+                57.8342,
+                57.6415,
+                58.3262,
+                58.2936,
+                58.6358
+            ],
+            "bundled_runs_ms": [
+                58.1461,
+                57.3104,
+                57.9849,
+                58.1894,
+                58.3374,
+                58.3673,
+                58.4893
+            ],
+            "paired_ratios": [
+                0.99697,
+                1.01292,
+                1.00261,
+                1.00951,
+                1.00019,
+                1.00126,
+                0.9975
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9986,
+            "delta_pct": -0.14,
+            "ci_delta_pct": [
+                -0.33,
+                0.18
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.03,
+                "B2/C1": -0.33
+            },
+            "build_spread_pct": 0.36,
+            "builds": 2,
+            "system_ms": 20.6183,
+            "bundled_ms": 20.5919,
+            "raw_delta_pct": -0.15,
+            "spread_pct": [
+                0.4,
+                0.4
+            ],
+            "system_runs_ms": [
+                20.5941,
+                20.6641,
+                20.6581,
+                20.6183,
+                20.5836,
+                20.6517,
+                20.6004
+            ],
+            "bundled_runs_ms": [
+                20.6576,
+                20.5919,
+                20.6262,
+                20.5814,
+                20.6167,
+                20.5703,
+                20.5747
+            ],
+            "paired_ratios": [
+                1.00308,
+                0.99651,
+                0.99846,
+                0.99821,
+                1.00161,
+                0.99606,
+                0.99875
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00076,
+            "delta_pct": 0.08,
+            "ci_delta_pct": [
+                -0.05,
+                0.22
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.21,
+                "B2/C1": -0.01
+            },
+            "build_spread_pct": 0.22,
+            "builds": 2,
+            "system_ms": 10.5334,
+            "bundled_ms": 10.5398,
+            "raw_delta_pct": 0.06,
+            "spread_pct": [
+                0.5,
+                0.6
+            ],
+            "system_runs_ms": [
+                10.5165,
+                10.5466,
+                10.5664,
+                10.5682,
+                10.5256,
+                10.5143,
+                10.5334
+            ],
+            "bundled_runs_ms": [
+                10.5383,
+                10.5398,
+                10.5856,
+                10.5656,
+                10.5603,
+                10.5207,
+                10.5225
+            ],
+            "paired_ratios": [
+                1.00207,
+                0.99936,
+                1.00182,
+                0.99975,
+                1.0033,
+                1.00061,
+                0.99897
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00183,
+            "delta_pct": 0.18,
+            "ci_delta_pct": [
+                0.04,
+                0.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.11,
+                "B2/C1": 0.3
+            },
+            "build_spread_pct": 0.19,
+            "builds": 2,
+            "system_ms": 51.132,
+            "bundled_ms": 51.184,
+            "raw_delta_pct": 0.17,
+            "spread_pct": [
+                0.7,
+                0.6
+            ],
+            "system_runs_ms": [
+                51.0656,
+                51.0381,
+                51.1489,
+                51.2561,
+                51.136,
+                50.9126,
+                51.132
+            ],
+            "bundled_runs_ms": [
+                51.0144,
+                51.184,
+                51.3208,
+                51.3356,
+                51.2219,
+                51.1449,
+                51.1427
+            ],
+            "paired_ratios": [
+                0.999,
+                1.00286,
+                1.00336,
+                1.00155,
+                1.00168,
+                1.00456,
+                1.00021
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.9999,
+            "delta_pct": -0.01,
+            "ci_delta_pct": [
+                -0.3,
+                0.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.1,
+                "B2/C1": -0.01
+            },
+            "build_spread_pct": 0.09,
+            "builds": 2,
+            "system_ms": 29.3302,
+            "bundled_ms": 29.3258,
+            "raw_delta_pct": -0.02,
+            "spread_pct": [
+                0.7,
+                0.5
+            ],
+            "system_runs_ms": [
+                29.2753,
+                29.3392,
+                29.4574,
+                29.4502,
+                29.2623,
+                29.2921,
+                29.3302
+            ],
+            "bundled_runs_ms": [
+                29.3672,
+                29.3319,
+                29.3793,
+                29.3258,
+                29.273,
+                29.3087,
+                29.2374
+            ],
+            "paired_ratios": [
+                1.00314,
+                0.99975,
+                0.99735,
+                0.99578,
+                1.00037,
+                1.00057,
+                0.99684
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00183,
+            "delta_pct": 0.18,
+            "ci_delta_pct": [
+                -0.62,
+                0.69
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.13,
+                "B2/C1": 0.27
+            },
+            "build_spread_pct": 0.14,
+            "builds": 2,
+            "system_ms": 18.0079,
+            "bundled_ms": 18.0157,
+            "raw_delta_pct": 0.17,
+            "spread_pct": [
+                1.4,
+                0.8
+            ],
+            "system_runs_ms": [
+                18.1432,
+                18.1092,
+                18.0866,
+                18.0079,
+                17.8953,
+                17.9478,
+                17.986
+            ],
+            "bundled_runs_ms": [
+                17.984,
+                17.9939,
+                18.0995,
+                18.1363,
+                18.0157,
+                17.9929,
+                18.0163
+            ],
+            "paired_ratios": [
+                0.99123,
+                0.99363,
+                1.00071,
+                1.00713,
+                1.00673,
+                1.00251,
+                1.00168
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00352,
+            "delta_pct": 0.35,
+            "ci_delta_pct": [
+                -0.6,
+                0.65
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.43,
+                "B2/C1": 0.21
+            },
+            "build_spread_pct": 0.22,
+            "builds": 2,
+            "system_ms": 61.3224,
+            "bundled_ms": 61.544,
+            "raw_delta_pct": 0.34,
+            "spread_pct": [
+                1.3,
+                1
+            ],
+            "system_runs_ms": [
+                61.9744,
+                61.7235,
+                61.3992,
+                61.1469,
+                61.1549,
+                61.272,
+                61.3224
+            ],
+            "bundled_runs_ms": [
+                61.2384,
+                61.3457,
+                61.6065,
+                61.8441,
+                61.544,
+                61.3912,
+                61.6206
+            ],
+            "paired_ratios": [
+                0.98812,
+                0.99388,
+                1.00338,
+                1.0114,
+                1.00636,
+                1.00195,
+                1.00486
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99779,
+            "delta_pct": -0.22,
+            "ci_delta_pct": [
+                -0.56,
+                0.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.12,
+                "B2/C1": -0.56
+            },
+            "build_spread_pct": 0.44,
+            "builds": 2,
+            "system_ms": 16.2957,
+            "bundled_ms": 16.231,
+            "raw_delta_pct": -0.24,
+            "spread_pct": [
+                1.2,
+                0.8
+            ],
+            "system_runs_ms": [
+                16.2359,
+                16.2172,
+                16.3478,
+                16.2957,
+                16.1598,
+                16.3002,
+                16.2964
+            ],
+            "bundled_runs_ms": [
+                16.231,
+                16.2515,
+                16.224,
+                16.202,
+                16.3334,
+                16.206,
+                16.258
+            ],
+            "paired_ratios": [
+                0.9997,
+                1.00212,
+                0.99243,
+                0.99425,
+                1.01074,
+                0.99422,
+                0.99764
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99914,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.43,
+                0.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.04,
+                "B2/C1": -0.43
+            },
+            "build_spread_pct": 0.39,
+            "builds": 2,
+            "system_ms": 18.8917,
+            "bundled_ms": 18.8726,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                1.1,
+                1.4
+            ],
+            "system_runs_ms": [
+                18.8691,
+                18.9459,
+                18.8917,
+                19.0696,
+                18.8673,
+                18.9434,
+                18.857
+            ],
+            "bundled_runs_ms": [
+                18.8821,
+                18.8613,
+                18.8726,
+                18.9512,
+                18.8667,
+                19.0784,
+                18.8227
+            ],
+            "paired_ratios": [
+                1.00069,
+                0.99553,
+                0.99899,
+                0.99379,
+                0.99997,
+                1.00713,
+                0.99818
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00069,
+            "delta_pct": 0.07,
+            "ci_delta_pct": [
+                -0.64,
+                0.68
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.09,
+                "B2/C1": -0.03
+            },
+            "build_spread_pct": 0.12,
+            "builds": 2,
+            "system_ms": 116.2182,
+            "bundled_ms": 116.3251,
+            "raw_delta_pct": 0.05,
+            "spread_pct": [
+                1.3,
+                1.9
+            ],
+            "system_runs_ms": [
+                116.2182,
+                116.8264,
+                115.5614,
+                117.0218,
+                116.7551,
+                116.2155,
+                115.7124
+            ],
+            "bundled_runs_ms": [
+                116.334,
+                116.0587,
+                116.3251,
+                116.9682,
+                115.5097,
+                117.7247,
+                115.7754
+            ],
+            "paired_ratios": [
+                1.001,
+                0.99343,
+                1.00661,
+                0.99954,
+                0.98933,
+                1.01299,
+                1.00054
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99936,
+            "delta_pct": -0.06,
+            "ci_delta_pct": [
+                -0.41,
+                0.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.15,
+                "B2/C1": -0.06
+            },
+            "build_spread_pct": 0.09,
+            "builds": 2,
+            "system_ms": 16.2133,
+            "bundled_ms": 16.1927,
+            "raw_delta_pct": -0.08,
+            "spread_pct": [
+                0.7,
+                0.3
+            ],
+            "system_runs_ms": [
+                16.1624,
+                16.2133,
+                16.1707,
+                16.1668,
+                16.2378,
+                16.2737,
+                16.237
+            ],
+            "bundled_runs_ms": [
+                16.1927,
+                16.2017,
+                16.158,
+                16.1808,
+                16.1971,
+                16.2044,
+                16.1555
+            ],
+            "paired_ratios": [
+                1.00187,
+                0.99928,
+                0.99921,
+                1.00087,
+                0.99749,
+                0.99574,
+                0.99498
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99927,
+            "delta_pct": -0.07,
+            "ci_delta_pct": [
+                -0.16,
+                0.54
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.01,
+                "B2/C1": -0.11
+            },
+            "build_spread_pct": 0.1,
+            "builds": 2,
+            "system_ms": 18.9983,
+            "bundled_ms": 19.009,
+            "raw_delta_pct": -0.09,
+            "spread_pct": [
+                0.7,
+                0.8
+            ],
+            "system_runs_ms": [
+                19.0655,
+                18.9983,
+                19,
+                19.0631,
+                18.9763,
+                18.929,
+                18.9782
+            ],
+            "bundled_runs_ms": [
+                18.971,
+                18.965,
+                19.009,
+                19.0397,
+                18.9596,
+                19.028,
+                19.1073
+            ],
+            "paired_ratios": [
+                0.99504,
+                0.99825,
+                1.00047,
+                0.99877,
+                0.99912,
+                1.00523,
+                1.0068
+            ]
+        },
+        "adv.optiter.ratio.increment.string_to_int_hash": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00141,
+            "delta_pct": 0.14,
+            "ci_delta_pct": [
+                -0.19,
+                0.97
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.16,
+                "B2/C1": -0.09
+            },
+            "build_spread_pct": 0.25,
+            "builds": 2,
+            "system_ms": 117.1772,
+            "bundled_ms": 117.4253,
+            "raw_delta_pct": 0.13,
+            "spread_pct": [
+                1.4,
+                1
+            ],
+            "system_runs_ms": [
+                117.9621,
+                117.1772,
+                117.4967,
+                117.9146,
+                116.8648,
+                116.3168,
+                116.8828
+            ],
+            "bundled_runs_ms": [
+                117.1582,
+                117.0554,
+                117.6448,
+                117.6688,
+                117.0558,
+                117.4253,
+                118.271
+            ],
+            "paired_ratios": [
+                0.99319,
+                0.99896,
+                1.00126,
+                0.99792,
+                1.00163,
+                1.00953,
+                1.01188
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00077,
+            "delta_pct": 0.08,
+            "ci_delta_pct": [
+                -0.33,
+                0.25
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.06,
+                "B2/C1": 0.25
+            },
+            "build_spread_pct": 0.31,
+            "builds": 2,
+            "system_ms": 30.1108,
+            "bundled_ms": 30.0469,
+            "raw_delta_pct": 0.06,
+            "spread_pct": [
+                1.3,
+                0.6
+            ],
+            "system_runs_ms": [
+                30.1319,
+                30.1522,
+                30.0952,
+                29.7572,
+                30.0894,
+                30.1293,
+                30.1108
+            ],
+            "bundled_runs_ms": [
+                30.0295,
+                30.0469,
+                30.1484,
+                30.0434,
+                30.1082,
+                30.2006,
+                30.0458
+            ],
+            "paired_ratios": [
+                0.9966,
+                0.99651,
+                1.00177,
+                1.00962,
+                1.00062,
+                1.00237,
+                0.99784
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99589,
+            "delta_pct": -0.41,
+            "ci_delta_pct": [
+                -1.95,
+                0.39
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.5,
+                "B2/C1": -0.4
+            },
+            "build_spread_pct": 0.1,
+            "builds": 2,
+            "system_ms": 13.9856,
+            "bundled_ms": 13.9532,
+            "raw_delta_pct": -0.43,
+            "spread_pct": [
+                2.4,
+                0.9
+            ],
+            "system_runs_ms": [
+                14.0245,
+                14.2327,
+                13.9625,
+                13.9856,
+                14.2188,
+                13.9029,
+                13.9065
+            ],
+            "bundled_runs_ms": [
+                13.9648,
+                13.9532,
+                13.8781,
+                13.9274,
+                13.9398,
+                14.0021,
+                13.9585
+            ],
+            "paired_ratios": [
+                0.99574,
+                0.98036,
+                0.99396,
+                0.99584,
+                0.98038,
+                1.00714,
+                1.00374
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99235,
+            "delta_pct": -0.77,
+            "ci_delta_pct": [
+                -1.61,
+                0.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.42,
+                "B2/C1": -1.35
+            },
+            "build_spread_pct": 0.93,
+            "builds": 2,
+            "system_ms": 46.5436,
+            "bundled_ms": 46.3636,
+            "raw_delta_pct": -0.78,
+            "spread_pct": [
+                2.4,
+                1
+            ],
+            "system_runs_ms": [
+                46.5436,
+                47.2029,
+                46.3945,
+                46.999,
+                47.255,
+                46.1442,
+                46.1843
+            ],
+            "bundled_runs_ms": [
+                46.5036,
+                46.4379,
+                46.0328,
+                46.3575,
+                46.299,
+                46.3636,
+                46.4573
+            ],
+            "paired_ratios": [
+                0.99914,
+                0.98379,
+                0.9922,
+                0.98635,
+                0.97977,
+                1.00475,
+                1.00591
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00085,
+            "delta_pct": 0.09,
+            "ci_delta_pct": [
+                -0.27,
+                0.39
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.35,
+                "B2/C1": -0.27
+            },
+            "build_spread_pct": 0.62,
+            "builds": 2,
+            "system_ms": 29.2546,
+            "bundled_ms": 29.2769,
+            "raw_delta_pct": 0.07,
+            "spread_pct": [
+                0.9,
+                1.2
+            ],
+            "system_runs_ms": [
+                29.1746,
+                29.2563,
+                29.3194,
+                29.3965,
+                29.2546,
+                29.1544,
+                29.1305
+            ],
+            "bundled_runs_ms": [
+                29.2612,
+                29.2769,
+                29.4288,
+                29.3118,
+                29.1794,
+                29.07,
+                29.2807
+            ],
+            "paired_ratios": [
+                1.00297,
+                1.0007,
+                1.00373,
+                0.99712,
+                0.99743,
+                0.99711,
+                1.00516
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99908,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.25,
+                0.41
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.16,
+                "B2/C1": 0.15
+            },
+            "build_spread_pct": 0.31,
+            "builds": 2,
+            "system_ms": 12.4294,
+            "bundled_ms": 12.4113,
+            "raw_delta_pct": -0.11,
+            "spread_pct": [
+                0.9,
+                0.8
+            ],
+            "system_runs_ms": [
+                12.4751,
+                12.4294,
+                12.4367,
+                12.4437,
+                12.4214,
+                12.3687,
+                12.3688
+            ],
+            "bundled_runs_ms": [
+                12.4044,
+                12.483,
+                12.4234,
+                12.4113,
+                12.3908,
+                12.3851,
+                12.4179
+            ],
+            "paired_ratios": [
+                0.99433,
+                1.00431,
+                0.99893,
+                0.9974,
+                0.99754,
+                1.00133,
+                1.00397
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00026,
+            "delta_pct": 0.03,
+            "ci_delta_pct": [
+                -0.46,
+                0.38
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.28,
+                "B2/C1": 0.38
+            },
+            "build_spread_pct": 0.66,
+            "builds": 2,
+            "system_ms": 42.4596,
+            "bundled_ms": 42.4099,
+            "raw_delta_pct": 0.01,
+            "spread_pct": [
+                1,
+                1
+            ],
+            "system_runs_ms": [
+                42.7599,
+                42.4844,
+                42.4182,
+                42.3305,
+                42.4596,
+                42.4249,
+                42.4599
+            ],
+            "bundled_runs_ms": [
+                42.392,
+                42.6378,
+                42.2151,
+                42.3422,
+                42.4642,
+                42.6044,
+                42.4099
+            ],
+            "paired_ratios": [
+                0.9914,
+                1.00361,
+                0.99521,
+                1.00028,
+                1.00011,
+                1.00423,
+                0.99882
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99956,
+            "delta_pct": -0.04,
+            "ci_delta_pct": [
+                -0.39,
+                0.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.21,
+                "B2/C1": -0.04
+            },
+            "build_spread_pct": 0.17,
+            "builds": 2,
+            "system_ms": 39.5128,
+            "bundled_ms": 39.4811,
+            "raw_delta_pct": -0.06,
+            "spread_pct": [
+                0.6,
+                0.5
+            ],
+            "system_runs_ms": [
+                39.5095,
+                39.5128,
+                39.4874,
+                39.5736,
+                39.5768,
+                39.3409,
+                39.543
+            ],
+            "bundled_runs_ms": [
+                39.4938,
+                39.4811,
+                39.5091,
+                39.5504,
+                39.3674,
+                39.3525,
+                39.3847
+            ],
+            "paired_ratios": [
+                0.9996,
+                0.9992,
+                1.00055,
+                0.99941,
+                0.99471,
+                1.00029,
+                0.996
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99949,
+            "delta_pct": -0.05,
+            "ci_delta_pct": [
+                -0.33,
+                0.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0,
+                "B2/C1": -0.05
+            },
+            "build_spread_pct": 0.05,
+            "builds": 2,
+            "system_ms": 21.7059,
+            "bundled_ms": 21.7139,
+            "raw_delta_pct": -0.07,
+            "spread_pct": [
+                1.2,
+                0.6
+            ],
+            "system_runs_ms": [
+                21.6986,
+                21.7532,
+                21.8092,
+                21.7858,
+                21.7059,
+                21.58,
+                21.5546
+            ],
+            "bundled_runs_ms": [
+                21.7405,
+                21.739,
+                21.7626,
+                21.6877,
+                21.6312,
+                21.6388,
+                21.7139
+            ],
+            "paired_ratios": [
+                1.00193,
+                0.99935,
+                0.99786,
+                0.9955,
+                0.99656,
+                1.00272,
+                1.00739
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.002,
+            "delta_pct": 0.2,
+            "ci_delta_pct": [
+                -0.25,
+                0.26
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.22,
+                "B2/C1": 0.03
+            },
+            "build_spread_pct": 0.19,
+            "builds": 2,
+            "system_ms": 54.9199,
+            "bundled_ms": 55.0478,
+            "raw_delta_pct": 0.19,
+            "spread_pct": [
+                1.3,
+                0.5
+            ],
+            "system_runs_ms": [
+                54.9199,
+                55.0537,
+                55.2308,
+                55.0514,
+                54.8451,
+                54.8538,
+                54.5094
+            ],
+            "bundled_runs_ms": [
+                55.0478,
+                55.0619,
+                55.0825,
+                54.8356,
+                54.9469,
+                54.9872,
+                55.133
+            ],
+            "paired_ratios": [
+                1.00233,
+                1.00015,
+                0.99731,
+                0.99608,
+                1.00186,
+                1.00243,
+                1.01144
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.00286,
+            "delta_pct": 0.29,
+            "ci_delta_pct": [
+                -0.66,
+                0.37
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.17,
+                "B2/C1": 0.29
+            },
+            "build_spread_pct": 0.46,
+            "builds": 2,
+            "system_ms": 24.5332,
+            "bundled_ms": 24.5488,
+            "raw_delta_pct": 0.27,
+            "spread_pct": [
+                1.1,
+                1.6
+            ],
+            "system_runs_ms": [
+                24.4625,
+                24.5332,
+                24.6669,
+                24.5033,
+                24.5174,
+                24.551,
+                24.7399
+            ],
+            "bundled_runs_ms": [
+                24.5488,
+                24.4997,
+                24.4998,
+                24.5697,
+                24.5925,
+                24.8317,
+                24.4413
+            ],
+            "paired_ratios": [
+                1.00353,
+                0.99863,
+                0.99323,
+                1.00271,
+                1.00306,
+                1.01143,
+                0.98793
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.optimized": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99912,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.12,
+                0.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -0.04,
+                "B2/C1": -0.09
+            },
+            "build_spread_pct": 0.05,
+            "builds": 2,
+            "system_ms": 26.2429,
+            "bundled_ms": 26.2523,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                0.5,
+                0.4
+            ],
+            "system_runs_ms": [
+                26.1877,
+                26.3164,
+                26.2879,
+                26.2511,
+                26.1888,
+                26.2429,
+                26.2276
+            ],
+            "bundled_runs_ms": [
+                26.2633,
+                26.2532,
+                26.2523,
+                26.2715,
+                26.1607,
+                26.216,
+                26.2259
+            ],
+            "paired_ratios": [
+                1.00289,
+                0.9976,
+                0.99865,
+                1.00078,
+                0.99893,
+                0.99897,
+                0.99994
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_adaptive": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.99911,
+            "delta_pct": -0.09,
+            "ci_delta_pct": [
+                -0.4,
+                0.56
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 0.26,
+                "B2/C1": -0.18
+            },
+            "build_spread_pct": 0.44,
+            "builds": 2,
+            "system_ms": 106.8911,
+            "bundled_ms": 106.9839,
+            "raw_delta_pct": -0.1,
+            "spread_pct": [
+                1.2,
+                1.6
+            ],
+            "system_runs_ms": [
+                107.0527,
+                107.2682,
+                106.5713,
+                107.1329,
+                106.8174,
+                106.8911,
+                106.0131
+            ],
+            "bundled_runs_ms": [
+                106.9839,
+                107.157,
+                107.1534,
+                106.9264,
+                106.3768,
+                105.5749,
+                107.3015
+            ],
+            "paired_ratios": [
+                0.99936,
+                0.99896,
+                1.00546,
+                0.99807,
+                0.99588,
+                0.98769,
+                1.01215
+            ]
+        }
+    },
+    "array_vs_bundled": {
+        "core.bitset.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.14476,
+            "delta_pct": 14.48,
+            "ci_delta_pct": [
+                14.24,
+                15.03
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                89.821,
+                92.5064,
+                89.483,
+                90.0078,
+                89.8821,
+                89.9311,
+                89.6162
+            ],
+            "judy_runs_ms": [
+                102.725,
+                103.0643,
+                102.8966,
+                102.826,
+                102.8938,
+                103.4951,
+                103.0895
+            ],
+            "array_ms": 89.8821,
+            "judy_ms": 102.8966,
+            "judy_over_array": 1.145,
+            "winner": "php-array"
+        },
+        "core.bitset.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.05624,
+            "delta_pct": 205.62,
+            "ci_delta_pct": [
+                203.16,
+                209.29
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                21.9951,
+                23.2681,
+                22.0431,
+                21.8748,
+                22.2316,
+                21.815,
+                22.215
+            ],
+            "judy_runs_ms": [
+                67.2222,
+                69.1733,
+                67.6468,
+                67.6572,
+                67.4739,
+                67.5465,
+                67.3479
+            ],
+            "array_ms": 22.0431,
+            "judy_ms": 67.5465,
+            "judy_over_array": 3.064,
+            "winner": "php-array"
+        },
+        "core.bitset.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.72546,
+            "delta_pct": 472.55,
+            "ci_delta_pct": [
+                472.1,
+                477.99
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.6775,
+                18.6568,
+                18.6775,
+                18.7006,
+                18.7296,
+                18.7787,
+                18.6689
+            ],
+            "judy_runs_ms": [
+                106.7418,
+                107.4959,
+                106.9373,
+                106.9868,
+                108.2549,
+                107.4812,
+                108.0094
+            ],
+            "array_ms": 18.6775,
+            "judy_ms": 107.4812,
+            "judy_over_array": 5.755,
+            "winner": "php-array"
+        },
+        "core.bitset.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.00343,
+            "delta_pct": -99.66,
+            "ci_delta_pct": [
+                -99.66,
+                -99.64
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.5517,
+                5.595,
+                5.5764,
+                5.5369,
+                5.5057,
+                5.5374,
+                5.4772
+            ],
+            "judy_runs_ms": [
+                0.02,
+                0.0188,
+                0.0201,
+                0.019,
+                0.0186,
+                0.0189,
+                0.0193
+            ],
+            "array_ms": 5.5374,
+            "judy_ms": 0.019,
+            "judy_over_array": 0.003,
+            "winner": "php-judy"
+        },
+        "core.int_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.56156,
+            "delta_pct": 56.16,
+            "ci_delta_pct": [
+                55.84,
+                56.54
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.4239,
+                92.228,
+                92.6502,
+                93.0142,
+                96.1237,
+                92.5493,
+                92.7214
+            ],
+            "judy_runs_ms": [
+                144.4174,
+                150.4855,
+                145.0328,
+                145.1867,
+                144.8664,
+                144.5212,
+                144.4985
+            ],
+            "array_ms": 92.6502,
+            "judy_ms": 144.8664,
+            "judy_over_array": 1.564,
+            "winner": "php-array"
+        },
+        "core.int_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.06179,
+            "delta_pct": 206.18,
+            "ci_delta_pct": [
+                202.64,
+                207.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                21.8494,
+                22.0828,
+                22.2116,
+                21.9227,
+                21.8229,
+                21.8616,
+                22.822
+            ],
+            "judy_runs_ms": [
+                66.8983,
+                67.0507,
+                67.221,
+                67.3862,
+                67.5783,
+                67.0005,
+                67.1811
+            ],
+            "array_ms": 21.9227,
+            "judy_ms": 67.1811,
+            "judy_over_array": 3.064,
+            "winner": "php-array"
+        },
+        "core.int_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.08435,
+            "delta_pct": 508.43,
+            "ci_delta_pct": [
+                505.24,
+                510.6
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.6942,
+                18.6273,
+                18.5718,
+                18.6046,
+                18.5705,
+                18.6155,
+                18.6436
+            ],
+            "judy_runs_ms": [
+                113.742,
+                113.7384,
+                112.8614,
+                114.3344,
+                112.3957,
+                113.5094,
+                112.5001
+            ],
+            "array_ms": 18.6155,
+            "judy_ms": 113.5094,
+            "judy_over_array": 6.098,
+            "winner": "php-array"
+        },
+        "core.int_to_int.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.40165,
+            "delta_pct": -59.83,
+            "ci_delta_pct": [
+                -60.18,
+                -59.73
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.2388,
+                5.3754,
+                5.4764,
+                5.5087,
+                5.4784,
+                5.458,
+                5.4979
+            ],
+            "judy_runs_ms": [
+                2.2354,
+                2.149,
+                2.2055,
+                2.2129,
+                2.2004,
+                2.1697,
+                2.1894
+            ],
+            "array_ms": 5.4764,
+            "judy_ms": 2.2004,
+            "judy_over_array": 0.402,
+            "winner": "php-judy"
+        },
+        "core.int_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.5051,
+            "delta_pct": 50.51,
+            "ci_delta_pct": [
+                49.87,
+                52.01
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                266.2136,
+                265.663,
+                266.7842,
+                267.212,
+                267.0062,
+                267.6054,
+                267.3407
+            ],
+            "judy_runs_ms": [
+                404.6785,
+                407.2962,
+                399.8164,
+                402.1801,
+                401.4752,
+                399.7588,
+                402.4808
+            ],
+            "array_ms": 267.0062,
+            "judy_ms": 402.1801,
+            "judy_over_array": 1.506,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.29029,
+            "delta_pct": 129.03,
+            "ci_delta_pct": [
+                127.72,
+                129.07
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                121.4148,
+                121.8038,
+                121.8671,
+                122.5637,
+                122.0876,
+                122.9461,
+                121.8011
+            ],
+            "judy_runs_ms": [
+                277.9227,
+                279.795,
+                279.1111,
+                279.1029,
+                279.6624,
+                279.8186,
+                278.9621
+            ],
+            "array_ms": 121.8671,
+            "judy_ms": 279.1111,
+            "judy_over_array": 2.29,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.72979,
+            "delta_pct": 272.98,
+            "ci_delta_pct": [
+                272.04,
+                274.69
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                85.9369,
+                85.8544,
+                86.0371,
+                86.2321,
+                86.2506,
+                86.5936,
+                86.5908
+            ],
+            "judy_runs_ms": [
+                321.9997,
+                320.1109,
+                321.9846,
+                323.1812,
+                321.6965,
+                321.8427,
+                322.1492
+            ],
+            "array_ms": 86.2321,
+            "judy_ms": 321.9846,
+            "judy_over_array": 3.734,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.1591,
+            "delta_pct": 115.91,
+            "ci_delta_pct": [
+                114.63,
+                117.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                46.3421,
+                46.4833,
+                46.8808,
+                46.6631,
+                46.6498,
+                46.7876,
+                46.62
+            ],
+            "judy_runs_ms": [
+                100.9816,
+                101.1999,
+                100.3802,
+                100.6087,
+                101.2273,
+                101.0193,
+                100.0604
+            ],
+            "array_ms": 46.6498,
+            "judy_ms": 100.9816,
+            "judy_over_array": 2.165,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.39131,
+            "delta_pct": 39.13,
+            "ci_delta_pct": [
+                38.23,
+                39.8
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                254.3958,
+                250.9909,
+                251.4169,
+                252.9265,
+                251.631,
+                251.579,
+                250.9343
+            ],
+            "judy_runs_ms": [
+                346.1556,
+                358.6959,
+                351.4893,
+                349.6312,
+                349.5575,
+                350.9368,
+                349.1281
+            ],
+            "array_ms": 251.579,
+            "judy_ms": 349.6312,
+            "judy_over_array": 1.39,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.902,
+            "delta_pct": 90.2,
+            "ci_delta_pct": [
+                90.09,
+                90.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                107.6079,
+                107.9225,
+                108.0579,
+                107.6791,
+                108.0903,
+                108.127,
+                107.9634
+            ],
+            "judy_runs_ms": [
+                205.1865,
+                205.2684,
+                205.3869,
+                205.7361,
+                205.4722,
+                205.5619,
+                205.5217
+            ],
+            "array_ms": 107.9634,
+            "judy_ms": 205.4722,
+            "judy_over_array": 1.903,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 11.59347,
+            "delta_pct": 1059.35,
+            "ci_delta_pct": [
+                1052.54,
+                1062.11
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                21.3461,
+                21.3298,
+                21.2892,
+                21.5217,
+                21.3073,
+                21.441,
+                21.4193
+            ],
+            "judy_runs_ms": [
+                248.386,
+                247.3002,
+                247.403,
+                247.9125,
+                247.0255,
+                247.4031,
+                246.865
+            ],
+            "array_ms": 21.3461,
+            "judy_ms": 247.403,
+            "judy_over_array": 11.59,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.10009,
+            "delta_pct": 10.01,
+            "ci_delta_pct": [
+                9.75,
+                10.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                47.5445,
+                47.5835,
+                47.7482,
+                49.1174,
+                47.5355,
+                47.8081,
+                47.6816
+            ],
+            "judy_runs_ms": [
+                52.6017,
+                52.4047,
+                52.4058,
+                52.1988,
+                52.5672,
+                52.5294,
+                52.4542
+            ],
+            "array_ms": 47.6816,
+            "judy_ms": 52.4542,
+            "judy_over_array": 1.1,
+            "winner": "php-array"
+        },
+        "core.string_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.60479,
+            "delta_pct": 160.48,
+            "ci_delta_pct": [
+                159.85,
+                160.72
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                245.1355,
+                245.71,
+                246.2383,
+                247.1391,
+                245.461,
+                246.1314,
+                245.8589
+            ],
+            "judy_runs_ms": [
+                640.713,
+                640.6131,
+                641.7364,
+                639.9591,
+                639.3744,
+                639.5788,
+                639.789
+            ],
+            "array_ms": 245.8589,
+            "judy_ms": 639.9591,
+            "judy_over_array": 2.603,
+            "winner": "php-array"
+        },
+        "core.string_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.12373,
+            "delta_pct": 312.37,
+            "ci_delta_pct": [
+                308.63,
+                315.45
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                48.6312,
+                49.7199,
+                50.5923,
+                50.3496,
+                49.2898,
+                49.1885,
+                49.767
+            ],
+            "judy_runs_ms": [
+                205.3388,
+                205.0315,
+                206.7337,
+                204.9717,
+                204.4778,
+                204.3554,
+                204.6255
+            ],
+            "array_ms": 49.7199,
+            "judy_ms": 204.9717,
+            "judy_over_array": 4.123,
+            "winner": "php-array"
+        },
+        "core.string_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.31263,
+            "delta_pct": 931.26,
+            "ci_delta_pct": [
+                922.08,
+                932.72
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                28.48,
+                28.2556,
+                28.2455,
+                28.1716,
+                28.4099,
+                28.2454,
+                27.9987
+            ],
+            "judy_runs_ms": [
+                290.9574,
+                291.206,
+                291.3178,
+                290.9336,
+                290.3728,
+                291.2844,
+                292.9071
+            ],
+            "array_ms": 28.2455,
+            "judy_ms": 291.206,
+            "judy_over_array": 10.31,
+            "winner": "php-array"
+        },
+        "core.string_to_int.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.95688,
+            "delta_pct": 395.69,
+            "ci_delta_pct": [
+                394.2,
+                396.52
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.1903,
+                22.2859,
+                22.3116,
+                22.1802,
+                22.2126,
+                22.3185,
+                22.2521
+            ],
+            "judy_runs_ms": [
+                110.7448,
+                110.1364,
+                110.3011,
+                110.1288,
+                110.2139,
+                109.9295,
+                110.301
+            ],
+            "array_ms": 22.2521,
+            "judy_ms": 110.2139,
+            "judy_over_array": 4.953,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.11149,
+            "delta_pct": 111.15,
+            "ci_delta_pct": [
+                109.82,
+                111.66
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                469.6382,
+                471.4328,
+                470.4549,
+                469.1111,
+                469.5668,
+                471.4265,
+                470.2728
+            ],
+            "judy_runs_ms": [
+                991.6477,
+                989.1745,
+                995.757,
+                1003.7372,
+                991.4836,
+                987.7196,
+                989.4244
+            ],
+            "array_ms": 470.2728,
+            "judy_ms": 991.4836,
+            "judy_over_array": 2.108,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.31122,
+            "delta_pct": 231.12,
+            "ci_delta_pct": [
+                230.85,
+                232.4
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                237.5879,
+                238.091,
+                237.7656,
+                236.3527,
+                236.8035,
+                238.2154,
+                237.1596
+            ],
+            "judy_runs_ms": [
+                786.7059,
+                787.7166,
+                786.7103,
+                785.9475,
+                787.1274,
+                786.2054,
+                786.9566
+            ],
+            "array_ms": 237.5879,
+            "judy_ms": 786.7103,
+            "judy_over_array": 3.311,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.60087,
+            "delta_pct": 460.09,
+            "ci_delta_pct": [
+                459.49,
+                461.39
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                148.5647,
+                146.7679,
+                146.3891,
+                146.2214,
+                146.2593,
+                146.4518,
+                146.2867
+            ],
+            "judy_runs_ms": [
+                821.4581,
+                822.4037,
+                819.9065,
+                818.101,
+                821.0843,
+                819.4484,
+                823.7054
+            ],
+            "array_ms": 146.3891,
+            "judy_ms": 821.0843,
+            "judy_over_array": 5.609,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.39509,
+            "delta_pct": 439.51,
+            "ci_delta_pct": [
+                438.18,
+                440.67
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                63.9748,
+                64.5341,
+                64.2249,
+                63.9554,
+                64.1819,
+                64.3811,
+                64.1353
+            ],
+            "judy_runs_ms": [
+                345.8905,
+                346.091,
+                346.4991,
+                346.0984,
+                345.4159,
+                346.8503,
+                346.7093
+            ],
+            "array_ms": 64.1819,
+            "judy_ms": 346.0984,
+            "judy_over_array": 5.392,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.28279,
+            "delta_pct": 328.28,
+            "ci_delta_pct": [
+                327.62,
+                329.51
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                245.0456,
+                244.7698,
+                245.1346,
+                244.7791,
+                244.7237,
+                245.6137,
+                244.9154
+            ],
+            "judy_runs_ms": [
+                1049.4798,
+                1048.5147,
+                1055.8519,
+                1047.1381,
+                1051.1106,
+                1047.6327,
+                1047.3091
+            ],
+            "array_ms": 244.9154,
+            "judy_ms": 1048.5147,
+            "judy_over_array": 4.281,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.4096,
+            "delta_pct": 240.96,
+            "ci_delta_pct": [
+                237.11,
+                245.78
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                49.0343,
+                49.2252,
+                51.2199,
+                50.4344,
+                50.4096,
+                49.8051,
+                50.0173
+            ],
+            "judy_runs_ms": [
+                171.5751,
+                170.2103,
+                170.3249,
+                170.7519,
+                169.9357,
+                171.1508,
+                170.5389
+            ],
+            "array_ms": 50.0173,
+            "judy_ms": 170.5389,
+            "judy_over_array": 3.41,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.77387,
+            "delta_pct": 1277.39,
+            "ci_delta_pct": [
+                1267.21,
+                1288.63
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                28.4313,
+                27.8174,
+                28.0914,
+                28.5983,
+                28.2399,
+                28.0204,
+                28.1857
+            ],
+            "judy_runs_ms": [
+                388.7145,
+                389.1141,
+                387.735,
+                388.1019,
+                387.6313,
+                389.1006,
+                388.2263
+            ],
+            "array_ms": 28.1857,
+            "judy_ms": 388.2263,
+            "judy_over_array": 13.774,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.6125,
+            "delta_pct": 961.25,
+            "ci_delta_pct": [
+                958.87,
+                965.05
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.1383,
+                22.0596,
+                22.2526,
+                22.0924,
+                22.1415,
+                22.1074,
+                22.0911
+            ],
+            "judy_runs_ms": [
+                234.4168,
+                235.116,
+                234.604,
+                234.9547,
+                234.9169,
+                234.6148,
+                235.2802
+            ],
+            "array_ms": 22.1074,
+            "judy_ms": 234.9169,
+            "judy_over_array": 10.626,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.21425,
+            "delta_pct": 321.42,
+            "ci_delta_pct": [
+                321.29,
+                323.05
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                453.0537,
+                452.3399,
+                453.494,
+                451.2185,
+                451.5381,
+                452.7563,
+                452.691
+            ],
+            "judy_runs_ms": [
+                1905.4464,
+                1906.2198,
+                1918.4924,
+                1914.739,
+                1908.5081,
+                1907.3984,
+                1907.7527
+            ],
+            "array_ms": 452.691,
+            "judy_ms": 1907.7527,
+            "judy_over_array": 4.214,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 16.62673,
+            "delta_pct": 1562.67,
+            "ci_delta_pct": [
+                1549.52,
+                1576.58
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                55.5997,
+                56.0783,
+                56.1243,
+                55.4269,
+                56.4855,
+                57.1076,
+                56.3728
+            ],
+            "judy_runs_ms": [
+                932.1733,
+                932.3985,
+                933.3162,
+                931.559,
+                931.7406,
+                931.0606,
+                932.623
+            ],
+            "array_ms": 56.1243,
+            "judy_ms": 932.1733,
+            "judy_over_array": 16.609,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.10301,
+            "delta_pct": 1110.3,
+            "ci_delta_pct": [
+                1106.04,
+                1117.71
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                35.4394,
+                34.9643,
+                35.5981,
+                35.3322,
+                35.5278,
+                35.8805,
+                35.126
+            ],
+            "judy_runs_ms": [
+                427.736,
+                432.0613,
+                429.3266,
+                428.2379,
+                429.9933,
+                428.5544,
+                427.7315
+            ],
+            "array_ms": 35.4394,
+            "judy_ms": 428.5544,
+            "judy_over_array": 12.093,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 9.4818,
+            "delta_pct": 848.18,
+            "ci_delta_pct": [
+                847.1,
+                849.87
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                64.7652,
+                65.0932,
+                64.8149,
+                64.7211,
+                64.8849,
+                64.8349,
+                64.8417
+            ],
+            "judy_runs_ms": [
+                613.7464,
+                614.6129,
+                613.8644,
+                614.7654,
+                616.2662,
+                614.7517,
+                618.6391
+            ],
+            "array_ms": 64.8349,
+            "judy_ms": 614.7517,
+            "judy_over_array": 9.482,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.25399,
+            "delta_pct": 325.4,
+            "ci_delta_pct": [
+                324.89,
+                326.08
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                246.942,
+                246.3501,
+                246.793,
+                246.2467,
+                246.8577,
+                246.675,
+                245.4006
+            ],
+            "judy_runs_ms": [
+                1050.2367,
+                1048.5221,
+                1051.5296,
+                1046.277,
+                1050.13,
+                1045.9655,
+                1047.9316
+            ],
+            "array_ms": 246.675,
+            "judy_ms": 1048.5221,
+            "judy_over_array": 4.251,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.4382,
+            "delta_pct": 243.82,
+            "ci_delta_pct": [
+                237.88,
+                246.74
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                48.2377,
+                50.6024,
+                49.3295,
+                50.0027,
+                50.6204,
+                49.5574,
+                49.8013
+            ],
+            "judy_runs_ms": [
+                170.7917,
+                170.4481,
+                171.0453,
+                171.9192,
+                171.0371,
+                171.3583,
+                170.4238
+            ],
+            "array_ms": 49.8013,
+            "judy_ms": 171.0371,
+            "judy_over_array": 3.434,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.71003,
+            "delta_pct": 1271,
+            "ci_delta_pct": [
+                1265.38,
+                1276.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                28.3878,
+                28.0822,
+                28.1709,
+                28.2868,
+                28.4726,
+                28.1783,
+                28.3597
+            ],
+            "judy_runs_ms": [
+                387.0634,
+                390.4505,
+                387.7884,
+                387.2768,
+                390.3602,
+                387.7204,
+                387.2188
+            ],
+            "array_ms": 28.2868,
+            "judy_ms": 387.7204,
+            "judy_over_array": 13.707,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.59865,
+            "delta_pct": 959.87,
+            "ci_delta_pct": [
+                950.95,
+                960.61
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.4032,
+                22.1409,
+                22.2136,
+                22.1427,
+                22.1895,
+                22.1556,
+                22.1502
+            ],
+            "judy_runs_ms": [
+                234.9156,
+                234.7508,
+                235.3924,
+                234.9384,
+                235.3448,
+                232.8441,
+                234.7623
+            ],
+            "array_ms": 22.1556,
+            "judy_ms": 234.9156,
+            "judy_over_array": 10.603,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.12488,
+            "delta_pct": 412.49,
+            "ci_delta_pct": [
+                410,
+                413.08
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                264.6472,
+                263.376,
+                264.3582,
+                263.144,
+                263.8566,
+                265.0037,
+                263.101
+            ],
+            "judy_runs_ms": [
+                1349.7098,
+                1351.3363,
+                1354.8034,
+                1358.4111,
+                1351.7266,
+                1350.662,
+                1349.7857
+            ],
+            "array_ms": 263.8566,
+            "judy_ms": 1351.3363,
+            "judy_over_array": 5.121,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.10543,
+            "delta_pct": 210.54,
+            "ci_delta_pct": [
+                207.74,
+                216.73
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                55.6352,
+                57.1503,
+                57.281,
+                55.877,
+                55.4738,
+                56.7842,
+                56.6911
+            ],
+            "judy_runs_ms": [
+                176.3936,
+                175.8719,
+                176.2201,
+                175.7124,
+                175.7045,
+                174.9681,
+                176.0504
+            ],
+            "array_ms": 56.6911,
+            "judy_ms": 175.8719,
+            "judy_over_array": 3.102,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.75384,
+            "delta_pct": 1175.38,
+            "ci_delta_pct": [
+                1151.29,
+                1179.9
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                35.5654,
+                35.1103,
+                35.9833,
+                35.216,
+                35.1592,
+                35.1364,
+                35.9957
+            ],
+            "judy_runs_ms": [
+                449.2589,
+                450.092,
+                449.6333,
+                449.1394,
+                450.003,
+                449.1999,
+                450.411
+            ],
+            "array_ms": 35.216,
+            "judy_ms": 449.6333,
+            "judy_over_array": 12.768,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.01922,
+            "delta_pct": 901.92,
+            "ci_delta_pct": [
+                899.73,
+                902.26
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                64.6628,
+                64.8452,
+                64.8541,
+                64.8036,
+                64.7684,
+                65.0175,
+                64.7822
+            ],
+            "judy_runs_ms": [
+                647.8736,
+                649.9177,
+                650.6088,
+                648.215,
+                648.9287,
+                648.7412,
+                647.6445
+            ],
+            "array_ms": 64.8036,
+            "judy_ms": 648.7412,
+            "judy_over_array": 10.011,
+            "winner": "php-array"
+        },
+        "api.increment.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.52961,
+            "delta_pct": 152.96,
+            "ci_delta_pct": [
+                152.26,
+                153.38
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                57.4476,
+                57.3123,
+                57.0501,
+                57.3101,
+                57.298,
+                57.5097,
+                57.3914
+            ],
+            "judy_runs_ms": [
+                145.5619,
+                145.2116,
+                141.8969,
+                144.7407,
+                144.5387,
+                146.4351,
+                145.1778
+            ],
+            "array_ms": 57.3123,
+            "judy_ms": 145.1778,
+            "judy_over_array": 2.533,
+            "winner": "php-array"
+        },
+        "api.setop.union.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.98498,
+            "delta_pct": 98.5,
+            "ci_delta_pct": [
+                97.66,
+                98.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.3464,
+                92.3235,
+                92.2149,
+                92.4477,
+                92.1441,
+                92.3837,
+                92.0702
+            ],
+            "judy_runs_ms": [
+                182.3108,
+                185.5733,
+                182.2712,
+                182.9012,
+                183.3426,
+                183.5152,
+                182.7579
+            ],
+            "array_ms": 92.3235,
+            "judy_ms": 182.9012,
+            "judy_over_array": 1.981,
+            "winner": "php-array"
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91211,
+            "delta_pct": -8.79,
+            "ci_delta_pct": [
+                -9.19,
+                -8.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                95.3567,
+                95.3482,
+                95.3742,
+                95.5685,
+                95.4051,
+                95.586,
+                95.381
+            ],
+            "judy_runs_ms": [
+                87.067,
+                87.2746,
+                87.094,
+                86.7833,
+                86.3858,
+                87.0472,
+                86.9984
+            ],
+            "array_ms": 95.381,
+            "judy_ms": 87.0472,
+            "judy_over_array": 0.913,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.0063,
+            "delta_pct": 100.63,
+            "ci_delta_pct": [
+                100.38,
+                101.48
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                43.0008,
+                43.0226,
+                42.9464,
+                43.1625,
+                43.0139,
+                43.0451,
+                42.7951
+            ],
+            "judy_runs_ms": [
+                86.4453,
+                86.249,
+                86.1632,
+                86.1097,
+                86.6663,
+                86.2545,
+                86.3291
+            ],
+            "array_ms": 43.0139,
+            "judy_ms": 86.2545,
+            "judy_over_array": 2.005,
+            "winner": "php-array"
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78122,
+            "delta_pct": -21.88,
+            "ci_delta_pct": [
+                -21.89,
+                -21.74
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                221.0851,
+                220.6686,
+                221.267,
+                221.2708,
+                220.9529,
+                221.103,
+                221.1354
+            ],
+            "judy_runs_ms": [
+                172.6965,
+                173.0343,
+                172.4826,
+                172.8478,
+                172.6119,
+                172.9824,
+                173.0564
+            ],
+            "array_ms": 221.103,
+            "judy_ms": 172.8478,
+            "judy_over_array": 0.782,
+            "winner": "php-judy"
+        }
+    },
+    "judy_vs_phploop": {
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69603,
+            "delta_pct": -30.4,
+            "ci_delta_pct": [
+                -31.06,
+                -29.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                182.4045,
+                182.976,
+                181.6699,
+                183.2188,
+                182.5508,
+                180.9851,
+                181.4868
+            ],
+            "judy_runs_ms": [
+                126.0116,
+                125.9638,
+                128.1993,
+                126.3074,
+                127.8482,
+                126.1096,
+                126.3206
+            ],
+            "array_ms": 182.4045,
+            "judy_ms": 126.3074,
+            "judy_over_array": 0.692,
+            "winner": "php-judy"
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69686,
+            "delta_pct": -30.31,
+            "ci_delta_pct": [
+                -31.1,
+                -30.2
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                182.4045,
+                182.976,
+                181.6699,
+                183.2188,
+                182.5508,
+                180.9851,
+                181.4868
+            ],
+            "judy_runs_ms": [
+                125.6858,
+                125.3277,
+                127.3972,
+                126.8529,
+                127.2116,
+                126.3286,
+                126.4939
+            ],
+            "array_ms": 182.4045,
+            "judy_ms": 126.4939,
+            "judy_over_array": 0.693,
+            "winner": "php-judy"
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.81872,
+            "delta_pct": -18.13,
+            "ci_delta_pct": [
+                -18.54,
+                -17.37
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                361.9477,
+                369.0703,
+                362.2336,
+                365.1433,
+                363.371,
+                361.4233,
+                362.0296
+            ],
+            "judy_runs_ms": [
+                299.0632,
+                297.5284,
+                296.5668,
+                297.4463,
+                297.066,
+                296.8664,
+                299.7599
+            ],
+            "array_ms": 362.2336,
+            "judy_ms": 297.4463,
+            "judy_over_array": 0.821,
+            "winner": "php-judy"
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78124,
+            "delta_pct": -21.88,
+            "ci_delta_pct": [
+                -22.02,
+                -21.77
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                27.3994,
+                27.2989,
+                27.2445,
+                27.2882,
+                27.3315,
+                27.6055,
+                27.3686
+            ],
+            "judy_runs_ms": [
+                21.4056,
+                21.2887,
+                21.3486,
+                21.3229,
+                21.3807,
+                21.4213,
+                21.3784
+            ],
+            "array_ms": 27.3315,
+            "judy_ms": 21.3784,
+            "judy_over_array": 0.782,
+            "winner": "php-judy"
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.59765,
+            "delta_pct": -40.23,
+            "ci_delta_pct": [
+                -40.3,
+                -39.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.8354,
+                193.9374,
+                193.5751,
+                194.9343,
+                194.3653,
+                194.0754,
+                194.5255
+            ],
+            "judy_runs_ms": [
+                116.5602,
+                115.7902,
+                116.2124,
+                115.8449,
+                116.1625,
+                115.9359,
+                116.7727
+            ],
+            "array_ms": 194.3653,
+            "judy_ms": 116.1625,
+            "judy_over_array": 0.598,
+            "winner": "php-judy"
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.62404,
+            "delta_pct": -37.6,
+            "ci_delta_pct": [
+                -37.81,
+                -37.33
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.0034,
+                193.9507,
+                193.5062,
+                192.9138,
+                194.4093,
+                194.3353,
+                194.5332
+            ],
+            "judy_runs_ms": [
+                121.24,
+                120.705,
+                120.7557,
+                123.4573,
+                120.8973,
+                120.8473,
+                121.9134
+            ],
+            "array_ms": 194.0034,
+            "judy_ms": 120.8973,
+            "judy_over_array": 0.623,
+            "winner": "php-judy"
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.06844,
+            "delta_pct": -93.16,
+            "ci_delta_pct": [
+                -93.17,
+                -93.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                148.1019,
+                148.2412,
+                147.2577,
+                147.7132,
+                147.94,
+                148.169,
+                147.8146
+            ],
+            "judy_runs_ms": [
+                10.1364,
+                10.1529,
+                10.08,
+                10.0871,
+                10.1093,
+                10.1138,
+                10.1534
+            ],
+            "array_ms": 147.94,
+            "judy_ms": 10.1138,
+            "judy_over_array": 0.068,
+            "winner": "php-judy"
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41195,
+            "delta_pct": -58.81,
+            "ci_delta_pct": [
+                -58.9,
+                -58.66
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                118.7104,
+                117.8701,
+                117.7919,
+                117.2022,
+                117.164,
+                117.2031,
+                117.604
+            ],
+            "judy_runs_ms": [
+                48.3496,
+                48.6787,
+                48.4155,
+                48.2774,
+                48.6271,
+                48.4473,
+                48.4467
+            ],
+            "array_ms": 117.604,
+            "judy_ms": 48.4467,
+            "judy_over_array": 0.412,
+            "winner": "php-judy"
+        },
+        "api.populationCount.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0,
+            "delta_pct": -100,
+            "ci_delta_pct": [
+                -100,
+                -100
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                118.9176,
+                118.6635,
+                120.314,
+                118.6368,
+                118.9765,
+                119.1662,
+                118.5277
+            ],
+            "judy_runs_ms": [
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001
+            ],
+            "array_ms": 118.9176,
+            "judy_ms": 0.0001,
+            "judy_over_array": 0,
+            "winner": "php-judy"
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69961,
+            "delta_pct": -30.04,
+            "ci_delta_pct": [
+                -30.08,
+                -29.89
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                338.8113,
+                338.4346,
+                338.2464,
+                338.373,
+                339.0644,
+                339.4886,
+                339.0531
+            ],
+            "judy_runs_ms": [
+                236.9022,
+                236.7718,
+                236.9143,
+                237.3313,
+                236.7143,
+                238.0207,
+                237.1513
+            ],
+            "array_ms": 338.8113,
+            "judy_ms": 236.9143,
+            "judy_over_array": 0.699,
+            "winner": "php-judy"
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.25863,
+            "delta_pct": -74.14,
+            "ci_delta_pct": [
+                -74.22,
+                -74.04
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                274.995,
+                275.5194,
+                278.1718,
+                274.6283,
+                274.5721,
+                275.1857,
+                276.5981
+            ],
+            "judy_runs_ms": [
+                70.9924,
+                71.527,
+                71.185,
+                71.3658,
+                71.0115,
+                71.2161,
+                71.2967
+            ],
+            "array_ms": 275.1857,
+            "judy_ms": 71.2161,
+            "judy_over_array": 0.259,
+            "winner": "php-judy"
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.5244,
+            "delta_pct": -47.56,
+            "ci_delta_pct": [
+                -47.69,
+                -47.41
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                508.9541,
+                511.5167,
+                507.7765,
+                508.15,
+                508.8969,
+                512.3563,
+                508.4234
+            ],
+            "judy_runs_ms": [
+                266.239,
+                269.0234,
+                265.7866,
+                266.4736,
+                267.4036,
+                265.4999,
+                268.0678
+            ],
+            "array_ms": 508.8969,
+            "judy_ms": 266.4736,
+            "judy_over_array": 0.524,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.44125,
+            "delta_pct": -55.88,
+            "ci_delta_pct": [
+                -56.15,
+                -55.66
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                246.3799,
+                248.0206,
+                247.7924,
+                248.0048,
+                246.9736,
+                248.4425,
+                247.1483
+            ],
+            "judy_runs_ms": [
+                109.2477,
+                109.9984,
+                108.6642,
+                108.9449,
+                109.414,
+                108.8791,
+                109.0533
+            ],
+            "array_ms": 247.7924,
+            "judy_ms": 109.0533,
+            "judy_over_array": 0.44,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42211,
+            "delta_pct": -57.79,
+            "ci_delta_pct": [
+                -57.91,
+                -57.7
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                254.4714,
+                254.9491,
+                256.6765,
+                256.5398,
+                257.321,
+                256.3326,
+                256.1049
+            ],
+            "judy_runs_ms": [
+                107.7275,
+                107.8434,
+                108.0288,
+                107.9777,
+                108.3966,
+                108.2003,
+                108.2089
+            ],
+            "array_ms": 256.3326,
+            "judy_ms": 108.0288,
+            "judy_over_array": 0.421,
+            "winner": "php-judy"
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42239,
+            "delta_pct": -57.76,
+            "ci_delta_pct": [
+                -57.89,
+                -57.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                511.9164,
+                510.8088,
+                512.2597,
+                514.9941,
+                517.174,
+                515.1894,
+                511.4359
+            ],
+            "judy_runs_ms": [
+                216.2274,
+                218.0716,
+                216.7956,
+                216.8782,
+                217.7339,
+                216.9988,
+                216.1776
+            ],
+            "array_ms": 512.2597,
+            "judy_ms": 216.8782,
+            "judy_over_array": 0.423,
+            "winner": "php-judy"
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.8618,
+            "delta_pct": -13.82,
+            "ci_delta_pct": [
+                -14,
+                -13.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1689.2008,
+                1687.1993,
+                1687.1653,
+                1683.6907,
+                1697.0458,
+                1699.7015,
+                1687.5615
+            ],
+            "judy_runs_ms": [
+                1455.7458,
+                1458.8227,
+                1456.0335,
+                1453.416,
+                1459.4202,
+                1448.7014,
+                1452.9215
+            ],
+            "array_ms": 1687.5615,
+            "judy_ms": 1455.7458,
+            "judy_over_array": 0.863,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84282,
+            "delta_pct": -15.72,
+            "ci_delta_pct": [
+                -15.95,
+                -14.95
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                776.5495,
+                772.4082,
+                769.9525,
+                770.8078,
+                775.3008,
+                773.8347,
+                779.0032
+            ],
+            "judy_runs_ms": [
+                651.0061,
+                657.7933,
+                648.5774,
+                649.6544,
+                651.6157,
+                656.4931,
+                662.5451
+            ],
+            "array_ms": 773.8347,
+            "judy_ms": 651.6157,
+            "judy_over_array": 0.842,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86253,
+            "delta_pct": -13.75,
+            "ci_delta_pct": [
+                -13.8,
+                -13.62
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                776.8541,
+                777.2693,
+                778.339,
+                775.9797,
+                781.3979,
+                779.1844,
+                779.8309
+            ],
+            "judy_runs_ms": [
+                670.0581,
+                670.1665,
+                672.2965,
+                671.7647,
+                671.2991,
+                671.641,
+                673.565
+            ],
+            "array_ms": 778.339,
+            "judy_ms": 671.641,
+            "judy_over_array": 0.863,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78204,
+            "delta_pct": -21.8,
+            "ci_delta_pct": [
+                -22.05,
+                -21.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                387.6461,
+                388.7965,
+                390.0365,
+                386.6584,
+                387.9444,
+                388.635,
+                386.9198
+            ],
+            "judy_runs_ms": [
+                303.1554,
+                303.0581,
+                302.1051,
+                302.8379,
+                303.5602,
+                303.555,
+                303.1704
+            ],
+            "array_ms": 387.9444,
+            "judy_ms": 303.1554,
+            "judy_over_array": 0.781,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91063,
+            "delta_pct": -8.94,
+            "ci_delta_pct": [
+                -9.34,
+                -8.77
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1319.6001,
+                1319.4748,
+                1313.3008,
+                1312.0542,
+                1318.2878,
+                1320.4978,
+                1319.1965
+            ],
+            "judy_runs_ms": [
+                1204.2184,
+                1201.9803,
+                1190.594,
+                1193.4476,
+                1202.6897,
+                1195.6496,
+                1201.2973
+            ],
+            "array_ms": 1319.1965,
+            "judy_ms": 1201.2973,
+            "judy_over_array": 0.911,
+            "winner": "php-judy"
+        },
+        "adv.forEach.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.49292,
+            "delta_pct": 49.29,
+            "ci_delta_pct": [
+                48.18,
+                50.26
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                127.1759,
+                126.9011,
+                127.2186,
+                127.1625,
+                127.145,
+                126.5636,
+                127.2522
+            ],
+            "judy_runs_ms": [
+                189.8636,
+                188.4064,
+                190.8257,
+                191.0787,
+                188.3585,
+                190.6425,
+                188.5638
+            ],
+            "array_ms": 127.1625,
+            "judy_ms": 189.8636,
+            "judy_over_array": 1.493,
+            "winner": "php-array"
+        },
+        "adv.forEach.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.17432,
+            "delta_pct": 17.43,
+            "ci_delta_pct": [
+                17.12,
+                17.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                302.0358,
+                302.4283,
+                304.1518,
+                301.4921,
+                304.6807,
+                301.5765,
+                303.271
+            ],
+            "judy_runs_ms": [
+                354.6881,
+                355.5494,
+                354.4387,
+                357.5204,
+                358.0298,
+                353.7622,
+                355.2025
+            ],
+            "array_ms": 302.4283,
+            "judy_ms": 355.2025,
+            "judy_over_array": 1.175,
+            "winner": "php-array"
+        },
+        "adv.filter.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.22427,
+            "delta_pct": 22.43,
+            "ci_delta_pct": [
+                21.49,
+                22.87
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                230.6143,
+                230.9756,
+                231.6913,
+                231.0688,
+                232.4615,
+                231.0607,
+                234.8432
+            ],
+            "judy_runs_ms": [
+                282.3339,
+                283.8048,
+                284.3871,
+                284.1589,
+                282.4149,
+                281.864,
+                281.9701
+            ],
+            "array_ms": 231.0688,
+            "judy_ms": 282.4149,
+            "judy_over_array": 1.222,
+            "winner": "php-array"
+        },
+        "adv.filter.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.061,
+            "delta_pct": 6.1,
+            "ci_delta_pct": [
+                6.05,
+                6.33
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                735.4282,
+                735.0091,
+                736.2173,
+                735.1961,
+                735.3896,
+                734.6487,
+                738.1813
+            ],
+            "judy_runs_ms": [
+                779.2169,
+                781.7831,
+                780.7435,
+                781.5833,
+                780.2476,
+                781.1413,
+                782.8624
+            ],
+            "array_ms": 735.3896,
+            "judy_ms": 781.1413,
+            "judy_over_array": 1.062,
+            "winner": "php-array"
+        },
+        "adv.map.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.09488,
+            "delta_pct": 9.49,
+            "ci_delta_pct": [
+                8.82,
+                10.05
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                271.789,
+                271.777,
+                274.1965,
+                272.5973,
+                275.3167,
+                271.7293,
+                274.3298
+            ],
+            "judy_runs_ms": [
+                299.1071,
+                298.0578,
+                298.3694,
+                297.1772,
+                304.2754,
+                297.5103,
+                297.4202
+            ],
+            "array_ms": 272.5973,
+            "judy_ms": 298.0578,
+            "judy_over_array": 1.093,
+            "winner": "php-array"
+        },
+        "adv.map.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.0234,
+            "delta_pct": 2.34,
+            "ci_delta_pct": [
+                2.14,
+                2.58
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1037.7362,
+                1043.486,
+                1041.0054,
+                1044.6117,
+                1043.4385,
+                1039.3752,
+                1044.1126
+            ],
+            "judy_runs_ms": [
+                1066.8213,
+                1066.3385,
+                1065.8104,
+                1066.9639,
+                1063.8354,
+                1066.1625,
+                1068.5465
+            ],
+            "array_ms": 1043.4385,
+            "judy_ms": 1066.3385,
+            "judy_over_array": 1.022,
+            "winner": "php-array"
+        }
+    },
+    "memory": [],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B2": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/B2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/run7-cvsc-control-6m-str.txt
+++ b/research/three-arm-benchmark/results/run7-cvsc-control-6m-str.txt
@@ -1,0 +1,222 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /usr/src/php-judy/arms/judy-C-1.so, /usr/src/php-judy/arms/judy-C-3.so
+  C  php-judy + bundled libJudy : /usr/src/php-judy/arms/judy-C-2.so
+  timing core.int     round 1/7
+  timing core.int     round 2/7
+  timing core.int     round 3/7
+  timing core.int     round 4/7
+  timing core.int     round 5/7
+  timing core.int     round 6/7
+  timing core.int     round 7/7
+  timing core.int     done          
+  timing core.str     round 1/7
+  timing core.str     round 2/7
+  timing core.str     round 3/7
+  timing core.str     round 4/7
+  timing core.str     round 5/7
+  timing core.str     round 6/7
+  timing core.str     round 7/7
+  timing core.str     done          
+  timing api.batch    round 1/7
+  timing api.batch    round 2/7
+  timing api.batch    round 3/7
+  timing api.batch    round 4/7
+  timing api.batch    round 5/7
+  timing api.batch    round 6/7
+  timing api.batch    round 7/7
+  timing api.batch    done          
+  timing api.setops   round 1/7
+  timing api.setops   round 2/7
+  timing api.setops   round 3/7
+  timing api.setops   round 4/7
+  timing api.setops   round 5/7
+  timing api.setops   round 6/7
+  timing api.setops   round 7/7
+  timing api.setops   done          
+  timing adv.iter     round 1/7
+  timing adv.iter     round 2/7
+  timing adv.iter     round 3/7
+  timing adv.iter     round 4/7
+  timing adv.iter     round 5/7
+  timing adv.iter     round 6/7
+  timing adv.iter     round 7/7
+  timing adv.iter     done          
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — cvsc-control-out-of-cache-6m-with-core-str
+------------------------------------------------------------------------------------------------
+  PHP 8.4.24, Linux x86_64
+  arm B system libJudy : (provenance NOT recorded — B is uninterpretable)
+  arm C bundled libJudy: vendored libjudy/ tree
+  size 6000000 (out-of-cache), 7 rounds, 3 iterations, floor 1.3%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=0      cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-timing   load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    end            load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+
+  control (PHP-only rows, touch no libJudy): -0.01% [-0.09, +0.05] over 45 rows
+  measured control scatter: 0.81%  (assumed floor 1.3%)
+
+------------------------------------------------------------------------------------------------
+  B vs C — bundled libJudy against system libJudy (this project's contribution)
+  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears
+  the 1.3% floor assert anything; everything else is null.
+------------------------------------------------------------------------------------------------
+  benchmark                                     system   bundled    delta CI                 verdict
+  core.int_to_int.free                            2.20      2.20   -1.02% [ -2.50, +3.02] null
+  api.getAll.int_to_int                          21.57     21.38   -0.93% [ -1.10, -0.65] null
+  adv.optiter.ratio.foreach.string_to_int_adaptive     46.54     46.36   -0.77% [ -1.61, +0.49] null
+  adv.optiter.foreach.string_to_int_hash.default     22.06     21.98   -0.48% [ -0.64, -0.05] null
+  adv.optiter.foreach.string_to_int_adaptive.optimized     13.99     13.95   -0.41% [ -1.95, +0.39] null
+  adv.forEach.int_to_int                        190.39    189.86   -0.37% [ -0.98, +0.72] null
+  core.bitset.iter                              107.72    107.48   -0.33% [ -0.88, +0.72] null
+  core.string_to_int_adaptive.write            1051.13   1048.52   -0.33% [ -0.42, +0.01] null
+  api.toArray.int_to_int                        299.07    297.45   -0.33% [ -0.74, +0.23] null
+  core.string_to_mixed_adaptive.free            650.48    648.74   -0.31% [ -0.40, -0.12] null
+  api.setop.union.bitset                        182.91    182.90   -0.31% [ -0.60, +0.88] null
+  adv.map.int_to_int                            298.69    298.06   -0.27% [ -0.38, -0.02] null
+  core.string_to_int.write                      641.12    639.96   -0.26% [ -0.52, +0.09] null
+  core.string_to_mixed_adaptive.iter            450.78    449.63   -0.24% [ -0.32, -0.15] null
+  api.setop.xor.bitset                          173.11    172.85   -0.23% [ -0.42, +0.08] null
+  core.string_to_mixed.write                    992.03    991.48   -0.22% [ -0.42, +0.59] null
+  adv.optiter.overwrite.string_to_int_hash.default     16.30     16.23   -0.22% [ -0.56, +0.23] null
+  adv.filter.int_to_int                         283.58    282.41   -0.20% [ -0.60, +0.52] null
+  core.string_to_int_adaptive.iter              388.30    387.72   -0.19% [ -0.35, +0.05] null
+  core.string_to_int.free                       110.35    110.21   -0.18% [ -0.44, +0.60] null
+  adv.optiter.foreach.string_to_int_hash.optimized     12.85     12.83   -0.18% [ -0.77, +0.02] null
+  core.string_to_int_hash.write                1049.61   1048.51   -0.17% [ -0.31, +0.28] null
+  adv.map.string_to_int                        1067.75   1066.34   -0.17% [ -0.25, +0.10] null
+  core.int_to_int.read                           67.30     67.18   -0.14% [ -0.36, +0.10] null
+  core.string_to_int.iter                       291.75    291.21   -0.14% [ -0.86, -0.10] null
+  core.string_to_mixed.read                     787.67    786.71   -0.14% [ -0.30, +0.08] null
+  adv.optiter.values.string_to_int_hash.default     20.62     20.59   -0.14% [ -0.33, +0.18] null
+  core.int_to_int.write                         144.82    144.87   -0.11% [ -0.26, +0.19] null
+  core.string_to_mixed_hash.free                615.49    614.75   -0.11% [ -0.25, +0.25] null
+  api.setop.intersect.bitset                     87.03     87.05   -0.11% [ -0.45, +0.31] null
+  api.setop.diff.string_to_int                  671.52    671.64   -0.10% [ -0.19, +0.51] null
+  core.string_to_mixed_hash.read                932.96    932.17   -0.09% [ -0.44, -0.05] null
+  api.keys.int_to_int                           116.22    116.16   -0.09% [ -0.40, +0.32] null
+  adv.optiter.overwrite.string_to_int_hash.optimized     18.89     18.87   -0.09% [ -0.43, +0.08] null
+  adv.optiter.values.string_to_int_adaptive.optimized     12.43     12.41   -0.09% [ -0.25, +0.41] null
+  adv.optiter.overwrite.string_to_int_adaptive.optimized     26.24     26.25   -0.09% [ -0.12, +0.09] null
+  adv.optiter.ratio.overwrite.string_to_int_adaptive    106.89    106.98   -0.09% [ -0.40, +0.56] null
+  core.bitset.write                             102.92    102.90   -0.08% [ -0.47, +0.16] null
+  core.string_to_mixed_adaptive.read            176.09    175.87   -0.08% [ -0.30, +0.08] null
+  adv.filter.string_to_int                      781.57    781.14   -0.08% [ -0.09, +0.11] null
+  core.int_to_packed.read                       205.56    205.47   -0.07% [ -0.39, +0.13] null
+  core.string_to_int_adaptive.free              235.31    234.92   -0.07% [ -0.45, +0.04] null
+  api.setop.diff.bitset                          86.26     86.25   -0.07% [ -0.11, +0.25] null
+  adv.optiter.increment.string_to_int_hash.optimized     19.00     19.01   -0.07% [ -0.16, +0.54] null
+  api.sumValues.int_to_int                       48.52     48.45   -0.06% [ -0.67, +0.25] null
+  adv.optiter.increment.string_to_int_hash.default     16.21     16.19   -0.06% [ -0.41, +0.10] null
+  core.string_to_int.read                       205.26    204.97   -0.05% [ -0.51, +0.05] null
+  adv.optiter.toArray.string_to_int_adaptive.optimized     21.71     21.71   -0.05% [ -0.33, +0.29] null
+  core.string_to_int_adaptive.read              171.06    171.04   -0.04% [ -0.47, +0.44] null
+  api.mergeWith.int_to_int                      303.07    303.16   -0.04% [ -0.14, +0.40] null
+  adv.optiter.toArray.string_to_int_adaptive.default     39.51     39.48   -0.04% [ -0.39, +0.04] null
+  core.string_to_int_hash.iter                  388.35    388.23   -0.02% [ -0.13, +0.17] null
+  core.string_to_int_hash.free                  234.67    234.92   -0.01% [ -0.17, +0.22] null
+  api.putAll.int_to_int                         126.22    126.31   -0.01% [ -0.87, +1.20] null
+  api.deleteRange.int_to_int                    237.26    236.91   -0.01% [ -0.22, +0.11] null
+  adv.optiter.toArray.string_to_int_hash.default     29.33     29.33   -0.01% [ -0.30, +0.07] null
+  core.int_to_mixed.iter                        321.72    321.98    0.01% [ -0.46, +0.31] null
+  core.string_to_mixed.iter                     821.12    821.08    0.01% [ -0.58, +0.24] null
+  core.string_to_mixed_adaptive.write          1351.19   1351.34    0.03% [ -0.13, +0.37] null
+  adv.optiter.ratio.values.string_to_int_adaptive     42.46     42.41    0.03% [ -0.46, +0.38] null
+  adv.optiter.ratio.overwrite.string_to_int_hash    116.22    116.33    0.07% [ -0.64, +0.68] null
+  core.int_to_mixed.read                        279.35    279.11    0.08% [ -0.18, +0.41] null
+  core.string_to_mixed.free                     346.21    346.10    0.08% [ -0.24, +0.16] null
+  core.string_to_mixed_hash.iter                428.29    428.55    0.08% [ +0.00, +0.37] null
+  api.setop.xor.int_to_int                      217.04    216.88    0.08% [ -0.24, +0.29] null
+  api.setop.intersect.string_to_int             654.17    651.62    0.08% [ -1.13, +0.61] null
+  adv.optiter.values.string_to_int_hash.optimized     10.53     10.54    0.08% [ -0.05, +0.22] null
+  adv.optiter.foreach.string_to_int_adaptive.default     30.11     30.05    0.08% [ -0.33, +0.25] null
+  core.int_to_mixed.free                        100.52    100.98    0.09% [ -0.12, +1.39] null
+  adv.optiter.values.string_to_int_adaptive.default     29.25     29.28    0.09% [ -0.27, +0.39] null
+  api.setop.intersect.int_to_int                109.23    109.05    0.10% [ -0.23, +0.37] null
+  core.string_to_mixed_hash.write              1907.43   1907.75    0.11% [ -0.07, +0.29] null
+  api.range.keys.int_to_int                      10.09     10.11    0.14% [ -0.05, +0.81] null
+  adv.optiter.ratio.foreach.string_to_int_hash     58.29     58.19    0.14% [ -0.24, +0.97] null
+  adv.optiter.ratio.increment.string_to_int_hash    117.18    117.43    0.14% [ -0.19, +0.97] null
+  core.string_to_int_hash.read                  170.42    170.54    0.15% [ -0.69, +0.25] null
+  api.range.size.string_to_int                   20.94     20.95    0.16% [ -0.02, +0.27] null
+  api.setop.union.string_to_int                1452.17   1455.75    0.16% [ -0.51, +0.42] null
+  api.values.int_to_int                         120.72    120.90    0.17% [ -0.12, +0.85] null
+  api.setop.diff.int_to_int                     107.87    108.03    0.18% [ -0.01, +0.32] null
+  adv.optiter.ratio.values.string_to_int_hash     51.13     51.18    0.18% [ +0.04, +0.35] null
+  adv.optiter.toArray.string_to_int_hash.optimized     18.01     18.02    0.18% [ -0.62, +0.69] null
+  api.fromArray.int_to_int                      126.27    126.49    0.19% [ -0.84, +1.04] null
+  core.bitset.read                               67.65     67.55    0.20% [ -1.59, +0.42] null
+  adv.optiter.ratio.toArray.string_to_int_adaptive     54.92     55.05    0.20% [ -0.25, +0.26] null
+  api.equals.int_to_int                          71.04     71.22    0.21% [ -0.33, +0.85] null
+  core.int_to_mixed.write                       401.17    402.18    0.26% [ -0.56, +1.60] null
+  adv.optiter.overwrite.string_to_int_adaptive.default     24.53     24.55    0.29% [ -0.66, +0.37] null
+  core.int_to_packed.free                        52.37     52.45    0.31% [ -0.02, +0.40] null
+  adv.optiter.ratio.toArray.string_to_int_hash     61.32     61.54    0.35% [ -0.60, +0.65] null
+  api.setop.union.int_to_int                    265.57    266.47    0.36% [ -0.10, +0.99] null
+  core.int_to_int.iter                          113.02    113.51    0.44% [ -0.51, +0.99] null
+  adv.forEach.string_to_int                     354.02    355.20    0.46% [ -0.28, +0.55] null
+  core.int_to_packed.iter                       246.96    247.40    0.48% [ -0.18, +0.95] null
+  api.increment.int_to_int                      144.79    145.18    0.51% [ -0.92, +1.87] null
+  api.mergeWith.string_to_int                  1194.96   1201.30    0.52% [ -0.10, +0.69] null
+  core.int_to_packed.write                      348.26    349.63    0.64% [ +0.11, +0.93] null
+  totals: 0 faster, 0 slower, 97 null
+
+------------------------------------------------------------------------------------------------
+  A vs C — PHP native array against php-judy (bundled)
+  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means
+  the PHP array is FASTER — publish these, they are the honest half of the story.
+------------------------------------------------------------------------------------------------
+  benchmark                                   array ms   judy ms  judy/arr winner
+  core.bitset.free                                5.54      0.02     0.00x php-judy
+  core.int_to_int.free                            5.48      2.20     0.40x php-judy
+  api.setop.xor.bitset                          221.10    172.85     0.78x php-judy
+  api.setop.intersect.bitset                     95.38     87.05     0.91x php-judy
+  core.int_to_packed.free                        47.68     52.45     1.10x php-array
+  core.bitset.write                              89.88    102.90     1.15x php-array
+  core.int_to_packed.write                      251.58    349.63     1.39x php-array
+  core.int_to_mixed.write                       267.01    402.18     1.51x php-array
+  core.int_to_int.write                          92.65    144.87     1.56x php-array
+  core.int_to_packed.read                       107.96    205.47     1.90x php-array
+  api.setop.union.bitset                         92.32    182.90     1.98x php-array
+  api.setop.diff.bitset                          43.01     86.25     2.00x php-array
+  core.string_to_mixed.write                    470.27    991.48     2.11x php-array
+  core.int_to_mixed.free                         46.65    100.98     2.17x php-array
+  core.int_to_mixed.read                        121.87    279.11     2.29x php-array
+  api.increment.int_to_int                       57.31    145.18     2.53x php-array
+  core.string_to_int.write                      245.86    639.96     2.60x php-array
+  core.bitset.read                               22.04     67.55     3.06x php-array
+  core.int_to_int.read                           21.92     67.18     3.06x php-array
+  core.string_to_mixed_adaptive.read             56.69    175.87     3.10x php-array
+  core.string_to_mixed.read                     237.59    786.71     3.31x php-array
+  core.string_to_int_hash.read                   50.02    170.54     3.41x php-array
+  core.string_to_int_adaptive.read               49.80    171.04     3.43x php-array
+  core.int_to_mixed.iter                         86.23    321.98     3.73x php-array
+  core.string_to_int.read                        49.72    204.97     4.12x php-array
+  core.string_to_mixed_hash.write               452.69   1907.75     4.21x php-array
+  core.string_to_int_adaptive.write             246.68   1048.52     4.25x php-array
+  core.string_to_int_hash.write                 244.92   1048.51     4.28x php-array
+  core.string_to_int.free                        22.25    110.21     4.95x php-array
+  core.string_to_mixed_adaptive.write           263.86   1351.34     5.12x php-array
+  core.string_to_mixed.free                      64.18    346.10     5.39x php-array
+  core.string_to_mixed.iter                     146.39    821.08     5.61x php-array
+  core.bitset.iter                               18.68    107.48     5.75x php-array
+  core.int_to_int.iter                           18.62    113.51     6.10x php-array
+  core.string_to_mixed_hash.free                 64.83    614.75     9.48x php-array
+  core.string_to_mixed_adaptive.free             64.80    648.74    10.01x php-array
+  core.string_to_int.iter                        28.25    291.21    10.31x php-array
+  core.string_to_int_adaptive.free               22.16    234.92    10.60x php-array
+  core.string_to_int_hash.free                   22.11    234.92    10.63x php-array
+  core.int_to_packed.iter                        21.35    247.40    11.59x php-array
+  core.string_to_mixed_hash.iter                 35.44    428.55    12.09x php-array
+  core.string_to_mixed_adaptive.iter             35.22    449.63    12.77x php-array
+  core.string_to_int_adaptive.iter               28.29    387.72    13.71x php-array
+  core.string_to_int_hash.iter                   28.19    388.23    13.77x php-array
+  core.string_to_mixed_hash.read                 56.12    932.17    16.61x php-array
+  totals: php-judy wins 4, PHP array wins 41, parity 0
+
+Wrote /usr/src/php-judy/run7-cvsc-control-6m-str.json
+rc=0

--- a/research/three-arm-benchmark/results/run7-out-of-cache-6m-str.json
+++ b/research/three-arm-benchmark/results/run7-out-of-cache-6m-str.json
@@ -1,0 +1,8430 @@
+{
+    "metadata": {
+        "schema": "judy-bench-threearm/1",
+        "label": "linux-x86_64-gcc14-out-of-cache-6m-with-core-str",
+        "date": "2026-08-19T20:03:56+00:00",
+        "php_version": "8.4.24",
+        "platform": "Linux x86_64",
+        "uname": "Linux a73593d8048e 6.8.0-136-generic #136~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  3 16:29:11 UTC  x86_64",
+        "judy_version": "2.6.0",
+        "system_so": [
+            "/usr/src/php-judy/arms/judy-B-1.so",
+            "/usr/src/php-judy/arms/judy-B-2.so",
+            "/usr/src/php-judy/arms/judy-B-3.so"
+        ],
+        "bundled_so": [
+            "/usr/src/php-judy/arms/judy-C-1.so",
+            "/usr/src/php-judy/arms/judy-C-2.so",
+            "/usr/src/php-judy/arms/judy-C-3.so"
+        ],
+        "system_so_sha256": [
+            "8fa7fc86c2311835c742f4e75cc008ebfdce801fc44360c41e9bfc71d225a93b",
+            "635e88fb29be39a57ccb3b3f6b0acfe6b4fa37134b74202092c9683ea44627c1",
+            "db3fe23cc955adeddee62f39c7ebe7294602c1b0a29344392c3db949a6274fa8"
+        ],
+        "bundled_so_sha256": [
+            "c39c3ad51e63355d74f3c9ce4c429870d5775f59e48bd4c9874511ae5668efaf",
+            "71bac259a3202658342ac6d04597bf986716b44070af8a68700e80b44bf16ca4",
+            "cda430e9c2fab6eefeb7a5075a06954a9b3c45ceeefa72d1bce5cbc463ff299b"
+        ],
+        "system_provenance": "Debian 13 libjudy-dev 1.0.5-5.1",
+        "bundled_provenance": null,
+        "same_source_asserted": true,
+        "identical_builds": false,
+        "is_control_run": false,
+        "size": 6000000,
+        "iterations": 3,
+        "rounds": 7,
+        "groups": [
+            "core.int",
+            "core.str",
+            "api.batch",
+            "api.setops",
+            "adv.iter"
+        ],
+        "mem_sizes": [
+            6000000
+        ],
+        "mem_workloads": [
+            "int_to_int",
+            "int_sparse",
+            "int_to_mixed",
+            "string_to_int",
+            "bitset"
+        ],
+        "mem_runs": 3,
+        "min_ms": 0.5,
+        "residency": "out-of-cache",
+        "claim_floor_pct": 1.3,
+        "cache_floor_pct": 3,
+        "dram_floor_pct": 1.3,
+        "timing_children": 70,
+        "memory_children": 54,
+        "wall_seconds": 4672.3
+    },
+    "hygiene": {
+        "snapshots": [
+            {
+                "phase": "start",
+                "at": "2026-08-19T18:46:03+00:00",
+                "load1": 0.09,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-timing",
+                "at": "2026-08-19T20:03:41+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "after-memory",
+                "at": "2026-08-19T20:03:56+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            },
+            {
+                "phase": "end",
+                "at": "2026-08-19T20:03:56+00:00",
+                "load1": 1,
+                "cpus": 24,
+                "threshold": 12,
+                "over": false,
+                "cpus_known": true,
+                "foreign_cpu_pct": 0,
+                "foreign_busy": false,
+                "heavy": []
+            }
+        ],
+        "failed": false,
+        "foreign_tenant": false,
+        "contaminated": false,
+        "note": "load average alone is necessary but not sufficient: a co-resident memory-bound benchmark contends for LLC and memory bandwidth at low load, and a PHP-array control does not detect it"
+    },
+    "control": {
+        "php_only": {
+            "median_ratio": 1.00125,
+            "delta_pct": 0.12,
+            "ci_delta_pct": [
+                -0.01,
+                0.21
+            ],
+            "measured_spread_pct": 1.59,
+            "row_count": 45,
+            "eligibility": "genuine PHP-array rows only (TAM_ARM_A_ROWS); Judy-touching .php rows are excluded because they carry real signal",
+            "rows": {
+                "core.bitset.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00362,
+                    "delta_pct": 0.36,
+                    "ci_delta_pct": [
+                        0.15,
+                        0.61
+                    ],
+                    "n": 7,
+                    "b_ms": 89.5149,
+                    "c_ms": 89.8805
+                },
+                "core.bitset.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00315,
+                    "delta_pct": 0.32,
+                    "ci_delta_pct": [
+                        -2.34,
+                        2.45
+                    ],
+                    "n": 7,
+                    "b_ms": 22.1641,
+                    "c_ms": 22.3056
+                },
+                "core.bitset.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99984,
+                    "delta_pct": -0.02,
+                    "ci_delta_pct": [
+                        -0.11,
+                        0.67
+                    ],
+                    "n": 7,
+                    "b_ms": 18.6903,
+                    "c_ms": 18.6974
+                },
+                "core.bitset.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00388,
+                    "delta_pct": 0.39,
+                    "ci_delta_pct": [
+                        -0.16,
+                        2.41
+                    ],
+                    "n": 7,
+                    "b_ms": 5.522,
+                    "c_ms": 5.5595
+                },
+                "core.int_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00186,
+                    "delta_pct": 0.19,
+                    "ci_delta_pct": [
+                        -0.13,
+                        0.84
+                    ],
+                    "n": 7,
+                    "b_ms": 92.4412,
+                    "c_ms": 92.5808
+                },
+                "core.int_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.01591,
+                    "delta_pct": 1.59,
+                    "ci_delta_pct": [
+                        -0.59,
+                        4.94
+                    ],
+                    "n": 7,
+                    "b_ms": 22.1723,
+                    "c_ms": 22.4958
+                },
+                "core.int_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99836,
+                    "delta_pct": -0.16,
+                    "ci_delta_pct": [
+                        -0.41,
+                        0.21
+                    ],
+                    "n": 7,
+                    "b_ms": 18.6329,
+                    "c_ms": 18.6317
+                },
+                "core.int_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00125,
+                    "delta_pct": 0.12,
+                    "ci_delta_pct": [
+                        -0.12,
+                        0.96
+                    ],
+                    "n": 7,
+                    "b_ms": 5.4141,
+                    "c_ms": 5.4571
+                },
+                "core.int_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.0026,
+                    "delta_pct": 0.26,
+                    "ci_delta_pct": [
+                        -0.15,
+                        0.75
+                    ],
+                    "n": 7,
+                    "b_ms": 266.2871,
+                    "c_ms": 266.2376
+                },
+                "core.int_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.0049,
+                    "delta_pct": 0.49,
+                    "ci_delta_pct": [
+                        -0.03,
+                        1.56
+                    ],
+                    "n": 7,
+                    "b_ms": 121.5624,
+                    "c_ms": 122.0691
+                },
+                "core.int_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00473,
+                    "delta_pct": 0.47,
+                    "ci_delta_pct": [
+                        0.06,
+                        0.52
+                    ],
+                    "n": 7,
+                    "b_ms": 85.9464,
+                    "c_ms": 86.1427
+                },
+                "core.int_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99985,
+                    "delta_pct": -0.01,
+                    "ci_delta_pct": [
+                        -0.57,
+                        0.65
+                    ],
+                    "n": 7,
+                    "b_ms": 46.4908,
+                    "c_ms": 46.5423
+                },
+                "core.int_to_packed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00041,
+                    "delta_pct": 0.04,
+                    "ci_delta_pct": [
+                        -0.07,
+                        0.46
+                    ],
+                    "n": 7,
+                    "b_ms": 250.4876,
+                    "c_ms": 250.4973
+                },
+                "core.int_to_packed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00202,
+                    "delta_pct": 0.2,
+                    "ci_delta_pct": [
+                        -0.03,
+                        1.22
+                    ],
+                    "n": 7,
+                    "b_ms": 107.5722,
+                    "c_ms": 107.6936
+                },
+                "core.int_to_packed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00711,
+                    "delta_pct": 0.71,
+                    "ci_delta_pct": [
+                        0.36,
+                        1.96
+                    ],
+                    "n": 7,
+                    "b_ms": 21.2879,
+                    "c_ms": 21.5978
+                },
+                "core.int_to_packed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00276,
+                    "delta_pct": 0.28,
+                    "ci_delta_pct": [
+                        0.04,
+                        0.55
+                    ],
+                    "n": 7,
+                    "b_ms": 47.5002,
+                    "c_ms": 47.6416
+                },
+                "core.string_to_int.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99959,
+                    "delta_pct": -0.04,
+                    "ci_delta_pct": [
+                        -0.14,
+                        0.11
+                    ],
+                    "n": 7,
+                    "b_ms": 244.9496,
+                    "c_ms": 245.0001
+                },
+                "core.string_to_int.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.98686,
+                    "delta_pct": -1.31,
+                    "ci_delta_pct": [
+                        -2.97,
+                        1
+                    ],
+                    "n": 7,
+                    "b_ms": 50.0514,
+                    "c_ms": 49.4706
+                },
+                "core.string_to_int.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99362,
+                    "delta_pct": -0.64,
+                    "ci_delta_pct": [
+                        -1.39,
+                        -0.05
+                    ],
+                    "n": 7,
+                    "b_ms": 28.4091,
+                    "c_ms": 28.2138
+                },
+                "core.string_to_int.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99867,
+                    "delta_pct": -0.13,
+                    "ci_delta_pct": [
+                        -0.23,
+                        -0.08
+                    ],
+                    "n": 7,
+                    "b_ms": 22.1448,
+                    "c_ms": 22.1028
+                },
+                "core.string_to_mixed.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99964,
+                    "delta_pct": -0.04,
+                    "ci_delta_pct": [
+                        -0.3,
+                        0.12
+                    ],
+                    "n": 7,
+                    "b_ms": 468.0046,
+                    "c_ms": 466.7511
+                },
+                "core.string_to_mixed.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00234,
+                    "delta_pct": 0.23,
+                    "ci_delta_pct": [
+                        -0.03,
+                        0.31
+                    ],
+                    "n": 7,
+                    "b_ms": 235.8152,
+                    "c_ms": 236.3211
+                },
+                "core.string_to_mixed.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00037,
+                    "delta_pct": 0.04,
+                    "ci_delta_pct": [
+                        -0.53,
+                        0.29
+                    ],
+                    "n": 7,
+                    "b_ms": 145.5439,
+                    "c_ms": 145.5207
+                },
+                "core.string_to_mixed.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99979,
+                    "delta_pct": -0.02,
+                    "ci_delta_pct": [
+                        -0.37,
+                        0.09
+                    ],
+                    "n": 7,
+                    "b_ms": 63.7224,
+                    "c_ms": 63.6959
+                },
+                "core.string_to_int_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99999,
+                    "delta_pct": -0,
+                    "ci_delta_pct": [
+                        -0.03,
+                        0.23
+                    ],
+                    "n": 7,
+                    "b_ms": 244.4151,
+                    "c_ms": 244.66
+                },
+                "core.string_to_int_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.01323,
+                    "delta_pct": 1.32,
+                    "ci_delta_pct": [
+                        -1.94,
+                        3.53
+                    ],
+                    "n": 7,
+                    "b_ms": 49.6034,
+                    "c_ms": 49.9551
+                },
+                "core.string_to_int_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00205,
+                    "delta_pct": 0.21,
+                    "ci_delta_pct": [
+                        0.03,
+                        0.71
+                    ],
+                    "n": 7,
+                    "b_ms": 28.1858,
+                    "c_ms": 28.2078
+                },
+                "core.string_to_int_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99989,
+                    "delta_pct": -0.01,
+                    "ci_delta_pct": [
+                        -0.4,
+                        0.05
+                    ],
+                    "n": 7,
+                    "b_ms": 22.0838,
+                    "c_ms": 22.0326
+                },
+                "core.string_to_mixed_hash.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99957,
+                    "delta_pct": -0.04,
+                    "ci_delta_pct": [
+                        -0.24,
+                        0.08
+                    ],
+                    "n": 7,
+                    "b_ms": 449.3051,
+                    "c_ms": 449.2684
+                },
+                "core.string_to_mixed_hash.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00827,
+                    "delta_pct": 0.83,
+                    "ci_delta_pct": [
+                        -0.36,
+                        2.78
+                    ],
+                    "n": 7,
+                    "b_ms": 56.3234,
+                    "c_ms": 56.804
+                },
+                "core.string_to_mixed_hash.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99252,
+                    "delta_pct": -0.75,
+                    "ci_delta_pct": [
+                        -1.79,
+                        1.23
+                    ],
+                    "n": 7,
+                    "b_ms": 35.4517,
+                    "c_ms": 35.2752
+                },
+                "core.string_to_mixed_hash.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99907,
+                    "delta_pct": -0.09,
+                    "ci_delta_pct": [
+                        -0.21,
+                        0.05
+                    ],
+                    "n": 7,
+                    "b_ms": 64.3739,
+                    "c_ms": 64.2646
+                },
+                "core.string_to_int_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00186,
+                    "delta_pct": 0.19,
+                    "ci_delta_pct": [
+                        -0.01,
+                        0.4
+                    ],
+                    "n": 7,
+                    "b_ms": 245.3144,
+                    "c_ms": 245.8077
+                },
+                "core.string_to_int_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00875,
+                    "delta_pct": 0.88,
+                    "ci_delta_pct": [
+                        0.15,
+                        2.16
+                    ],
+                    "n": 7,
+                    "b_ms": 49.3575,
+                    "c_ms": 49.9718
+                },
+                "core.string_to_int_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99294,
+                    "delta_pct": -0.71,
+                    "ci_delta_pct": [
+                        -1.67,
+                        0.52
+                    ],
+                    "n": 7,
+                    "b_ms": 28.4911,
+                    "c_ms": 28.1814
+                },
+                "core.string_to_int_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00022,
+                    "delta_pct": 0.02,
+                    "ci_delta_pct": [
+                        -0.92,
+                        0.11
+                    ],
+                    "n": 7,
+                    "b_ms": 22.0876,
+                    "c_ms": 22.0714
+                },
+                "core.string_to_mixed_adaptive.write": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99974,
+                    "delta_pct": -0.03,
+                    "ci_delta_pct": [
+                        -0.33,
+                        0.13
+                    ],
+                    "n": 7,
+                    "b_ms": 263.2062,
+                    "c_ms": 263.1209
+                },
+                "core.string_to_mixed_adaptive.read": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00732,
+                    "delta_pct": 0.73,
+                    "ci_delta_pct": [
+                        -1.24,
+                        2.53
+                    ],
+                    "n": 7,
+                    "b_ms": 56.2626,
+                    "c_ms": 56.8624
+                },
+                "core.string_to_mixed_adaptive.iter": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99486,
+                    "delta_pct": -0.51,
+                    "ci_delta_pct": [
+                        -2.16,
+                        0.51
+                    ],
+                    "n": 7,
+                    "b_ms": 35.6387,
+                    "c_ms": 35.1348
+                },
+                "core.string_to_mixed_adaptive.free": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99674,
+                    "delta_pct": -0.33,
+                    "ci_delta_pct": [
+                        -0.34,
+                        0.09
+                    ],
+                    "n": 7,
+                    "b_ms": 64.3883,
+                    "c_ms": 64.2026
+                },
+                "api.increment.int_to_int": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 0.99902,
+                    "delta_pct": -0.1,
+                    "ci_delta_pct": [
+                        -0.27,
+                        0.22
+                    ],
+                    "n": 7,
+                    "b_ms": 57.4151,
+                    "c_ms": 57.3834
+                },
+                "api.setop.union.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.0013,
+                    "delta_pct": 0.13,
+                    "ci_delta_pct": [
+                        -0.21,
+                        0.45
+                    ],
+                    "n": 7,
+                    "b_ms": 92.124,
+                    "c_ms": 92.2319
+                },
+                "api.setop.intersect.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00213,
+                    "delta_pct": 0.21,
+                    "ci_delta_pct": [
+                        0.12,
+                        0.26
+                    ],
+                    "n": 7,
+                    "b_ms": 95.1343,
+                    "c_ms": 95.323
+                },
+                "api.setop.diff.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00428,
+                    "delta_pct": 0.43,
+                    "ci_delta_pct": [
+                        0.01,
+                        0.61
+                    ],
+                    "n": 7,
+                    "b_ms": 42.8602,
+                    "c_ms": 42.9808
+                },
+                "api.setop.xor.bitset": {
+                    "status": "null",
+                    "reason": "inside the 1.3% claim floor (CI straddles it)",
+                    "ratio": 1.00176,
+                    "delta_pct": 0.18,
+                    "ci_delta_pct": [
+                        -0.1,
+                        0.29
+                    ],
+                    "n": 7,
+                    "b_ms": 220.707,
+                    "c_ms": 221.1372
+                }
+            }
+        },
+        "rebuild_control_run": false
+    },
+    "counts": {
+        "faster": 94,
+        "slower": 0,
+        "null": 3
+    },
+    "a_counts": {
+        "php-judy": 4,
+        "php-array": 41,
+        "parity": 0
+    },
+    "bundled_vs_system": {
+        "core.bitset.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88277,
+            "delta_pct": -11.72,
+            "ci_delta_pct": [
+                -12.1,
+                -11.58
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.72,
+                "B2/C2": -11.74,
+                "B3/C3": -11.88
+            },
+            "build_spread_pct": 0.16,
+            "builds": 3,
+            "system_ms": 116.9469,
+            "bundled_ms": 103.3036,
+            "raw_delta_pct": -11.61,
+            "spread_pct": [
+                0.3,
+                0.6
+            ],
+            "system_runs_ms": [
+                117.0207,
+                116.6946,
+                116.8275,
+                116.8759,
+                117.0987,
+                116.9469,
+                117.023
+            ],
+            "bundled_runs_ms": [
+                102.9866,
+                103.4399,
+                103.4319,
+                103.3036,
+                103.1547,
+                102.8257,
+                103.4892
+            ],
+            "paired_ratios": [
+                0.88007,
+                0.88642,
+                0.88534,
+                0.88387,
+                0.88092,
+                0.87925,
+                0.88435
+            ]
+        },
+        "core.bitset.read": {
+            "status": "null",
+            "reason": "per-build spread 5.70% exceeds the 4.85% delta \u2014 layout, not libJudy",
+            "ratio": 0.95148,
+            "delta_pct": -4.85,
+            "ci_delta_pct": [
+                -9.12,
+                -3.63
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.63,
+                "B2/C2": -4.89,
+                "B3/C3": -9.33
+            },
+            "build_spread_pct": 5.7,
+            "builds": 3,
+            "system_ms": 70.8892,
+            "bundled_ms": 67.5386,
+            "raw_delta_pct": -4.73,
+            "spread_pct": [
+                4.9,
+                3.8
+            ],
+            "system_runs_ms": [
+                70.763,
+                71.1561,
+                73.9685,
+                70.8892,
+                70.863,
+                74.216,
+                70.889
+            ],
+            "bundled_runs_ms": [
+                69.5471,
+                67.7883,
+                66.9984,
+                68.4026,
+                67.4512,
+                67.5312,
+                67.5386
+            ],
+            "paired_ratios": [
+                0.98282,
+                0.95267,
+                0.90577,
+                0.96492,
+                0.95185,
+                0.90993,
+                0.95274
+            ]
+        },
+        "core.bitset.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91452,
+            "delta_pct": -8.55,
+            "ci_delta_pct": [
+                -8.66,
+                -7.26
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.66,
+                "B2/C2": -7.26,
+                "B3/C3": -7.92
+            },
+            "build_spread_pct": 1.4,
+            "builds": 3,
+            "system_ms": 116.5055,
+            "bundled_ms": 107.3533,
+            "raw_delta_pct": -8.43,
+            "spread_pct": [
+                2.3,
+                1.4
+            ],
+            "system_runs_ms": [
+                116.5055,
+                116.5436,
+                116.2723,
+                117.5806,
+                114.921,
+                116.3195,
+                117.1205
+            ],
+            "bundled_runs_ms": [
+                106.6801,
+                107.5644,
+                107.9675,
+                107.5332,
+                107.3533,
+                106.4713,
+                106.6285
+            ],
+            "paired_ratios": [
+                0.91567,
+                0.92295,
+                0.92857,
+                0.91455,
+                0.93415,
+                0.91533,
+                0.91042
+            ]
+        },
+        "core.int_to_int.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75873,
+            "delta_pct": -24.13,
+            "ci_delta_pct": [
+                -24.22,
+                -24.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.11,
+                "B2/C2": -24.3,
+                "B3/C3": -23.84
+            },
+            "build_spread_pct": 0.46,
+            "builds": 3,
+            "system_ms": 190.3708,
+            "bundled_ms": 144.539,
+            "raw_delta_pct": -24.03,
+            "spread_pct": [
+                0.6,
+                1
+            ],
+            "system_runs_ms": [
+                190.1357,
+                190.3708,
+                190.4705,
+                190.0447,
+                191.1855,
+                190.3271,
+                190.6171
+            ],
+            "bundled_runs_ms": [
+                144.4422,
+                144.539,
+                144.5129,
+                144.4011,
+                144.6536,
+                145.8645,
+                144.8944
+            ],
+            "paired_ratios": [
+                0.75968,
+                0.75925,
+                0.75872,
+                0.75983,
+                0.75661,
+                0.76639,
+                0.76013
+            ]
+        },
+        "core.int_to_int.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83952,
+            "delta_pct": -16.05,
+            "ci_delta_pct": [
+                -16.1,
+                -15.63
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.63,
+                "B2/C2": -16.07,
+                "B3/C3": -16.1
+            },
+            "build_spread_pct": 0.47,
+            "builds": 3,
+            "system_ms": 79.7115,
+            "bundled_ms": 66.9918,
+            "raw_delta_pct": -15.94,
+            "spread_pct": [
+                0.2,
+                0.9
+            ],
+            "system_runs_ms": [
+                79.7115,
+                79.6411,
+                79.5904,
+                79.7502,
+                79.7303,
+                79.7448,
+                79.6831
+            ],
+            "bundled_runs_ms": [
+                67.3401,
+                66.9435,
+                66.8504,
+                67.0948,
+                66.9891,
+                66.9918,
+                67.4766
+            ],
+            "paired_ratios": [
+                0.8448,
+                0.84056,
+                0.83993,
+                0.84131,
+                0.8402,
+                0.84008,
+                0.84681
+            ]
+        },
+        "core.int_to_int.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92285,
+            "delta_pct": -7.72,
+            "ci_delta_pct": [
+                -7.94,
+                -7.43
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.45,
+                "B2/C2": -7.57,
+                "B3/C3": -7.94
+            },
+            "build_spread_pct": 0.49,
+            "builds": 3,
+            "system_ms": 122.7575,
+            "bundled_ms": 113.3588,
+            "raw_delta_pct": -7.6,
+            "spread_pct": [
+                1,
+                0.5
+            ],
+            "system_runs_ms": [
+                122.7975,
+                122.0955,
+                123.2742,
+                122.3349,
+                122.8728,
+                122.7575,
+                122.0389
+            ],
+            "bundled_runs_ms": [
+                113.186,
+                113.1614,
+                113.6812,
+                113.3588,
+                113.5342,
+                113.1077,
+                113.3676
+            ],
+            "paired_ratios": [
+                0.92173,
+                0.92683,
+                0.92218,
+                0.92663,
+                0.924,
+                0.92139,
+                0.92895
+            ]
+        },
+        "core.int_to_int.free": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 1.02607,
+            "delta_pct": 2.61,
+            "ci_delta_pct": [
+                -0.91,
+                4.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": 2.81,
+                "B2/C2": 3.31,
+                "B3/C3": -2.61
+            },
+            "build_spread_pct": 5.92,
+            "builds": 3,
+            "system_ms": 2.1244,
+            "bundled_ms": 2.1565,
+            "raw_delta_pct": 2.73,
+            "spread_pct": [
+                14.3,
+                4.1
+            ],
+            "system_runs_ms": [
+                1.9262,
+                2.1139,
+                2.2293,
+                2.1187,
+                2.1283,
+                2.1737,
+                2.1244
+            ],
+            "bundled_runs_ms": [
+                2.1133,
+                2.2014,
+                2.1362,
+                2.181,
+                2.1865,
+                2.1565,
+                2.1446
+            ],
+            "paired_ratios": [
+                1.09713,
+                1.04139,
+                0.95824,
+                1.0294,
+                1.02735,
+                0.99209,
+                1.00951
+            ]
+        },
+        "core.int_to_mixed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90649,
+            "delta_pct": -9.35,
+            "ci_delta_pct": [
+                -9.75,
+                -8.94
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.35,
+                "B2/C2": -9.88,
+                "B3/C3": -9.11
+            },
+            "build_spread_pct": 0.77,
+            "builds": 3,
+            "system_ms": 440.5012,
+            "bundled_ms": 399.8489,
+            "raw_delta_pct": -9.24,
+            "spread_pct": [
+                2,
+                1.4
+            ],
+            "system_runs_ms": [
+                433.8693,
+                440.5012,
+                440.4959,
+                440.5635,
+                442.5097,
+                441.4533,
+                440.4771
+            ],
+            "bundled_runs_ms": [
+                398.4241,
+                396.9591,
+                400.1514,
+                399.8628,
+                399.8489,
+                402.4771,
+                399.7483
+            ],
+            "paired_ratios": [
+                0.9183,
+                0.90115,
+                0.90841,
+                0.90762,
+                0.90359,
+                0.91171,
+                0.90753
+            ]
+        },
+        "core.int_to_mixed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88578,
+            "delta_pct": -11.42,
+            "ci_delta_pct": [
+                -11.86,
+                -11.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.42,
+                "B2/C2": -11.53,
+                "B3/C3": -11.61
+            },
+            "build_spread_pct": 0.19,
+            "builds": 3,
+            "system_ms": 314.819,
+            "bundled_ms": 279.1393,
+            "raw_delta_pct": -11.31,
+            "spread_pct": [
+                1.3,
+                0.9
+            ],
+            "system_runs_ms": [
+                311.9984,
+                314.4825,
+                315.1451,
+                314.819,
+                314.1897,
+                316.2266,
+                315.265
+            ],
+            "bundled_runs_ms": [
+                278.3719,
+                277.2152,
+                279.7075,
+                279.1393,
+                279.6768,
+                279.0806,
+                279.6029
+            ],
+            "paired_ratios": [
+                0.89222,
+                0.8815,
+                0.88755,
+                0.88667,
+                0.89015,
+                0.88253,
+                0.88688
+            ]
+        },
+        "core.int_to_mixed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93176,
+            "delta_pct": -6.82,
+            "ci_delta_pct": [
+                -7.22,
+                -6.68
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.82,
+                "B2/C2": -6.95,
+                "B3/C3": -7.02
+            },
+            "build_spread_pct": 0.2,
+            "builds": 3,
+            "system_ms": 345.1987,
+            "bundled_ms": 321.1417,
+            "raw_delta_pct": -6.71,
+            "spread_pct": [
+                1.1,
+                0.5
+            ],
+            "system_runs_ms": [
+                341.8039,
+                343.8812,
+                345.1987,
+                345.3542,
+                345.7189,
+                343.714,
+                345.4939
+            ],
+            "bundled_runs_ms": [
+                320.5624,
+                321.3212,
+                320.6506,
+                322.19,
+                321.1417,
+                320.68,
+                322.2497
+            ],
+            "paired_ratios": [
+                0.93785,
+                0.9344,
+                0.92889,
+                0.93293,
+                0.92891,
+                0.93298,
+                0.93272
+            ]
+        },
+        "core.int_to_mixed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92533,
+            "delta_pct": -7.47,
+            "ci_delta_pct": [
+                -8.26,
+                -7.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.21,
+                "B2/C2": -8.32,
+                "B3/C3": -7.14
+            },
+            "build_spread_pct": 1.18,
+            "builds": 3,
+            "system_ms": 108.6889,
+            "bundled_ms": 100.4224,
+            "raw_delta_pct": -7.35,
+            "spread_pct": [
+                1.8,
+                2.4
+            ],
+            "system_runs_ms": [
+                106.893,
+                108.8449,
+                108.6889,
+                108.557,
+                108.8626,
+                108.7555,
+                108.491
+            ],
+            "bundled_runs_ms": [
+                99.3057,
+                99.979,
+                100.4224,
+                100.9869,
+                99.8544,
+                101.7466,
+                100.515
+            ],
+            "paired_ratios": [
+                0.92902,
+                0.91855,
+                0.92394,
+                0.93027,
+                0.91725,
+                0.93555,
+                0.92648
+            ]
+        },
+        "core.int_to_packed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90923,
+            "delta_pct": -9.08,
+            "ci_delta_pct": [
+                -9.25,
+                -8.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.68,
+                "B2/C2": -9.52,
+                "B3/C3": -8.6
+            },
+            "build_spread_pct": 0.92,
+            "builds": 3,
+            "system_ms": 380.6197,
+            "bundled_ms": 347.0775,
+            "raw_delta_pct": -8.96,
+            "spread_pct": [
+                1.8,
+                1.4
+            ],
+            "system_runs_ms": [
+                378.6615,
+                380.4879,
+                380.853,
+                380.6197,
+                385.3545,
+                381.077,
+                380.4436
+            ],
+            "bundled_runs_ms": [
+                347.0775,
+                345.7287,
+                346.5853,
+                346.5017,
+                348.0214,
+                350.7111,
+                347.836
+            ],
+            "paired_ratios": [
+                0.91659,
+                0.90865,
+                0.91002,
+                0.91036,
+                0.90312,
+                0.92032,
+                0.91429
+            ]
+        },
+        "core.int_to_packed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95152,
+            "delta_pct": -4.85,
+            "ci_delta_pct": [
+                -5.05,
+                -4.59
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.85,
+                "B2/C2": -4.62,
+                "B3/C3": -4.83
+            },
+            "build_spread_pct": 0.23,
+            "builds": 3,
+            "system_ms": 215.5097,
+            "bundled_ms": 205.1662,
+            "raw_delta_pct": -4.73,
+            "spread_pct": [
+                0.7,
+                0.7
+            ],
+            "system_runs_ms": [
+                216.4832,
+                215.7699,
+                214.9587,
+                215.3517,
+                215.2445,
+                215.5097,
+                216.1747
+            ],
+            "bundled_runs_ms": [
+                205.2883,
+                205.124,
+                205.1585,
+                205.1662,
+                206.471,
+                205.0344,
+                206.5098
+            ],
+            "paired_ratios": [
+                0.94829,
+                0.95066,
+                0.95441,
+                0.9527,
+                0.95924,
+                0.95139,
+                0.95529
+            ]
+        },
+        "core.int_to_packed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93986,
+            "delta_pct": -6.01,
+            "ci_delta_pct": [
+                -6.35,
+                -5.62
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.01,
+                "B2/C2": -5.96,
+                "B3/C3": -5.96
+            },
+            "build_spread_pct": 0.05,
+            "builds": 3,
+            "system_ms": 262.4304,
+            "bundled_ms": 246.4935,
+            "raw_delta_pct": -5.9,
+            "spread_pct": [
+                1,
+                1.3
+            ],
+            "system_runs_ms": [
+                260.8467,
+                261.7657,
+                263.3699,
+                262.4304,
+                260.8042,
+                262.5002,
+                262.92
+            ],
+            "bundled_runs_ms": [
+                246.4935,
+                246.0151,
+                245.92,
+                246.9549,
+                246.0157,
+                249.2317,
+                246.5231
+            ],
+            "paired_ratios": [
+                0.94497,
+                0.93983,
+                0.93374,
+                0.94103,
+                0.9433,
+                0.94945,
+                0.93764
+            ]
+        },
+        "core.int_to_packed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85081,
+            "delta_pct": -14.92,
+            "ci_delta_pct": [
+                -15.35,
+                -14.54
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.92,
+                "B2/C2": -14.65,
+                "B3/C3": -15.28
+            },
+            "build_spread_pct": 0.63,
+            "builds": 3,
+            "system_ms": 61.4974,
+            "bundled_ms": 52.294,
+            "raw_delta_pct": -14.81,
+            "spread_pct": [
+                0.7,
+                0.9
+            ],
+            "system_runs_ms": [
+                61.3964,
+                61.3264,
+                61.6971,
+                61.7462,
+                61.4771,
+                61.4974,
+                61.5083
+            ],
+            "bundled_runs_ms": [
+                52.5376,
+                52.2461,
+                52.294,
+                52.2787,
+                52.699,
+                52.2097,
+                52.3972
+            ],
+            "paired_ratios": [
+                0.85571,
+                0.85193,
+                0.84759,
+                0.84667,
+                0.85721,
+                0.84897,
+                0.85187
+            ]
+        },
+        "core.string_to_int.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7156,
+            "delta_pct": -28.44,
+            "ci_delta_pct": [
+                -28.67,
+                -28.38
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -28.38,
+                "B2/C2": -28.76,
+                "B3/C3": -28.44
+            },
+            "build_spread_pct": 0.38,
+            "builds": 3,
+            "system_ms": 895.0357,
+            "bundled_ms": 640.3671,
+            "raw_delta_pct": -28.35,
+            "spread_pct": [
+                0.7,
+                0.6
+            ],
+            "system_runs_ms": [
+                896.2007,
+                893.6018,
+                893.7136,
+                893.1982,
+                899.0926,
+                895.5532,
+                895.0357
+            ],
+            "bundled_runs_ms": [
+                642.7227,
+                638.7772,
+                640.3671,
+                640.4649,
+                639.9329,
+                641.6552,
+                639.2268
+            ],
+            "paired_ratios": [
+                0.71716,
+                0.71483,
+                0.71652,
+                0.71705,
+                0.71175,
+                0.71649,
+                0.71419
+            ]
+        },
+        "core.string_to_int.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.63219,
+            "delta_pct": -36.78,
+            "ci_delta_pct": [
+                -36.82,
+                -36.17
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -36.82,
+                "B2/C2": -36.88,
+                "B3/C3": -36.08
+            },
+            "build_spread_pct": 0.8,
+            "builds": 3,
+            "system_ms": 323.852,
+            "bundled_ms": 205.0967,
+            "raw_delta_pct": -36.7,
+            "spread_pct": [
+                0.3,
+                1.6
+            ],
+            "system_runs_ms": [
+                324.0202,
+                323.6074,
+                323.5788,
+                323.3605,
+                323.852,
+                323.8574,
+                324.2385
+            ],
+            "bundled_runs_ms": [
+                204.9596,
+                204.1817,
+                207.3778,
+                205.4339,
+                204.993,
+                206.9812,
+                205.0967
+            ],
+            "paired_ratios": [
+                0.63255,
+                0.63095,
+                0.64089,
+                0.63531,
+                0.63298,
+                0.63911,
+                0.63255
+            ]
+        },
+        "core.string_to_int.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.63765,
+            "delta_pct": -36.23,
+            "ci_delta_pct": [
+                -36.67,
+                -36.1
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -36.23,
+                "B2/C2": -36.26,
+                "B3/C3": -36.92
+            },
+            "build_spread_pct": 0.69,
+            "builds": 3,
+            "system_ms": 455.542,
+            "bundled_ms": 290.9893,
+            "raw_delta_pct": -36.16,
+            "spread_pct": [
+                2.4,
+                0.8
+            ],
+            "system_runs_ms": [
+                455.3973,
+                458.738,
+                465.9351,
+                458.9092,
+                455.542,
+                455.0165,
+                455.2773
+            ],
+            "bundled_runs_ms": [
+                292.8921,
+                292.0385,
+                290.9669,
+                290.9893,
+                291.4375,
+                290.6031,
+                290.6708
+            ],
+            "paired_ratios": [
+                0.64316,
+                0.63661,
+                0.62448,
+                0.63409,
+                0.63976,
+                0.63866,
+                0.63845
+            ]
+        },
+        "core.string_to_int.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.5744,
+            "delta_pct": -42.56,
+            "ci_delta_pct": [
+                -42.7,
+                -42.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -42.35,
+                "B2/C2": -42.8,
+                "B3/C3": -42.57
+            },
+            "build_spread_pct": 0.45,
+            "builds": 3,
+            "system_ms": 191.6034,
+            "bundled_ms": 110.3436,
+            "raw_delta_pct": -42.49,
+            "spread_pct": [
+                0.6,
+                1.1
+            ],
+            "system_runs_ms": [
+                191.937,
+                192.2005,
+                191.0739,
+                191.2217,
+                191.6109,
+                191.6034,
+                191.2029
+            ],
+            "bundled_runs_ms": [
+                110.3859,
+                110.3436,
+                110.1166,
+                110.3842,
+                109.4701,
+                109.9343,
+                110.7124
+            ],
+            "paired_ratios": [
+                0.57512,
+                0.57411,
+                0.5763,
+                0.57726,
+                0.57131,
+                0.57376,
+                0.57903
+            ]
+        },
+        "core.string_to_mixed.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.71836,
+            "delta_pct": -28.16,
+            "ci_delta_pct": [
+                -28.37,
+                -27.82
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -28.25,
+                "B2/C2": -26.98,
+                "B3/C3": -27.99
+            },
+            "build_spread_pct": 1.27,
+            "builds": 3,
+            "system_ms": 1371.9443,
+            "bundled_ms": 987.0119,
+            "raw_delta_pct": -28.07,
+            "spread_pct": [
+                0.7,
+                3.6
+            ],
+            "system_runs_ms": [
+                1378.9911,
+                1369.4669,
+                1369.5262,
+                1371.9443,
+                1375.3749,
+                1370.0383,
+                1373.19
+            ],
+            "bundled_runs_ms": [
+                987.0119,
+                1020.3408,
+                985.0373,
+                985.5718,
+                986.3736,
+                990.1897,
+                987.9889
+            ],
+            "paired_ratios": [
+                0.71575,
+                0.74506,
+                0.71925,
+                0.71838,
+                0.71717,
+                0.72275,
+                0.71948
+            ]
+        },
+        "core.string_to_mixed.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.66378,
+            "delta_pct": -33.62,
+            "ci_delta_pct": [
+                -33.78,
+                -33.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -33.78,
+                "B2/C2": -33.62,
+                "B3/C3": -33.39
+            },
+            "build_spread_pct": 0.39,
+            "builds": 3,
+            "system_ms": 1180.1575,
+            "bundled_ms": 784.4513,
+            "raw_delta_pct": -33.54,
+            "spread_pct": [
+                0.7,
+                0.4
+            ],
+            "system_runs_ms": [
+                1185.6782,
+                1179.5737,
+                1178.4556,
+                1180.3366,
+                1180.1575,
+                1179.2827,
+                1186.2758
+            ],
+            "bundled_runs_ms": [
+                784.0579,
+                784.1004,
+                786.8556,
+                784.4513,
+                784.3375,
+                785.6656,
+                786.4843
+            ],
+            "paired_ratios": [
+                0.66127,
+                0.66473,
+                0.6677,
+                0.6646,
+                0.6646,
+                0.66622,
+                0.66299
+            ]
+        },
+        "core.string_to_mixed.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.65369,
+            "delta_pct": -34.63,
+            "ci_delta_pct": [
+                -34.75,
+                -34.43
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -34.64,
+                "B2/C2": -34.62,
+                "B3/C3": -34.94
+            },
+            "build_spread_pct": 0.32,
+            "builds": 3,
+            "system_ms": 1251.489,
+            "bundled_ms": 818.8243,
+            "raw_delta_pct": -34.55,
+            "spread_pct": [
+                1.3,
+                0.5
+            ],
+            "system_runs_ms": [
+                1254.6752,
+                1250.3079,
+                1265.6879,
+                1251.1775,
+                1250.0204,
+                1251.9163,
+                1251.489
+            ],
+            "bundled_runs_ms": [
+                819.6782,
+                818.33,
+                817.9262,
+                818.8243,
+                818.5234,
+                821.8994,
+                821.7356
+            ],
+            "paired_ratios": [
+                0.6533,
+                0.6545,
+                0.64623,
+                0.65444,
+                0.65481,
+                0.65651,
+                0.65661
+            ]
+        },
+        "core.string_to_mixed.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.60883,
+            "delta_pct": -39.12,
+            "ci_delta_pct": [
+                -39.17,
+                -39.04
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -39.17,
+                "B2/C2": -39.06,
+                "B3/C3": -39.05
+            },
+            "build_spread_pct": 0.12,
+            "builds": 3,
+            "system_ms": 567.2833,
+            "bundled_ms": 346.0519,
+            "raw_delta_pct": -39.04,
+            "spread_pct": [
+                0.5,
+                0.3
+            ],
+            "system_runs_ms": [
+                569.1411,
+                567.2833,
+                566.1715,
+                566.95,
+                566.8532,
+                567.5608,
+                568.1022
+            ],
+            "bundled_runs_ms": [
+                346.4269,
+                345.8117,
+                345.5679,
+                345.3082,
+                346.1654,
+                346.3456,
+                346.0519
+            ],
+            "paired_ratios": [
+                0.60868,
+                0.60959,
+                0.61036,
+                0.60906,
+                0.61068,
+                0.61024,
+                0.60914
+            ]
+        },
+        "core.string_to_int_hash.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.80883,
+            "delta_pct": -19.12,
+            "ci_delta_pct": [
+                -19.29,
+                -18.99
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -19.12,
+                "B2/C2": -20.48,
+                "B3/C3": -18.97
+            },
+            "build_spread_pct": 1.51,
+            "builds": 3,
+            "system_ms": 1294.6299,
+            "bundled_ms": 1048.0178,
+            "raw_delta_pct": -19.02,
+            "spread_pct": [
+                3.5,
+                0.8
+            ],
+            "system_runs_ms": [
+                1293.9082,
+                1293.4336,
+                1296.763,
+                1294.6299,
+                1338.0385,
+                1295.4058,
+                1292.2689
+            ],
+            "bundled_runs_ms": [
+                1047.8571,
+                1048.15,
+                1047.9007,
+                1048.0178,
+                1046.2552,
+                1055.0751,
+                1048.207
+            ],
+            "paired_ratios": [
+                0.80984,
+                0.81036,
+                0.80809,
+                0.80951,
+                0.78193,
+                0.81447,
+                0.81114
+            ]
+        },
+        "core.string_to_int_hash.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90272,
+            "delta_pct": -9.73,
+            "ci_delta_pct": [
+                -9.84,
+                -9.55
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.76,
+                "B2/C2": -9.78,
+                "B3/C3": -9.63
+            },
+            "build_spread_pct": 0.15,
+            "builds": 3,
+            "system_ms": 188.4071,
+            "bundled_ms": 170.412,
+            "raw_delta_pct": -9.62,
+            "spread_pct": [
+                0.4,
+                0.6
+            ],
+            "system_runs_ms": [
+                188.4071,
+                188.4223,
+                188.2683,
+                188.273,
+                188.9381,
+                188.4989,
+                188.2808
+            ],
+            "bundled_runs_ms": [
+                170.2271,
+                170.0917,
+                170.503,
+                169.7569,
+                170.7709,
+                170.412,
+                170.6627
+            ],
+            "paired_ratios": [
+                0.90351,
+                0.90272,
+                0.90564,
+                0.90165,
+                0.90385,
+                0.90405,
+                0.90643
+            ]
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.65494,
+            "delta_pct": -34.51,
+            "ci_delta_pct": [
+                -34.77,
+                -34.5
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -34.5,
+                "B2/C2": -34.57,
+                "B3/C3": -35.58
+            },
+            "build_spread_pct": 1.08,
+            "builds": 3,
+            "system_ms": 593.0963,
+            "bundled_ms": 388.3749,
+            "raw_delta_pct": -34.42,
+            "spread_pct": [
+                4.7,
+                1.8
+            ],
+            "system_runs_ms": [
+                592.7747,
+                593.0963,
+                619.8924,
+                593.5672,
+                592.2547,
+                593.8632,
+                592.4535
+            ],
+            "bundled_runs_ms": [
+                388.7382,
+                388.1823,
+                387.9145,
+                387.6542,
+                388.3749,
+                394.4982,
+                388.5616
+            ],
+            "paired_ratios": [
+                0.65579,
+                0.6545,
+                0.62578,
+                0.65309,
+                0.65576,
+                0.66429,
+                0.65585
+            ]
+        },
+        "core.string_to_int_hash.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69464,
+            "delta_pct": -30.54,
+            "ci_delta_pct": [
+                -30.79,
+                -30.42
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -30.48,
+                "B2/C2": -30.48,
+                "B3/C3": -30.74
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 337.7456,
+            "bundled_ms": 234.6785,
+            "raw_delta_pct": -30.45,
+            "spread_pct": [
+                0.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                336.5425,
+                337.4208,
+                337.7456,
+                338.5158,
+                336.9222,
+                338.0223,
+                337.8147
+            ],
+            "bundled_runs_ms": [
+                235.3804,
+                234.6785,
+                233.9831,
+                234.5738,
+                234.7167,
+                234.6698,
+                235.1461
+            ],
+            "paired_ratios": [
+                0.69941,
+                0.69551,
+                0.69278,
+                0.69295,
+                0.69665,
+                0.69424,
+                0.69608
+            ]
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.72569,
+            "delta_pct": -27.43,
+            "ci_delta_pct": [
+                -27.6,
+                -27.14
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -27.43,
+                "B2/C2": -27.47,
+                "B3/C3": -27.37
+            },
+            "build_spread_pct": 0.1,
+            "builds": 3,
+            "system_ms": 2618.4808,
+            "bundled_ms": 1904.3218,
+            "raw_delta_pct": -27.34,
+            "spread_pct": [
+                2,
+                1.9
+            ],
+            "system_runs_ms": [
+                2626.6492,
+                2622.4033,
+                2618.4808,
+                2613.7131,
+                2665.2455,
+                2615.9426,
+                2613.6198
+            ],
+            "bundled_runs_ms": [
+                1905.4875,
+                1935.1637,
+                1898.2432,
+                1899.1242,
+                1904.3218,
+                1908.2951,
+                1903.9381
+            ],
+            "paired_ratios": [
+                0.72544,
+                0.73794,
+                0.72494,
+                0.7266,
+                0.7145,
+                0.72949,
+                0.72847
+            ]
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.67555,
+            "delta_pct": -32.45,
+            "ci_delta_pct": [
+                -32.59,
+                -32.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -32.45,
+                "B2/C2": -32.49,
+                "B3/C3": -32.47
+            },
+            "build_spread_pct": 0.04,
+            "builds": 3,
+            "system_ms": 1375.5176,
+            "bundled_ms": 929.6826,
+            "raw_delta_pct": -32.36,
+            "spread_pct": [
+                0.3,
+                0.3
+            ],
+            "system_runs_ms": [
+                1377.4914,
+                1375.6801,
+                1372.9169,
+                1372.8135,
+                1374.3766,
+                1376.1232,
+                1375.5176
+            ],
+            "bundled_runs_ms": [
+                928.0944,
+                929.092,
+                929.9307,
+                930.893,
+                929.6826,
+                928.8497,
+                930.3895
+            ],
+            "paired_ratios": [
+                0.67376,
+                0.67537,
+                0.67734,
+                0.67809,
+                0.67644,
+                0.67498,
+                0.67639
+            ]
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.6717,
+            "delta_pct": -32.83,
+            "ci_delta_pct": [
+                -33.11,
+                -32.76
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -32.81,
+                "B2/C2": -32.94,
+                "B3/C3": -33.92
+            },
+            "build_spread_pct": 1.11,
+            "builds": 3,
+            "system_ms": 636.1857,
+            "bundled_ms": 427.7752,
+            "raw_delta_pct": -32.75,
+            "spread_pct": [
+                3.9,
+                0.9
+            ],
+            "system_runs_ms": [
+                634.7189,
+                635.2943,
+                659.3654,
+                635.6516,
+                636.1857,
+                636.5789,
+                639.1823
+            ],
+            "bundled_runs_ms": [
+                427.017,
+                427.725,
+                429.4748,
+                428.2581,
+                426.0538,
+                427.7752,
+                429.8716
+            ],
+            "paired_ratios": [
+                0.67277,
+                0.67327,
+                0.65135,
+                0.67373,
+                0.6697,
+                0.67199,
+                0.67253
+            ]
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.65802,
+            "delta_pct": -34.2,
+            "ci_delta_pct": [
+                -34.22,
+                -34.01
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -34.2,
+                "B2/C2": -34.11,
+                "B3/C3": -34.12
+            },
+            "build_spread_pct": 0.09,
+            "builds": 3,
+            "system_ms": 931.4135,
+            "bundled_ms": 614.6235,
+            "raw_delta_pct": -34.12,
+            "spread_pct": [
+                0.4,
+                0.3
+            ],
+            "system_runs_ms": [
+                932.9039,
+                931.637,
+                931.4135,
+                933.5221,
+                930.2602,
+                931.2489,
+                930.4094
+            ],
+            "bundled_runs_ms": [
+                614.6385,
+                613.5668,
+                613.4063,
+                614.3311,
+                614.7987,
+                615.3113,
+                614.6235
+            ],
+            "paired_ratios": [
+                0.65884,
+                0.65859,
+                0.65858,
+                0.65808,
+                0.66089,
+                0.66074,
+                0.66059
+            ]
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.80784,
+            "delta_pct": -19.22,
+            "ci_delta_pct": [
+                -19.49,
+                -19.18
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -19.22,
+                "B2/C2": -20.75,
+                "B3/C3": -19.07
+            },
+            "build_spread_pct": 1.68,
+            "builds": 3,
+            "system_ms": 1296.4231,
+            "bundled_ms": 1048.5857,
+            "raw_delta_pct": -19.11,
+            "spread_pct": [
+                4,
+                0.7
+            ],
+            "system_runs_ms": [
+                1296.388,
+                1296.4231,
+                1298.2497,
+                1296.173,
+                1344.7462,
+                1293.0818,
+                1296.8677
+            ],
+            "bundled_runs_ms": [
+                1048.5857,
+                1048.7068,
+                1046.4854,
+                1048.9058,
+                1046.3792,
+                1053.3074,
+                1047.6071
+            ],
+            "paired_ratios": [
+                0.80885,
+                0.80892,
+                0.80607,
+                0.80923,
+                0.77812,
+                0.81457,
+                0.8078
+            ]
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90086,
+            "delta_pct": -9.91,
+            "ci_delta_pct": [
+                -9.94,
+                -9.58
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -9.93,
+                "B2/C2": -9.67,
+                "B3/C3": -10.43
+            },
+            "build_spread_pct": 0.76,
+            "builds": 3,
+            "system_ms": 189.0741,
+            "bundled_ms": 170.9125,
+            "raw_delta_pct": -9.8,
+            "spread_pct": [
+                2.4,
+                0.6
+            ],
+            "system_runs_ms": [
+                188.8288,
+                189.6389,
+                188.5574,
+                188.9854,
+                189.0741,
+                193.0561,
+                189.2178
+            ],
+            "bundled_runs_ms": [
+                170.3201,
+                171.3492,
+                170.9125,
+                170.4185,
+                171.172,
+                171.2793,
+                170.6384
+            ],
+            "paired_ratios": [
+                0.90198,
+                0.90356,
+                0.90642,
+                0.90175,
+                0.90532,
+                0.8872,
+                0.90181
+            ]
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.64979,
+            "delta_pct": -35.02,
+            "ci_delta_pct": [
+                -35.1,
+                -34.79
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -35.01,
+                "B2/C2": -34.91,
+                "B3/C3": -36.29
+            },
+            "build_spread_pct": 1.38,
+            "builds": 3,
+            "system_ms": 595.036,
+            "bundled_ms": 387.5351,
+            "raw_delta_pct": -34.94,
+            "spread_pct": [
+                4.8,
+                0.6
+            ],
+            "system_runs_ms": [
+                595.036,
+                593.5773,
+                621.6756,
+                595.8741,
+                594.8539,
+                595.7073,
+                592.9175
+            ],
+            "bundled_runs_ms": [
+                387.1303,
+                387.5351,
+                389.2298,
+                387.7344,
+                386.9554,
+                387.0816,
+                387.856
+            ],
+            "paired_ratios": [
+                0.6506,
+                0.65288,
+                0.6261,
+                0.6507,
+                0.6505,
+                0.64978,
+                0.65415
+            ]
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69514,
+            "delta_pct": -30.49,
+            "ci_delta_pct": [
+                -30.62,
+                -30.3
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -30.62,
+                "B2/C2": -30.32,
+                "B3/C3": -30.52
+            },
+            "build_spread_pct": 0.3,
+            "builds": 3,
+            "system_ms": 337.1748,
+            "bundled_ms": 234.6697,
+            "raw_delta_pct": -30.4,
+            "spread_pct": [
+                0.2,
+                1.3
+            ],
+            "system_runs_ms": [
+                336.8028,
+                336.7424,
+                337.2204,
+                337.5067,
+                337.2021,
+                337.1665,
+                337.1748
+            ],
+            "bundled_runs_ms": [
+                233.9657,
+                235.4673,
+                234.4689,
+                232.4622,
+                234.7458,
+                234.6697,
+                235.3182
+            ],
+            "paired_ratios": [
+                0.69467,
+                0.69925,
+                0.6953,
+                0.68876,
+                0.69616,
+                0.69601,
+                0.69791
+            ]
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74529,
+            "delta_pct": -25.47,
+            "ci_delta_pct": [
+                -25.86,
+                -25.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.47,
+                "B2/C2": -25.91,
+                "B3/C3": -25.57
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 1809.1203,
+            "bundled_ms": 1349.8182,
+            "raw_delta_pct": -25.38,
+            "spread_pct": [
+                2.7,
+                1.4
+            ],
+            "system_runs_ms": [
+                1806.024,
+                1804.3029,
+                1809.8805,
+                1815.9257,
+                1852.4385,
+                1809.1203,
+                1806.1485
+            ],
+            "bundled_runs_ms": [
+                1350.077,
+                1362.1735,
+                1343.6665,
+                1348.0299,
+                1349.8182,
+                1353.2079,
+                1347.785
+            ],
+            "paired_ratios": [
+                0.74754,
+                0.75496,
+                0.74241,
+                0.74234,
+                0.72867,
+                0.74799,
+                0.74622
+            ]
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89197,
+            "delta_pct": -10.8,
+            "ci_delta_pct": [
+                -11.35,
+                -10.71
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.71,
+                "B2/C2": -11.09,
+                "B3/C3": -10.22
+            },
+            "build_spread_pct": 0.87,
+            "builds": 3,
+            "system_ms": 196.9795,
+            "bundled_ms": 175.8186,
+            "raw_delta_pct": -10.69,
+            "spread_pct": [
+                0.8,
+                2.2
+            ],
+            "system_runs_ms": [
+                197.0732,
+                196.8191,
+                196.7245,
+                196.6721,
+                197.1221,
+                198.2042,
+                196.9795
+            ],
+            "bundled_runs_ms": [
+                174.9259,
+                175.7757,
+                178.8659,
+                175.8186,
+                174.9208,
+                176.1126,
+                176.1005
+            ],
+            "paired_ratios": [
+                0.88762,
+                0.89308,
+                0.90922,
+                0.89397,
+                0.88737,
+                0.88854,
+                0.894
+            ]
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.67493,
+            "delta_pct": -32.51,
+            "ci_delta_pct": [
+                -32.63,
+                -31.85
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -32.41,
+                "B2/C2": -32.57,
+                "B3/C3": -33.2
+            },
+            "build_spread_pct": 0.79,
+            "builds": 3,
+            "system_ms": 667.6896,
+            "bundled_ms": 450.7286,
+            "raw_delta_pct": -32.42,
+            "spread_pct": [
+                3.5,
+                1.4
+            ],
+            "system_runs_ms": [
+                666.0385,
+                667.1577,
+                686.6662,
+                663.1689,
+                668.1006,
+                668.7673,
+                667.6896
+            ],
+            "bundled_runs_ms": [
+                450.7286,
+                450.8447,
+                449.933,
+                452.6129,
+                450.6296,
+                456.3215,
+                450.4109
+            ],
+            "paired_ratios": [
+                0.67673,
+                0.67577,
+                0.65524,
+                0.6825,
+                0.67449,
+                0.68233,
+                0.67458
+            ]
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.67099,
+            "delta_pct": -32.9,
+            "ci_delta_pct": [
+                -32.98,
+                -32.58
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -32.9,
+                "B2/C2": -32.88,
+                "B3/C3": -32.78
+            },
+            "build_spread_pct": 0.12,
+            "builds": 3,
+            "system_ms": 963.7144,
+            "bundled_ms": 647.4938,
+            "raw_delta_pct": -32.82,
+            "spread_pct": [
+                0.3,
+                0.7
+            ],
+            "system_runs_ms": [
+                963.5044,
+                963.1065,
+                962.53,
+                965.2109,
+                963.7144,
+                964.8668,
+                963.7849
+            ],
+            "bundled_runs_ms": [
+                647.3097,
+                646.624,
+                649.7268,
+                647.4938,
+                648.2407,
+                647.4615,
+                650.8683
+            ],
+            "paired_ratios": [
+                0.67183,
+                0.67139,
+                0.67502,
+                0.67083,
+                0.67265,
+                0.67104,
+                0.67533
+            ]
+        },
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.73639,
+            "delta_pct": -26.36,
+            "ci_delta_pct": [
+                -26.52,
+                -26.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.36,
+                "B2/C2": -24.75,
+                "B3/C3": -27.77
+            },
+            "build_spread_pct": 3.02,
+            "builds": 3,
+            "system_ms": 171.0644,
+            "bundled_ms": 126.4609,
+            "raw_delta_pct": -26.27,
+            "spread_pct": [
+                4.3,
+                4.1
+            ],
+            "system_runs_ms": [
+                171.0644,
+                171.037,
+                177.9389,
+                171.8424,
+                170.8095,
+                171.5333,
+                170.5936
+            ],
+            "bundled_runs_ms": [
+                125.8534,
+                126.5015,
+                126.1956,
+                126.7007,
+                131.0549,
+                126.4609,
+                126.2729
+            ],
+            "paired_ratios": [
+                0.73571,
+                0.73961,
+                0.70921,
+                0.73731,
+                0.76726,
+                0.73724,
+                0.7402
+            ]
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.73853,
+            "delta_pct": -26.15,
+            "ci_delta_pct": [
+                -26.22,
+                -26.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -26.17,
+                "B2/C2": -26.18,
+                "B3/C3": -26.02
+            },
+            "build_spread_pct": 0.16,
+            "builds": 3,
+            "system_ms": 170.7331,
+            "bundled_ms": 126.2483,
+            "raw_delta_pct": -26.06,
+            "spread_pct": [
+                1,
+                1.2
+            ],
+            "system_runs_ms": [
+                170.8553,
+                170.7406,
+                170.7075,
+                172.3144,
+                170.7331,
+                170.667,
+                170.587
+            ],
+            "bundled_runs_ms": [
+                125.9764,
+                126.1297,
+                126.5521,
+                127.4304,
+                126.2483,
+                126.3271,
+                126.1052
+            ],
+            "paired_ratios": [
+                0.73733,
+                0.73872,
+                0.74134,
+                0.73952,
+                0.73945,
+                0.7402,
+                0.73924
+            ]
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92784,
+            "delta_pct": -7.22,
+            "ci_delta_pct": [
+                -7.39,
+                -6.71
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -6.97,
+                "B2/C2": -6.72,
+                "B3/C3": -7.25
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 319.1413,
+            "bundled_ms": 297.2557,
+            "raw_delta_pct": -7.1,
+            "spread_pct": [
+                1,
+                1
+            ],
+            "system_runs_ms": [
+                320.5483,
+                321.1445,
+                320.7931,
+                319.1413,
+                318.3713,
+                319.0878,
+                318.0647
+            ],
+            "bundled_runs_ms": [
+                296.9377,
+                297.7688,
+                297.8001,
+                297.2557,
+                299.4844,
+                296.4311,
+                297.0942
+            ],
+            "paired_ratios": [
+                0.92634,
+                0.92721,
+                0.92832,
+                0.93142,
+                0.94068,
+                0.929,
+                0.93407
+            ]
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89935,
+            "delta_pct": -10.06,
+            "ci_delta_pct": [
+                -10.31,
+                -9.88
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.06,
+                "B2/C2": -10.15,
+                "B3/C3": -10.16
+            },
+            "build_spread_pct": 0.1,
+            "builds": 3,
+            "system_ms": 23.8223,
+            "bundled_ms": 21.4209,
+            "raw_delta_pct": -9.95,
+            "spread_pct": [
+                0.8,
+                0.7
+            ],
+            "system_runs_ms": [
+                23.8557,
+                23.7848,
+                23.8377,
+                23.8532,
+                23.8223,
+                23.7263,
+                23.6684
+            ],
+            "bundled_runs_ms": [
+                21.4814,
+                21.435,
+                21.3766,
+                21.4209,
+                21.3932,
+                21.4079,
+                21.535
+            ],
+            "paired_ratios": [
+                0.90047,
+                0.90121,
+                0.89676,
+                0.89803,
+                0.89803,
+                0.90229,
+                0.90986
+            ]
+        },
+        "api.increment.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.81167,
+            "delta_pct": -18.83,
+            "ci_delta_pct": [
+                -19.57,
+                -18.73
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -19.57,
+                "B2/C2": -18.78,
+                "B3/C3": -18.86
+            },
+            "build_spread_pct": 0.79,
+            "builds": 3,
+            "system_ms": 179.1704,
+            "bundled_ms": 145.5156,
+            "raw_delta_pct": -18.73,
+            "spread_pct": [
+                0.9,
+                1.6
+            ],
+            "system_runs_ms": [
+                180.039,
+                179.0754,
+                179.1704,
+                180.5964,
+                179.055,
+                179.0401,
+                179.3734
+            ],
+            "bundled_runs_ms": [
+                146.808,
+                145.7222,
+                145.6843,
+                145.4002,
+                145.5156,
+                145.3413,
+                144.4419
+            ],
+            "paired_ratios": [
+                0.81542,
+                0.81375,
+                0.8131,
+                0.80511,
+                0.81269,
+                0.81178,
+                0.80526
+            ]
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92221,
+            "delta_pct": -7.78,
+            "ci_delta_pct": [
+                -7.84,
+                -7.53
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.53,
+                "B2/C2": -7.93,
+                "B3/C3": -7.68
+            },
+            "build_spread_pct": 0.4,
+            "builds": 3,
+            "system_ms": 125.7125,
+            "bundled_ms": 116.2983,
+            "raw_delta_pct": -7.66,
+            "spread_pct": [
+                0.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                125.5422,
+                126.0099,
+                125.7125,
+                125.7887,
+                126.2857,
+                125.6438,
+                125.6081
+            ],
+            "bundled_runs_ms": [
+                116.3361,
+                115.9669,
+                116.3371,
+                116.0761,
+                116.6074,
+                116.0084,
+                116.2983
+            ],
+            "paired_ratios": [
+                0.92667,
+                0.9203,
+                0.92542,
+                0.92279,
+                0.92336,
+                0.92331,
+                0.92588
+            ]
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92257,
+            "delta_pct": -7.74,
+            "ci_delta_pct": [
+                -7.84,
+                -7.55
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.57,
+                "B2/C2": -7.87,
+                "B3/C3": -7.61
+            },
+            "build_spread_pct": 0.3,
+            "builds": 3,
+            "system_ms": 130.7982,
+            "bundled_ms": 120.9467,
+            "raw_delta_pct": -7.63,
+            "spread_pct": [
+                0.5,
+                0.4
+            ],
+            "system_runs_ms": [
+                130.7454,
+                131.1549,
+                130.7982,
+                130.8052,
+                131.3204,
+                130.6393,
+                130.6643
+            ],
+            "bundled_runs_ms": [
+                121.0209,
+                120.9467,
+                121.1627,
+                120.7018,
+                121.1851,
+                120.6747,
+                120.9195
+            ],
+            "paired_ratios": [
+                0.92562,
+                0.92217,
+                0.92633,
+                0.92276,
+                0.92282,
+                0.92372,
+                0.92542
+            ]
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91252,
+            "delta_pct": -8.75,
+            "ci_delta_pct": [
+                -9.04,
+                -8.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.75,
+                "B2/C2": -9.1,
+                "B3/C3": -8.39
+            },
+            "build_spread_pct": 0.71,
+            "builds": 3,
+            "system_ms": 11.0167,
+            "bundled_ms": 10.0528,
+            "raw_delta_pct": -8.63,
+            "spread_pct": [
+                0.3,
+                1.2
+            ],
+            "system_runs_ms": [
+                11.0205,
+                11.0167,
+                11.004,
+                11.0237,
+                11.0368,
+                11.0093,
+                11.0016
+            ],
+            "bundled_runs_ms": [
+                10.1556,
+                10.0332,
+                10.1113,
+                10.0528,
+                10.0392,
+                10.0807,
+                10.0517
+            ],
+            "paired_ratios": [
+                0.92152,
+                0.91073,
+                0.91887,
+                0.91193,
+                0.90961,
+                0.91565,
+                0.91366
+            ]
+        },
+        "api.range.size.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.57149,
+            "delta_pct": -42.85,
+            "ci_delta_pct": [
+                -42.86,
+                -42.65
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -42.85,
+                "B2/C2": -42.75,
+                "B3/C3": -42.76
+            },
+            "build_spread_pct": 0.1,
+            "builds": 3,
+            "system_ms": 36.4795,
+            "bundled_ms": 20.8812,
+            "raw_delta_pct": -42.78,
+            "spread_pct": [
+                0.5,
+                0.3
+            ],
+            "system_runs_ms": [
+                36.4643,
+                36.493,
+                36.4795,
+                36.5926,
+                36.4018,
+                36.4377,
+                36.4847
+            ],
+            "bundled_runs_ms": [
+                20.8812,
+                20.8801,
+                20.8689,
+                20.8884,
+                20.9015,
+                20.9231,
+                20.8767
+            ],
+            "paired_ratios": [
+                0.57265,
+                0.57217,
+                0.57207,
+                0.57084,
+                0.57419,
+                0.57422,
+                0.5722
+            ]
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.82711,
+            "delta_pct": -17.29,
+            "ci_delta_pct": [
+                -17.44,
+                -17.19
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -17.35,
+                "B2/C2": -16.93,
+                "B3/C3": -17.28
+            },
+            "build_spread_pct": 0.42,
+            "builds": 3,
+            "system_ms": 58.6997,
+            "bundled_ms": 48.6127,
+            "raw_delta_pct": -17.19,
+            "spread_pct": [
+                1,
+                0.6
+            ],
+            "system_runs_ms": [
+                58.3701,
+                58.1844,
+                58.7011,
+                58.7552,
+                58.6606,
+                58.6997,
+                58.7127
+            ],
+            "bundled_runs_ms": [
+                48.3942,
+                48.693,
+                48.6127,
+                48.621,
+                48.4912,
+                48.6225,
+                48.5054
+            ],
+            "paired_ratios": [
+                0.82909,
+                0.83687,
+                0.82814,
+                0.82752,
+                0.82664,
+                0.82833,
+                0.82615
+            ]
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74611,
+            "delta_pct": -25.39,
+            "ci_delta_pct": [
+                -25.51,
+                -25.29
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.39,
+                "B2/C2": -25.46,
+                "B3/C3": -25.35
+            },
+            "build_spread_pct": 0.11,
+            "builds": 3,
+            "system_ms": 317.4738,
+            "bundled_ms": 237.0493,
+            "raw_delta_pct": -25.3,
+            "spread_pct": [
+                0.5,
+                0.2
+            ],
+            "system_runs_ms": [
+                317.5514,
+                318.2452,
+                317.8372,
+                317.4738,
+                316.7333,
+                316.894,
+                317.1557
+            ],
+            "bundled_runs_ms": [
+                237.3563,
+                236.9472,
+                237.0493,
+                237.162,
+                236.9398,
+                237.3413,
+                236.9268
+            ],
+            "paired_ratios": [
+                0.74746,
+                0.74454,
+                0.74582,
+                0.74703,
+                0.74807,
+                0.74896,
+                0.74704
+            ]
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.72779,
+            "delta_pct": -27.22,
+            "ci_delta_pct": [
+                -27.31,
+                -26.87
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -27.22,
+                "B2/C2": -27.35,
+                "B3/C3": -26.95
+            },
+            "build_spread_pct": 0.4,
+            "builds": 3,
+            "system_ms": 97.8342,
+            "bundled_ms": 71.2378,
+            "raw_delta_pct": -27.13,
+            "spread_pct": [
+                0.2,
+                0.9
+            ],
+            "system_runs_ms": [
+                97.7599,
+                97.8847,
+                97.8342,
+                97.9464,
+                97.7566,
+                97.9271,
+                97.8237
+            ],
+            "bundled_runs_ms": [
+                71.2378,
+                71.1392,
+                71.474,
+                71.7493,
+                71.1802,
+                71.7016,
+                71.1981
+            ],
+            "paired_ratios": [
+                0.7287,
+                0.72677,
+                0.73056,
+                0.73254,
+                0.72814,
+                0.73219,
+                0.72782
+            ]
+        },
+        "api.setop.union.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75342,
+            "delta_pct": -24.66,
+            "ci_delta_pct": [
+                -24.96,
+                -24.09
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.66,
+                "B2/C2": -24.12,
+                "B3/C3": -25
+            },
+            "build_spread_pct": 0.88,
+            "builds": 3,
+            "system_ms": 242.5056,
+            "bundled_ms": 182.9599,
+            "raw_delta_pct": -24.56,
+            "spread_pct": [
+                0.4,
+                1.4
+            ],
+            "system_runs_ms": [
+                242.0617,
+                241.8864,
+                242.5056,
+                242.5372,
+                241.6725,
+                242.7404,
+                242.5731
+            ],
+            "bundled_runs_ms": [
+                184.0337,
+                183.8407,
+                181.4904,
+                182.9599,
+                183.52,
+                182.9215,
+                182.2431
+            ],
+            "paired_ratios": [
+                0.76028,
+                0.76003,
+                0.7484,
+                0.75436,
+                0.75937,
+                0.75357,
+                0.75129
+            ]
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74529,
+            "delta_pct": -25.47,
+            "ci_delta_pct": [
+                -25.71,
+                -25.33
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.47,
+                "B2/C2": -25.4,
+                "B3/C3": -26.03
+            },
+            "build_spread_pct": 0.63,
+            "builds": 3,
+            "system_ms": 116.7904,
+            "bundled_ms": 86.9828,
+            "raw_delta_pct": -25.38,
+            "spread_pct": [
+                0.6,
+                1.7
+            ],
+            "system_runs_ms": [
+                116.6048,
+                116.5828,
+                117.2624,
+                116.7904,
+                116.508,
+                116.8039,
+                116.9203
+            ],
+            "bundled_runs_ms": [
+                87.9114,
+                87.1588,
+                86.4581,
+                86.9828,
+                86.9502,
+                86.8851,
+                87.2481
+            ],
+            "paired_ratios": [
+                0.75393,
+                0.74761,
+                0.7373,
+                0.74478,
+                0.7463,
+                0.74385,
+                0.74622
+            ]
+        },
+        "api.setop.diff.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76208,
+            "delta_pct": -23.79,
+            "ci_delta_pct": [
+                -24.26,
+                -23.34
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.71,
+                "B2/C2": -23.66,
+                "B3/C3": -24.29
+            },
+            "build_spread_pct": 0.63,
+            "builds": 3,
+            "system_ms": 112.9153,
+            "bundled_ms": 86.2399,
+            "raw_delta_pct": -23.7,
+            "spread_pct": [
+                1.4,
+                1.6
+            ],
+            "system_runs_ms": [
+                112.8597,
+                112.8394,
+                113.2219,
+                112.7263,
+                112.9153,
+                114.3167,
+                113.0227
+            ],
+            "bundled_runs_ms": [
+                87.2291,
+                86.6139,
+                85.865,
+                86.1115,
+                85.9474,
+                86.6191,
+                86.2399
+            ],
+            "paired_ratios": [
+                0.7729,
+                0.76759,
+                0.75838,
+                0.7639,
+                0.76117,
+                0.75771,
+                0.76303
+            ]
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76681,
+            "delta_pct": -23.32,
+            "ci_delta_pct": [
+                -23.36,
+                -23.27
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.27,
+                "B2/C2": -23.35,
+                "B3/C3": -23.34
+            },
+            "build_spread_pct": 0.08,
+            "builds": 3,
+            "system_ms": 225.0345,
+            "bundled_ms": 172.7222,
+            "raw_delta_pct": -23.22,
+            "spread_pct": [
+                0.2,
+                0.6
+            ],
+            "system_runs_ms": [
+                225.0763,
+                224.8516,
+                224.652,
+                225.0509,
+                224.8885,
+                225.0345,
+                225.2108
+            ],
+            "bundled_runs_ms": [
+                173.404,
+                172.7222,
+                172.3885,
+                172.7027,
+                172.4204,
+                172.773,
+                173.0151
+            ],
+            "paired_ratios": [
+                0.77042,
+                0.76816,
+                0.76736,
+                0.76739,
+                0.76669,
+                0.76776,
+                0.76824
+            ]
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.74758,
+            "delta_pct": -25.24,
+            "ci_delta_pct": [
+                -25.45,
+                -24.87
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.14,
+                "B2/C2": -25.52,
+                "B3/C3": -25.07
+            },
+            "build_spread_pct": 0.45,
+            "builds": 3,
+            "system_ms": 354.2883,
+            "bundled_ms": 265.1862,
+            "raw_delta_pct": -25.15,
+            "spread_pct": [
+                0.6,
+                0.6
+            ],
+            "system_runs_ms": [
+                353.7935,
+                355.8957,
+                353.7856,
+                354.2883,
+                355.1285,
+                354.8796,
+                353.9437
+            ],
+            "bundled_runs_ms": [
+                265.1862,
+                265.184,
+                266.5648,
+                265.189,
+                265.081,
+                265.0767,
+                266.2542
+            ],
+            "paired_ratios": [
+                0.74955,
+                0.74512,
+                0.75346,
+                0.74851,
+                0.74644,
+                0.74695,
+                0.75225
+            ]
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.73659,
+            "delta_pct": -26.34,
+            "ci_delta_pct": [
+                -26.54,
+                -25.96
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -25.96,
+                "B2/C2": -26.34,
+                "B3/C3": -26.37
+            },
+            "build_spread_pct": 0.41,
+            "builds": 3,
+            "system_ms": 147.8932,
+            "bundled_ms": 109.0469,
+            "raw_delta_pct": -26.25,
+            "spread_pct": [
+                0.5,
+                0.6
+            ],
+            "system_runs_ms": [
+                147.6962,
+                147.8932,
+                147.8129,
+                148.0508,
+                148.2639,
+                147.9871,
+                147.5538
+            ],
+            "bundled_runs_ms": [
+                109.5001,
+                109.3612,
+                109.0136,
+                108.8134,
+                109.0469,
+                109.0435,
+                109.3782
+            ],
+            "paired_ratios": [
+                0.74139,
+                0.73946,
+                0.73751,
+                0.73497,
+                0.73549,
+                0.73684,
+                0.74128
+            ]
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.76914,
+            "delta_pct": -23.09,
+            "ci_delta_pct": [
+                -23.31,
+                -22.94
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -23.29,
+                "B2/C2": -23.14,
+                "B3/C3": -23.01
+            },
+            "build_spread_pct": 0.28,
+            "builds": 3,
+            "system_ms": 140.0104,
+            "bundled_ms": 107.8219,
+            "raw_delta_pct": -22.99,
+            "spread_pct": [
+                0.5,
+                0.8
+            ],
+            "system_runs_ms": [
+                139.9315,
+                140.5412,
+                140.1689,
+                140.2134,
+                139.7984,
+                140.0104,
+                139.8852
+            ],
+            "bundled_runs_ms": [
+                107.2703,
+                107.9153,
+                108.1543,
+                107.6872,
+                107.8155,
+                107.8219,
+                108.0571
+            ],
+            "paired_ratios": [
+                0.76659,
+                0.76786,
+                0.7716,
+                0.76802,
+                0.77122,
+                0.7701,
+                0.77247
+            ]
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77309,
+            "delta_pct": -22.69,
+            "ci_delta_pct": [
+                -22.9,
+                -22.28
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.84,
+                "B2/C2": -21.89,
+                "B3/C3": -22.49
+            },
+            "build_spread_pct": 0.95,
+            "builds": 3,
+            "system_ms": 280.2932,
+            "bundled_ms": 216.8374,
+            "raw_delta_pct": -22.59,
+            "spread_pct": [
+                1.6,
+                2.7
+            ],
+            "system_runs_ms": [
+                284.473,
+                280.755,
+                280.3568,
+                279.99,
+                280.2932,
+                280.1333,
+                280.1308
+            ],
+            "bundled_runs_ms": [
+                216.1929,
+                216.7347,
+                218.1551,
+                216.3134,
+                222.0448,
+                216.8374,
+                216.9194
+            ],
+            "paired_ratios": [
+                0.75998,
+                0.77197,
+                0.77813,
+                0.77258,
+                0.79219,
+                0.77405,
+                0.77435
+            ]
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.81165,
+            "delta_pct": -18.83,
+            "ci_delta_pct": [
+                -19.52,
+                -18.58
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -19.23,
+                "B2/C2": -19.28,
+                "B3/C3": -18.43
+            },
+            "build_spread_pct": 0.85,
+            "builds": 3,
+            "system_ms": 1794.8482,
+            "bundled_ms": 1457.7153,
+            "raw_delta_pct": -18.73,
+            "spread_pct": [
+                0.6,
+                1.4
+            ],
+            "system_runs_ms": [
+                1792.8926,
+                1804.1088,
+                1794.8482,
+                1795.9581,
+                1793.7427,
+                1794.7839,
+                1798.5575
+            ],
+            "bundled_runs_ms": [
+                1461.5168,
+                1450.1357,
+                1470.2155,
+                1452.4405,
+                1457.7153,
+                1461.369,
+                1449.3132
+            ],
+            "paired_ratios": [
+                0.81517,
+                0.8038,
+                0.81913,
+                0.80873,
+                0.81267,
+                0.81423,
+                0.80582
+            ]
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77099,
+            "delta_pct": -22.9,
+            "ci_delta_pct": [
+                -23.26,
+                -22.52
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.84,
+                "B2/C2": -22.89,
+                "B3/C3": -23.18
+            },
+            "build_spread_pct": 0.34,
+            "builds": 3,
+            "system_ms": 846.4977,
+            "bundled_ms": 652.7642,
+            "raw_delta_pct": -22.8,
+            "spread_pct": [
+                0.5,
+                1.1
+            ],
+            "system_runs_ms": [
+                844.8795,
+                846.6774,
+                846.8308,
+                845.2444,
+                846.4977,
+                849.0399,
+                844.9494
+            ],
+            "bundled_runs_ms": [
+                657.3346,
+                656.8429,
+                653.7128,
+                651.5287,
+                650.3983,
+                650.7453,
+                652.7642
+            ],
+            "paired_ratios": [
+                0.77802,
+                0.77579,
+                0.77195,
+                0.77082,
+                0.76834,
+                0.76645,
+                0.77255
+            ]
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78479,
+            "delta_pct": -21.52,
+            "ci_delta_pct": [
+                -21.66,
+                -21.23
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.23,
+                "B2/C2": -21.59,
+                "B3/C3": -23.2
+            },
+            "build_spread_pct": 1.97,
+            "builds": 3,
+            "system_ms": 854.7407,
+            "bundled_ms": 671.6287,
+            "raw_delta_pct": -21.42,
+            "spread_pct": [
+                4.8,
+                1.6
+            ],
+            "system_runs_ms": [
+                855.2631,
+                854.7407,
+                892.7799,
+                853.1579,
+                852.5501,
+                856.6393,
+                851.5525
+            ],
+            "bundled_runs_ms": [
+                679.456,
+                671.6287,
+                671.52,
+                672.8718,
+                668.7012,
+                673.0982,
+                670.5138
+            ],
+            "paired_ratios": [
+                0.79444,
+                0.78577,
+                0.75217,
+                0.78868,
+                0.78435,
+                0.78574,
+                0.7874
+            ]
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78605,
+            "delta_pct": -21.4,
+            "ci_delta_pct": [
+                -21.64,
+                -21.31
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.38,
+                "B2/C2": -21.88,
+                "B3/C3": -21.43
+            },
+            "build_spread_pct": 0.5,
+            "builds": 3,
+            "system_ms": 384.5695,
+            "bundled_ms": 302.4213,
+            "raw_delta_pct": -21.3,
+            "spread_pct": [
+                1.1,
+                0.7
+            ],
+            "system_runs_ms": [
+                384.5695,
+                388.3546,
+                384.64,
+                384.1982,
+                385.5581,
+                384.1294,
+                384.5216
+            ],
+            "bundled_runs_ms": [
+                303.1056,
+                301.5295,
+                302.4842,
+                302.4213,
+                303.7675,
+                302.3214,
+                301.7
+            ],
+            "paired_ratios": [
+                0.78817,
+                0.77643,
+                0.78641,
+                0.78715,
+                0.78786,
+                0.78703,
+                0.78461
+            ]
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79851,
+            "delta_pct": -20.15,
+            "ci_delta_pct": [
+                -20.33,
+                -19.73
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.27,
+                "B2/C2": -20.13,
+                "B3/C3": -19.63
+            },
+            "build_spread_pct": 0.64,
+            "builds": 3,
+            "system_ms": 1495.9828,
+            "bundled_ms": 1196.7865,
+            "raw_delta_pct": -20.05,
+            "spread_pct": [
+                0.4,
+                0.8
+            ],
+            "system_runs_ms": [
+                1500.5767,
+                1500.2821,
+                1494.0076,
+                1496.4286,
+                1495.9828,
+                1494.5762,
+                1495.1016
+            ],
+            "bundled_runs_ms": [
+                1193.9026,
+                1196.7865,
+                1203.8596,
+                1194.6362,
+                1199.1876,
+                1201.1701,
+                1195.3384
+            ],
+            "paired_ratios": [
+                0.79563,
+                0.79771,
+                0.80579,
+                0.79832,
+                0.80161,
+                0.80369,
+                0.7995
+            ]
+        },
+        "adv.forEach.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95429,
+            "delta_pct": -4.57,
+            "ci_delta_pct": [
+                -5.37,
+                -4.12
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.34,
+                "B2/C2": -5.03,
+                "B3/C3": -4.87
+            },
+            "build_spread_pct": 0.69,
+            "builds": 3,
+            "system_ms": 197.9914,
+            "bundled_ms": 189.2385,
+            "raw_delta_pct": -4.45,
+            "spread_pct": [
+                1.9,
+                1.4
+            ],
+            "system_runs_ms": [
+                197.3876,
+                200.373,
+                199.0611,
+                197.9914,
+                198.5942,
+                196.7061,
+                197.5715
+            ],
+            "bundled_runs_ms": [
+                188.5991,
+                189.8499,
+                188.1051,
+                190.7656,
+                189.5317,
+                188.8409,
+                189.2385
+            ],
+            "paired_ratios": [
+                0.95548,
+                0.94748,
+                0.94496,
+                0.9635,
+                0.95437,
+                0.96002,
+                0.95782
+            ]
+        },
+        "adv.forEach.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.70094,
+            "delta_pct": -29.91,
+            "ci_delta_pct": [
+                -30.79,
+                -29.82
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -29.82,
+                "B2/C2": -30.35,
+                "B3/C3": -30.32
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 507.5406,
+            "bundled_ms": 355.4241,
+            "raw_delta_pct": -29.82,
+            "spread_pct": [
+                1.9,
+                0.9
+            ],
+            "system_runs_ms": [
+                507.8471,
+                505.8288,
+                513.0101,
+                507.5406,
+                514.4325,
+                505.8981,
+                504.9797
+            ],
+            "bundled_runs_ms": [
+                354.4157,
+                354.9999,
+                355.4137,
+                356.655,
+                356.5013,
+                355.4241,
+                357.7069
+            ],
+            "paired_ratios": [
+                0.69788,
+                0.70182,
+                0.6928,
+                0.70271,
+                0.693,
+                0.70256,
+                0.70836
+            ]
+        },
+        "adv.filter.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.93736,
+            "delta_pct": -6.26,
+            "ci_delta_pct": [
+                -6.66,
+                -5.66
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.95,
+                "B2/C2": -6.39,
+                "B3/C3": -6.4
+            },
+            "build_spread_pct": 0.45,
+            "builds": 3,
+            "system_ms": 302.5318,
+            "bundled_ms": 284.2056,
+            "raw_delta_pct": -6.15,
+            "spread_pct": [
+                1.2,
+                1.1
+            ],
+            "system_runs_ms": [
+                301.6642,
+                303.2183,
+                304.0074,
+                302.5318,
+                302.852,
+                300.8908,
+                300.517
+            ],
+            "bundled_runs_ms": [
+                281.9209,
+                283.8369,
+                282.6605,
+                284.8879,
+                284.2353,
+                284.2056,
+                284.9558
+            ],
+            "paired_ratios": [
+                0.93455,
+                0.93608,
+                0.92978,
+                0.94168,
+                0.93853,
+                0.94455,
+                0.94822
+            ]
+        },
+        "adv.filter.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77144,
+            "delta_pct": -22.86,
+            "ci_delta_pct": [
+                -23.18,
+                -22.48
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -22.65,
+                "B2/C2": -22.7,
+                "B3/C3": -22.91
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 1013.0361,
+            "bundled_ms": 781.8061,
+            "raw_delta_pct": -22.76,
+            "spread_pct": [
+                0.4,
+                1.1
+            ],
+            "system_runs_ms": [
+                1015.7228,
+                1015.639,
+                1012.171,
+                1013.0361,
+                1012.7446,
+                1013.3745,
+                1012.8627
+            ],
+            "bundled_runs_ms": [
+                780.0273,
+                781.2284,
+                781.8061,
+                786.2564,
+                788.7224,
+                781.5453,
+                784.3955
+            ],
+            "paired_ratios": [
+                0.76795,
+                0.7692,
+                0.77241,
+                0.77614,
+                0.7788,
+                0.77123,
+                0.77443
+            ]
+        },
+        "adv.map.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90765,
+            "delta_pct": -9.24,
+            "ci_delta_pct": [
+                -9.41,
+                -8.96
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -8.96,
+                "B2/C2": -9.38,
+                "B3/C3": -9.34
+            },
+            "build_spread_pct": 0.42,
+            "builds": 3,
+            "system_ms": 327.8307,
+            "bundled_ms": 298.8248,
+            "raw_delta_pct": -9.12,
+            "spread_pct": [
+                0.8,
+                1.1
+            ],
+            "system_runs_ms": [
+                329.1528,
+                327.6527,
+                329.5948,
+                327.8307,
+                328.027,
+                327.1227,
+                327.7274
+            ],
+            "bundled_runs_ms": [
+                300.007,
+                297.7638,
+                298.9414,
+                298.8248,
+                297.143,
+                297.1833,
+                300.2813
+            ],
+            "paired_ratios": [
+                0.91145,
+                0.90878,
+                0.907,
+                0.91152,
+                0.90585,
+                0.90848,
+                0.91625
+            ]
+        },
+        "adv.map.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75079,
+            "delta_pct": -24.92,
+            "ci_delta_pct": [
+                -25.15,
+                -24.53
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.77,
+                "B2/C2": -24.74,
+                "B3/C3": -25.1
+            },
+            "build_spread_pct": 0.36,
+            "builds": 3,
+            "system_ms": 1420.2146,
+            "bundled_ms": 1067.609,
+            "raw_delta_pct": -24.83,
+            "spread_pct": [
+                0.4,
+                0.9
+            ],
+            "system_runs_ms": [
+                1419.4857,
+                1420.4787,
+                1420.2146,
+                1422.5241,
+                1419.9929,
+                1424.6309,
+                1418.8894
+            ],
+            "bundled_runs_ms": [
+                1063.7409,
+                1067.4764,
+                1067.609,
+                1071.5653,
+                1073.045,
+                1065.7977,
+                1072.5116
+            ],
+            "paired_ratios": [
+                0.74938,
+                0.75149,
+                0.75172,
+                0.75328,
+                0.75567,
+                0.74812,
+                0.75588
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79842,
+            "delta_pct": -20.16,
+            "ci_delta_pct": [
+                -20.7,
+                -19.91
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.16,
+                "B2/C2": -20.65,
+                "B3/C3": -18.91
+            },
+            "build_spread_pct": 1.74,
+            "builds": 3,
+            "system_ms": 27.6666,
+            "bundled_ms": 22.0453,
+            "raw_delta_pct": -20.06,
+            "spread_pct": [
+                1.8,
+                3.7
+            ],
+            "system_runs_ms": [
+                27.5766,
+                27.6666,
+                27.7218,
+                28.0566,
+                27.697,
+                27.5681,
+                27.6256
+            ],
+            "bundled_runs_ms": [
+                22.0453,
+                21.9937,
+                22.8084,
+                22.0102,
+                21.9923,
+                22.0864,
+                22.154
+            ],
+            "paired_ratios": [
+                0.79942,
+                0.79495,
+                0.82276,
+                0.78449,
+                0.79403,
+                0.80116,
+                0.80194
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.66849,
+            "delta_pct": -33.15,
+            "ci_delta_pct": [
+                -33.7,
+                -33.08
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -33.1,
+                "B2/C2": -33.2,
+                "B3/C3": -33.43
+            },
+            "build_spread_pct": 0.33,
+            "builds": 3,
+            "system_ms": 19.1068,
+            "bundled_ms": 12.7825,
+            "raw_delta_pct": -33.07,
+            "spread_pct": [
+                1.1,
+                1.5
+            ],
+            "system_runs_ms": [
+                19.0864,
+                19.0766,
+                19.2809,
+                19.2225,
+                19.1068,
+                19.1534,
+                19.0933
+            ],
+            "bundled_runs_ms": [
+                12.7853,
+                12.7825,
+                12.9051,
+                12.7548,
+                12.7561,
+                12.7136,
+                12.8892
+            ],
+            "paired_ratios": [
+                0.66986,
+                0.67006,
+                0.66932,
+                0.66353,
+                0.66762,
+                0.66378,
+                0.67506
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83975,
+            "delta_pct": -16.02,
+            "ci_delta_pct": [
+                -17.25,
+                -15.82
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -15.93,
+                "B2/C2": -15.92,
+                "B3/C3": -18
+            },
+            "build_spread_pct": 2.08,
+            "builds": 3,
+            "system_ms": 69.1144,
+            "bundled_ms": 57.9953,
+            "raw_delta_pct": -15.92,
+            "spread_pct": [
+                1.5,
+                2.8
+            ],
+            "system_runs_ms": [
+                69.2122,
+                68.9519,
+                69.5515,
+                68.5132,
+                68.9851,
+                69.4769,
+                69.1144
+            ],
+            "bundled_runs_ms": [
+                57.9953,
+                58.1188,
+                56.5806,
+                57.9495,
+                58.0027,
+                57.5632,
+                58.1801
+            ],
+            "paired_ratios": [
+                0.83793,
+                0.84289,
+                0.81351,
+                0.84582,
+                0.8408,
+                0.82852,
+                0.84179
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7848,
+            "delta_pct": -21.52,
+            "ci_delta_pct": [
+                -21.75,
+                -21.4
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.44,
+                "B2/C2": -21.84,
+                "B3/C3": -21.67
+            },
+            "build_spread_pct": 0.4,
+            "builds": 3,
+            "system_ms": 26.1466,
+            "bundled_ms": 20.5596,
+            "raw_delta_pct": -21.42,
+            "spread_pct": [
+                1,
+                1.6
+            ],
+            "system_runs_ms": [
+                26.0068,
+                26.1466,
+                26.074,
+                26.0789,
+                26.1718,
+                26.241,
+                26.2696
+            ],
+            "bundled_runs_ms": [
+                20.4357,
+                20.3441,
+                20.4702,
+                20.6049,
+                20.597,
+                20.5596,
+                20.6636
+            ],
+            "paired_ratios": [
+                0.78578,
+                0.77808,
+                0.78508,
+                0.7901,
+                0.78699,
+                0.78349,
+                0.7866
+            ]
+        },
+        "adv.optiter.values.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.65347,
+            "delta_pct": -34.65,
+            "ci_delta_pct": [
+                -34.91,
+                -34.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -34.72,
+                "B2/C2": -34.56,
+                "B3/C3": -34.19
+            },
+            "build_spread_pct": 0.53,
+            "builds": 3,
+            "system_ms": 16.1287,
+            "bundled_ms": 10.5312,
+            "raw_delta_pct": -34.57,
+            "spread_pct": [
+                1.1,
+                2
+            ],
+            "system_runs_ms": [
+                16.0248,
+                16.0113,
+                16.0669,
+                16.1287,
+                16.1857,
+                16.16,
+                16.1659
+            ],
+            "bundled_runs_ms": [
+                10.4918,
+                10.5074,
+                10.7038,
+                10.5096,
+                10.59,
+                10.5312,
+                10.5657
+            ],
+            "paired_ratios": [
+                0.65472,
+                0.65625,
+                0.6662,
+                0.65161,
+                0.65428,
+                0.65168,
+                0.65358
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.83073,
+            "delta_pct": -16.93,
+            "ci_delta_pct": [
+                -17.01,
+                -15.76
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -17.01,
+                "B2/C2": -16.36,
+                "B3/C3": -16.09
+            },
+            "build_spread_pct": 0.92,
+            "builds": 3,
+            "system_ms": 61.6178,
+            "bundled_ms": 51.3405,
+            "raw_delta_pct": -16.82,
+            "spread_pct": [
+                1,
+                2.5
+            ],
+            "system_runs_ms": [
+                61.6178,
+                61.2366,
+                61.6202,
+                61.8456,
+                61.8441,
+                61.583,
+                61.5386
+            ],
+            "bundled_runs_ms": [
+                51.3405,
+                51.6484,
+                52.2895,
+                51.0051,
+                51.4151,
+                51.2226,
+                51.1319
+            ],
+            "paired_ratios": [
+                0.83321,
+                0.84342,
+                0.84858,
+                0.82472,
+                0.83137,
+                0.83177,
+                0.83089
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.85034,
+            "delta_pct": -14.97,
+            "ci_delta_pct": [
+                -15.06,
+                -14.57
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -14.78,
+                "B2/C2": -14.87,
+                "B3/C3": -15.03
+            },
+            "build_spread_pct": 0.25,
+            "builds": 3,
+            "system_ms": 34.326,
+            "bundled_ms": 29.3061,
+            "raw_delta_pct": -14.86,
+            "spread_pct": [
+                0.9,
+                1.3
+            ],
+            "system_runs_ms": [
+                34.264,
+                34.2628,
+                34.1598,
+                34.3644,
+                34.4138,
+                34.4698,
+                34.326
+            ],
+            "bundled_runs_ms": [
+                29.1725,
+                29.3061,
+                29.0517,
+                29.3228,
+                29.2317,
+                29.3347,
+                29.4181
+            ],
+            "paired_ratios": [
+                0.8514,
+                0.85533,
+                0.85046,
+                0.85329,
+                0.84942,
+                0.85103,
+                0.85702
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78657,
+            "delta_pct": -21.34,
+            "ci_delta_pct": [
+                -21.46,
+                -21.13
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.34,
+                "B2/C2": -21.24,
+                "B3/C3": -21.34
+            },
+            "build_spread_pct": 0.1,
+            "builds": 3,
+            "system_ms": 22.7789,
+            "bundled_ms": 17.9431,
+            "raw_delta_pct": -21.24,
+            "spread_pct": [
+                0.9,
+                0.7
+            ],
+            "system_runs_ms": [
+                22.7566,
+                22.6658,
+                22.648,
+                22.7789,
+                22.8631,
+                22.8308,
+                22.8164
+            ],
+            "bundled_runs_ms": [
+                17.9221,
+                17.9062,
+                17.8729,
+                17.9872,
+                17.9989,
+                17.9437,
+                17.9431
+            ],
+            "paired_ratios": [
+                0.78756,
+                0.79001,
+                0.78916,
+                0.78964,
+                0.78725,
+                0.78594,
+                0.78641
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92386,
+            "delta_pct": -7.61,
+            "ci_delta_pct": [
+                -7.76,
+                -7.43
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.61,
+                "B2/C2": -7.59,
+                "B3/C3": -7.54
+            },
+            "build_spread_pct": 0.07,
+            "builds": 3,
+            "system_ms": 66.3002,
+            "bundled_ms": 61.3422,
+            "raw_delta_pct": -7.5,
+            "spread_pct": [
+                0.5,
+                0.9
+            ],
+            "system_runs_ms": [
+                66.4156,
+                66.1529,
+                66.3002,
+                66.2862,
+                66.436,
+                66.2342,
+                66.4697
+            ],
+            "bundled_runs_ms": [
+                61.435,
+                61.1008,
+                61.5211,
+                61.3422,
+                61.5734,
+                61.1689,
+                60.9933
+            ],
+            "paired_ratios": [
+                0.92501,
+                0.92363,
+                0.92792,
+                0.92541,
+                0.92681,
+                0.92352,
+                0.91761
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.96012,
+            "delta_pct": -3.99,
+            "ci_delta_pct": [
+                -4.25,
+                -3.66
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -3.72,
+                "B2/C2": -4.16,
+                "B3/C3": -3.83
+            },
+            "build_spread_pct": 0.44,
+            "builds": 3,
+            "system_ms": 16.8769,
+            "bundled_ms": 16.226,
+            "raw_delta_pct": -3.87,
+            "spread_pct": [
+                0.5,
+                1.3
+            ],
+            "system_runs_ms": [
+                16.8769,
+                16.8363,
+                16.8573,
+                16.9045,
+                16.8749,
+                16.8789,
+                16.914
+            ],
+            "bundled_runs_ms": [
+                16.2701,
+                16.1772,
+                16.26,
+                16.2068,
+                16.1732,
+                16.226,
+                16.3883
+            ],
+            "paired_ratios": [
+                0.96405,
+                0.96085,
+                0.96457,
+                0.95873,
+                0.95842,
+                0.96132,
+                0.96892
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.89087,
+            "delta_pct": -10.91,
+            "ci_delta_pct": [
+                -11.3,
+                -10.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.91,
+                "B2/C2": -10.94,
+                "B3/C3": -10.89
+            },
+            "build_spread_pct": 0.05,
+            "builds": 3,
+            "system_ms": 21.2168,
+            "bundled_ms": 18.905,
+            "raw_delta_pct": -10.8,
+            "spread_pct": [
+                0.9,
+                1.2
+            ],
+            "system_runs_ms": [
+                21.2743,
+                21.2232,
+                21.1692,
+                21.0902,
+                21.1663,
+                21.2168,
+                21.2591
+            ],
+            "bundled_runs_ms": [
+                18.8935,
+                18.7865,
+                18.9117,
+                18.902,
+                19.011,
+                18.905,
+                18.9628
+            ],
+            "paired_ratios": [
+                0.88809,
+                0.88519,
+                0.89336,
+                0.89625,
+                0.89817,
+                0.89104,
+                0.89199
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.92502,
+            "delta_pct": -7.5,
+            "ci_delta_pct": [
+                -7.99,
+                -6.63
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.99,
+                "B2/C2": -7.2,
+                "B3/C3": -7.46
+            },
+            "build_spread_pct": 0.79,
+            "builds": 3,
+            "system_ms": 125.6893,
+            "bundled_ms": 116.3081,
+            "raw_delta_pct": -7.38,
+            "spread_pct": [
+                1,
+                1.6
+            ],
+            "system_runs_ms": [
+                126.0555,
+                126.0558,
+                125.5787,
+                124.761,
+                125.4307,
+                125.7001,
+                125.6893
+            ],
+            "bundled_runs_ms": [
+                116.1238,
+                116.1299,
+                116.3081,
+                116.6304,
+                117.5465,
+                116.5101,
+                115.7093
+            ],
+            "paired_ratios": [
+                0.92121,
+                0.92126,
+                0.92618,
+                0.93483,
+                0.93714,
+                0.92689,
+                0.9206
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95649,
+            "delta_pct": -4.35,
+            "ci_delta_pct": [
+                -4.37,
+                -3.97
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.36,
+                "B2/C2": -3.24,
+                "B3/C3": -4.36
+            },
+            "build_spread_pct": 1.12,
+            "builds": 3,
+            "system_ms": 16.9178,
+            "bundled_ms": 16.2469,
+            "raw_delta_pct": -4.23,
+            "spread_pct": [
+                0.8,
+                2.1
+            ],
+            "system_runs_ms": [
+                16.9601,
+                16.8826,
+                16.9055,
+                17.0132,
+                16.9049,
+                16.9178,
+                16.9967
+            ],
+            "bundled_runs_ms": [
+                16.2469,
+                16.4801,
+                16.1869,
+                16.1331,
+                16.2541,
+                16.2019,
+                16.2759
+            ],
+            "paired_ratios": [
+                0.95795,
+                0.97616,
+                0.95749,
+                0.94827,
+                0.9615,
+                0.95768,
+                0.95759
+            ]
+        },
+        "adv.optiter.increment.string_to_int_hash.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88044,
+            "delta_pct": -11.96,
+            "ci_delta_pct": [
+                -12.1,
+                -11.42
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.96,
+                "B2/C2": -11.89,
+                "B3/C3": -11.6
+            },
+            "build_spread_pct": 0.36,
+            "builds": 3,
+            "system_ms": 21.5154,
+            "bundled_ms": 18.9621,
+            "raw_delta_pct": -11.85,
+            "spread_pct": [
+                2.7,
+                0.9
+            ],
+            "system_runs_ms": [
+                22.0022,
+                21.4304,
+                21.4156,
+                21.494,
+                21.5243,
+                21.5154,
+                21.55
+            ],
+            "bundled_runs_ms": [
+                19.004,
+                18.9329,
+                19.06,
+                18.9478,
+                18.9621,
+                18.9358,
+                19.1123
+            ],
+            "paired_ratios": [
+                0.86373,
+                0.88346,
+                0.89001,
+                0.88154,
+                0.88096,
+                0.8801,
+                0.88688
+            ]
+        },
+        "adv.optiter.ratio.increment.string_to_int_hash": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91785,
+            "delta_pct": -8.22,
+            "ci_delta_pct": [
+                -9.61,
+                -7.16
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -7.5,
+                "B2/C2": -9.05,
+                "B3/C3": -7.69
+            },
+            "build_spread_pct": 1.55,
+            "builds": 3,
+            "system_ms": 126.9372,
+            "bundled_ms": 116.9701,
+            "raw_delta_pct": -8.1,
+            "spread_pct": [
+                2.7,
+                2.5
+            ],
+            "system_runs_ms": [
+                129.7288,
+                126.9372,
+                126.6784,
+                126.3372,
+                127.3259,
+                127.1763,
+                126.7895
+            ],
+            "bundled_runs_ms": [
+                116.9701,
+                114.8831,
+                117.7496,
+                117.4471,
+                116.6602,
+                116.874,
+                117.4266
+            ],
+            "paired_ratios": [
+                0.90165,
+                0.90504,
+                0.92952,
+                0.92963,
+                0.91623,
+                0.91899,
+                0.92615
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.87731,
+            "delta_pct": -12.27,
+            "ci_delta_pct": [
+                -12.45,
+                -11.9
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -11.9,
+                "B2/C2": -12.3,
+                "B3/C3": -12.36
+            },
+            "build_spread_pct": 0.46,
+            "builds": 3,
+            "system_ms": 34.2894,
+            "bundled_ms": 30.1197,
+            "raw_delta_pct": -12.16,
+            "spread_pct": [
+                0.6,
+                0.9
+            ],
+            "system_runs_ms": [
+                34.2894,
+                34.2326,
+                34.2331,
+                34.423,
+                34.2722,
+                34.3289,
+                34.2933
+            ],
+            "bundled_runs_ms": [
+                30.3012,
+                30.0701,
+                30.1197,
+                30.1737,
+                30.0807,
+                30.0426,
+                30.2492
+            ],
+            "paired_ratios": [
+                0.88369,
+                0.87841,
+                0.87984,
+                0.87656,
+                0.8777,
+                0.87514,
+                0.88207
+            ]
+        },
+        "adv.optiter.foreach.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.66258,
+            "delta_pct": -33.74,
+            "ci_delta_pct": [
+                -33.87,
+                -33.65
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -33.74,
+                "B2/C2": -33.69,
+                "B3/C3": -33.95
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 21.0695,
+            "bundled_ms": 13.9632,
+            "raw_delta_pct": -33.66,
+            "spread_pct": [
+                0.6,
+                1
+            ],
+            "system_runs_ms": [
+                21.0473,
+                21.0462,
+                21.1433,
+                21.0695,
+                21.0264,
+                21.0715,
+                21.1131
+            ],
+            "bundled_runs_ms": [
+                13.9629,
+                13.982,
+                13.9632,
+                13.9717,
+                13.9523,
+                13.9525,
+                14.0853
+            ],
+            "paired_ratios": [
+                0.66341,
+                0.66435,
+                0.66041,
+                0.66312,
+                0.66356,
+                0.66215,
+                0.66714
+            ]
+        },
+        "adv.optiter.ratio.foreach.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.75537,
+            "delta_pct": -24.46,
+            "ci_delta_pct": [
+                -25.02,
+                -24.44
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -24.46,
+                "B2/C2": -24.48,
+                "B3/C3": -24.73
+            },
+            "build_spread_pct": 0.27,
+            "builds": 3,
+            "system_ms": 61.3812,
+            "bundled_ms": 46.383,
+            "raw_delta_pct": -24.37,
+            "spread_pct": [
+                0.9,
+                1
+            ],
+            "system_runs_ms": [
+                61.3812,
+                61.4801,
+                61.7626,
+                61.2075,
+                61.3512,
+                61.3812,
+                61.5662
+            ],
+            "bundled_runs_ms": [
+                46.0804,
+                46.4981,
+                46.359,
+                46.3042,
+                46.383,
+                46.4424,
+                46.5643
+            ],
+            "paired_ratios": [
+                0.75072,
+                0.75631,
+                0.7506,
+                0.75651,
+                0.75602,
+                0.75662,
+                0.75633
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86216,
+            "delta_pct": -13.78,
+            "ci_delta_pct": [
+                -14.04,
+                -13.52
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -13.78,
+                "B2/C2": -13.55,
+                "B3/C3": -14.07
+            },
+            "build_spread_pct": 0.52,
+            "builds": 3,
+            "system_ms": 33.6817,
+            "bundled_ms": 29.122,
+            "raw_delta_pct": -13.68,
+            "spread_pct": [
+                0.7,
+                0.9
+            ],
+            "system_runs_ms": [
+                33.5891,
+                33.6193,
+                33.6709,
+                33.7756,
+                33.6817,
+                33.837,
+                33.7607
+            ],
+            "bundled_runs_ms": [
+                28.9952,
+                29.0695,
+                28.9569,
+                29.1387,
+                29.1859,
+                29.122,
+                29.2323
+            ],
+            "paired_ratios": [
+                0.86323,
+                0.86467,
+                0.86,
+                0.86271,
+                0.86652,
+                0.86066,
+                0.86587
+            ]
+        },
+        "adv.optiter.values.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.68613,
+            "delta_pct": -31.39,
+            "ci_delta_pct": [
+                -31.66,
+                -31.28
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -31.39,
+                "B2/C2": -31.47,
+                "B3/C3": -31.28
+            },
+            "build_spread_pct": 0.19,
+            "builds": 3,
+            "system_ms": 17.9801,
+            "bundled_ms": 12.3526,
+            "raw_delta_pct": -31.3,
+            "spread_pct": [
+                1.6,
+                1.2
+            ],
+            "system_runs_ms": [
+                17.9466,
+                17.9105,
+                17.8951,
+                17.9801,
+                18.0585,
+                18.1739,
+                18.0651
+            ],
+            "bundled_runs_ms": [
+                12.3291,
+                12.3229,
+                12.4668,
+                12.3526,
+                12.3574,
+                12.3475,
+                12.3839
+            ],
+            "paired_ratios": [
+                0.68699,
+                0.68803,
+                0.69666,
+                0.68702,
+                0.6843,
+                0.67941,
+                0.68552
+            ]
+        },
+        "adv.optiter.ratio.values.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.79472,
+            "delta_pct": -20.53,
+            "ci_delta_pct": [
+                -21.13,
+                -20.46
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -20.52,
+                "B2/C2": -20.83,
+                "B3/C3": -20.13
+            },
+            "build_spread_pct": 0.7,
+            "builds": 3,
+            "system_ms": 53.43,
+            "bundled_ms": 42.3925,
+            "raw_delta_pct": -20.43,
+            "spread_pct": [
+                1.1,
+                1.7
+            ],
+            "system_runs_ms": [
+                53.43,
+                53.2743,
+                53.147,
+                53.2339,
+                53.6152,
+                53.7102,
+                53.5093
+            ],
+            "bundled_runs_ms": [
+                42.5212,
+                42.3912,
+                43.0531,
+                42.3925,
+                42.3403,
+                42.3991,
+                42.3638
+            ],
+            "paired_ratios": [
+                0.79583,
+                0.79572,
+                0.81008,
+                0.79634,
+                0.78971,
+                0.7894,
+                0.79171
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.default": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.893,
+            "delta_pct": -10.7,
+            "ci_delta_pct": [
+                -10.93,
+                -10.57
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -10.77,
+                "B2/C2": -10.63,
+                "B3/C3": -10.94
+            },
+            "build_spread_pct": 0.31,
+            "builds": 3,
+            "system_ms": 43.9831,
+            "bundled_ms": 39.2295,
+            "raw_delta_pct": -10.59,
+            "spread_pct": [
+                0.8,
+                1
+            ],
+            "system_runs_ms": [
+                43.8619,
+                43.8676,
+                43.7643,
+                44.1169,
+                43.9831,
+                44.0831,
+                44.0771
+            ],
+            "bundled_runs_ms": [
+                39.1152,
+                39.2295,
+                39.1303,
+                39.413,
+                39.3849,
+                39.2024,
+                39.4937
+            ],
+            "paired_ratios": [
+                0.89178,
+                0.89427,
+                0.89411,
+                0.89338,
+                0.89546,
+                0.88928,
+                0.89601
+            ]
+        },
+        "adv.optiter.toArray.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78838,
+            "delta_pct": -21.16,
+            "ci_delta_pct": [
+                -21.38,
+                -20.61
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -21.38,
+                "B2/C2": -20.13,
+                "B3/C3": -21.12
+            },
+            "build_spread_pct": 1.25,
+            "builds": 3,
+            "system_ms": 27.4331,
+            "bundled_ms": 21.6546,
+            "raw_delta_pct": -21.06,
+            "spread_pct": [
+                0.8,
+                2.1
+            ],
+            "system_runs_ms": [
+                27.4399,
+                27.3582,
+                27.2967,
+                27.4707,
+                27.3195,
+                27.5283,
+                27.4331
+            ],
+            "bundled_runs_ms": [
+                21.5564,
+                22.0087,
+                21.6269,
+                21.6243,
+                21.7149,
+                21.6705,
+                21.6546
+            ],
+            "paired_ratios": [
+                0.78559,
+                0.80446,
+                0.79229,
+                0.78718,
+                0.79485,
+                0.78721,
+                0.78936
+            ]
+        },
+        "adv.optiter.ratio.toArray.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.88411,
+            "delta_pct": -11.59,
+            "ci_delta_pct": [
+                -12.01,
+                -11.35
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -12.01,
+                "B2/C2": -10.75,
+                "B3/C3": -11.54
+            },
+            "build_spread_pct": 1.26,
+            "builds": 3,
+            "system_ms": 62.3654,
+            "bundled_ms": 55.1352,
+            "raw_delta_pct": -11.48,
+            "spread_pct": [
+                0.7,
+                2.3
+            ],
+            "system_runs_ms": [
+                62.5598,
+                62.3654,
+                62.3721,
+                62.2679,
+                62.1136,
+                62.4464,
+                62.2388
+            ],
+            "bundled_runs_ms": [
+                55.1099,
+                56.1025,
+                55.2689,
+                54.8658,
+                55.1352,
+                55.2785,
+                54.8305
+            ],
+            "paired_ratios": [
+                0.88092,
+                0.89958,
+                0.88612,
+                0.88112,
+                0.88765,
+                0.88522,
+                0.88097
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.default": {
+            "status": "null",
+            "reason": "inside the 1.3% claim floor (CI straddles it)",
+            "ratio": 0.98976,
+            "delta_pct": -1.02,
+            "ci_delta_pct": [
+                -1.57,
+                -0.49
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -1.02,
+                "B2/C2": -1.01,
+                "B3/C3": -0.76
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 24.7171,
+            "bundled_ms": 24.5208,
+            "raw_delta_pct": -0.9,
+            "spread_pct": [
+                1.3,
+                1
+            ],
+            "system_runs_ms": [
+                24.7171,
+                24.6759,
+                24.6027,
+                24.7445,
+                24.717,
+                24.8055,
+                24.9281
+            ],
+            "bundled_runs_ms": [
+                24.4946,
+                24.5972,
+                24.5137,
+                24.5352,
+                24.3599,
+                24.5785,
+                24.5208
+            ],
+            "paired_ratios": [
+                0.991,
+                0.99681,
+                0.99638,
+                0.99154,
+                0.98555,
+                0.99085,
+                0.98366
+            ]
+        },
+        "adv.optiter.overwrite.string_to_int_adaptive.optimized": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.94747,
+            "delta_pct": -5.25,
+            "ci_delta_pct": [
+                -5.35,
+                -5.19
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -5.25,
+                "B2/C2": -5.25,
+                "B3/C3": -5.27
+            },
+            "build_spread_pct": 0.02,
+            "builds": 3,
+            "system_ms": 27.6412,
+            "bundled_ms": 26.24,
+            "raw_delta_pct": -5.14,
+            "spread_pct": [
+                2.8,
+                0.7
+            ],
+            "system_runs_ms": [
+                27.5,
+                27.6098,
+                27.6321,
+                27.6823,
+                27.7235,
+                27.6412,
+                28.2716
+            ],
+            "bundled_runs_ms": [
+                26.1764,
+                26.1905,
+                26.1861,
+                26.2608,
+                26.3054,
+                26.24,
+                26.3668
+            ],
+            "paired_ratios": [
+                0.95187,
+                0.94859,
+                0.94767,
+                0.94865,
+                0.94885,
+                0.94931,
+                0.93262
+            ]
+        },
+        "adv.optiter.ratio.overwrite.string_to_int_adaptive": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.95555,
+            "delta_pct": -4.45,
+            "ci_delta_pct": [
+                -5.01,
+                -4.07
+            ],
+            "n": 7,
+            "per_build_delta_pct": {
+                "B1/C1": -4.45,
+                "B2/C2": -4.4,
+                "B3/C3": -4.66
+            },
+            "build_spread_pct": 0.26,
+            "builds": 3,
+            "system_ms": 111.8897,
+            "bundled_ms": 106.8661,
+            "raw_delta_pct": -4.33,
+            "spread_pct": [
+                1.9,
+                1.4
+            ],
+            "system_runs_ms": [
+                111.2588,
+                111.8897,
+                112.3136,
+                111.8727,
+                112.1636,
+                111.4318,
+                113.4127
+            ],
+            "bundled_runs_ms": [
+                106.8661,
+                106.4776,
+                106.8223,
+                107.0333,
+                107.9865,
+                106.7599,
+                107.5283
+            ],
+            "paired_ratios": [
+                0.96052,
+                0.95163,
+                0.95111,
+                0.95674,
+                0.96276,
+                0.95807,
+                0.94812
+            ]
+        }
+    },
+    "array_vs_bundled": {
+        "core.bitset.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.14934,
+            "delta_pct": 14.93,
+            "ci_delta_pct": [
+                14.84,
+                15.06
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                89.5134,
+                90.0716,
+                89.7227,
+                89.8805,
+                89.9421,
+                89.5255,
+                89.9403
+            ],
+            "judy_runs_ms": [
+                102.9866,
+                103.4399,
+                103.4319,
+                103.3036,
+                103.1547,
+                102.8257,
+                103.4892
+            ],
+            "array_ms": 89.8805,
+            "judy_ms": 103.3036,
+            "judy_over_array": 1.149,
+            "winner": "php-array"
+        },
+        "core.bitset.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.04886,
+            "delta_pct": 204.89,
+            "ci_delta_pct": [
+                200.61,
+                206.8
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.6687,
+                22.234,
+                22.4013,
+                21.9929,
+                22.4384,
+                22.3056,
+                22.1419
+            ],
+            "judy_runs_ms": [
+                69.5471,
+                67.7883,
+                66.9984,
+                68.4026,
+                67.4512,
+                67.5312,
+                67.5386
+            ],
+            "array_ms": 22.3056,
+            "judy_ms": 67.5386,
+            "judy_over_array": 3.028,
+            "winner": "php-array"
+        },
+        "core.bitset.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.70928,
+            "delta_pct": 470.93,
+            "ci_delta_pct": [
+                464.24,
+                477.04
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.6854,
+                18.6512,
+                18.6974,
+                18.6354,
+                19.0701,
+                18.7113,
+                18.8976
+            ],
+            "judy_runs_ms": [
+                106.6801,
+                107.5644,
+                107.9675,
+                107.5332,
+                107.3533,
+                106.4713,
+                106.6285
+            ],
+            "array_ms": 18.6974,
+            "judy_ms": 107.3533,
+            "judy_over_array": 5.742,
+            "winner": "php-array"
+        },
+        "core.bitset.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.00345,
+            "delta_pct": -99.65,
+            "ci_delta_pct": [
+                -99.66,
+                -99.65
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.4995,
+                5.5388,
+                5.5634,
+                5.5657,
+                5.5595,
+                5.4718,
+                5.593
+            ],
+            "judy_runs_ms": [
+                0.0194,
+                0.0188,
+                0.0206,
+                0.0193,
+                0.0192,
+                0.0185,
+                0.0192
+            ],
+            "array_ms": 5.5595,
+            "judy_ms": 0.0192,
+            "judy_over_array": 0.003,
+            "winner": "php-judy"
+        },
+        "core.int_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.56506,
+            "delta_pct": 56.51,
+            "ci_delta_pct": [
+                55.83,
+                56.76
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.1889,
+                92.2064,
+                92.43,
+                92.9109,
+                92.8293,
+                92.6184,
+                92.5808
+            ],
+            "judy_runs_ms": [
+                144.4422,
+                144.539,
+                144.5129,
+                144.4011,
+                144.6536,
+                145.8645,
+                144.8944
+            ],
+            "array_ms": 92.5808,
+            "judy_ms": 144.539,
+            "judy_over_array": 1.561,
+            "winner": "php-array"
+        },
+        "core.int_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.97582,
+            "delta_pct": 197.58,
+            "ci_delta_pct": [
+                186.31,
+                202.22
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.8987,
+                22.4958,
+                22.1776,
+                22.192,
+                23.4772,
+                23.3984,
+                22.3271
+            ],
+            "judy_runs_ms": [
+                67.3401,
+                66.9435,
+                66.8504,
+                67.0948,
+                66.9891,
+                66.9918,
+                67.4766
+            ],
+            "array_ms": 22.4958,
+            "judy_ms": 66.9918,
+            "judy_over_array": 2.978,
+            "winner": "php-array"
+        },
+        "core.int_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 6.09132,
+            "delta_pct": 509.13,
+            "ci_delta_pct": [
+                506.5,
+                510.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                18.644,
+                18.6582,
+                18.6317,
+                18.6099,
+                19.0484,
+                18.562,
+                18.5791
+            ],
+            "judy_runs_ms": [
+                113.186,
+                113.1614,
+                113.6812,
+                113.3588,
+                113.5342,
+                113.1077,
+                113.3676
+            ],
+            "array_ms": 18.6317,
+            "judy_ms": 113.3588,
+            "judy_over_array": 6.084,
+            "winner": "php-array"
+        },
+        "core.int_to_int.free": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.4004,
+            "delta_pct": -59.96,
+            "ci_delta_pct": [
+                -60.7,
+                -57.75
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                5.0022,
+                5.1489,
+                5.466,
+                5.4315,
+                5.4608,
+                5.462,
+                5.4571
+            ],
+            "judy_runs_ms": [
+                2.1133,
+                2.2014,
+                2.1362,
+                2.181,
+                2.1865,
+                2.1565,
+                2.1446
+            ],
+            "array_ms": 5.4571,
+            "judy_ms": 2.1565,
+            "judy_over_array": 0.395,
+            "winner": "php-judy"
+        },
+        "core.int_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.50241,
+            "delta_pct": 50.24,
+            "ci_delta_pct": [
+                49.66,
+                51.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                263.5914,
+                265.2388,
+                266.3395,
+                266.1417,
+                268.2813,
+                266.2376,
+                266.6088
+            ],
+            "judy_runs_ms": [
+                398.4241,
+                396.9591,
+                400.1514,
+                399.8628,
+                399.8489,
+                402.4771,
+                399.7483
+            ],
+            "array_ms": 266.2376,
+            "judy_ms": 399.8489,
+            "judy_over_array": 1.502,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.28637,
+            "delta_pct": 128.64,
+            "ci_delta_pct": [
+                128.43,
+                129.86
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                120.6586,
+                121.2812,
+                122.0691,
+                121.4374,
+                123.469,
+                122.1748,
+                122.2913
+            ],
+            "judy_runs_ms": [
+                278.3719,
+                277.2152,
+                279.7075,
+                279.1393,
+                279.6768,
+                279.0806,
+                279.6029
+            ],
+            "array_ms": 122.0691,
+            "judy_ms": 279.1393,
+            "judy_over_array": 2.287,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.7359,
+            "delta_pct": 273.59,
+            "ci_delta_pct": [
+                271.51,
+                275.69
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                85.2041,
+                85.5274,
+                86.3104,
+                86.1427,
+                86.4961,
+                86.1128,
+                86.2576
+            ],
+            "judy_runs_ms": [
+                320.5624,
+                321.3212,
+                320.6506,
+                322.19,
+                321.1417,
+                320.68,
+                322.2497
+            ],
+            "array_ms": 86.1427,
+            "judy_ms": 321.1417,
+            "judy_over_array": 3.728,
+            "winner": "php-array"
+        },
+        "core.int_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.16695,
+            "delta_pct": 116.7,
+            "ci_delta_pct": [
+                114.97,
+                117.25
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                45.7538,
+                46.1381,
+                46.7142,
+                46.4839,
+                46.5423,
+                46.6527,
+                46.7398
+            ],
+            "judy_runs_ms": [
+                99.3057,
+                99.979,
+                100.4224,
+                100.9869,
+                99.8544,
+                101.7466,
+                100.515
+            ],
+            "array_ms": 46.5423,
+            "judy_ms": 100.4224,
+            "judy_over_array": 2.158,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.38584,
+            "delta_pct": 38.58,
+            "ci_delta_pct": [
+                38.36,
+                39.5
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                248.7936,
+                249.4716,
+                250.4973,
+                250.2433,
+                251.8531,
+                250.6799,
+                250.9351
+            ],
+            "judy_runs_ms": [
+                347.0775,
+                345.7287,
+                346.5853,
+                346.5017,
+                348.0214,
+                350.7111,
+                347.836
+            ],
+            "array_ms": 250.4973,
+            "judy_ms": 347.0775,
+            "judy_over_array": 1.386,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.90502,
+            "delta_pct": 90.5,
+            "ci_delta_pct": [
+                90.24,
+                91.69
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                106.6323,
+                107.1753,
+                107.6936,
+                107.8468,
+                109.8662,
+                107.6544,
+                107.7308
+            ],
+            "judy_runs_ms": [
+                205.2883,
+                205.124,
+                205.1585,
+                205.1662,
+                206.471,
+                205.0344,
+                206.5098
+            ],
+            "array_ms": 107.6936,
+            "judy_ms": 205.1662,
+            "judy_over_array": 1.905,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 11.46777,
+            "delta_pct": 1046.78,
+            "ci_delta_pct": [
+                1035.63,
+                1053.97
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                21.3707,
+                21.6633,
+                21.2897,
+                22.1687,
+                21.4528,
+                21.5978,
+                21.689
+            ],
+            "judy_runs_ms": [
+                246.4935,
+                246.0151,
+                245.92,
+                246.9549,
+                246.0157,
+                249.2317,
+                246.5231
+            ],
+            "array_ms": 21.5978,
+            "judy_ms": 246.4935,
+            "judy_over_array": 11.413,
+            "winner": "php-array"
+        },
+        "core.int_to_packed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.09982,
+            "delta_pct": 9.98,
+            "ci_delta_pct": [
+                9.69,
+                10.58
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                46.9587,
+                47.3194,
+                47.6722,
+                47.5353,
+                47.6556,
+                47.6663,
+                47.6416
+            ],
+            "judy_runs_ms": [
+                52.5376,
+                52.2461,
+                52.294,
+                52.2787,
+                52.699,
+                52.2097,
+                52.3972
+            ],
+            "array_ms": 47.6416,
+            "judy_ms": 52.294,
+            "judy_over_array": 1.098,
+            "winner": "php-array"
+        },
+        "core.string_to_int.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.61208,
+            "delta_pct": 161.21,
+            "ci_delta_pct": [
+                160.94,
+                161.66
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                244.4846,
+                244.5473,
+                245.5109,
+                245.0001,
+                245.0874,
+                245.2227,
+                244.971
+            ],
+            "judy_runs_ms": [
+                642.7227,
+                638.7772,
+                640.3671,
+                640.4649,
+                639.9329,
+                641.6552,
+                639.2268
+            ],
+            "array_ms": 245.0001,
+            "judy_ms": 640.3671,
+            "judy_over_array": 2.614,
+            "winner": "php-array"
+        },
+        "core.string_to_int.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.14285,
+            "delta_pct": 314.29,
+            "ci_delta_pct": [
+                310.54,
+                317.98
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                49.7667,
+                49.2853,
+                50.5134,
+                49.2015,
+                51.1444,
+                49.4706,
+                49.0683
+            ],
+            "judy_runs_ms": [
+                204.9596,
+                204.1817,
+                207.3778,
+                205.4339,
+                204.993,
+                206.9812,
+                205.0967
+            ],
+            "array_ms": 49.4706,
+            "judy_ms": 205.0967,
+            "judy_over_array": 4.146,
+            "winner": "php-array"
+        },
+        "core.string_to_int.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.35877,
+            "delta_pct": 935.88,
+            "ci_delta_pct": [
+                932.96,
+                938.75
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                28.2748,
+                28.2397,
+                27.8737,
+                28.0226,
+                28.2138,
+                27.9761,
+                28.2543
+            ],
+            "judy_runs_ms": [
+                292.8921,
+                292.0385,
+                290.9669,
+                290.9893,
+                291.4375,
+                290.6031,
+                290.6708
+            ],
+            "array_ms": 28.2138,
+            "judy_ms": 290.9893,
+            "judy_over_array": 10.314,
+            "winner": "php-array"
+        },
+        "core.string_to_int.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.98844,
+            "delta_pct": 398.84,
+            "ci_delta_pct": [
+                397.1,
+                399.77
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.0924,
+                22.0584,
+                22.107,
+                22.0868,
+                22.1028,
+                22.1153,
+                22.1938
+            ],
+            "judy_runs_ms": [
+                110.3859,
+                110.3436,
+                110.1166,
+                110.3842,
+                109.4701,
+                109.9343,
+                110.7124
+            ],
+            "array_ms": 22.1028,
+            "judy_ms": 110.3436,
+            "judy_over_array": 4.992,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.11203,
+            "delta_pct": 111.2,
+            "ci_delta_pct": [
+                110.87,
+                112.15
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                465.7798,
+                466.6723,
+                467.5558,
+                466.6474,
+                467.1461,
+                466.7511,
+                468.5195
+            ],
+            "judy_runs_ms": [
+                987.0119,
+                1020.3408,
+                985.0373,
+                985.5718,
+                986.3736,
+                990.1897,
+                987.9889
+            ],
+            "array_ms": 466.7511,
+            "judy_ms": 987.0119,
+            "judy_over_array": 2.115,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.32449,
+            "delta_pct": 232.45,
+            "ci_delta_pct": [
+                232.2,
+                232.58
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                236.0189,
+                235.8325,
+                236.5916,
+                236.3211,
+                235.7964,
+                236.3265,
+                236.6225
+            ],
+            "judy_runs_ms": [
+                784.0579,
+                784.1004,
+                786.8556,
+                784.4513,
+                784.3375,
+                785.6656,
+                786.4843
+            ],
+            "array_ms": 236.3211,
+            "judy_ms": 784.4513,
+            "judy_over_array": 3.319,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.63265,
+            "delta_pct": 463.27,
+            "ci_delta_pct": [
+                462.48,
+                465
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                145.0096,
+                145.8004,
+                144.7666,
+                145.0479,
+                145.5207,
+                145.9997,
+                145.8879
+            ],
+            "judy_runs_ms": [
+                819.6782,
+                818.33,
+                817.9262,
+                818.8243,
+                818.5234,
+                821.8994,
+                821.7356
+            ],
+            "array_ms": 145.5207,
+            "judy_ms": 818.8243,
+            "judy_over_array": 5.627,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.43483,
+            "delta_pct": 443.48,
+            "ci_delta_pct": [
+                442.07,
+                444.78
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                63.5906,
+                63.6959,
+                63.7492,
+                63.5149,
+                63.4853,
+                63.727,
+                63.8575
+            ],
+            "judy_runs_ms": [
+                346.4269,
+                345.8117,
+                345.5679,
+                345.3082,
+                346.1654,
+                346.3456,
+                346.0519
+            ],
+            "array_ms": 63.6959,
+            "judy_ms": 346.0519,
+            "judy_over_array": 5.433,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.28494,
+            "delta_pct": 328.49,
+            "ci_delta_pct": [
+                327.65,
+                329.43
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                244.0097,
+                244.4097,
+                245.0364,
+                244.5817,
+                244.8482,
+                244.985,
+                244.66
+            ],
+            "judy_runs_ms": [
+                1047.8571,
+                1048.15,
+                1047.9007,
+                1048.0178,
+                1046.2552,
+                1055.0751,
+                1048.207
+            ],
+            "array_ms": 244.66,
+            "judy_ms": 1048.0178,
+            "judy_over_array": 4.284,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.4076,
+            "delta_pct": 240.76,
+            "ci_delta_pct": [
+                233.8,
+                246.73
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                49.9551,
+                50.2469,
+                51.0794,
+                49.3222,
+                49.2516,
+                51.3529,
+                48.6488
+            ],
+            "judy_runs_ms": [
+                170.2271,
+                170.0917,
+                170.503,
+                169.7569,
+                170.7709,
+                170.412,
+                170.6627
+            ],
+            "array_ms": 49.9551,
+            "judy_ms": 170.412,
+            "judy_over_array": 3.411,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.76907,
+            "delta_pct": 1276.91,
+            "ci_delta_pct": [
+                1273.07,
+                1283.6
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                28.3116,
+                28.1679,
+                28.1729,
+                28.0177,
+                28.2078,
+                28.2977,
+                28.3846
+            ],
+            "judy_runs_ms": [
+                388.7382,
+                388.1823,
+                387.9145,
+                387.6542,
+                388.3749,
+                394.4982,
+                388.5616
+            ],
+            "array_ms": 28.2078,
+            "judy_ms": 388.3749,
+            "judy_over_array": 13.768,
+            "winner": "php-array"
+        },
+        "core.string_to_int_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.62961,
+            "delta_pct": 962.96,
+            "ci_delta_pct": [
+                961.99,
+                966.13
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.0293,
+                22.0121,
+                22.0326,
+                22.0093,
+                22.0814,
+                22.0925,
+                22.1564
+            ],
+            "judy_runs_ms": [
+                235.3804,
+                234.6785,
+                233.9831,
+                234.5738,
+                234.7167,
+                234.6698,
+                235.1461
+            ],
+            "array_ms": 22.0326,
+            "judy_ms": 234.6785,
+            "judy_over_array": 10.651,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.23872,
+            "delta_pct": 323.87,
+            "ci_delta_pct": [
+                322.86,
+                325.37
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                447.9622,
+                448.418,
+                449.3473,
+                448.7434,
+                449.2684,
+                449.4653,
+                450.2547
+            ],
+            "judy_runs_ms": [
+                1905.4875,
+                1935.1637,
+                1898.2432,
+                1899.1242,
+                1904.3218,
+                1908.2951,
+                1903.9381
+            ],
+            "array_ms": 449.2684,
+            "judy_ms": 1904.3218,
+            "judy_over_array": 4.239,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 16.3561,
+            "delta_pct": 1535.61,
+            "ci_delta_pct": [
+                1527.8,
+                1549.04
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                56.3977,
+                56.804,
+                58.6423,
+                56.4506,
+                55.7312,
+                57.0615,
+                56.925
+            ],
+            "judy_runs_ms": [
+                928.0944,
+                929.092,
+                929.9307,
+                930.893,
+                929.6826,
+                928.8497,
+                930.3895
+            ],
+            "array_ms": 56.804,
+            "judy_ms": 929.6826,
+            "judy_over_array": 16.366,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.17498,
+            "delta_pct": 1117.5,
+            "ci_delta_pct": [
+                1093.18,
+                1123.61
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                34.8981,
+                35.6504,
+                35.2752,
+                35.0156,
+                35.8633,
+                35.8517,
+                34.8173
+            ],
+            "judy_runs_ms": [
+                427.017,
+                427.725,
+                429.4748,
+                428.2581,
+                426.0538,
+                427.7752,
+                429.8716
+            ],
+            "array_ms": 35.2752,
+            "judy_ms": 427.7752,
+            "judy_over_array": 12.127,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_hash.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 9.56142,
+            "delta_pct": 856.14,
+            "ci_delta_pct": [
+                854.36,
+                856.67
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                64.1361,
+                64.1711,
+                64.2742,
+                64.2372,
+                64.2646,
+                64.3894,
+                64.5458
+            ],
+            "judy_runs_ms": [
+                614.6385,
+                613.5668,
+                613.4063,
+                614.3311,
+                614.7987,
+                615.3113,
+                614.6235
+            ],
+            "array_ms": 64.2646,
+            "judy_ms": 614.6235,
+            "judy_over_array": 9.564,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 4.26718,
+            "delta_pct": 326.72,
+            "ci_delta_pct": [
+                324.88,
+                327.79
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                245.1195,
+                245.3117,
+                246.3013,
+                245.8077,
+                245.4401,
+                245.8172,
+                246.9707
+            ],
+            "judy_runs_ms": [
+                1048.5857,
+                1048.7068,
+                1046.4854,
+                1048.9058,
+                1046.3792,
+                1053.3074,
+                1047.6071
+            ],
+            "array_ms": 245.8077,
+            "judy_ms": 1048.5857,
+            "judy_over_array": 4.266,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.42702,
+            "delta_pct": 242.7,
+            "ci_delta_pct": [
+                235.22,
+                243.79
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                50.8091,
+                50.2775,
+                51.0637,
+                49.4189,
+                49.7896,
+                49.9718,
+                49.792
+            ],
+            "judy_runs_ms": [
+                170.3201,
+                171.3492,
+                170.9125,
+                170.4185,
+                171.172,
+                171.2793,
+                170.6384
+            ],
+            "array_ms": 49.9718,
+            "judy_ms": 170.9125,
+            "judy_over_array": 3.42,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 13.73536,
+            "delta_pct": 1273.54,
+            "ci_delta_pct": [
+                1268.54,
+                1284.82
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                28.3167,
+                28.1057,
+                28.0323,
+                27.999,
+                28.275,
+                28.1814,
+                28.2605
+            ],
+            "judy_runs_ms": [
+                387.1303,
+                387.5351,
+                389.2298,
+                387.7344,
+                386.9554,
+                387.0816,
+                387.856
+            ],
+            "array_ms": 28.1814,
+            "judy_ms": 387.5351,
+            "judy_over_array": 13.751,
+            "winner": "php-array"
+        },
+        "core.string_to_int_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.62623,
+            "delta_pct": 962.62,
+            "ci_delta_pct": [
+                959.6,
+                963.57
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                22.0485,
+                22.0545,
+                22.0574,
+                22.1108,
+                22.0714,
+                22.084,
+                22.2082
+            ],
+            "judy_runs_ms": [
+                233.9657,
+                235.4673,
+                234.4689,
+                232.4622,
+                234.7458,
+                234.6697,
+                235.3182
+            ],
+            "array_ms": 22.0714,
+            "judy_ms": 234.6697,
+            "judy_over_array": 10.632,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.write": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 5.13222,
+            "delta_pct": 413.22,
+            "ci_delta_pct": [
+                411.28,
+                414.29
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                262.5995,
+                263.0079,
+                263.7711,
+                263.1379,
+                263.0084,
+                263.1209,
+                263.6099
+            ],
+            "judy_runs_ms": [
+                1350.077,
+                1362.1735,
+                1343.6665,
+                1348.0299,
+                1349.8182,
+                1353.2079,
+                1347.785
+            ],
+            "array_ms": 263.1209,
+            "judy_ms": 1349.8182,
+            "judy_over_array": 5.13,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.read": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 3.09717,
+            "delta_pct": 209.72,
+            "ci_delta_pct": [
+                207.53,
+                211.93
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                56.3786,
+                56.9264,
+                58.1628,
+                56.3643,
+                56.8817,
+                56.8624,
+                55.386
+            ],
+            "judy_runs_ms": [
+                174.9259,
+                175.7757,
+                178.8659,
+                175.8186,
+                174.9208,
+                176.1126,
+                176.1005
+            ],
+            "array_ms": 56.8624,
+            "judy_ms": 175.8186,
+            "judy_over_array": 3.092,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.iter": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 12.81951,
+            "delta_pct": 1181.95,
+            "ci_delta_pct": [
+                1168.6,
+                1192.5
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                35.5296,
+                35.9664,
+                34.4563,
+                35.0183,
+                34.9624,
+                35.9631,
+                35.1348
+            ],
+            "judy_runs_ms": [
+                450.7286,
+                450.8447,
+                449.933,
+                452.6129,
+                450.6296,
+                456.3215,
+                450.4109
+            ],
+            "array_ms": 35.1348,
+            "judy_ms": 450.7286,
+            "judy_over_array": 12.829,
+            "winner": "php-array"
+        },
+        "core.string_to_mixed_adaptive.free": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 10.09039,
+            "delta_pct": 909.04,
+            "ci_delta_pct": [
+                907.32,
+                909.93
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                64.0942,
+                64.1732,
+                64.2026,
+                64.2789,
+                64.1939,
+                64.3713,
+                64.5038
+            ],
+            "judy_runs_ms": [
+                647.3097,
+                646.624,
+                649.7268,
+                647.4938,
+                648.2407,
+                647.4615,
+                650.8683
+            ],
+            "array_ms": 64.2026,
+            "judy_ms": 647.4938,
+            "judy_over_array": 10.085,
+            "winner": "php-array"
+        },
+        "api.increment.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.5385,
+            "delta_pct": 153.85,
+            "ci_delta_pct": [
+                152.51,
+                154.47
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                57.6915,
+                57.3834,
+                57.3899,
+                57.3053,
+                57.6268,
+                57.0906,
+                57.2784
+            ],
+            "judy_runs_ms": [
+                146.808,
+                145.7222,
+                145.6843,
+                145.4002,
+                145.5156,
+                145.3413,
+                144.4419
+            ],
+            "array_ms": 57.3834,
+            "judy_ms": 145.5156,
+            "judy_over_array": 2.536,
+            "winner": "php-array"
+        },
+        "api.setop.union.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.98341,
+            "delta_pct": 98.34,
+            "ci_delta_pct": [
+                96.83,
+                99.32
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                92.154,
+                92.2319,
+                92.2064,
+                92.2449,
+                93.7544,
+                92.0911,
+                92.4783
+            ],
+            "judy_runs_ms": [
+                184.0337,
+                183.8407,
+                181.4904,
+                182.9599,
+                183.52,
+                182.9215,
+                182.2431
+            ],
+            "array_ms": 92.2319,
+            "judy_ms": 182.9599,
+            "judy_over_array": 1.984,
+            "winner": "php-array"
+        },
+        "api.setop.intersect.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.91135,
+            "delta_pct": -8.87,
+            "ci_delta_pct": [
+                -8.95,
+                -8.36
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                95.1587,
+                95.7297,
+                95.323,
+                94.9776,
+                95.493,
+                95.3369,
+                95.2025
+            ],
+            "judy_runs_ms": [
+                87.9114,
+                87.1588,
+                86.4581,
+                86.9828,
+                86.9502,
+                86.8851,
+                87.2481
+            ],
+            "array_ms": 95.323,
+            "judy_ms": 86.9828,
+            "judy_over_array": 0.913,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.bitset": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 2.00647,
+            "delta_pct": 100.65,
+            "ci_delta_pct": [
+                99.35,
+                101.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                42.8543,
+                43.3234,
+                43.0729,
+                42.8643,
+                43.1162,
+                42.9684,
+                42.9808
+            ],
+            "judy_runs_ms": [
+                87.2291,
+                86.6139,
+                85.865,
+                86.1115,
+                85.9474,
+                86.6191,
+                86.2399
+            ],
+            "array_ms": 42.9808,
+            "judy_ms": 86.2399,
+            "judy_over_array": 2.006,
+            "winner": "php-array"
+        },
+        "api.setop.xor.bitset": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.78014,
+            "delta_pct": -21.99,
+            "ci_delta_pct": [
+                -22.18,
+                -21.5
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                220.8974,
+                221.9503,
+                221.1372,
+                220.4547,
+                221.6291,
+                221.4633,
+                220.2163
+            ],
+            "judy_runs_ms": [
+                173.404,
+                172.7222,
+                172.3885,
+                172.7027,
+                172.4204,
+                172.773,
+                173.0151
+            ],
+            "array_ms": 221.1372,
+            "judy_ms": 172.7222,
+            "judy_over_array": 0.781,
+            "winner": "php-judy"
+        }
+    },
+    "judy_vs_phploop": {
+        "api.putAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69367,
+            "delta_pct": -30.63,
+            "ci_delta_pct": [
+                -30.93,
+                -30.06
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                181.4306,
+                182.9604,
+                183.0525,
+                183.447,
+                181.1037,
+                180.8179,
+                181.1762
+            ],
+            "judy_runs_ms": [
+                125.8534,
+                126.5015,
+                126.1956,
+                126.7007,
+                131.0549,
+                126.4609,
+                126.2729
+            ],
+            "array_ms": 181.4306,
+            "judy_ms": 126.4609,
+            "judy_over_array": 0.697,
+            "winner": "php-judy"
+        },
+        "api.fromArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69464,
+            "delta_pct": -30.54,
+            "ci_delta_pct": [
+                -30.87,
+                -30.29
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                181.4306,
+                182.9604,
+                183.0525,
+                183.447,
+                181.1037,
+                180.8179,
+                181.1762
+            ],
+            "judy_runs_ms": [
+                125.9764,
+                126.1297,
+                126.5521,
+                127.4304,
+                126.2483,
+                126.3271,
+                126.1052
+            ],
+            "array_ms": 181.4306,
+            "judy_ms": 126.2483,
+            "judy_over_array": 0.696,
+            "winner": "php-judy"
+        },
+        "api.toArray.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.81845,
+            "delta_pct": -18.15,
+            "ci_delta_pct": [
+                -19.38,
+                -17.91
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                361.7245,
+                363.8185,
+                369.4026,
+                369.404,
+                361.8156,
+                365.0053,
+                362.1513
+            ],
+            "judy_runs_ms": [
+                296.9377,
+                297.7688,
+                297.8001,
+                297.2557,
+                299.4844,
+                296.4311,
+                297.0942
+            ],
+            "array_ms": 363.8185,
+            "judy_ms": 297.2557,
+            "judy_over_array": 0.817,
+            "winner": "php-judy"
+        },
+        "api.getAll.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.7806,
+            "delta_pct": -21.94,
+            "ci_delta_pct": [
+                -22.09,
+                -21.68
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                27.3792,
+                27.4166,
+                27.4359,
+                27.4619,
+                27.4062,
+                27.4932,
+                27.4976
+            ],
+            "judy_runs_ms": [
+                21.4814,
+                21.435,
+                21.3766,
+                21.4209,
+                21.3932,
+                21.4079,
+                21.535
+            ],
+            "array_ms": 27.4359,
+            "judy_ms": 21.4209,
+            "judy_over_array": 0.781,
+            "winner": "php-judy"
+        },
+        "api.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.59791,
+            "delta_pct": -40.21,
+            "ci_delta_pct": [
+                -40.29,
+                -40.05
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.0483,
+                194.7113,
+                194.573,
+                194.3978,
+                194.9635,
+                193.136,
+                194.5993
+            ],
+            "judy_runs_ms": [
+                116.3361,
+                115.9669,
+                116.3371,
+                116.0761,
+                116.6074,
+                116.0084,
+                116.2983
+            ],
+            "array_ms": 194.573,
+            "judy_ms": 116.2983,
+            "judy_over_array": 0.598,
+            "winner": "php-judy"
+        },
+        "api.values.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.62214,
+            "delta_pct": -37.79,
+            "ci_delta_pct": [
+                -37.93,
+                -37.56
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                194.5249,
+                194.4816,
+                195.3671,
+                194.4517,
+                194.0833,
+                193.1095,
+                194.3415
+            ],
+            "judy_runs_ms": [
+                121.0209,
+                120.9467,
+                121.1627,
+                120.7018,
+                121.1851,
+                120.6747,
+                120.9195
+            ],
+            "array_ms": 194.4517,
+            "judy_ms": 120.9467,
+            "judy_over_array": 0.622,
+            "winner": "php-judy"
+        },
+        "api.range.keys.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.06778,
+            "delta_pct": -93.22,
+            "ci_delta_pct": [
+                -93.23,
+                -93.19
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                148.2457,
+                148.0297,
+                149.2185,
+                148.3836,
+                148.4941,
+                147.9202,
+                148.243
+            ],
+            "judy_runs_ms": [
+                10.1556,
+                10.0332,
+                10.1113,
+                10.0528,
+                10.0392,
+                10.0807,
+                10.0517
+            ],
+            "array_ms": 148.2457,
+            "judy_ms": 10.0528,
+            "judy_over_array": 0.068,
+            "winner": "php-judy"
+        },
+        "api.sumValues.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.41289,
+            "delta_pct": -58.71,
+            "ci_delta_pct": [
+                -58.79,
+                -58.62
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                116.9449,
+                118.9046,
+                117.7364,
+                117.6315,
+                117.6102,
+                117.1795,
+                117.6937
+            ],
+            "judy_runs_ms": [
+                48.3942,
+                48.693,
+                48.6127,
+                48.621,
+                48.4912,
+                48.6225,
+                48.5054
+            ],
+            "array_ms": 117.6315,
+            "judy_ms": 48.6127,
+            "judy_over_array": 0.413,
+            "winner": "php-judy"
+        },
+        "api.populationCount.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0,
+            "delta_pct": -100,
+            "ci_delta_pct": [
+                -100,
+                -100
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                118.4279,
+                118.2735,
+                119.2019,
+                118.7661,
+                118.4925,
+                118.5956,
+                118.9066
+            ],
+            "judy_runs_ms": [
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001
+            ],
+            "array_ms": 118.5956,
+            "judy_ms": 0.0001,
+            "judy_over_array": 0,
+            "winner": "php-judy"
+        },
+        "api.deleteRange.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.69986,
+            "delta_pct": -30.01,
+            "ci_delta_pct": [
+                -30.02,
+                -29.94
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                338.7799,
+                338.5931,
+                338.7097,
+                338.2374,
+                339.0219,
+                339.1409,
+                338.2898
+            ],
+            "judy_runs_ms": [
+                237.3563,
+                236.9472,
+                237.0493,
+                237.162,
+                236.9398,
+                237.3413,
+                236.9268
+            ],
+            "array_ms": 338.7097,
+            "judy_ms": 237.0493,
+            "judy_over_array": 0.7,
+            "winner": "php-judy"
+        },
+        "api.equals.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.25941,
+            "delta_pct": -74.06,
+            "ci_delta_pct": [
+                -74.19,
+                -73.89
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                272.6527,
+                275.5112,
+                274.8123,
+                278.0817,
+                274.3951,
+                274.6073,
+                275.8063
+            ],
+            "judy_runs_ms": [
+                71.2378,
+                71.1392,
+                71.474,
+                71.7493,
+                71.1802,
+                71.7016,
+                71.1981
+            ],
+            "array_ms": 274.8123,
+            "judy_ms": 71.2378,
+            "judy_over_array": 0.259,
+            "winner": "php-judy"
+        },
+        "api.setop.union.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.52101,
+            "delta_pct": -47.9,
+            "ci_delta_pct": [
+                -48.23,
+                -47.83
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                508.324,
+                508.9825,
+                512.1123,
+                512.2465,
+                513.4086,
+                506.7979,
+                510.4847
+            ],
+            "judy_runs_ms": [
+                265.1862,
+                265.184,
+                266.5648,
+                265.189,
+                265.081,
+                265.0767,
+                266.2542
+            ],
+            "array_ms": 510.4847,
+            "judy_ms": 265.1862,
+            "judy_over_array": 0.519,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.43882,
+            "delta_pct": -56.12,
+            "ci_delta_pct": [
+                -56.14,
+                -55.88
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                248.1821,
+                247.5814,
+                248.4268,
+                248.0063,
+                249.0137,
+                248.6273,
+                249.1348
+            ],
+            "judy_runs_ms": [
+                109.5001,
+                109.3612,
+                109.0136,
+                108.8134,
+                109.0469,
+                109.0435,
+                109.3782
+            ],
+            "array_ms": 248.4268,
+            "judy_ms": 109.0469,
+            "judy_over_array": 0.439,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.4205,
+            "delta_pct": -57.95,
+            "ci_delta_pct": [
+                -58.31,
+                -57.88
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                258.3545,
+                256.2386,
+                256.4141,
+                255.6876,
+                256.4005,
+                258.6041,
+                257.7238
+            ],
+            "judy_runs_ms": [
+                107.2703,
+                107.9153,
+                108.1543,
+                107.6872,
+                107.8155,
+                107.8219,
+                108.0571
+            ],
+            "array_ms": 256.4141,
+            "judy_ms": 107.8219,
+            "judy_over_array": 0.42,
+            "winner": "php-judy"
+        },
+        "api.setop.xor.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.42196,
+            "delta_pct": -57.8,
+            "ci_delta_pct": [
+                -58.17,
+                -57.67
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                533.2263,
+                512.7693,
+                515.3189,
+                513.6072,
+                521.305,
+                518.4366,
+                514.0724
+            ],
+            "judy_runs_ms": [
+                216.1929,
+                216.7347,
+                218.1551,
+                216.3134,
+                222.0448,
+                216.8374,
+                216.9194
+            ],
+            "array_ms": 515.3189,
+            "judy_ms": 216.8374,
+            "judy_over_array": 0.421,
+            "winner": "php-judy"
+        },
+        "api.setop.union.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86221,
+            "delta_pct": -13.78,
+            "ci_delta_pct": [
+                -14.12,
+                -13.29
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1685.5924,
+                1681.889,
+                1688.739,
+                1690.4572,
+                1685.1314,
+                1701.6517,
+                1695.7797
+            ],
+            "judy_runs_ms": [
+                1461.5168,
+                1450.1357,
+                1470.2155,
+                1452.4405,
+                1457.7153,
+                1461.369,
+                1449.3132
+            ],
+            "array_ms": 1688.739,
+            "judy_ms": 1457.7153,
+            "judy_over_array": 0.863,
+            "winner": "php-judy"
+        },
+        "api.setop.intersect.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.84368,
+            "delta_pct": -15.63,
+            "ci_delta_pct": [
+                -15.9,
+                -14.98
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                773.1254,
+                768.1527,
+                776.3778,
+                780.8978,
+                770.9032,
+                773.7655,
+                770.9785
+            ],
+            "judy_runs_ms": [
+                657.3346,
+                656.8429,
+                653.7128,
+                651.5287,
+                650.3983,
+                650.7453,
+                652.7642
+            ],
+            "array_ms": 773.1254,
+            "judy_ms": 652.7642,
+            "judy_over_array": 0.844,
+            "winner": "php-judy"
+        },
+        "api.setop.diff.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.86417,
+            "delta_pct": -13.58,
+            "ci_delta_pct": [
+                -13.77,
+                -13.28
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                769.8655,
+                777.1986,
+                777.7898,
+                775.9553,
+                779.7105,
+                780.5931,
+                775.5744
+            ],
+            "judy_runs_ms": [
+                679.456,
+                671.6287,
+                671.52,
+                672.8718,
+                668.7012,
+                673.0982,
+                670.5138
+            ],
+            "array_ms": 777.1986,
+            "judy_ms": 671.6287,
+            "judy_over_array": 0.864,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.int_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.77759,
+            "delta_pct": -22.24,
+            "ci_delta_pct": [
+                -22.28,
+                -21.87
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                389.9068,
+                387.9712,
+                389.0044,
+                388.2128,
+                388.7848,
+                386.2435,
+                389.937
+            ],
+            "judy_runs_ms": [
+                303.1056,
+                301.5295,
+                302.4842,
+                302.4213,
+                303.7675,
+                302.3214,
+                301.7
+            ],
+            "array_ms": 388.7848,
+            "judy_ms": 302.4213,
+            "judy_over_array": 0.778,
+            "winner": "php-judy"
+        },
+        "api.mergeWith.string_to_int": {
+            "status": "FASTER",
+            "reason": null,
+            "ratio": 0.90571,
+            "delta_pct": -9.43,
+            "ci_delta_pct": [
+                -9.72,
+                -9.11
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1315.8372,
+                1321.3858,
+                1330.8309,
+                1327.8706,
+                1319.4251,
+                1318.4679,
+                1324.0711
+            ],
+            "judy_runs_ms": [
+                1193.9026,
+                1196.7865,
+                1203.8596,
+                1194.6362,
+                1199.1876,
+                1201.1701,
+                1195.3384
+            ],
+            "array_ms": 1321.3858,
+            "judy_ms": 1196.7865,
+            "judy_over_array": 0.906,
+            "winner": "php-judy"
+        },
+        "adv.forEach.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.48801,
+            "delta_pct": 48.8,
+            "ci_delta_pct": [
+                47.94,
+                49.22
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                129.2867,
+                127.5663,
+                127.1485,
+                127.6203,
+                127.019,
+                127.3007,
+                127.1756
+            ],
+            "judy_runs_ms": [
+                188.5991,
+                189.8499,
+                188.1051,
+                190.7656,
+                189.5317,
+                188.8409,
+                189.2385
+            ],
+            "array_ms": 127.3007,
+            "judy_ms": 189.2385,
+            "judy_over_array": 1.487,
+            "winner": "php-array"
+        },
+        "adv.forEach.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.17217,
+            "delta_pct": 17.22,
+            "ci_delta_pct": [
+                16.95,
+                17.67
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                302.359,
+                303.5356,
+                302.4544,
+                303.0861,
+                302.529,
+                303.3522,
+                305.9044
+            ],
+            "judy_runs_ms": [
+                354.4157,
+                354.9999,
+                355.4137,
+                356.655,
+                356.5013,
+                355.4241,
+                357.7069
+            ],
+            "array_ms": 303.0861,
+            "judy_ms": 355.4241,
+            "judy_over_array": 1.173,
+            "winner": "php-array"
+        },
+        "adv.filter.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.22196,
+            "delta_pct": 22.2,
+            "ci_delta_pct": [
+                20.52,
+                22.43
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                232.1042,
+                230.3877,
+                237.0725,
+                232.6882,
+                235.8317,
+                232.388,
+                233.1957
+            ],
+            "judy_runs_ms": [
+                281.9209,
+                283.8369,
+                282.6605,
+                284.8879,
+                284.2353,
+                284.2056,
+                284.9558
+            ],
+            "array_ms": 232.6882,
+            "judy_ms": 284.2056,
+            "judy_over_array": 1.221,
+            "winner": "php-array"
+        },
+        "adv.filter.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.06221,
+            "delta_pct": 6.22,
+            "ci_delta_pct": [
+                5.98,
+                6.54
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                736.4873,
+                734.5639,
+                737.7267,
+                738.0259,
+                738.1809,
+                735.773,
+                740.1383
+            ],
+            "judy_runs_ms": [
+                780.0273,
+                781.2284,
+                781.8061,
+                786.2564,
+                788.7224,
+                781.5453,
+                784.3955
+            ],
+            "array_ms": 737.7267,
+            "judy_ms": 781.8061,
+            "judy_over_array": 1.06,
+            "winner": "php-array"
+        },
+        "adv.map.int_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.08944,
+            "delta_pct": 8.94,
+            "ci_delta_pct": [
+                8.74,
+                9.5
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                276.2867,
+                271.9202,
+                272.0394,
+                274.8018,
+                272.9196,
+                272.0148,
+                275.629
+            ],
+            "judy_runs_ms": [
+                300.007,
+                297.7638,
+                298.9414,
+                298.8248,
+                297.143,
+                297.1833,
+                300.2813
+            ],
+            "array_ms": 272.9196,
+            "judy_ms": 298.8248,
+            "judy_over_array": 1.095,
+            "winner": "php-array"
+        },
+        "adv.map.string_to_int": {
+            "status": "SLOWER",
+            "reason": null,
+            "ratio": 1.02499,
+            "delta_pct": 2.5,
+            "ci_delta_pct": [
+                2.08,
+                2.59
+            ],
+            "n": 7,
+            "array_runs_ms": [
+                1042.049,
+                1040.4842,
+                1041.5792,
+                1045.9139,
+                1046.7663,
+                1038.6927,
+                1052.4451
+            ],
+            "judy_runs_ms": [
+                1063.7409,
+                1067.4764,
+                1067.609,
+                1071.5653,
+                1073.045,
+                1065.7977,
+                1072.5116
+            ],
+            "array_ms": 1042.049,
+            "judy_ms": 1067.609,
+            "judy_over_array": 1.025,
+            "winner": "php-array"
+        }
+    },
+    "memory": [
+        {
+            "workload": "int_to_int",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 159449088,
+                    "peak_rss_ci": [
+                        159252480,
+                        159449088
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 134221904,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 135462912,
+                    "bytes_per_element": 22.58
+                },
+                "B": {
+                    "peak_rss_bytes": 76087296,
+                    "peak_rss_ci": [
+                        76087296,
+                        76087296
+                    ],
+                    "index_bytes": 49885112,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 51707904,
+                    "bytes_per_element": 8.62
+                },
+                "C": {
+                    "peak_rss_bytes": 76283904,
+                    "peak_rss_ci": [
+                        76283904,
+                        76283904
+                    ],
+                    "index_bytes": 49885112,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 52101120,
+                    "bytes_per_element": 8.68
+                }
+            },
+            "array_over_bundled": 2.6,
+            "system_over_bundled": 0.992
+        },
+        {
+            "workload": "int_sparse",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 328613888,
+                    "peak_rss_ci": [
+                        328613888,
+                        328613888
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 335544400,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 304627712,
+                    "bytes_per_element": 50.77
+                },
+                "B": {
+                    "peak_rss_bytes": 102432768,
+                    "peak_rss_ci": [
+                        102236160,
+                        102432768
+                    ],
+                    "index_bytes": 75088096,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 78053376,
+                    "bytes_per_element": 13.01
+                },
+                "C": {
+                    "peak_rss_bytes": 102629376,
+                    "peak_rss_ci": [
+                        102432768,
+                        102629376
+                    ],
+                    "index_bytes": 75088096,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 78446592,
+                    "bytes_per_element": 13.07
+                }
+            },
+            "array_over_bundled": 3.883,
+            "system_over_bundled": 0.995
+        },
+        {
+            "workload": "int_to_mixed",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 225501184,
+                    "peak_rss_ci": [
+                        225308672,
+                        225505280
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 230221744,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 201515008,
+                    "bytes_per_element": 33.59
+                },
+                "B": {
+                    "peak_rss_bytes": 268566528,
+                    "peak_rss_ci": [
+                        268369920,
+                        268566528
+                    ],
+                    "index_bytes": 49885112,
+                    "php_heap_bytes": 192000000,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 244187136,
+                    "bytes_per_element": 40.7
+                },
+                "C": {
+                    "peak_rss_bytes": 268566528,
+                    "peak_rss_ci": [
+                        268369920,
+                        268566528
+                    ],
+                    "index_bytes": 49885112,
+                    "php_heap_bytes": 192000000,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 244383744,
+                    "bytes_per_element": 40.73
+                }
+            },
+            "array_over_bundled": 0.825,
+            "system_over_bundled": 0.999
+        },
+        {
+            "workload": "string_to_int",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 524394496,
+                    "peak_rss_ci": [
+                        524390400,
+                        524587008
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 575536400,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 500408320,
+                    "bytes_per_element": 83.4
+                },
+                "B": {
+                    "peak_rss_bytes": 169279488,
+                    "peak_rss_ci": [
+                        169279488,
+                        169476096
+                    ],
+                    "index_bytes": 118888890,
+                    "php_heap_bytes": 65696,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 144900096,
+                    "bytes_per_element": 24.15
+                },
+                "C": {
+                    "peak_rss_bytes": 169476096,
+                    "peak_rss_ci": [
+                        169476096,
+                        169476096
+                    ],
+                    "index_bytes": 118888890,
+                    "php_heap_bytes": 65696,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 145293312,
+                    "bytes_per_element": 24.22
+                }
+            },
+            "array_over_bundled": 3.444,
+            "system_over_bundled": 0.997
+        },
+        {
+            "workload": "bitset",
+            "n": 6000000,
+            "arms": {
+                "A": {
+                    "peak_rss_bytes": 328417280,
+                    "peak_rss_ci": [
+                        328413184,
+                        328421376
+                    ],
+                    "index_bytes": null,
+                    "php_heap_bytes": 335544400,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 304431104,
+                    "bytes_per_element": 50.74
+                },
+                "B": {
+                    "peak_rss_bytes": 34996224,
+                    "peak_rss_ci": [
+                        34799616,
+                        34996224
+                    ],
+                    "index_bytes": 7896080,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 10616832,
+                    "bytes_per_element": 1.77
+                },
+                "C": {
+                    "peak_rss_bytes": 34799616,
+                    "peak_rss_ci": [
+                        34799616,
+                        34996224
+                    ],
+                    "index_bytes": 7896080,
+                    "php_heap_bytes": 160,
+                    "count": 6000000,
+                    "runs": 3,
+                    "over_floor_bytes": 10616832,
+                    "bytes_per_element": 1.77
+                }
+            },
+            "array_over_bundled": 28.674,
+            "system_over_bundled": 1
+        }
+    ],
+    "verify": {
+        "B1": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-B-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/B1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B2": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-B-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/B2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "B3": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-B-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/B3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C1": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-C-1.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/C1-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C2": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-C-2.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/C2-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        },
+        "C3": {
+            "loaded": 1,
+            "version": "2.6.0",
+            "paths": [
+                "/usr/src/php-judy/arms/judy-C-3.so"
+            ],
+            "inis": [
+                "/tmp/judy-bench-arms-7/C3-ini/judy.ini"
+            ],
+            "main_loads_judy": 0
+        }
+    }
+}

--- a/research/three-arm-benchmark/results/run7-out-of-cache-6m-str.txt
+++ b/research/three-arm-benchmark/results/run7-out-of-cache-6m-str.txt
@@ -1,0 +1,239 @@
+php-judy three-arm benchmark
+  A  PHP native array
+  B  php-judy + system libJudy  : /usr/src/php-judy/arms/judy-B-1.so, /usr/src/php-judy/arms/judy-B-2.so, /usr/src/php-judy/arms/judy-B-3.so
+  C  php-judy + bundled libJudy : /usr/src/php-judy/arms/judy-C-1.so, /usr/src/php-judy/arms/judy-C-2.so, /usr/src/php-judy/arms/judy-C-3.so
+  timing core.int     round 1/7
+  timing core.int     round 2/7
+  timing core.int     round 3/7
+  timing core.int     round 4/7
+  timing core.int     round 5/7
+  timing core.int     round 6/7
+  timing core.int     round 7/7
+  timing core.int     done          
+  timing core.str     round 1/7
+  timing core.str     round 2/7
+  timing core.str     round 3/7
+  timing core.str     round 4/7
+  timing core.str     round 5/7
+  timing core.str     round 6/7
+  timing core.str     round 7/7
+  timing core.str     done          
+  timing api.batch    round 1/7
+  timing api.batch    round 2/7
+  timing api.batch    round 3/7
+  timing api.batch    round 4/7
+  timing api.batch    round 5/7
+  timing api.batch    round 6/7
+  timing api.batch    round 7/7
+  timing api.batch    done          
+  timing api.setops   round 1/7
+  timing api.setops   round 2/7
+  timing api.setops   round 3/7
+  timing api.setops   round 4/7
+  timing api.setops   round 5/7
+  timing api.setops   round 6/7
+  timing api.setops   round 7/7
+  timing api.setops   done          
+  timing adv.iter     round 1/7
+  timing adv.iter     round 2/7
+  timing adv.iter     round 3/7
+  timing adv.iter     round 4/7
+  timing adv.iter     round 5/7
+  timing adv.iter     round 6/7
+  timing adv.iter     round 7/7
+  timing adv.iter     done          
+  memory int_to_int     n=6000000   A=129.2 MB   B=49.3 MB    C=49.7 MB     A/C=2.60x
+  memory int_sparse     n=6000000   A=290.5 MB   B=74.4 MB    C=74.8 MB     A/C=3.88x
+  memory int_to_mixed   n=6000000   A=192.2 MB   B=232.9 MB   C=233.1 MB    A/C=0.82x
+  memory string_to_int  n=6000000   A=477.2 MB   B=138.2 MB   C=138.6 MB    A/C=3.44x
+  memory bitset         n=6000000   A=290.3 MB   B=10.1 MB    C=10.1 MB     A/C=28.67x
+
+------------------------------------------------------------------------------------------------
+php-judy three-arm benchmark — linux-x86_64-gcc14-out-of-cache-6m-with-core-str
+------------------------------------------------------------------------------------------------
+  PHP 8.4.24, Linux x86_64
+  arm B system libJudy : Debian 13 libjudy-dev 1.0.5-5.1
+  arm C bundled libJudy: vendored libjudy/ tree
+  size 6000000 (out-of-cache), 7 rounds, 3 iterations, floor 1.3%
+  same-source attested : yes
+
+  host hygiene
+    start          load1=0.09   cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-timing   load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    after-memory   load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+    end            load1=1      cpus=24   threshold=12.0  foreign=  0.0% ok
+
+  control (PHP-only rows, touch no libJudy): +0.12% [-0.01, +0.21] over 45 rows
+  measured control scatter: 1.59%  (assumed floor 1.3%)
+
+------------------------------------------------------------------------------------------------
+  MEMORY — peak RSS over per-arm empty-process floor (the headline axis)
+------------------------------------------------------------------------------------------------
+  workload                n      A array     B system    C bundled       A/C       B/C
+  int_to_int        6000000     129.2 MB      49.3 MB      49.7 MB     2.60x     0.99x
+  int_sparse        6000000     290.5 MB      74.4 MB      74.8 MB     3.88x     0.99x
+  int_to_mixed      6000000     192.2 MB     232.9 MB     233.1 MB     0.82x     1.00x
+  string_to_int     6000000     477.2 MB     138.2 MB     138.6 MB     3.44x     1.00x
+  bitset            6000000     290.3 MB      10.1 MB      10.1 MB    28.67x     1.00x
+  A/C above 1.00 means the PHP array uses that many times more memory than php-judy.
+
+------------------------------------------------------------------------------------------------
+  B vs C — bundled libJudy against system libJudy (this project's contribution)
+  ratio < 1 means the bundled tree is faster. Only rows whose whole CI clears
+  the 1.3% floor assert anything; everything else is null.
+------------------------------------------------------------------------------------------------
+  benchmark                                     system   bundled    delta CI                 verdict
+  api.range.size.string_to_int                   36.48     20.88  -42.85% [-42.86,-42.65] FASTER
+  core.string_to_int.free                       191.60    110.34  -42.56% [-42.70,-42.35] FASTER
+  core.string_to_mixed.free                     567.28    346.05  -39.12% [-39.17,-39.04] FASTER
+  core.string_to_int.read                       323.85    205.10  -36.78% [-36.82,-36.17] FASTER
+  core.string_to_int.iter                       455.54    290.99  -36.23% [-36.67,-36.10] FASTER
+  core.string_to_int_adaptive.iter              595.04    387.54  -35.02% [-35.10,-34.79] FASTER
+  adv.optiter.values.string_to_int_hash.optimized     16.13     10.53  -34.65% [-34.91,-34.46] FASTER
+  core.string_to_mixed.iter                    1251.49    818.82  -34.63% [-34.75,-34.43] FASTER
+  core.string_to_int_hash.iter                  593.10    388.37  -34.51% [-34.77,-34.50] FASTER
+  core.string_to_mixed_hash.free                931.41    614.62  -34.20% [-34.22,-34.01] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.optimized     21.07     13.96  -33.74% [-33.87,-33.65] FASTER
+  core.string_to_mixed.read                    1180.16    784.45  -33.62% [-33.78,-33.46] FASTER
+  adv.optiter.foreach.string_to_int_hash.optimized     19.11     12.78  -33.15% [-33.70,-33.08] FASTER
+  core.string_to_mixed_adaptive.free            963.71    647.49  -32.90% [-32.98,-32.58] FASTER
+  core.string_to_mixed_hash.iter                636.19    427.78  -32.83% [-33.11,-32.76] FASTER
+  core.string_to_mixed_adaptive.iter            667.69    450.73  -32.51% [-32.63,-31.85] FASTER
+  core.string_to_mixed_hash.read               1375.52    929.68  -32.45% [-32.59,-32.35] FASTER
+  adv.optiter.values.string_to_int_adaptive.optimized     17.98     12.35  -31.39% [-31.66,-31.28] FASTER
+  core.string_to_int_hash.free                  337.75    234.68  -30.54% [-30.79,-30.42] FASTER
+  core.string_to_int_adaptive.free              337.17    234.67  -30.49% [-30.62,-30.30] FASTER
+  adv.forEach.string_to_int                     507.54    355.42  -29.91% [-30.79,-29.82] FASTER
+  core.string_to_int.write                      895.04    640.37  -28.44% [-28.67,-28.38] FASTER
+  core.string_to_mixed.write                   1371.94    987.01  -28.16% [-28.37,-27.82] FASTER
+  core.string_to_mixed_hash.write              2618.48   1904.32  -27.43% [-27.60,-27.14] FASTER
+  api.equals.int_to_int                          97.83     71.24  -27.22% [-27.31,-26.87] FASTER
+  api.putAll.int_to_int                         171.06    126.46  -26.36% [-26.52,-26.07] FASTER
+  api.setop.intersect.int_to_int                147.89    109.05  -26.34% [-26.54,-25.96] FASTER
+  api.fromArray.int_to_int                      170.73    126.25  -26.15% [-26.22,-26.07] FASTER
+  core.string_to_mixed_adaptive.write          1809.12   1349.82  -25.47% [-25.86,-25.29] FASTER
+  api.setop.intersect.bitset                    116.79     86.98  -25.47% [-25.71,-25.33] FASTER
+  api.deleteRange.int_to_int                    317.47    237.05  -25.39% [-25.51,-25.29] FASTER
+  api.setop.union.int_to_int                    354.29    265.19  -25.24% [-25.45,-24.87] FASTER
+  adv.map.string_to_int                        1420.21   1067.61  -24.92% [-25.15,-24.53] FASTER
+  api.setop.union.bitset                        242.51    182.96  -24.66% [-24.96,-24.09] FASTER
+  adv.optiter.ratio.foreach.string_to_int_adaptive     61.38     46.38  -24.46% [-25.02,-24.44] FASTER
+  core.int_to_int.write                         190.37    144.54  -24.13% [-24.22,-24.08] FASTER
+  api.setop.diff.bitset                         112.92     86.24  -23.79% [-24.26,-23.34] FASTER
+  api.setop.xor.bitset                          225.03    172.72  -23.32% [-23.36,-23.27] FASTER
+  api.setop.diff.int_to_int                     140.01    107.82  -23.09% [-23.31,-22.94] FASTER
+  api.setop.intersect.string_to_int             846.50    652.76  -22.90% [-23.26,-22.52] FASTER
+  adv.filter.string_to_int                     1013.04    781.81  -22.86% [-23.18,-22.48] FASTER
+  api.setop.xor.int_to_int                      280.29    216.84  -22.69% [-22.90,-22.28] FASTER
+  api.setop.diff.string_to_int                  854.74    671.63  -21.52% [-21.66,-21.23] FASTER
+  adv.optiter.values.string_to_int_hash.default     26.15     20.56  -21.52% [-21.75,-21.40] FASTER
+  api.mergeWith.int_to_int                      384.57    302.42  -21.40% [-21.64,-21.31] FASTER
+  adv.optiter.toArray.string_to_int_hash.optimized     22.78     17.94  -21.34% [-21.46,-21.13] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.optimized     27.43     21.65  -21.16% [-21.38,-20.61] FASTER
+  adv.optiter.ratio.values.string_to_int_adaptive     53.43     42.39  -20.53% [-21.13,-20.46] FASTER
+  adv.optiter.foreach.string_to_int_hash.default     27.67     22.05  -20.16% [-20.70,-19.91] FASTER
+  api.mergeWith.string_to_int                  1495.98   1196.79  -20.15% [-20.33,-19.73] FASTER
+  core.string_to_int_adaptive.write            1296.42   1048.59  -19.22% [-19.49,-19.18] FASTER
+  core.string_to_int_hash.write                1294.63   1048.02  -19.12% [-19.29,-18.99] FASTER
+  api.increment.int_to_int                      179.17    145.52  -18.83% [-19.57,-18.73] FASTER
+  api.setop.union.string_to_int                1794.85   1457.72  -18.83% [-19.52,-18.58] FASTER
+  api.sumValues.int_to_int                       58.70     48.61  -17.29% [-17.44,-17.19] FASTER
+  adv.optiter.ratio.values.string_to_int_hash     61.62     51.34  -16.93% [-17.01,-15.76] FASTER
+  core.int_to_int.read                           79.71     66.99  -16.05% [-16.10,-15.63] FASTER
+  adv.optiter.ratio.foreach.string_to_int_hash     69.11     58.00  -16.02% [-17.25,-15.82] FASTER
+  adv.optiter.toArray.string_to_int_hash.default     34.33     29.31  -14.97% [-15.06,-14.57] FASTER
+  core.int_to_packed.free                        61.50     52.29  -14.92% [-15.35,-14.54] FASTER
+  adv.optiter.values.string_to_int_adaptive.default     33.68     29.12  -13.78% [-14.04,-13.52] FASTER
+  adv.optiter.foreach.string_to_int_adaptive.default     34.29     30.12  -12.27% [-12.45,-11.90] FASTER
+  adv.optiter.increment.string_to_int_hash.optimized     21.52     18.96  -11.96% [-12.10,-11.42] FASTER
+  core.bitset.write                             116.95    103.30  -11.72% [-12.10,-11.58] FASTER
+  adv.optiter.ratio.toArray.string_to_int_adaptive     62.37     55.14  -11.59% [-12.01,-11.35] FASTER
+  core.int_to_mixed.read                        314.82    279.14  -11.42% [-11.86,-11.10] FASTER
+  adv.optiter.overwrite.string_to_int_hash.optimized     21.22     18.91  -10.91% [-11.30,-10.49] FASTER
+  core.string_to_mixed_adaptive.read            196.98    175.82  -10.80% [-11.35,-10.71] FASTER
+  adv.optiter.toArray.string_to_int_adaptive.default     43.98     39.23  -10.70% [-10.93,-10.57] FASTER
+  api.getAll.int_to_int                          23.82     21.42  -10.06% [-10.31, -9.88] FASTER
+  core.string_to_int_adaptive.read              189.07    170.91   -9.91% [ -9.94, -9.58] FASTER
+  core.string_to_int_hash.read                  188.41    170.41   -9.73% [ -9.84, -9.55] FASTER
+  core.int_to_mixed.write                       440.50    399.85   -9.35% [ -9.75, -8.94] FASTER
+  adv.map.int_to_int                            327.83    298.82   -9.24% [ -9.41, -8.96] FASTER
+  core.int_to_packed.write                      380.62    347.08   -9.08% [ -9.25, -8.46] FASTER
+  api.range.keys.int_to_int                      11.02     10.05   -8.75% [ -9.04, -8.23] FASTER
+  core.bitset.iter                              116.51    107.35   -8.55% [ -8.66, -7.26] FASTER
+  adv.optiter.ratio.increment.string_to_int_hash    126.94    116.97   -8.22% [ -9.61, -7.16] FASTER
+  api.keys.int_to_int                           125.71    116.30   -7.78% [ -7.84, -7.53] FASTER
+  api.values.int_to_int                         130.80    120.95   -7.74% [ -7.84, -7.55] FASTER
+  core.int_to_int.iter                          122.76    113.36   -7.72% [ -7.94, -7.43] FASTER
+  adv.optiter.ratio.toArray.string_to_int_hash     66.30     61.34   -7.61% [ -7.76, -7.43] FASTER
+  adv.optiter.ratio.overwrite.string_to_int_hash    125.69    116.31   -7.50% [ -7.99, -6.63] FASTER
+  core.int_to_mixed.free                        108.69    100.42   -7.47% [ -8.26, -7.09] FASTER
+  api.toArray.int_to_int                        319.14    297.26   -7.22% [ -7.39, -6.71] FASTER
+  core.int_to_mixed.iter                        345.20    321.14   -6.82% [ -7.22, -6.68] FASTER
+  adv.filter.int_to_int                         302.53    284.21   -6.26% [ -6.66, -5.66] FASTER
+  core.int_to_packed.iter                       262.43    246.49   -6.01% [ -6.35, -5.62] FASTER
+  adv.optiter.overwrite.string_to_int_adaptive.optimized     27.64     26.24   -5.25% [ -5.35, -5.19] FASTER
+  core.bitset.read                               70.89     67.54   -4.85% [ -9.12, -3.63] null
+  core.int_to_packed.read                       215.51    205.17   -4.85% [ -5.05, -4.59] FASTER
+  adv.forEach.int_to_int                        197.99    189.24   -4.57% [ -5.37, -4.12] FASTER
+  adv.optiter.ratio.overwrite.string_to_int_adaptive    111.89    106.87   -4.45% [ -5.01, -4.07] FASTER
+  adv.optiter.increment.string_to_int_hash.default     16.92     16.25   -4.35% [ -4.37, -3.97] FASTER
+  adv.optiter.overwrite.string_to_int_hash.default     16.88     16.23   -3.99% [ -4.25, -3.66] FASTER
+  adv.optiter.overwrite.string_to_int_adaptive.default     24.72     24.52   -1.02% [ -1.57, -0.49] null
+  core.int_to_int.free                            2.12      2.16    2.61% [ -0.91, +4.01] null
+  totals: 94 faster, 0 slower, 3 null
+
+------------------------------------------------------------------------------------------------
+  A vs C — PHP native array against php-judy (bundled)
+  Only rows whose PHP arm is a genuine PHP array. judy/array above 1.00 means
+  the PHP array is FASTER — publish these, they are the honest half of the story.
+------------------------------------------------------------------------------------------------
+  benchmark                                   array ms   judy ms  judy/arr winner
+  core.bitset.free                                5.56      0.02     0.00x php-judy
+  core.int_to_int.free                            5.46      2.16     0.40x php-judy
+  api.setop.xor.bitset                          221.14    172.72     0.78x php-judy
+  api.setop.intersect.bitset                     95.32     86.98     0.91x php-judy
+  core.int_to_packed.free                        47.64     52.29     1.10x php-array
+  core.bitset.write                              89.88    103.30     1.15x php-array
+  core.int_to_packed.write                      250.50    347.08     1.39x php-array
+  core.int_to_mixed.write                       266.24    399.85     1.50x php-array
+  core.int_to_int.write                          92.58    144.54     1.56x php-array
+  core.int_to_packed.read                       107.69    205.17     1.91x php-array
+  api.setop.union.bitset                         92.23    182.96     1.98x php-array
+  api.setop.diff.bitset                          42.98     86.24     2.01x php-array
+  core.string_to_mixed.write                    466.75    987.01     2.12x php-array
+  core.int_to_mixed.free                         46.54    100.42     2.16x php-array
+  core.int_to_mixed.read                        122.07    279.14     2.29x php-array
+  api.increment.int_to_int                       57.38    145.52     2.54x php-array
+  core.string_to_int.write                      245.00    640.37     2.61x php-array
+  core.int_to_int.read                           22.50     66.99     2.98x php-array
+  core.bitset.read                               22.31     67.54     3.03x php-array
+  core.string_to_mixed_adaptive.read             56.86    175.82     3.09x php-array
+  core.string_to_mixed.read                     236.32    784.45     3.32x php-array
+  core.string_to_int_hash.read                   49.96    170.41     3.41x php-array
+  core.string_to_int_adaptive.read               49.97    170.91     3.42x php-array
+  core.int_to_mixed.iter                         86.14    321.14     3.73x php-array
+  core.string_to_int.read                        49.47    205.10     4.15x php-array
+  core.string_to_mixed_hash.write               449.27   1904.32     4.24x php-array
+  core.string_to_int_adaptive.write             245.81   1048.59     4.27x php-array
+  core.string_to_int_hash.write                 244.66   1048.02     4.28x php-array
+  core.string_to_int.free                        22.10    110.34     4.99x php-array
+  core.string_to_mixed_adaptive.write           263.12   1349.82     5.13x php-array
+  core.string_to_mixed.free                      63.70    346.05     5.43x php-array
+  core.string_to_mixed.iter                     145.52    818.82     5.63x php-array
+  core.bitset.iter                               18.70    107.35     5.74x php-array
+  core.int_to_int.iter                           18.63    113.36     6.08x php-array
+  core.string_to_mixed_hash.free                 64.26    614.62     9.56x php-array
+  core.string_to_mixed_adaptive.free             64.20    647.49    10.09x php-array
+  core.string_to_int.iter                        28.21    290.99    10.31x php-array
+  core.string_to_int_adaptive.free               22.07    234.67    10.63x php-array
+  core.string_to_int_hash.free                   22.03    234.68    10.65x php-array
+  core.int_to_packed.iter                        21.60    246.49    11.41x php-array
+  core.string_to_mixed_hash.iter                 35.28    427.78    12.13x php-array
+  core.string_to_mixed_adaptive.iter             35.13    450.73    12.83x php-array
+  core.string_to_int_adaptive.iter               28.18    387.54    13.75x php-array
+  core.string_to_int_hash.iter                   28.21    388.37    13.77x php-array
+  core.string_to_mixed_hash.read                 56.80    929.68    16.37x php-array
+  totals: php-judy wins 4, PHP array wins 41, parity 0
+
+Wrote /usr/src/php-judy/run7-out-of-cache-6m-str.json
+rc=0


### PR DESCRIPTION
Closes #179.

## What was measured

The `core.str` per-element write/read/iterate/free table at n=6M — the one
group the published out-of-cache campaign (run6/#171) could not run, blocked by
the unconditional `2G` `memory_limit` that #170 turned into a floor.

Taken on honeycomb under the full published protocol: 7 interleaved ABBA
rounds, 3 independently linked builds per arm rotated across rounds,
`--cpuset-cpus=2`, `/var/tmp/BENCH_LOCK` held throughout, foreign CPU 0.0% at
every phase boundary, PHP-only drift control +0.12% [−0.01, +0.21] over 45
rows, run not self-marked contaminated.

## Controls, before the headline

- **C-vs-C rebuild control** at the same working set (independently linked
  builds of identical source, offset so no round compares a binary against
  itself): **97 of 97 cells null**, median |Δ| 0.14%, p90 0.44%, worst 1.02% —
  all inside the 1.3% floor. Without this the deltas below would not be
  interpretable. (The JSON's `is_control_run` flag reads false because that
  detection is hash-based and independently linked builds are not byte-identical;
  the run's label and arms mark it as the control.)
- **Replication**: the run re-measured every group run6 covered and reproduces
  its aggregates within half a point — integer/bitset −11.6% (n=38) vs run6's
  −12.0%; string API −18.8% (n=35) vs −19.7% — on independently rebuilt arms.
  The memory matrix reproduces within rounding. This is the more load-bearing
  number and the write-up states it first.

## The new cells

All 24 B→C cells FASTER, median **−32.5%**, every CI clear of the 1.3% floor by
7× or more, per-build spread ≤ 1.7% on every cell:

| type | write | read | iter | free |
| --- | ---: | ---: | ---: | ---: |
| `STRING_TO_INT` | −28.4% | −36.8% | −36.2% | −42.6% |
| `STRING_TO_MIXED` | −28.2% | −33.6% | −34.6% | −39.1% |
| `STRING_TO_INT_HASH` | −19.1% | −9.7% | −34.5% | −30.5% |
| `STRING_TO_MIXED_HASH` | −27.4% | −32.5% | −32.8% | −34.2% |
| `STRING_TO_INT_ADAPTIVE` | −19.2% | −9.9% | −35.0% | −30.5% |
| `STRING_TO_MIXED_ADAPTIVE` | −25.5% | −10.8% | −32.5% | −32.9% |

The ~−10% `read` outliers are all HASH/ADAPTIVE variants (lookups mostly in the
extension's own hash layer, not the component being swapped) — reported as an
observation, not a mechanism, since `STRING_TO_MIXED_HASH.read` at −32.5% does
not fit that story.

## Deliberately not claimed

- **Attribution.** No pristine-static S arm was run, so no S→C share exists for
  the new cells; the decomposition table keeps its API-paths-only scope. Whether
  `core.str`'s −32.5% splits toward the patches or toward static linkage the way
  the API cells' 40% does is unmeasured.
- **A-vs-C reversal.** The PHP array still wins all 24 per-element timing cells
  (2.1×–16.4×) while Judy stays 3.44× smaller on `string_to_int` memory — the
  standing string-type trade-off, now stated at full working set.

## Changes

- `BENCHMARK.md`: new subsection in the out-of-cache section; tier row loses its
  `core.str not measured` caveat; the "one hole remains" record is closed in
  place; reproduce command now includes the group (budget ~3.7 GB RSS per timing
  child).
- `research/three-arm-benchmark/results/`: `run7-out-of-cache-6m-str.{json,txt}`,
  `run7-cvsc-control-6m-str.{json,txt}`. Not shipped via `package.xml` (no
  research/ files are), so no packaging change.
