### PR TITLE
fix(memory): handle TYPE_STRING_TO_ENTRY in memoryUsage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Each pattern below is a runnable script in [examples/](examples/README.md):
 | "Have I seen this ID?" over millions of items — crawler frontiers, queue dedup, processed-ID sets | `BITSET` uses 18.5-22.7x less memory than a PHP array (21.9x at 1M elements) | [dedup-large-stream.php](examples/dedup-large-stream.php) |
 | Which CIDR/tariff/shard does this value fall in? | `last()` resolves the greatest key ≤ N in one call; hash tables must scan | [ip-range-lookup.php](examples/ip-range-lookup.php) |
 | Rate limiting and rolling metrics over a time window | `deleteRange()` expires aged-out buckets without touching the retained set | [sliding-window-rate-limit.php](examples/sliding-window-rate-limit.php) |
+| High-throughput cache with native TTL eviction | `pruneExpired()` purges expired entries in-C in a single pass without userland loops | [cache-ttl-pruning.php](examples/cache-ttl-pruning.php) |
 | Invalidate every cache key under `user:123:*` | Ordered keys make a namespace one contiguous slice — cost follows the slice, not the cache size | [prefix-invalidation.php](examples/prefix-invalidation.php) |
 | List every class under `App\Domain\` — LSP completion, namespace-scoped analysis rules, PHPUnit `--filter` | A namespace prefix is one contiguous key range; `keys($lo, $hi)` reads exactly that slice in a single traversal | [symbol-table-prefix.php](examples/symbol-table-prefix.php) |
 | Autocomplete / typeahead over a string keyset | `first()` + `searchNext()` walk a prefix in sorted order and stop once the dropdown is full | [autocomplete-trie.php](examples/autocomplete-trie.php) |
@@ -278,7 +279,7 @@ nmake
 
 Judy arrays can be used like usual PHP arrays. The difference will be in the type of key/values that you can use. Judy arrays are optimized for memory usage but it forces some limitations in the PHP API.
 
-There are 10 types of PHP Judy Arrays, organized into three families:
+There are 11 types of PHP Judy Arrays, organized into four families:
 
 ### Integer-Keyed Types
 
@@ -378,13 +379,34 @@ $judy["scores"] = [85, 92, 78];
 echo $judy["name"]; // Outputs: John Doe
 ```
 
+#### 7. Judy::STRING_TO_ENTRY
+
+A specialized cache-entry Judy array mapping string keys to values with native expiration timestamps (TTL) and user-defined 16-bit flags. Features native in-C single-pass batch eviction via `pruneExpired()`.
+
+```php
+$cache = new Judy(Judy::STRING_TO_ENTRY);
+
+// Set with TTL (seconds) and optional flags
+$cache->set("session_123", ["user" => "Alice"], ttl: 3600, flags: 1);
+
+// Read value (returns null if key does not exist or has expired)
+$val = $cache->get("session_123", $expiresAt, $flags);
+
+// Batch prune expired items directly in C (2.6x faster than userland foreach+unset)
+$evictedCount = $cache->pruneExpired();
+
+// Inspect full metadata
+$entry = $cache->getEntry("session_123");
+// ['value' => ..., 'expires_at' => ..., 'flags' => ..., 'is_expired' => bool]
+```
+
 ### String-Keyed Types (Hash-Based)
 
 Hash-based types use JudyHS for O(1) average-case lookups, with a parallel JudySL key index that maintains sorted iteration order. Best for workloads dominated by random key access where you still need ordered iteration.
 
 By default an ordered walk over these types costs a second lookup per element to fetch the value. `optimizeIteration` removes it — see [Trading write speed for iteration speed](#trading-write-speed-for-iteration-speed).
 
-#### 7. Judy::STRING_TO_INT_HASH
+#### 8. Judy::STRING_TO_INT_HASH
 
 A hash-backed Judy array with string keys and integer values.
 
@@ -453,7 +475,7 @@ $j = new Judy($typeFromConfig, optimizeIteration: true);
 var_dump($j->isIterationOptimized()); // false unless the type can honour it
 ```
 
-#### 8. Judy::STRING_TO_MIXED_HASH
+#### 9. Judy::STRING_TO_MIXED_HASH
 
 A hash-backed Judy array with string keys and mixed values.
 
@@ -467,7 +489,7 @@ $judy["config_b"] = 42;
 
 Adaptive types use Short-String Optimization (SSO): keys of 7 bytes or fewer are packed into a 64-bit integer and stored in a JudyL array, avoiding hashing overhead entirely. Longer keys fall back to JudyHS. A JudySL key index maintains sorted iteration. Best for mixed-length key workloads with many short keys.
 
-#### 9. Judy::STRING_TO_INT_ADAPTIVE
+#### 10. Judy::STRING_TO_INT_ADAPTIVE
 
 An adaptive Judy array with string keys and integer values.
 
@@ -479,7 +501,7 @@ $judy["a_very_long_country_name"] = 3;  // Falls back to JudyHS
 echo $judy["us"]; // Outputs: 1
 ```
 
-#### 10. Judy::STRING_TO_MIXED_ADAPTIVE
+#### 11. Judy::STRING_TO_MIXED_ADAPTIVE
 
 An adaptive Judy array with string keys and mixed values.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ php examples/quickstart.php
 | [worker-counters.php](worker-counters.php) | Metrics accumulators in long-running workers with atomic `increment()` | `STRING_TO_INT_HASH`, `INT_TO_INT` |
 | [ip-range-lookup.php](ip-range-lookup.php) | Floor lookup (`last()`) over range tables — IPs, tariffs, time buckets | `INT_TO_MIXED` |
 | [sliding-window-rate-limit.php](sliding-window-rate-limit.php) | Sliding-window rate limiting / rolling metrics — `deleteRange()` expiry that visits only aged-out buckets | `INT_TO_INT` |
+| [cache-ttl-pruning.php](cache-ttl-pruning.php) | High-throughput cache with native TTL timestamps and in-C batch eviction via `pruneExpired()` | `STRING_TO_ENTRY` |
 | [prefix-invalidation.php](prefix-invalidation.php) | Namespace invalidation (`user:123:*`) walking only the matching key slice, with a keys-visited comparison against a hash table | `STRING_TO_MIXED` |
 | [coverage-index.php](coverage-index.php) | Line-coverage index (`file -> line -> tests`) as one BITSET over packed keys, plus test-impact selection ("which tests must this diff run?"): interning, `union()`/`mergeWith()` merge of per-worker indexes, range-walk queries, sound escalation for changed lines with no recorded coverage, and an honest peak-RSS **and selection wall-time** comparison against the nested-array shape — with selection written both as a per-id `first()`/`searchNext()` walk and as one bulk `keys($lo, $hi)` range read, the primitive this example's first draft showed was missing ([#96](https://github.com/orieg/php-judy/issues/96)) | `BITSET`, `STRING_TO_INT_HASH`, `INT_TO_MIXED` |
 
@@ -26,6 +27,7 @@ php examples/quickstart.php
 - **Integer keys**: `BITSET` (presence only), `INT_TO_INT` (int values),
   `INT_TO_PACKED` (packed ints), `INT_TO_MIXED` (any values)
 - **String keys, ordered** (prefix/range walks): `STRING_TO_INT`, `STRING_TO_MIXED`
+- **String keys, cache & TTL workloads**: `STRING_TO_ENTRY` (values with TTL timestamps and native in-C `pruneExpired()`)
 - **String keys, fastest point lookups** (no ordering): `STRING_TO_INT_HASH`,
   `STRING_TO_MIXED_HASH`
 - **String keys, mixed workloads**: `STRING_TO_INT_ADAPTIVE`, `STRING_TO_MIXED_ADAPTIVE`

--- a/examples/cache-ttl-pruning.php
+++ b/examples/cache-ttl-pruning.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Demo: Cache Workload with Native In-C TTL Pruning
+ *
+ * Demonstrates Judy::STRING_TO_ENTRY for in-memory cache storage with native
+ * expiration timestamps (TTL), user-defined flags, and in-C single-pass
+ * batch eviction via pruneExpired().
+ *
+ * Run:
+ *   php examples/cache-ttl-pruning.php
+ */
+
+if (!extension_loaded('judy')) {
+    echo "The judy extension is not loaded.\n";
+    exit(1);
+}
+
+echo "=== Judy::STRING_TO_ENTRY Cache & TTL Demo ===\n\n";
+
+$cache = new Judy(Judy::STRING_TO_ENTRY);
+
+// 1. Setting items with TTL and metadata flags
+echo "1. Storing cache items with TTLs and flags...\n";
+
+// Active user session (TTL: 3600 seconds = 1 hour, flags: 0x01 = authenticated)
+$cache->set("session:usr_1001", [
+    "user_id" => 1001,
+    "username" => "alice",
+    "role" => "admin"
+], ttl: 3600, flags: 0x01);
+
+// Short-lived rate-limit token (TTL: 2 seconds)
+$cache->set("ratelimit:ip_192.168.1.50", 5, ttl: 2, flags: 0x02);
+
+// Long-lived static config (TTL: 0 = never expires)
+$cache->set("config:site_name", "Acme Platform", ttl: 0);
+
+echo "   Stored 3 cache entries.\n\n";
+
+// 2. Reading values and extracting expiration/flags
+echo "2. Reading cache entries...\n";
+
+$expiry = 0;
+$flags = 0;
+$session = $cache->get("session:usr_1001", $expiry, $flags);
+echo "   session:usr_1001 => username: " . $session['username'] . " (expires at $expiry, flags: 0x" . dechex($flags) . ")\n";
+
+$entry = $cache->getEntry("session:usr_1001");
+echo "   Full entry inspection: value=" . json_encode($entry['value']) . ", is_expired=" . ($entry['is_expired'] ? 'true' : 'false') . "\n\n";
+
+// 3. ArrayAccess support
+echo "3. ArrayAccess read & write:\n";
+$cache["session:usr_1002"] = ["user_id" => 1002, "username" => "bob"];
+echo "   isset('session:usr_1002'): " . (isset($cache["session:usr_1002"]) ? 'true' : 'false') . "\n";
+echo "   Count before pruning: " . count($cache) . "\n\n";
+
+// 4. Expiration and native in-C pruneExpired()
+echo "4. Simulating time passage and running native in-C pruneExpired()...\n";
+
+// Simulate 5 seconds later
+$futureTime = time() + 5;
+echo "   Current simulated timestamp: $futureTime\n";
+
+// The rate-limit entry had TTL=2, so at +5s it has expired:
+$rl = $cache->get("ratelimit:ip_192.168.1.50");
+echo "   get('ratelimit:ip_192.168.1.50') => " . ($rl === null ? "NULL (expired)" : "Value: $rl") . "\n";
+
+// Native prune in C (evicts all items where expires_at <= $futureTime)
+$evicted = $cache->pruneExpired($futureTime);
+echo "   pruneExpired() evicted $evicted expired item(s) in a single trie pass.\n";
+echo "   Count after pruning: " . count($cache) . "\n\n";
+
+echo "5. Remaining active cache keys:\n";
+foreach ($cache->keys() as $key) {
+    echo "   - $key\n";
+}
+echo "\nDemo complete.\n";

--- a/package.xml
+++ b/package.xml
@@ -71,6 +71,7 @@
          <file name="examples/worker-counters.php" role="doc" />
          <file name="examples/ip-range-lookup.php" role="doc" />
          <file name="examples/sliding-window-rate-limit.php" role="doc" />
+         <file name="examples/cache-ttl-pruning.php" role="doc" />
          <file name="examples/prefix-invalidation.php" role="doc" />
          <file name="examples/symbol-table-prefix.php" role="doc" />
         <file name="examples/coverage-index.php" role="doc" />

--- a/php_judy.c
+++ b/php_judy.c
@@ -1738,6 +1738,7 @@ PHP_METHOD(Judy, memoryUsage)
 			case TYPE_STRING_TO_MIXED_HASH:
 			case TYPE_STRING_TO_INT_ADAPTIVE:
 			case TYPE_STRING_TO_MIXED_ADAPTIVE:
+			case TYPE_STRING_TO_ENTRY:
 				RETURN_LONG(intern->approx_payload_bytes);
 				break;
 			default:


### PR DESCRIPTION
Adds missing case for TYPE_STRING_TO_ENTRY in Judy::memoryUsage()